### PR TITLE
Fix reimporting

### DIFF
--- a/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
@@ -184,8 +184,12 @@
                     connectionStringsElement.Add(new XElement("add", new XAttribute("name", "NServiceBus/Transport"), new XAttribute("connectionString", transportToUse.ConnectionString)));
                 }
             }
-
+            CustomizeAppConfig(doc);
             doc.Save(pathToAppConfig);
+        }
+
+        protected virtual void CustomizeAppConfig(XDocument doc)
+        {
         }
 
         static void Delete(string path)

--- a/src/ServiceControl.AcceptanceTests/Audit/When_trying_to_import_a_badly_formatted_message.cs
+++ b/src/ServiceControl.AcceptanceTests/Audit/When_trying_to_import_a_badly_formatted_message.cs
@@ -17,7 +17,7 @@
         const string spyQueueName = "audit.spy.default";
 
         [Test]
-        public void Should_be_moved_to_the_service_control_error_queue()
+        public void Should_be_moved_to_the_configured_failed_imports_queue()
         {
             var context = new MyContext()
             {

--- a/src/ServiceControl.AcceptanceTests/Audit/When_trying_to_import_a_badly_formatted_message.cs
+++ b/src/ServiceControl.AcceptanceTests/Audit/When_trying_to_import_a_badly_formatted_message.cs
@@ -1,0 +1,123 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.Audit
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Xml.Linq;
+    using System.Xml.XPath;
+    using Contexts;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.MessageMutator;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_trying_to_import_a_badly_formatted_message : AcceptanceTest
+    {
+        const string spyQueueName = "audit.spy.default";
+
+        [Test]
+        public void Should_be_moved_to_the_service_control_error_queue()
+        {
+            var context = new MyContext()
+            {
+                Id = Guid.NewGuid()
+            };
+            Scenario.Define(context)
+                .WithEndpoint<ManagementEndpoint>(c => c.AppConfig(PathToAppConfig))
+                .WithEndpoint<ServerEndpoint>()
+                .WithEndpoint<Spy>()
+                .Done(c => c.MessageDetected)
+                .Run(TimeSpan.FromMinutes(2));
+
+            Assert.IsTrue(context.MessageDetected);
+        }
+
+        protected override void CustomizeAppConfig(XDocument doc)
+        {
+            var appSettingsElement = doc.XPathSelectElement(@"/configuration/appSettings");
+            var dbPathElement = appSettingsElement.XPathSelectElement(@"add[@key=""ServiceBus/AuditImportFailureQueue""]");
+            if (dbPathElement != null)
+            {
+                dbPathElement.SetAttributeValue("value", spyQueueName);
+            }
+            else
+            {
+                appSettingsElement.Add(new XElement("add",
+                    new XAttribute("key", "ServiceBus/AuditImportFailureQueue"), new XAttribute("value", spyQueueName)));
+            }
+        }
+
+        public class Spy : EndpointConfigurationBuilder
+        {
+            public Spy()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class BodySpy : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public MyContext Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    string contextId;
+                    if (transportMessage.Headers.TryGetValue("ContextId", out contextId)
+                        && Guid.Parse(contextId) == Context.Id)
+                    {
+                        Context.MessageDetected = true;
+                    }
+                }
+
+                public void Init()
+                {
+                    Configure.Component<BodySpy>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+        }
+
+        public class ServerEndpoint : EndpointConfigurationBuilder
+        {
+            public ServerEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class Foo : IWantToRunWhenBusStartsAndStops
+            {
+                public ISendMessages SendMessages { get; set; }
+                public MyContext Context { get; set; }
+
+                public void Start()
+                {
+                    //hack until we can fix the types filtering in default server
+                    if (Configure.EndpointName != "Particular.ServiceControl")
+                    {
+                        return;
+                    }
+
+                    //Missing all required headers
+                    var transportMessage = new TransportMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>()
+                    {
+                        {"ContextId", Context.Id.ToString()}
+                    })
+                    {
+                        MessageIntent = MessageIntentEnum.Send,
+                        Body = new byte[100],
+                    };
+                    SendMessages.Send(transportMessage, Address.Parse("audit"));
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+
+        public class MyContext : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool MessageDetected { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/MessageFailures/When_trying_to_import_a_badly_formatted_message.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageFailures/When_trying_to_import_a_badly_formatted_message.cs
@@ -1,0 +1,123 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.MessageFailures
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Xml.Linq;
+    using System.Xml.XPath;
+    using Contexts;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.MessageMutator;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_trying_to_import_a_badly_formatted_message : AcceptanceTest
+    {
+        const string spyQueueName = "messagefailures.spy.default";
+
+        [Test]
+        public void Should_be_moved_to_the_service_control_error_queue()
+        {
+            var context = new MyContext()
+            {
+                Id = Guid.NewGuid()
+            };
+            Scenario.Define(context)
+                .WithEndpoint<ManagementEndpoint>(c => c.AppConfig(PathToAppConfig))
+                .WithEndpoint<ServerEndpoint>()
+                .WithEndpoint<Spy>()
+                .Done(c => c.MessageDetected)
+                .Run(TimeSpan.FromMinutes(2));
+
+            Assert.IsTrue(context.MessageDetected);
+        }
+
+        protected override void CustomizeAppConfig(XDocument doc)
+        {
+            var appSettingsElement = doc.XPathSelectElement(@"/configuration/appSettings");
+            var dbPathElement = appSettingsElement.XPathSelectElement(@"add[@key=""ServiceBus/ErrorImportFailureQueue""]");
+            if (dbPathElement != null)
+            {
+                dbPathElement.SetAttributeValue("value", spyQueueName);
+            }
+            else
+            {
+                appSettingsElement.Add(new XElement("add",
+                    new XAttribute("key", "ServiceBus/ErrorImportFailureQueue"), new XAttribute("value", spyQueueName)));
+            }
+        }
+
+        public class Spy : EndpointConfigurationBuilder
+        {
+            public Spy()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class BodySpy : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public MyContext Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    string contextId;
+                    if (transportMessage.Headers.TryGetValue("ContextId", out contextId)
+                        && Guid.Parse(contextId) == Context.Id)
+                    {
+                        Context.MessageDetected = true;
+                    }
+                }
+
+                public void Init()
+                {
+                    Configure.Component<BodySpy>(DependencyLifecycle.InstancePerCall);
+                }
+            }
+        }
+
+        public class ServerEndpoint : EndpointConfigurationBuilder
+        {
+            public ServerEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class Foo : IWantToRunWhenBusStartsAndStops
+            {
+                public ISendMessages SendMessages { get; set; }
+                public MyContext Context { get; set; }
+
+                public void Start()
+                {
+                    //hack until we can fix the types filtering in default server
+                    if (Configure.EndpointName != "Particular.ServiceControl")
+                    {
+                        return;
+                    }
+
+                    //Missing FailedQ header
+                    var transportMessage = new TransportMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>()
+                    {
+                        {"ContextId", Context.Id.ToString()}
+                    })
+                    {
+                        MessageIntent = MessageIntentEnum.Send,
+                        Body = new byte[100],
+                    };
+                    SendMessages.Send(transportMessage, Address.Parse("error"));
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+
+        public class MyContext : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool MessageDetected { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/MessageFailures/When_trying_to_import_a_badly_formatted_message.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageFailures/When_trying_to_import_a_badly_formatted_message.cs
@@ -17,7 +17,7 @@
         const string spyQueueName = "messagefailures.spy.default";
 
         [Test]
-        public void Should_be_moved_to_the_service_control_error_queue()
+        public void Should_be_moved_to_the_configured_failed_imports_queue()
         {
             var context = new MyContext()
             {

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -168,6 +168,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Audit\Audit_Messages_Have_Proper_IsSystemMessage_Tests.cs" />
+    <Compile Include="Audit\When_trying_to_import_a_badly_formatted_message.cs" />
     <Compile Include="Contexts\ExternalIntegrationsManagementEndpointSetup.cs" />
     <Compile Include="Contexts\TransportIntegration\ActiveMqTransportIntegration.cs" />
     <Compile Include="Contexts\TransportIntegration\AzureStorageQueuesTransportIntegration.cs" />
@@ -198,6 +199,7 @@
     <Compile Include="Contexts\DefaultServer.cs" />
     <Compile Include="Contexts\ManagementEndpoint.cs" />
     <Compile Include="Contexts\ManagementEndpointSetup.cs" />
+    <Compile Include="MessageFailures\When_trying_to_import_a_badly_formatted_message.cs" />
     <Compile Include="SagaAudit\When_multiple_messages_are_emitted_by_a_saga.cs" />
     <Compile Include="SagaAudit\When_a_message_emitted_by_a_saga_is_audited.cs" />
     <Compile Include="SagaAudit\When_a_message_hitting_a_saga_is_not_a_start_message.cs" />

--- a/src/ServiceControl/Infrastructure/Installers/AuditImportFailureQueueInstaller.cs
+++ b/src/ServiceControl/Infrastructure/Installers/AuditImportFailureQueueInstaller.cs
@@ -1,0 +1,19 @@
+namespace ServiceBus.Management.Infrastructure.Installers
+{
+    using NServiceBus;
+    using NServiceBus.Unicast.Queuing;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    public class AuditImportFailureQueueInstaller : IWantQueueCreated
+    {
+        public Address Address
+        {
+            get { return Settings.AuditImportFailureQueue; }
+        }
+
+        public bool IsDisabled
+        {
+            get { return Settings.AuditLogQueue == Address.Undefined; }
+        }
+    }
+}

--- a/src/ServiceControl/Infrastructure/Installers/ErrorImportFailureQueueInstaller.cs
+++ b/src/ServiceControl/Infrastructure/Installers/ErrorImportFailureQueueInstaller.cs
@@ -1,0 +1,19 @@
+﻿namespace ServiceBus.Management.Infrastructure.Installers
+{
+    using NServiceBus;
+    using NServiceBus.Unicast.Queuing;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    public class ErrorImportFailureQueueInstaller : IWantQueueCreated
+    {
+        public Address Address
+        {
+            get { return Settings.ErrorImportFailureQueue; }
+        }
+
+        public bool IsDisabled
+        {
+            get { return Settings.ErrorLogQueue == Address.Undefined; }
+        }
+    }
+}

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -14,6 +14,8 @@
             ErrorQueue = GetErrorQueue();
             ErrorLogQueue = GetErrorLogQueue();
             AuditLogQueue = GetAuditLogQueue();
+            ErrorImportFailureQueue = GetErrorImportFailureQueue();
+            AuditImportFailureQueue = GetAuditImportFailureQueue();
             DbPath = GetDbPath();
             TransportType = SettingsReader<string>.Read("TransportType", typeof(Msmq).AssemblyQualifiedName);
         }
@@ -64,6 +66,17 @@
             }
             return Address.Parse(value);
         }
+        
+        static Address GetAuditImportFailureQueue()
+        {
+            var value = SettingsReader<string>.Read("ServiceBus", "AuditFailedImportQueue", null);
+            if (value == null)
+            {
+                Logger.Info("No settings found for failed import audit queue, default name will be used");
+                return AuditQueue.SubScope("failedimports");
+            }
+            return Address.Parse(value);
+        }
 
         static Address GetAuditQueue()
         {
@@ -100,6 +113,18 @@
             {
                 Logger.Info("No settings found for error log queue to import, default name will be used");
                 return ErrorQueue.SubScope("log");
+            }
+            return Address.Parse(value);
+        }
+        
+        static Address GetErrorImportFailureQueue()
+        {
+            var value = SettingsReader<string>.Read("ServiceBus", "ErrorImportFailureQueue", null);
+
+            if (value == null)
+            {
+                Logger.Info("No settings found for failed import error queue, default name will be used");
+                return ErrorQueue.SubScope("failedimports");
             }
             return Address.Parse(value);
         }
@@ -151,7 +176,9 @@
         public static string DbPath;
         public static Address ErrorLogQueue;
         public static Address ErrorQueue;
+        public static Address ErrorImportFailureQueue;
         public static Address AuditQueue;
+        public static Address AuditImportFailureQueue;
         public static bool? ForwardAuditMessages = NullableSettingsReader<bool>.Read("ForwardAuditMessages");
         public static bool CreateIndexSync = SettingsReader<bool>.Read("CreateIndexSync");
         public static Address AuditLogQueue;

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -69,7 +69,7 @@
         
         static Address GetAuditImportFailureQueue()
         {
-            var value = SettingsReader<string>.Read("ServiceBus", "AuditFailedImportQueue", null);
+            var value = SettingsReader<string>.Read("ServiceBus", "AuditImportFailureQueue", null);
             if (value == null)
             {
                 Logger.Info("No settings found for failed import audit queue, default name will be used");

--- a/src/ServiceControl/Operations/AuditQueueImport.cs
+++ b/src/ServiceControl/Operations/AuditQueueImport.cs
@@ -14,7 +14,6 @@
     using NServiceBus.Transports.Msmq;
     using NServiceBus.Unicast.Messages;
     using NServiceBus.Unicast.Transport;
-    using Raven.Client;
     using ServiceBus.Management.Infrastructure.Settings;
 
     public class AuditQueueImport : IAdvancedSatellite, IDisposable
@@ -112,11 +111,7 @@
 
         public Action<TransportReceiver> GetReceiverCustomization()
         {
-            satelliteImportFailuresHandler = new SatelliteImportFailuresHandler(Builder.Build<IDocumentStore>(),
-                Path.Combine(Settings.LogPath, @"FailedImports\Audit"), tm => new FailedAuditImport
-                {
-                    Message = tm,
-                });
+            satelliteImportFailuresHandler = new SatelliteImportFailuresHandler(Forwarder, Settings.AuditImportFailureQueue, Path.Combine(Settings.LogPath, @"FailedImports\Audit"));
 
             return receiver => { receiver.FailureManager = satelliteImportFailuresHandler; };
         }

--- a/src/ServiceControl/Operations/ErrorQueueImport.cs
+++ b/src/ServiceControl/Operations/ErrorQueueImport.cs
@@ -80,11 +80,7 @@
 
         public Action<TransportReceiver> GetReceiverCustomization()
         {
-            satelliteImportFailuresHandler = new SatelliteImportFailuresHandler(Builder.Build<IDocumentStore>(),
-                Path.Combine(Settings.LogPath, @"FailedImports\Error"), tm => new FailedErrorImport
-                {
-                    Message = tm,
-                });
+            satelliteImportFailuresHandler = new SatelliteImportFailuresHandler(Forwarder, Settings.ErrorImportFailureQueue, Path.Combine(Settings.LogPath, @"FailedImports\Error"));
 
             return receiver => { receiver.FailureManager = satelliteImportFailuresHandler; };
         }

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -289,6 +289,8 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Hosting\Options.cs" />
+    <Compile Include="Infrastructure\Installers\AuditImportFailureQueueInstaller.cs" />
+    <Compile Include="Infrastructure\Installers\ErrorImportFailureQueueInstaller.cs" />
     <Compile Include="Infrastructure\Settings\CheckSettingsOnStartup.cs" />
     <Compile Include="Infrastructure\Settings\NullableRegistryReader.cs" />
     <Compile Include="Infrastructure\RavenDB\Expiration\ExpiryProcessedMessageIndex.cs" />


### PR DESCRIPTION
This pull tries to address the issue in reimport code that caused loss of header values when attempting to reimport
 * Instead of creating a failed import documents, forward messages to special queues (error.failedimports and audit.failedimports)
 * If there are existing failed import documents in the DB, log a warning instructing user go through them in the maintenance mode and delete if they are no longer relevant
