### PR TITLE
Configure maximum message body size for audit storage optimisation

### DIFF
--- a/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
@@ -345,10 +345,27 @@
                 }
 
                 Console.Out.Write(urlToMessageBody);
-
+       
                 return client.DownloadData(urlToMessageBody);
             }
         }
+
+        //protected byte[] DownloadData(string url)
+        //{
+        //    using (var client = new WebClient())
+        //    {
+        //        var urlToMessageBody = url;
+        //        if (!url.StartsWith("http"))
+        //        {
+        //            urlToMessageBody = string.Format("http://localhost:{0}/api{1}", port, url);
+        //        }
+
+        //        Console.Out.Write(urlToMessageBody);
+
+        //        return client.DownloadData(urlToMessageBody);
+        //    }
+        //}
+
 
         protected bool TryGetSingle<T>(string url, out T item, Predicate<T> condition = null) where T : class
         {

--- a/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
@@ -350,23 +350,6 @@
             }
         }
 
-        //protected byte[] DownloadData(string url)
-        //{
-        //    using (var client = new WebClient())
-        //    {
-        //        var urlToMessageBody = url;
-        //        if (!url.StartsWith("http"))
-        //        {
-        //            urlToMessageBody = string.Format("http://localhost:{0}/api{1}", port, url);
-        //        }
-
-        //        Console.Out.Write(urlToMessageBody);
-
-        //        return client.DownloadData(urlToMessageBody);
-        //    }
-        //}
-
-
         protected bool TryGetSingle<T>(string url, out T item, Predicate<T> condition = null) where T : class
         {
             if (condition == null)

--- a/src/ServiceControl.AcceptanceTests/Audit/Audit_Messages_That_Big_Bodies_Audit_Test.cs
+++ b/src/ServiceControl.AcceptanceTests/Audit/Audit_Messages_That_Big_Bodies_Audit_Test.cs
@@ -1,0 +1,152 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.MessageFailures
+{
+    using System.Net;
+    using Contexts;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+    using ServiceControl.CompositeViews.Messages;
+
+    class Audit_Messages_That_Big_Bodies_Audit_Test : AcceptanceTest
+    {
+
+
+
+
+
+        [Test]
+        public void Should_get_an_empty_audit_message_body_when_configured_for_200K()
+        {
+            //Arrange
+            AppConfigurationSettings.Clear();
+            AppConfigurationSettings.Add("ServiceControl/MaxBodySizeToStore", "204800");
+          
+
+            var context = new Context();
+            byte[] body = null;
+
+            //Act
+            Scenario.Define(context)
+                .WithEndpoint<ManagementEndpoint>(c => c.AppConfig(PathToAppConfig)) // I want ServiceControl running
+                .WithEndpoint<ServerEndpoint>(c => c.Given(b => b.SendLocal(
+                    new BigFatMessage // An endpoint that is configured for audit
+                    {
+                        BigFatBody = new byte[(1024 * 100) + 1] //100K + 1 byte
+                    }))
+                )
+                .Done(
+                    c =>
+                        {
+                            MessagesView auditMessage;
+
+                            if (c.MessageId == null) return false;
+                            if (!TryGetSingle("/api/messages", out auditMessage, r => r.MessageId == c.MessageId)) return false;
+
+                            try
+                            {
+                                body = DownloadData(auditMessage.BodyUrl);
+                            }
+                            catch (WebException wex)
+                            {
+                                if (((HttpWebResponse) wex.Response).StatusCode != HttpStatusCode.NotFound)
+                                {
+                                    throw;
+                                }
+                            }
+
+                            return true;
+                        })
+                .Run();
+
+            //Assert
+            Assert.IsNotNull(body);
+
+        }
+
+        [Test]
+        public void Should_get_an_empty_audit_message_body_when_configured_for_100K()
+        {
+            //Arrange
+            AppConfigurationSettings.Clear();
+            AppConfigurationSettings.Add("ServiceControl/MaxBodySizeToStore", "102400");
+
+
+            var context = new Context();
+            byte[] body = null;
+
+            //Act
+            Scenario.Define(context)
+                .WithEndpoint<ManagementEndpoint>(c => c.AppConfig(PathToAppConfig)) // I want ServiceControl running
+                .WithEndpoint<ServerEndpoint>(c => c.Given(b => b.SendLocal(
+                    new BigFatMessage // An endpoint that is configured for audit
+                    {
+                        BigFatBody = new byte[(1024 * 100) + 1] //100K + 1 byte
+                    }))
+                )
+                .Done(
+                    c =>
+                    {
+                        MessagesView auditMessage;
+
+                        if (c.MessageId == null) return false;
+                        if (!TryGetSingle("/api/messages", out auditMessage, r => r.MessageId == c.MessageId)) return false;
+
+                        try
+                        {
+                            body = DownloadData(auditMessage.BodyUrl);
+                        }
+                        catch (WebException wex)
+                        {
+                            if (((HttpWebResponse)wex.Response).StatusCode != HttpStatusCode.NotFound)
+                            {
+                                throw;
+                            }
+                        }
+
+                        return true;
+                    })
+                .Run();
+
+            //Assert
+            Assert.IsNull(body);
+
+        }
+
+        class ServerEndpoint : EndpointConfigurationBuilder
+        {
+            public ServerEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo(Address.Parse("audit"));
+            }
+
+            public class BigFatMessageHandler : IHandleMessages<BigFatMessage>
+            {
+                readonly Context _context;
+
+                public BigFatMessageHandler(Context context)
+                {
+                    _context = context;
+                }
+
+                public void Handle(BigFatMessage message)
+                {
+                    _context.MessageId = message.GetHeader("NServiceBus.MessageId");
+                }
+            }
+        }
+
+        public class BigFatMessage : IMessage
+        {
+            public string MessageId { get; set; }
+            public byte[] BigFatBody { get; set; }
+        }
+
+        class Context : ScenarioContext
+        {
+            public string MessageId { get; set; }
+            public bool HasBodyBeenTamperedWith { get; set; }
+        }
+
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/Audit/Audit_Messages_That_Big_Bodies_Audit_Test.cs
+++ b/src/ServiceControl.AcceptanceTests/Audit/Audit_Messages_That_Big_Bodies_Audit_Test.cs
@@ -10,12 +10,8 @@
     class Audit_Messages_That_Big_Bodies_Audit_Test : AcceptanceTest
     {
 
-
-
-
-
         [Test]
-        public void Should_get_an_empty_audit_message_body_when_configured_for_200K()
+        public void Should_not_get_an_empty_audit_message_body_when_configured_for_200K()
         {
             //Arrange
             AppConfigurationSettings.Clear();
@@ -108,7 +104,7 @@
                 .Run();
 
             //Assert
-            Assert.IsNull(body);
+            Assert.AreEqual(body.Length, 0);
 
         }
 
@@ -136,7 +132,7 @@
             }
         }
 
-        public class BigFatMessage : IMessage
+        class BigFatMessage : IMessage
         {
             public string MessageId { get; set; }
             public byte[] BigFatBody { get; set; }

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -168,6 +168,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Audit\Audit_Messages_That_Big_Bodies_Audit_Test.cs" />
     <Compile Include="Audit\Audit_Messages_Have_Proper_IsSystemMessage_Tests.cs" />
     <Compile Include="Contexts\ExternalIntegrationsManagementEndpointSetup.cs" />
     <Compile Include="Contexts\TransportIntegration\ActiveMqTransportIntegration.cs" />

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -168,8 +168,10 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Audit\Audit_Messages_That_Big_Bodies_Audit_Test.cs" />
     <Compile Include="Audit\Audit_Messages_Have_Proper_IsSystemMessage_Tests.cs" />
+    <Compile Include="Audit\Audit_Messages_That_Big_Bodies_Audit_Test.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Contexts\ExternalIntegrationsManagementEndpointSetup.cs" />
     <Compile Include="Contexts\TransportIntegration\ActiveMqTransportIntegration.cs" />
     <Compile Include="Contexts\TransportIntegration\AzureStorageQueuesTransportIntegration.cs" />

--- a/src/ServiceControl/CompositeViews/Messages/MessagesBodyTransformer.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesBodyTransformer.cs
@@ -11,6 +11,7 @@ namespace ServiceControl.CompositeViews.Messages
             public string Body { get; set; }
             public string ContentType { get; set; }
             public int BodySize { get; set; }
+            public bool BodyNotStored { get; set; }
         }
 
         public MessagesBodyTransformer()
@@ -26,6 +27,8 @@ namespace ServiceControl.CompositeViews.Messages
                     Body = metadata["Body"],
                     BodySize = (int)metadata["ContentLength"],
                     ContentType = metadata["ContentType"],
+                    BodyNotStored = (bool)metadata["BodyNotStored"]
+                    
                 };
         }
     }

