### PR TITLE
Monitoring & Unmonitoring an endpoint without the hearbeat plugin

### DIFF
--- a/src/ServiceControl/CompositeViews/Endpoints/GetEndpoints.cs
+++ b/src/ServiceControl/CompositeViews/Endpoints/GetEndpoints.cs
@@ -80,7 +80,7 @@ namespace ServiceControl.CompositeViews.Endpoints
                                 Name = knownEndpoint.EndpointDetails.Name,
                                 HostDisplayName = knownEndpoint.HostDisplayName,
                                 Monitored = knownEndpoint.Monitored,
-                                MonitorHeartbeat = true,
+                                MonitorHeartbeat = knownEndpoint.Monitored,
                                 LicenseStatus = LicenseStatusKeeper.Get(knownEndpoint.EndpointDetails.Name + knownEndpoint.HostDisplayName)
                             };
 

--- a/src/ServiceControl/HeartbeatMonitoring/MonitoringDisabledForEndpointHandler.cs
+++ b/src/ServiceControl/HeartbeatMonitoring/MonitoringDisabledForEndpointHandler.cs
@@ -17,25 +17,25 @@
 
         public void Handle(MonitoringDisabledForEndpoint message)
         {
+            // The user could be disabling an endpoint that had the heartbeats plugin, or not.
+            // Check to see if the endpoint had associated heartbeat.
             var heartbeat = Session.Load<Heartbeat>(message.EndpointInstanceId);
-
-            if (heartbeat == null)
+            if (heartbeat != null)
             {
-                throw new Exception("No heartbeat with found with id: " + message.EndpointInstanceId);
+                if (heartbeat.Disabled)
+                {
+                    Logger.InfoFormat("Heartbeat monitoring for endpoint {0} is already disabled", message.EndpointInstanceId);
+                    return;
+                }
+                heartbeat.Disabled = true;
+                Session.Store(heartbeat);
             }
-
-            if (heartbeat.Disabled)
+            else
             {
-                Logger.InfoFormat("Heartbeat monitoring for endpoint {0} is already disabled", message.EndpointInstanceId);
-                return;
+                Logger.InfoFormat("Heartbeat for endpoint {0} not found. Possible cause is that the endpoint may not have the plug in installed.", message.EndpointInstanceId);
             }
-
-            heartbeat.Disabled = true;
 
             StatusProvider.DisableMonitoring(message.Endpoint);
-
-            Session.Store(heartbeat);
-
             Bus.Publish(new HeartbeatMonitoringDisabled
             {
                 EndpointInstanceId = message.EndpointInstanceId


### PR DESCRIPTION
When monitoring/unmonitoring an endpoint that had no heartbeats, a no heartbeat found exception was thrown. This fix ensures that endpoints that don't have the plugins can also be un-monitored.

**Question**
Any reason, why 
https://github.com/Particular/ServiceControl/blob/develop/src/ServiceControl/CompositeViews/Endpoints/GetEndpoints.cs#L83 
this was always set to true?
ServicePulse is looking at the MonitorHeartbeat value to filter out if an endpoint needs to be displayed or not in the active/inactive list.
@andreasohlund - please review. 
