### PR TITLE
The HeartbeatProvider needs to get updated every time the endpoint sends a heartbeat

### DIFF
--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_endpoint_starts_up.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_endpoint_starts_up.cs
@@ -7,7 +7,7 @@
     using NServiceBus.Config;
     using NServiceBus.Unicast;
     using NUnit.Framework;
-    using ServiceControl.Contracts.HeartbeatMonitoring;
+    using ServiceControl.Contracts.EndpointControl;
     using ServiceControl.EventLog;
 
     public class When_an_endpoint_starts_up : AcceptanceTest

--- a/src/ServiceControl/CompositeViews/Endpoints/EndpointsView.cs
+++ b/src/ServiceControl/CompositeViews/Endpoints/EndpointsView.cs
@@ -7,8 +7,12 @@ namespace ServiceControl.CompositeViews.Endpoints
         public Guid Id { get; set; }
         public string Name { get; set; }
         public string HostDisplayName { get; set; }
+
+        public bool Monitored { get; set; }
+
         public bool MonitorHeartbeat { get; set; }
         public string LicenseStatus { get; set; }
         public HeartbeatInformation HeartbeatInformation { get; set; }
+        public bool IsSendingHeartbeats { get; set; }
     }
 }

--- a/src/ServiceControl/CompositeViews/Endpoints/GetEndpoints.cs
+++ b/src/ServiceControl/CompositeViews/Endpoints/GetEndpoints.cs
@@ -39,7 +39,7 @@ namespace ServiceControl.CompositeViews.Endpoints
                         return HttpStatusCode.NotFound;
                     }
 
-                    if (data.MonitorHeartbeat == endpoint.MonitorHeartbeat)
+                    if (data.MonitorHeartbeat == endpoint.Monitored)
                     {
                         return HttpStatusCode.NotModified;
                     }
@@ -79,7 +79,8 @@ namespace ServiceControl.CompositeViews.Endpoints
                                 Id = knownEndpoint.Id,
                                 Name = knownEndpoint.EndpointDetails.Name,
                                 HostDisplayName = knownEndpoint.HostDisplayName,
-                                MonitorHeartbeat = knownEndpoint.MonitorHeartbeat,
+                                Monitored = knownEndpoint.Monitored,
+                                MonitorHeartbeat = true,
                                 LicenseStatus = LicenseStatusKeeper.Get(knownEndpoint.EndpointDetails.Name + knownEndpoint.HostDisplayName)
                             };
 
@@ -90,6 +91,10 @@ namespace ServiceControl.CompositeViews.Endpoints
                                     {
                                         return;
                                     }
+
+                                    view.IsSendingHeartbeats = true;
+
+                                    view.MonitorHeartbeat = !heartbeat.Disabled;
 
                                     view.HeartbeatInformation =
                                         new HeartbeatInformation

--- a/src/ServiceControl/CompositeViews/Endpoints/KnownEndpointIndex.cs
+++ b/src/ServiceControl/CompositeViews/Endpoints/KnownEndpointIndex.cs
@@ -13,7 +13,7 @@ namespace ServiceControl.CompositeViews.Endpoints
                               {
                                   EndpointDetails = message.EndpointDetails,
                                   HostDisplayName = message.HostDisplayName,
-                                  MonitorHeartbeat = message.MonitorHeartbeat,
+                                  Monitored = message.Monitored,
                               };
 
             DisableInMemoryIndexing = true;

--- a/src/ServiceControl/CompositeViews/Endpoints/KnownEndpointUpdateHandler.cs
+++ b/src/ServiceControl/CompositeViews/Endpoints/KnownEndpointUpdateHandler.cs
@@ -21,13 +21,13 @@ namespace ServiceControl.CompositeViews.Endpoints
                 throw new Exception("No endpoint with found with id: " + message.EndpointId);
             }
 