--- a/src/ServiceControl/Hosting/Help.txt
+++ b/src/ServiceControl/Hosting/Help.txt
@@ -75,6 +75,10 @@ The error queue name to use for forwarding error messages. Default <ErrorQueue>.
 ServiceBus/AuditLogQueue string
 The audit queue name to use for forwarding audit messages. This only works if ServiceControl/ForwardAuditMessages is true. Default <AuditQueue>.log
 
+ServiceControl/MaxBodySizeToStore int (representing amount in bytes)
+By default ServiceControl only stores bodies of audit messages that are smaller than 100Kb. Increase this number to store messages with larger bodies.  Default 102400 bytes
+Messages that have a large message body are not stored. This is to ensure that the majority of our users enjoy the best level of performance. For users with special analysis needs, edit MaxBodySizeToStore in ServiceControl.exe.config to increase the size of storeable messages.
+
 EXAMPLES:
    ServiceControl.exe --restart 
      -d="ServiceControl/LogPath==c:\MyLogs Files"

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -206,7 +206,22 @@
             set { expirationProcessBatchSize = value; }
         }
 
-      
+        const int MaxBodySizeToStoreDefault = 102400; //100 kb
+        static int maxBodySizeToStore = SettingsReader<int>.Read("MaxBodySizeToStore", MaxBodySizeToStoreDefault);
+        public static int MaxBodySizeToStore
+        {
+            get
+            {
+                if (maxBodySizeToStore < MaxBodySizeToStoreDefault)
+                {
+                    return MaxBodySizeToStoreDefault;
+                }
+                return maxBodySizeToStore;
+            }
+            set { maxBodySizeToStore = value; }
+        }
+
+
         static readonly ILog Logger = LogManager.GetLogger(typeof(Settings));
         public static string ServiceName;
 

