### PR TITLE
Issue-432

### DIFF
--- a/src/ServiceControl.UnitTests/AuditImport/AuditImportTests.cs
+++ b/src/ServiceControl.UnitTests/AuditImport/AuditImportTests.cs
@@ -1,0 +1,26 @@
+﻿namespace ServiceControl.UnitTests.AuditImport
+{
+    using System.Messaging;
+    using NServiceBus;
+    using NServiceBus.Transports.Msmq;
+    using NUnit.Framework;
+    
+    [TestFixture]
+    public class AuditImportTests
+    {
+        [Test, Explicit]
+        public void SendAMessageWithInvalidHeadersToTheAuditQueue()
+        {
+            // Generate a bad msg to test MSMQ Audit Queue Importer
+            // This message should fail to parse to a transport message because of the bad header and so should end up in the Particular.ServiceControl.Errors queue
+            var q = new MessageQueue(MsmqUtilities.GetFullPath(Address.Parse("audit")), false, true, QueueAccessMode.Send);
+            using (var tx = new MessageQueueTransaction())
+            {
+                tx.Begin();
+                var message = new Message("Message with invalid headers"){Extension = new byte[]{1}};
+                q.Send(message, tx);
+                tx.Commit();
+            }
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -81,6 +81,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Services.Client" />
+    <Reference Include="System.Messaging" />
     <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
@@ -89,6 +90,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AuditImport\AuditImportTests.cs" />
     <Compile Include="CompositeViews\FailedMessageTest.cs" />
     <Compile Include="ExternalIntegrations\MessageFailedConverterTests.cs" />
     <Compile Include="CompositeViews\MessagesViewTests.cs" />


### PR DESCRIPTION
Changed MSMQ bulk importer to forward message that cannot be converted to a transport message due to bad header serialization to the ServiceControl errors queue (e.g. particular.servicecontrol.errors) rather than discarding them