-            knownEndpoint.MonitorHeartbeat = true;
+            knownEndpoint.Monitored = true;
 
             Session.Store(knownEndpoint);
 
             Bus.Publish(new MonitoringEnabledForEndpoint
             {
-                EndpointId = message.EndpointId,
+                EndpointInstanceId = message.EndpointId,
                 Endpoint = knownEndpoint.EndpointDetails
             });
         }
@@ -41,13 +41,13 @@ namespace ServiceControl.CompositeViews.Endpoints
                 throw new Exception("No endpoint with found with id: " + message.EndpointId);
             }
 
-            knownEndpoint.MonitorHeartbeat = false;
+            knownEndpoint.Monitored = false;
 
             Session.Store(knownEndpoint);
 
             Bus.Publish(new MonitoringDisabledForEndpoint
             {
-                EndpointId = message.EndpointId,
+                EndpointInstanceId = message.EndpointId,
                 Endpoint = knownEndpoint.EndpointDetails
             });
         }

--- a/src/ServiceControl/Contracts/EndpointControl/EndpointStarted.cs
+++ b/src/ServiceControl/Contracts/EndpointControl/EndpointStarted.cs
@@ -1,12 +1,12 @@
-namespace ServiceControl.Contracts.HeartbeatMonitoring
+namespace ServiceControl.Contracts.EndpointControl
 {
     using System;
     using NServiceBus;
+    using Operations;
 
     public class EndpointStarted : IEvent
     {
-        public Guid HostId { get; set; }
-        public string Endpoint { get; set; }
+        public EndpointDetails EndpointDetails { get; set; }
         public DateTime StartedAt { get; set; }
     }
 }

--- a/src/ServiceControl/Contracts/EndpointControl/MonitoringDisabledForEndpoint.cs
+++ b/src/ServiceControl/Contracts/EndpointControl/MonitoringDisabledForEndpoint.cs
@@ -6,7 +6,7 @@ namespace ServiceControl.EndpointControl.Contracts
 
     public class MonitoringDisabledForEndpoint : IEvent
     {
-        public Guid EndpointId { get; set; }
+        public Guid EndpointInstanceId { get; set; }
 
         public EndpointDetails Endpoint { get; set; }
     }

