### PR TITLE
Processing of audit and error messages from v3.3.x endpoints

### DIFF
--- a/src/ServiceControl/EndpointControl/DetectNewEndpointsFromImportsEnricher.cs
+++ b/src/ServiceControl/EndpointControl/DetectNewEndpointsFromImportsEnricher.cs
@@ -21,6 +21,12 @@
 
         void TryAddEndpoint(EndpointDetails endpointDetails)
         {
+            // SendingEndpoint will be null for messages that are from v3.3.x endpoints because we don't
+            // have the relevant information via the headers, which were added in v4.
+            // The ReceivingEndpoint will be null for messages from v3.3.x endpoints that were successfully
+            // processed because we dont have the information from the relevant headers.
+            if (endpointDetails == null) return; 
+
             Guid id;
 
             if (endpointDetails.HostId == Guid.Empty)

--- a/src/ServiceControl/EndpointControl/EnrichWithEndpointDetails.cs
+++ b/src/ServiceControl/EndpointControl/EnrichWithEndpointDetails.cs
@@ -8,12 +8,20 @@
         public override void Enrich(ImportMessage message)
         {
             var sendingEndpoint = EndpointDetailsParser.SendingEndpoint(message.PhysicalMessage.Headers);
-
-            message.Metadata.Add("SendingEndpoint", sendingEndpoint);
+            // SendingEndpoint will be null for messages that are from v3.3.x endpoints because we don't
+            // have the relevant information via the headers, which were added in v4.
+            if (sendingEndpoint != null)
+            {
+                message.Metadata.Add("SendingEndpoint", sendingEndpoint);
+            }
 
             var receivingEndpoint = EndpointDetailsParser.ReceivingEndpoint(message.PhysicalMessage.Headers);
-
-            message.Metadata.Add("ReceivingEndpoint", receivingEndpoint);
+            // The ReceivingEndpoint will be null for messages from v3.3.x endpoints that were successfully
+            // processed because we dont have the information from the relevant headers.
+            if (receivingEndpoint != null)
+            {
+                message.Metadata.Add("ReceivingEndpoint", receivingEndpoint);
+            }
         }
     }
 }

--- a/src/ServiceControl/Operations/EndpointDetailsParser.cs
+++ b/src/ServiceControl/Operations/EndpointDetailsParser.cs
@@ -65,17 +65,21 @@ namespace ServiceControl.Contracts.Operations
             //use the failed q to determine the receiving endpoint
             DictionaryExtensions.CheckIfKeyExists("NServiceBus.FailedQ", headers, s => address = Address.Parse(s));
 
-            if (string.IsNullOrEmpty(endpoint.Name))
+            // If we have a failed queue, then construct an endpoint from the failed queue information
+            if (address != Address.Undefined)
             {
-                endpoint.Name = address.Queue;
+                if (string.IsNullOrEmpty(endpoint.Name))
+                {
+                    endpoint.Name = address.Queue;
+                }
+
+                if (string.IsNullOrEmpty(endpoint.Host))
+                {
+                    endpoint.Host = address.Machine;
+                }
             }
 
-            if (string.IsNullOrEmpty(endpoint.Host))
-            {
-                endpoint.Host = address.Machine;
-            }
-
-            return endpoint;
+            return null;
         }  
     }
 }

--- a/src/ServiceControl/Operations/UpdateLicenseEnricher.cs
+++ b/src/ServiceControl/Operations/UpdateLicenseEnricher.cs
@@ -8,10 +8,16 @@ namespace ServiceControl.Operations
         public LicenseStatusKeeper LicenseStatusKeeper { get; set; }
 
         public override void Enrich(ImportMessage message)
-        {   
+        {
             var status = GetLicenseStatus(message.PhysicalMessage.Headers);
             var endpoint = EndpointDetailsParser.ReceivingEndpoint(message.PhysicalMessage.Headers);
-            LicenseStatusKeeper.Set(endpoint.Name + endpoint.Host, status);
+            
+            // The ReceivingEndpoint will be null for messages from v3.3.x endpoints that were successfully
+            // processed because we dont have the information from the relevant headers.
+            if (endpoint != null)
+            {
+                LicenseStatusKeeper.Set(endpoint.Name + endpoint.Host, status);
+            }
         }
 
         public string GetLicenseStatus(Dictionary<string,string> headers)


### PR DESCRIPTION
SC will now be able to process messages from both the audit queue and error queue that originated from v3.3.x endpoints. 
Fixes #279. 
Also relates to #277