--- a/src/ServiceControl/MessageFailures/Handlers/ImportFailedMessageHandler.cs
+++ b/src/ServiceControl/MessageFailures/Handlers/ImportFailedMessageHandler.cs
@@ -23,6 +23,7 @@
 
             var timeOfFailure = message.FailureDetails.TimeOfFailure;
 
+
             //check for duplicate
             if (failure.ProcessingAttempts.Any(a => a.AttemptedAt == timeOfFailure))
             {

--- a/src/ServiceControl/Operations/BodyStorage/RavenAttachments/GetBodyById.cs
+++ b/src/ServiceControl/Operations/BodyStorage/RavenAttachments/GetBodyById.cs
@@ -43,10 +43,16 @@
                             return HttpStatusCode.NotFound;
                         }
 
+                        if (message.BodyNotStored)
+                        {
+                            return HttpStatusCode.NoContent;
+                        }
+
                         if (message.Body == null)
                         {
                             return HttpStatusCode.NotFound;
                         }
+
                         var data = Encoding.UTF8.GetBytes(message.Body);
                         contents = stream => stream.Write(data, 0, data.Length);
                         contentType = message.ContentType;

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -5,12 +5,6 @@
     <add key="enabled" value="True" />
     <add key="automatic" value="True" />
   </packageRestore>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="myget.org" value="https://www.myget.org/F/particular/" />
-  </packageSources>
-  <disabledPackageSources />
   <config>
     <add key="DependencyVersion" value="HighestMinor" />
   </config>
@@ -18,4 +12,8 @@
     <clear />
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="myget.org" value="https://www.myget.org/F/particular/" />
+  </packageSources>
 </configuration>


### PR DESCRIPTION
A new setting was added to ServiceControl that allows administrators to control the maximum size of message bodies that ServiceControl stores in its own internal database.
This facilitates systems that were affected by ServiceControl not storing audited message above 100Kb, which in turn affects the debugging experience when using ServiceInsight.

Up until version 1.6 ServiceControl only stores bodies of audit messages that are smaller than 100Kb by default. After version 1.6 Increase this number to store messages with larger bodies. Messages that have a larger message body in bytes than MaxBodySizeToStore are not stored for audit. This is to ensure that the majority of our users enjoy the best level of performance. For users with special analysis needs, edit MaxBodySizeToStore in ServiceControl.exe.config to increase the size of storeable audit messages