### PR TITLE
Return nulls when TimeSent is missing

### DIFF
--- a/src/ServiceControl.UnitTests/CompositeViews/FailedMessageTest.cs
+++ b/src/ServiceControl.UnitTests/CompositeViews/FailedMessageTest.cs
@@ -13,7 +13,7 @@
     public class FailedMessagesTests 
     {
         [Test]
-        public void Should_allow_errors_with_no_metadata()
+        public void Should_not_provide_defaults_for_missing_metadata()
         {
             using (var session = documentStore.OpenSession())
             {
@@ -54,7 +54,10 @@
                         Console.Out.WriteLine("Checking result");
                         Assert.AreEqual(1, results.Count);
 
-                        Assert.AreEqual(DateTime.MinValue,results.First().TimeSent);
+                        Assert.AreEqual(null, results.First().TimeSent);
+                        Assert.AreEqual(null, results.First().MessageType);
+                        Assert.AreEqual(null, results.First().ReceivingEndpoint);
+                        Assert.AreEqual(null, results.First().SendingEndpoint);
                     }
                 }
 

--- a/src/ServiceControl/CompositeViews/Messages/MessagesView.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesView.cs
@@ -13,7 +13,7 @@ namespace ServiceControl.CompositeViews.Messages
         public string MessageType { get; set; }
         public EndpointDetails SendingEndpoint { get; set; }
         public EndpointDetails ReceivingEndpoint { get; set; }
-        public DateTime TimeSent { get; set; }
+        public DateTime? TimeSent { get; set; }
         public DateTime ProcessedAt { get; set; }
         public TimeSpan CriticalTime { get; set; }
         public TimeSpan ProcessingTime { get; set; }

--- a/src/ServiceControl/CompositeViews/Messages/MessagesViewIndex.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesViewIndex.cs
@@ -24,7 +24,7 @@ namespace ServiceControl.CompositeViews.Messages
             public TimeSpan? DeliveryTime { get; set; }
             public string ConversationId { get; set; }
             public string[] Query { get; set; }
-            public DateTime TimeSent { get; set; }
+            public DateTime? TimeSent { get; set; }
         }
 
         public MessagesViewIndex()

--- a/src/ServiceControl/CompositeViews/Messages/MessagesViewTransformer.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesViewTransformer.cs
@@ -48,7 +48,7 @@ namespace ServiceControl.CompositeViews.Messages
                     MessageType = metadata["MessageType"],
                     SendingEndpoint = metadata["SendingEndpoint"],
                     ReceivingEndpoint = metadata["ReceivingEndpoint"],
-                    TimeSent = (DateTime) metadata["TimeSent"],
+                    TimeSent = (DateTime?) metadata["TimeSent"],
                     ProcessedAt = processedAt,
                     CriticalTime = (TimeSpan) metadata["CriticalTime"],
                     ProcessingTime = (TimeSpan) metadata["ProcessingTime"],

--- a/src/ServiceControl/MessageFailures/Api/FailedMessageView.cs
+++ b/src/ServiceControl/MessageFailures/Api/FailedMessageView.cs
@@ -7,7 +7,7 @@
     {
         public string Id { get; set; }
         public string MessageType { get; set; }
-        public DateTime TimeSent { get; set; }
+        public DateTime? TimeSent { get; set; }
         public bool IsSystemMessage { get; set; }
         public ExceptionDetails Exception { get; set; }
         public string MessageId { get; set; }

--- a/src/ServiceControl/MessageFailures/Api/FailedMessageViewIndex.cs
+++ b/src/ServiceControl/MessageFailures/Api/FailedMessageViewIndex.cs
@@ -11,7 +11,7 @@ namespace ServiceControl.MessageFailures.Api
         public class SortAndFilterOptions
         {
             public string MessageId { get; set; }
-            public DateTime TimeSent { get; set; }
+            public DateTime? TimeSent { get; set; }
             public string MessageType { get; set; }
             public FailedMessageStatus Status { get; set; }
             public string ReceivingEndpointName { get; set; }
@@ -26,7 +26,7 @@ namespace ServiceControl.MessageFailures.Api
                 MessageId = metadata["MessageId"],
                 MessageType = metadata["MessageType"], 
                 message.Status,
-                TimeSent = (DateTime)metadata["TimeSent"],
+                TimeSent = (DateTime?)metadata["TimeSent"],
                 ReceivingEndpointName = ((EndpointDetails)metadata["ReceivingEndpoint"]).Name,
             };
 

--- a/src/ServiceControl/MessageFailures/Api/FailedMessageViewTransformer.cs
+++ b/src/ServiceControl/MessageFailures/Api/FailedMessageViewTransformer.cs
@@ -17,7 +17,7 @@
                     IsSystemMessage = (bool)rec.MessageMetadata["IsSystemMessage"],
                     SendingEndpoint = rec.MessageMetadata["SendingEndpoint"],
                     ReceivingEndpoint = rec.MessageMetadata["ReceivingEndpoint"],
-                    TimeSent = (DateTime)rec.MessageMetadata["TimeSent"],
+                    TimeSent = (DateTime?)rec.MessageMetadata["TimeSent"],
                     MessageId = rec.MessageMetadata["MessageId"],
                     rec.FailureDetails.Exception,
                     NumberOfProcessingAttempts = failure.ProcessingAttempts.Count(),


### PR DESCRIPTION
Allow for nullable dates (SentTime header) for messages list and failed messages.