### PR TITLE
[WIP] Clean up message bodies

### DIFF
--- a/src/ServiceControl/Operations/BodyStorage/BodyStorageEnricher.cs
+++ b/src/ServiceControl/Operations/BodyStorage/BodyStorageEnricher.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Operations.BodyStorage
 {
     using System.IO;
+    using System.Text;
     using Contracts.Operations;
     using NServiceBus;
     using ServiceBus.Management.Infrastructure.Settings;
@@ -11,51 +12,103 @@
 
         public override void Enrich(ImportMessage message)
         {
-            if (message.PhysicalMessage.Body == null || message.PhysicalMessage.Body.Length == 0)
+            var bodySize = GetContentLength(message);
+            message.Metadata.Add("ContentLength", bodySize);
+            if (bodySize == 0)
             {
-                message.Metadata.Add("ContentLength", 0);
                 return;
             }
 
+            var contentType = GetContentType(message, "text/xml");
+            message.Metadata.Add("ContentType", contentType);
+
+            var stored = TryStoreBody(message, bodySize, contentType);
+            if (!stored)
+            {
+                message.Metadata.Add("BodyNotStored", true);
+            }
+        }
+
+        bool TryStoreBody(ImportMessage message, int bodySize, string contentType)
+        {
+            var bodyId = message.MessageId;
+            var stored = false;
+            var bodyUrl = string.Format("/messages/{0}/body", bodyId);
+
+            if (ShouldStoreInBodyStorage(message, bodySize, contentType))
+            {
+                bodyUrl = StoreBodyInBodyStorage(message, bodyId, contentType, bodySize);
+                stored = true;
+            }
+            
+            if (ShouldStoreBodyInMessageMetadata(bodySize, contentType))
+            {
+                message.Metadata.Add("Body", Encoding.UTF8.GetString(message.PhysicalMessage.Body));
+                stored = true;
+            }
+
+            message.Metadata.Add("BodyUrl", bodyUrl);
+
+            return stored;
+        }
+
+        static bool ShouldStoreInBodyStorage(ImportMessage message, int bodySize, string contentType)
+        {
+            if (message is ImportFailedMessage)
+            {
+                return true;
+            }
+
+            if (bodySize <= Settings.MaxBodySizeToStore && contentType.Contains("binary"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        static bool ShouldStoreBodyInMessageMetadata(int bodySize, string contentType)
+        {
+            if (bodySize > Settings.MaxBodySizeToStore)
+            {
+                return false;
+            }
+
+            if (contentType.Contains("binary"))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        static int GetContentLength(ImportMessage message)
+        {
+            if (message.PhysicalMessage.Body == null)
+            {
+                return 0;
+            }
+            return message.PhysicalMessage.Body.Length;
+        }
+
+        static string GetContentType(ImportMessage message, string defaultContentType)
+        {
             string contentType;
 
             if (!message.PhysicalMessage.Headers.TryGetValue(Headers.ContentType, out contentType))
             {
-                contentType = "text/xml"; //default to xml for now
+                contentType = defaultContentType;
             }
 
-            message.Metadata.Add("ContentType", contentType);
-
-            var bodySize = message.PhysicalMessage.Body.Length;
-
-            var bodyId = message.MessageId;
-
-            if (message is ImportFailedMessage || bodySize <= Settings.MaxBodySizeToStore)
-            {
-                StoreBody(message, bodyId, contentType, bodySize);  
-            }
-            else
-            {
-                var bodyUrl = string.Format("/messages/{0}/body", bodyId);
-                message.Metadata.Add("BodyUrl", bodyUrl);
-                message.Metadata.Add("BodyNotStored", true);
-            }
-
-            // Issue #296 Body Storage Enricher config
-            if (!contentType.Contains("binary") && bodySize <= Settings.MaxBodySizeToStore)
-            {
-                message.Metadata.Add("Body", System.Text.Encoding.UTF8.GetString(message.PhysicalMessage.Body));
-            }
-          
-            message.Metadata.Add("ContentLength", bodySize);
+            return contentType;
         }
 
-        void StoreBody(ImportMessage message, string bodyId, string contentType, int bodySize)
+        string StoreBodyInBodyStorage(ImportMessage message, string bodyId, string contentType, int bodySize)
         {
             using (var bodyStream = new MemoryStream(message.PhysicalMessage.Body))
             {
                 var bodyUrl = BodyStorage.Store(bodyId, contentType, bodySize, bodyStream);
-                message.Metadata.Add("BodyUrl", bodyUrl);
+                return bodyUrl;
             }
         }
     }


### PR DESCRIPTION
Changes related to https://github.com/Particular/PlatformDevelopment/issues/430

Message body is stored as Raven Attachment IF:
* The message is an error
OR
* The message is an audit AND the message is below the size threshold AND the message is binary

Message body is stored as message metadata IF:
* The message is below the size threshold AND the message is NOT binary

The NotStored flag is only set if the message body is not stored in either place.

Raven Attachment is deleted when corresponding Audit Message is deleted for expiry.