--- a/src/ServiceControl/Contracts/EndpointControl/MonitoringEnabledForEndpoint.cs
+++ b/src/ServiceControl/Contracts/EndpointControl/MonitoringEnabledForEndpoint.cs
@@ -6,7 +6,7 @@ namespace ServiceControl.EndpointControl.Contracts
 
     public class MonitoringEnabledForEndpoint : IEvent
     {
-        public Guid EndpointId { get; set; }
+        public Guid EndpointInstanceId { get; set; }
 
         public EndpointDetails Endpoint { get; set; }
     }

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/EndpointFailedToHeartbeat.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/EndpointFailedToHeartbeat.cs
@@ -1,10 +1,9 @@
 namespace ServiceControl.Contracts.HeartbeatMonitoring
 {
     using System;
-    using NServiceBus;
     using Operations;
 
-    public class EndpointFailedToHeartbeat : IEvent
+    public class EndpointFailedToHeartbeat : HeartbeatStatusChanged
     {
         public EndpointDetails Endpoint { get; set; }
         public DateTime LastReceivedAt { get; set; }

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/EndpointHeartbeatRestored.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/EndpointHeartbeatRestored.cs
@@ -1,10 +1,9 @@
 namespace ServiceControl.Contracts.HeartbeatMonitoring
 {
     using System;
-    using NServiceBus;
     using Operations;
 
-    public class EndpointHeartbeatRestored : IEvent
+    public class EndpointHeartbeatRestored : HeartbeatStatusChanged
     {
         public EndpointDetails Endpoint { get; set; }
         public DateTime RestoredAt { get; set; }

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatMonitoringDisabled.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatMonitoringDisabled.cs
@@ -1,0 +1,9 @@
+namespace ServiceControl.Contracts.HeartbeatMonitoring
+{
+    using System;
+
+    public class HeartbeatMonitoringDisabled : HeartbeatStatusChanged
+    {
+        public Guid EndpointInstanceId { get; set; }
+    }
+}

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatMonitoringEnabled.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatMonitoringEnabled.cs
@@ -1,0 +1,9 @@
+namespace ServiceControl.Contracts.HeartbeatMonitoring
+{
+    using System;
+
+    public class HeartbeatMonitoringEnabled : HeartbeatStatusChanged
+    {
+        public Guid EndpointInstanceId { get; set; } 
+    }
+}

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatStatusChanged.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatStatusChanged.cs
@@ -1,0 +1,9 @@
+﻿namespace ServiceControl.Contracts.HeartbeatMonitoring
+{
+    using NServiceBus;
+
+    public class HeartbeatStatusChanged : IEvent
+    {
+        
+    }
+}

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatingEndpointDetected.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatingEndpointDetected.cs
@@ -1,10 +1,9 @@
 ﻿namespace ServiceControl.Contracts.HeartbeatMonitoring
 {
     using System;
-    using NServiceBus;
     using Operations;
 
-    public class HeartbeatingEndpointDetected : IEvent
+    public class HeartbeatingEndpointDetected : HeartbeatStatusChanged
     {
         public EndpointDetails Endpoint { get; set; }
         public DateTime DetectedAt { get; set; }

--- a/src/ServiceControl/EndpointControl/KnownEndpoint.cs
+++ b/src/ServiceControl/EndpointControl/KnownEndpoint.cs
@@ -7,12 +7,12 @@
     {
         public KnownEndpoint()
         {
-            MonitorHeartbeat = true;
+            Monitored = true;
         }
 
         public Guid Id { get; set; }
         public string HostDisplayName { get; set; }
-        public bool MonitorHeartbeat { get; set; }
+        public bool Monitored { get; set; }
         public EndpointDetails EndpointDetails { get; set; }
         public bool HasTemporaryId{ get; set; }
     }

--- a/src/ServiceControl/EventLog/Definitions/EndpointStartedDefinition.cs
+++ b/src/ServiceControl/EventLog/Definitions/EndpointStartedDefinition.cs
@@ -1,15 +1,15 @@
 ﻿namespace ServiceControl.EventLog.Definitions
 {
-    using Contracts.HeartbeatMonitoring;
+    using Contracts.EndpointControl;
 
     public class EndpointStartedDefinition : EventLogMappingDefinition<EndpointStarted>
     {
         public EndpointStartedDefinition()
         {
-            Description(m => string.Format("Endpoint '{0}' started at {1} on host {2}", m.Endpoint, m.StartedAt, m.HostId));
+            Description(m => string.Format("Endpoint '{0}' started at {1} on host {2}", m.EndpointDetails.Name, m.StartedAt, m.EndpointDetails.Host));
 
-            RelatesToEndpoint(m => m.Endpoint);
-            RelatesToHost(m => m.HostId);
+            RelatesToEndpoint(m => m.EndpointDetails.Name);
+            RelatesToHost(m => m.EndpointDetails.HostId);
 
             RaisedAt(m => m.StartedAt);
         }

--- a/src/ServiceControl/HeartbeatMonitoring/Heartbeat.cs
+++ b/src/ServiceControl/HeartbeatMonitoring/Heartbeat.cs
@@ -9,6 +9,7 @@
         public DateTime LastReportAt { get; set; }
         public EndpointDetails EndpointDetails { get; set; }
         public Status ReportedStatus { get; set; }
+        public bool Disabled { get; set; }
     }
 
     public enum Status

--- a/src/ServiceControl/HeartbeatMonitoring/HeartbeatStatusInitializer.cs
+++ b/src/ServiceControl/HeartbeatMonitoring/HeartbeatStatusInitializer.cs
@@ -51,19 +51,11 @@ namespace ServiceControl.HeartbeatMonitoring
 
                 session.Query<KnownEndpoint, KnownEndpointIndex>()
                     .Customize(customization)
-                    .Lazily(heartbeats =>
+                    .Lazily(endpoints =>
                     {
-                        foreach (var knownEndpoint in heartbeats)
+                        foreach (var knownEndpoint in endpoints)
                         {
-                            if (knownEndpoint.MonitorHeartbeat)
-                            {
-                                statusProvider.EnableMonitoring(knownEndpoint.EndpointDetails);
-                            }
-                            else
-                            {
-                                statusProvider.DisableMonitoring(knownEndpoint.EndpointDetails);
-                            }
-
+                            statusProvider.RegisterNewEndpoint(knownEndpoint.EndpointDetails);
                         }
                     });
 
@@ -73,6 +65,14 @@ namespace ServiceControl.HeartbeatMonitoring
                     {
                         foreach (var heartbeat in heartbeats)
                         {
+                            if (heartbeat.Disabled)
+                            {
+                                statusProvider.DisableMonitoring(heartbeat.EndpointDetails);
+                                continue;
+                            }
+
+                            statusProvider.EnableMonitoring(heartbeat.EndpointDetails);
+
                             if (heartbeat.ReportedStatus == Status.Beating)
                             {
                                 statusProvider.RegisterHeartbeatingEndpoint(heartbeat.EndpointDetails, heartbeat.LastReportAt);

--- a/src/ServiceControl/HeartbeatMonitoring/HeartbeatStatusProvider.cs
+++ b/src/ServiceControl/HeartbeatMonitoring/HeartbeatStatusProvider.cs
@@ -173,11 +173,5 @@
         }
 
         public TimeSpan GracePeriod { get; set; }
-
-        public void RegisterHeartbeat(EndpointDetails endpointDetails)
-        {
-            var heartbeatingEndpoint = GetEndpoint(endpointDetails);
-            heartbeatingEndpoint.TimeOfLastHeartbeat = DateTime.UtcNow;
-        }
     }
 }

--- a/src/ServiceControl/HeartbeatMonitoring/MonitoringDisabledForEndpointHandler.cs
+++ b/src/ServiceControl/HeartbeatMonitoring/MonitoringDisabledForEndpointHandler.cs
@@ -1,0 +1,47 @@
+﻿namespace ServiceControl.HeartbeatMonitoring
+{
+    using System;
+    using Contracts.HeartbeatMonitoring;
+    using EndpointControl.Contracts;
+    using NServiceBus;
+    using NServiceBus.Logging;
+    using Raven.Client;
+
+    class MonitoringDisabledForEndpointHandler : IHandleMessages<MonitoringDisabledForEndpoint>
+    {
+        public HeartbeatStatusProvider StatusProvider { get; set; }
+
+        public IDocumentSession Session { get; set; }
+
+        public IBus Bus { get; set; }
+
+        public void Handle(MonitoringDisabledForEndpoint message)
+        {
+            var heartbeat = Session.Load<Heartbeat>(message.EndpointInstanceId);
+
+            if (heartbeat == null)
+            {
+                throw new Exception("No heartbeat with found with id: " + message.EndpointInstanceId);
+            }
+
+            if (heartbeat.Disabled)
+            {
+                Logger.InfoFormat("Heartbeat monitoring for endpoint {0} is already disabled", message.EndpointInstanceId);
+                return;
+            }
+
+            heartbeat.Disabled = true;
+
+            StatusProvider.DisableMonitoring(message.Endpoint);
+
+            Session.Store(heartbeat);
+
+            Bus.Publish(new HeartbeatMonitoringDisabled
+            {
+                EndpointInstanceId = message.EndpointInstanceId
+            });
+        }
+
+        static readonly ILog Logger = LogManager.GetLogger(typeof(MonitoringEnabledForEndpointHandler));
+    }
+}

--- a/src/ServiceControl/HeartbeatMonitoring/MonitoringEnabledForEndpointHandler.cs
+++ b/src/ServiceControl/HeartbeatMonitoring/MonitoringEnabledForEndpointHandler.cs
@@ -1,0 +1,47 @@
+﻿namespace ServiceControl.HeartbeatMonitoring
+{
+    using System;
+    using Contracts.HeartbeatMonitoring;
+    using EndpointControl.Contracts;
+    using NServiceBus;
+    using NServiceBus.Logging;
+    using Raven.Client;
+
+    class MonitoringEnabledForEndpointHandler : IHandleMessages<MonitoringEnabledForEndpoint>
+    {
+        public HeartbeatStatusProvider StatusProvider { get; set; }
+
+        public IDocumentSession Session { get; set; }
+
+        public IBus Bus { get; set; }
+
+        public void Handle(MonitoringEnabledForEndpoint message)
+        {
+            var heartbeat = Session.Load<Heartbeat>(message.EndpointInstanceId);
+
+            if (heartbeat == null)
+            {
+                throw new Exception("No heartbeat with found with id: " + message.EndpointInstanceId);
+            }
+
+            if (!heartbeat.Disabled)
+            {
+                Logger.InfoFormat("Heartbeat monitoring for endpoint {0} is already enabled",message.EndpointInstanceId);
+                return;
+            }
+
+            heartbeat.Disabled = false;
+
+            StatusProvider.EnableMonitoring(message.Endpoint);
+
+            Session.Store(heartbeat);
+
+            Bus.Publish(new HeartbeatMonitoringEnabled
+            {
+                EndpointInstanceId = message.EndpointInstanceId
+            });
+        }
+
+        static readonly ILog Logger = LogManager.GetLogger(typeof(MonitoringEnabledForEndpointHandler));
+    }
+}

--- a/src/ServiceControl/HeartbeatMonitoring/RaiseHeartbeatChanges.cs
+++ b/src/ServiceControl/HeartbeatMonitoring/RaiseHeartbeatChanges.cs
@@ -2,49 +2,25 @@
 {
     using Contracts.EndpointControl;
     using Contracts.HeartbeatMonitoring;
-    using EndpointControl.Contracts;
     using NServiceBus;
 
     public class RaiseHeartbeatChanges :
-        IHandleMessages<HeartbeatingEndpointDetected>,
-        IHandleMessages<EndpointFailedToHeartbeat>,
-        IHandleMessages<EndpointHeartbeatRestored>,
-        IHandleMessages<MonitoringEnabledForEndpoint>,
-        IHandleMessages<MonitoringDisabledForEndpoint>,
+        IHandleMessages<HeartbeatStatusChanged>,
         IHandleMessages<NewEndpointDetected>
     {
         public IBus Bus { get; set; }
-     
+
         public HeartbeatStatusProvider StatusProvider { get; set; }
 
-        public void Handle(EndpointFailedToHeartbeat message)
+        public void Handle(HeartbeatStatusChanged message)
         {
-            PublishUpdate(StatusProvider.RegisterEndpointThatFailedToHeartbeat(message.Endpoint));
-        }
-
-        public void Handle(EndpointHeartbeatRestored message)
-        {
-            PublishUpdate(StatusProvider.RegisterEndpointWhoseHeartbeatIsRestored(message.Endpoint, message.RestoredAt));
-        }
-
-        public void Handle(HeartbeatingEndpointDetected message)
-        {
-            PublishUpdate(StatusProvider.RegisterHeartbeatingEndpoint(message.Endpoint,message.DetectedAt));
-        }
-
-        public void Handle(MonitoringEnabledForEndpoint message)
-        {
-            PublishUpdate(StatusProvider.EnableMonitoring(message.Endpoint));
-        }
-
-        public void Handle(MonitoringDisabledForEndpoint message)
-        {
-
-            PublishUpdate(StatusProvider.DisableMonitoring(message.Endpoint));
+            PublishUpdate(StatusProvider.GetHeartbeatsStats());
         }
 
         public void Handle(NewEndpointDetected message)
         {
+            //this call is non intuitive, we just call it since endpoints without the heartbeat plugin installed should count as "failing"
+            // we need to revisit the requirements for this
             PublishUpdate(StatusProvider.RegisterNewEndpoint(message.Endpoint));
         }
 
@@ -56,8 +32,5 @@
                 Failing = stats.Dead,
             });
         }
-
-
-
     }
 }

--- a/src/ServiceControl/HeartbeatMonitoring/RegisterEndpointStartupHandler.cs
+++ b/src/ServiceControl/HeartbeatMonitoring/RegisterEndpointStartupHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.HeartbeatMonitoring
 {
-    using Contracts.HeartbeatMonitoring;
+    using Contracts.EndpointControl;
+    using Contracts.Operations;
     using NServiceBus;
     using Plugin.Heartbeat.Messages;
     using Raven.Client;
@@ -14,8 +15,12 @@
         {
             Bus.Publish<EndpointStarted>(e =>
             {
-                e.HostId = message.HostId;
-                e.Endpoint = message.Endpoint;
+                e.EndpointDetails = new EndpointDetails
+                {
+                    Host = message.Host,
+                    HostId = message.HostId,
+                    Name = message.Endpoint
+                };
                 e.StartedAt = message.StartedAt;
             });
         }

--- a/src/ServiceControl/HeartbeatMonitoring/RegisterPotentiallyMissingHeartbeatsHandler.cs
+++ b/src/ServiceControl/HeartbeatMonitoring/RegisterPotentiallyMissingHeartbeatsHandler.cs
@@ -10,6 +10,7 @@ namespace ServiceControl.HeartbeatMonitoring
     {
         public IDocumentSession Session { get; set; }
         public IBus Bus { get; set; }
+        public HeartbeatStatusProvider StatusProvider { get; set; }
 
         public void Handle(RegisterPotentiallyMissingHeartbeats message)
         {
@@ -37,6 +38,7 @@ namespace ServiceControl.HeartbeatMonitoring
                 DetectedAt = message.DetectedAt
             });
 
+            StatusProvider.RegisterEndpointThatFailedToHeartbeat(heartbeat.EndpointDetails);
 
             Session.Store(heartbeat);
         }

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -215,8 +215,11 @@
     <Compile Include="Contracts\EventLog\EventLogItemAdded.cs" />
     <Compile Include="Contracts\HeartbeatMonitoring\EndpointFailedToHeartbeat.cs" />
     <Compile Include="Contracts\HeartbeatMonitoring\EndpointHeartbeatRestored.cs" />
-    <Compile Include="Contracts\HeartbeatMonitoring\EndpointStarted.cs" />
+    <Compile Include="Contracts\EndpointControl\EndpointStarted.cs" />
     <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatingEndpointDetected.cs" />
+    <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatMonitoringDisabled.cs" />
+    <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatMonitoringEnabled.cs" />
+    <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatStatusChanged.cs" />
     <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatsUpdated.cs" />
     <Compile Include="Contracts\MessageFailures\FailedMessageArchived.cs" />
     <Compile Include="Contracts\MessageFailures\MessageFailedRepeatedly.cs" />
@@ -228,6 +231,8 @@
     <Compile Include="Contracts\EndpointControl\MonitoringDisabledForEndpoint.cs" />
     <Compile Include="HeartbeatMonitoring\HeartbeatsStats.cs" />
     <Compile Include="HeartbeatMonitoring\InternalMessages\RegisterPotentiallyMissingHeartbeats.cs" />
+    <Compile Include="HeartbeatMonitoring\MonitoringDisabledForEndpointHandler.cs" />
+    <Compile Include="HeartbeatMonitoring\MonitoringEnabledForEndpointHandler.cs" />
     <Compile Include="HeartbeatMonitoring\RegisterPotentiallyMissingHeartbeatsHandler.cs" />
     <Compile Include="Operations\EndpointDetailsParser.cs" />
     <Compile Include="Contracts\Operations\EndpointHeartbeatReceived.cs" />


### PR DESCRIPTION
relates to:
https://github.com/Particular/ServiceControl/pull/276
This relates to Particular/ServicePulse#104

@andreasohlund - Since the heartbeat provider is never updated with the heartbeat information, the logic for marking the endpoints dead was not happening. i.e. Endpoints won't be reported dead.

Please code review and merge.  
