### PR TITLE
Remove message body when Audit message is expired

### DIFF
--- a/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
@@ -431,12 +431,22 @@
             return true;
         }
 
+        public HttpStatusCode Patch<T>(string url, T payload = null) where T : class
+        {
+            return HttpAction(url, "PATCH", payload, false);
+        }
+
         public void Post<T>(string url, T payload = null) where T : class
         {
-            var request = (HttpWebRequest) WebRequest.Create(string.Format("http://localhost:{0}{1}", port, url));
+            HttpAction(url, "POST", payload);
+        }
+
+        protected HttpStatusCode HttpAction<T>(string url, string action, T payload = null, bool throwOnFailure = true) where T : class
+        {
+            var request = (HttpWebRequest)WebRequest.Create(string.Format("http://localhost:{0}{1}", port, url));
 
             request.ContentType = "application/json";
-            request.Method = "POST";
+            request.Method = action;
 
             var json = JsonConvert.SerializeObject(payload, serializerSettings);
             request.ContentLength = json.Length;
@@ -462,9 +472,9 @@
                 response = ex.Response as HttpWebResponse;
             }
 
-            Console.Out.WriteLine(" - {0}", (int) response.StatusCode);
+            Console.Out.WriteLine(" - {0}", (int)response.StatusCode);
 
-            if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.Accepted)
+            if (throwOnFailure && response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.Accepted)
             {
                 string body;
                 using (var reader = new StreamReader(response.GetResponseStream(), Encoding.GetEncoding("utf-8")))
@@ -472,8 +482,10 @@
                     body = reader.ReadToEnd();
                 }
                 throw new InvalidOperationException(String.Format("Call failed: {0} - {1} - {2}",
-                    (int) response.StatusCode, response.StatusDescription, body));
+                    (int)response.StatusCode, response.StatusDescription, body));
             }
+
+            return response.StatusCode;
         }
     }
 }

--- a/src/ServiceControl.AcceptanceTests/Contexts/TransportIntegration/RabbitMqTransportIntegration.cs
+++ b/src/ServiceControl.AcceptanceTests/Contexts/TransportIntegration/RabbitMqTransportIntegration.cs
@@ -3,14 +3,13 @@
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Text.RegularExpressions;
-    using System.Threading.Tasks;
     using Newtonsoft.Json;
     using NServiceBus;
+    using RabbitMQ.Client;
 
     public class RabbitMqTransportIntegration : ITransportIntegration
     {
@@ -26,109 +25,84 @@
 
         public void OnEndpointShutdown()
         {
-            // It is not possible to delete all queues and exchanges over the C# client
-            // we need the management plugin and call the proper HTTP apis to get all queues
-            // and exchanges for the given vhost
         }
 
         public void TearDown()
         {
-            // let's cheat for now because we cannot access ConnectionStringInformation
-            var match = Regex.Match(ConnectionString, string.Format("[^\\w]*{0}=(?<{0}>[^;]+)", "host"), RegexOptions.IgnoreCase);
+            PurgeQueues();
+        }
 
-            var username = match.Groups["UserName"].Success ? match.Groups["UserName"].Value : "guest";
-            var password = match.Groups["Password"].Success ? match.Groups["Password"].Value : "guest";
-            var virtualHost = match.Groups["VirtualHost"].Success ? match.Groups["VirtualHost"].Value : Uri.EscapeDataString("/"); // %2F is the name of the default virtual host
+        void PurgeQueues()
+        {
+            var connectionFactory = CreateConnectionFactory(ConnectionString);
 
-            var handler = new HttpClientHandler
+            var queues = GetQueues(connectionFactory);
+
+            var connection = connectionFactory.CreateConnection();
+            using (var model = connection.CreateModel())
             {
-                Credentials = new NetworkCredential(username, password),
-            };
-            var httpClient = new HttpClient(handler)
-            {
-                BaseAddress = new Uri(string.Format(CultureInfo.InvariantCulture, "http://{0}:15672/", match.Groups["host"].Value))
-            };
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-            var exchangeDeletionTasks = DeleteExchanges(httpClient, virtualHost);
-            var queueDeletionTasks = DeleteQueues(httpClient, virtualHost);
-            var cleanupTasks = exchangeDeletionTasks.Union(queueDeletionTasks).ToArray();
-            Task.WhenAll(cleanupTasks).Wait();
-
-            foreach (var cleanup in cleanupTasks)
-            {
-                var responseMessage = cleanup.Result;
-                try
+                connection.AutoClose = true;
+                foreach (var queue in queues)
                 {
-                    responseMessage.EnsureSuccessStatusCode();
-                }
-                catch (HttpRequestException)
-                {
-                    // TC has some weird problems when this code is executed inside the NUnit runner. It works on the agents as a 
-                    // seperate console executed with the same credentials as the agent, it also works when executed inside VS on the agents
-                    var requestMessage = responseMessage.RequestMessage;
-                    Console.WriteLine("Cleanup task failed for {0} {1}", requestMessage.Method, requestMessage.RequestUri);
+                    try
+                    {
+                        var cleared = model.QueuePurge(queue.Name);
+                        Console.WriteLine("Cleared {0} message(s) out of {1}", cleared, queue.Name);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine("Unable to clear queue {0}: {1}", queue.Name, ex);
+                    }
                 }
             }
         }
 
-        static IEnumerable<Task<HttpResponseMessage>> DeleteQueues(HttpClient httpClient, string virtualHost)
+        ConnectionFactory CreateConnectionFactory(string connectionString)
         {
-            var queueResult = httpClient.GetAsync(string.Format(CultureInfo.InvariantCulture, "api/queues/{0}", virtualHost)).Result;
+            var match = Regex.Match(connectionString, string.Format("[^\\w]*{0}=(?<{0}>[^;]+)", "host"), RegexOptions.IgnoreCase);
+
+            var username = match.Groups["UserName"].Success ? match.Groups["UserName"].Value : "guest";
+            var password = match.Groups["Password"].Success ? match.Groups["Password"].Value : "guest";
+            var host = match.Groups["host"].Success ? match.Groups["host"].Value : "localhost";
+            var virtualHost = match.Groups["VirtualHost"].Success ? match.Groups["VirtualHost"].Value : "/";
+
+            return new ConnectionFactory
+            {
+                UserName = username,
+                Password = password,
+                VirtualHost = virtualHost,
+                HostName = host,
+                //AutomaticRecoveryEnabled = true
+            };
+        }
+
+        // Requires that the RabbitMQ Management API has been enabled: https://www.rabbitmq.com/management.html
+        IEnumerable<Queue> GetQueues(ConnectionFactory connectionFactory)
+        {
+            var httpClient = CreateHttpClient(connectionFactory);
+            var queueResult = httpClient.GetAsync(string.Format(CultureInfo.InvariantCulture, "api/queues/{0}", Uri.EscapeDataString(connectionFactory.VirtualHost))).Result;
             queueResult.EnsureSuccessStatusCode();
-            var queues = JsonConvert.DeserializeObject<List<Queue>>(queueResult.Content.ReadAsStringAsync().Result);
-
-            var queueDeletionTasks = new List<Task<HttpResponseMessage>>(queues.Count);
-            queueDeletionTasks.AddRange(queues.Select(queue =>
-            {
-                var deletionTask = httpClient.DeleteAsync(string.Format(CultureInfo.InvariantCulture, "/api/queues/{0}/{1}", virtualHost, queue.Name));
-                deletionTask.ContinueWith((t, o) => { Console.WriteLine("Deleted queue {0}.", queue.Name); }, null, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion);
-                deletionTask.ContinueWith((t, o) => { Console.WriteLine("Failed to delete queue {0}.", queue.Name); }, null, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted);
-                return deletionTask;
-            }));
-            return queueDeletionTasks;
+            return JsonConvert.DeserializeObject<List<Queue>>(queueResult.Content.ReadAsStringAsync().Result);
         }
 
-        static IEnumerable<Task<HttpResponseMessage>> DeleteExchanges(HttpClient httpClient, string virtualHost)
+        HttpClient CreateHttpClient(ConnectionFactory details)
         {
-            // Delete exchanges
-            var exchangeResult = httpClient.GetAsync(string.Format(CultureInfo.InvariantCulture, "api/exchanges/{0}", virtualHost)).Result;
-            exchangeResult.EnsureSuccessStatusCode();
-            var allExchanges = JsonConvert.DeserializeObject<List<Exchange>>(exchangeResult.Content.ReadAsStringAsync().Result);
-            var exchanges = FilterAllExchangesByExcludingInternalTheDefaultAndAmq(allExchanges);
-
-            var exchangeDeletionTasks = new List<Task<HttpResponseMessage>>(exchanges.Count);
-            exchangeDeletionTasks.AddRange(exchanges.Select(exchange =>
+            var handler = new HttpClientHandler
             {
-                var deletionTask = httpClient.DeleteAsync(string.Format(CultureInfo.InvariantCulture, "/api/exchanges/{0}/{1}", virtualHost, exchange.Name));
-                deletionTask.ContinueWith((t, o) => { Console.WriteLine("Deleted exchange {0}.", exchange.Name); }, null, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion);
-                deletionTask.ContinueWith((t, o) => { Console.WriteLine("Failed to delete exchange {0}.", exchange.Name); }, null, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted);
-                return deletionTask;
-            }));
-            return exchangeDeletionTasks;
-        }
+                Credentials = new NetworkCredential(details.UserName, details.Password),
+            };
+            var httpClient = new HttpClient(handler)
+            {
+                BaseAddress = new Uri(string.Format(CultureInfo.InvariantCulture, "http://{0}:15672/", details.HostName))
+            };
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-        static List<Exchange> FilterAllExchangesByExcludingInternalTheDefaultAndAmq(IEnumerable<Exchange> allExchanges)
-        {
-            return (from exchange in allExchanges
-                let isInternal = exchange.Internal
-                let name = exchange.Name.ToLowerInvariant()
-                where !isInternal  // we should never delete rabbits internal exchanges
-                where !name.StartsWith("amq.") // amq.* we shouldn't remove
-                where name.Length > 0 // the default exchange which can't be deleted has a Name=string.Empty
-                select exchange)
-                .ToList();
+            return httpClient;
         }
 
         private class Queue
         {
             public string Name { get; set; }
-        }
-
-        private class Exchange
-        {
-            public string Name { get; set; }
-            public bool Internal { get; set; }
         }
     }
 }

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_endpoints_heartbeats_are_received_in_a_timely_manner.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_endpoints_heartbeats_are_received_in_a_timely_manner.cs
@@ -73,17 +73,20 @@
                     var foundOthers = false;
                     foreach (var otherEndpoint in otherEndpoints)
                     {
-                        Console.WriteLine("Disabling Heartbeats on {0}", otherEndpoint.Name);
-                        Patch("/api/endpoints/" + otherEndpoint.Id, new EndpointUpdateModel
-                        {
-                            MonitorHeartbeat = false
-                        });
-                        foundOthers = true;
+                        if(otherEndpoint.MonitorHeartbeat)
+                        { 
+                            Console.WriteLine("Disabling Heartbeats on {0}", otherEndpoint.MonitorHeartbeat);
+                            Patch("/api/endpoints/" + otherEndpoint.Id, new EndpointUpdateModel
+                            {
+                                MonitorHeartbeat = false
+                            });
+                            foundOthers = true;
+                        }
                     }
 
                     if (foundOthers)
                     {
-                        Thread.Sleep(50);
+                        return false;
                     }
 
                     HeartbeatSummary local;

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_endpoints_heartbeats_are_received_in_a_timely_manner.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_endpoints_heartbeats_are_received_in_a_timely_manner.cs
@@ -69,16 +69,21 @@
                         return false;
                     }
 
-                    if (endpoints.Count != 2)
+                    var otherEndpoints = endpoints.Except(endpoint1s).Except(endpoint2s).ToArray();
+                    var foundOthers = false;
+                    foreach (var otherEndpoint in otherEndpoints)
                     {
-                        Console.WriteLine("There should be two endpoints");
-                        return false;
+                        Console.WriteLine("Disabling Heartbeats on {0}", otherEndpoint.Name);
+                        Patch("/api/endpoints/" + otherEndpoint.Id, new EndpointUpdateModel
+                        {
+                            MonitorHeartbeat = false
+                        });
+                        foundOthers = true;
                     }
 
-                    if (endpoints.Except(endpoint1s).Except(endpoint2s).Any())
+                    if (foundOthers)
                     {
-                        Console.WriteLine("Endpoints other than 1 and 2 detected");
-                        return false;
+                        Thread.Sleep(50);
                     }
 
                     HeartbeatSummary local;

--- a/src/ServiceControl/Operations/BodyStorage/BodyStorageEnricher.cs
+++ b/src/ServiceControl/Operations/BodyStorage/BodyStorageEnricher.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Operations.BodyStorage
 {
     using System.IO;
+    using System.Text;
     using Contracts.Operations;
     using NServiceBus;
     using ServiceBus.Management.Infrastructure.Settings;
@@ -11,51 +12,103 @@
 
         public override void Enrich(ImportMessage message)
         {
-            if (message.PhysicalMessage.Body == null || message.PhysicalMessage.Body.Length == 0)
+            var bodySize = GetContentLength(message);
+            message.Metadata.Add("ContentLength", bodySize);
+            if (bodySize == 0)
             {
-                message.Metadata.Add("ContentLength", 0);
                 return;
             }
 
+            var contentType = GetContentType(message, "text/xml");
+            message.Metadata.Add("ContentType", contentType);
+
+            var stored = TryStoreBody(message, bodySize, contentType);
+            if (!stored)
+            {
+                message.Metadata.Add("BodyNotStored", true);
+            }
+        }
+
+        bool TryStoreBody(ImportMessage message, int bodySize, string contentType)
+        {
+            var bodyId = message.MessageId;
+            var stored = false;
+            var bodyUrl = string.Format("/messages/{0}/body", bodyId);
+
+            if (ShouldStoreInBodyStorage(message, bodySize, contentType))
+            {
+                bodyUrl = StoreBodyInBodyStorage(message, bodyId, contentType, bodySize);
+                stored = true;
+            }
+            
+            if (ShouldStoreBodyInMessageMetadata(bodySize, contentType))
+            {
+                message.Metadata.Add("Body", Encoding.UTF8.GetString(message.PhysicalMessage.Body));
+                stored = true;
+            }
+
+            message.Metadata.Add("BodyUrl", bodyUrl);
+
+            return stored;
+        }
+
+        static bool ShouldStoreInBodyStorage(ImportMessage message, int bodySize, string contentType)
+        {
+            if (message is ImportFailedMessage)
+            {
+                return true;
+            }
+
+            if (bodySize <= Settings.MaxBodySizeToStore && contentType.Contains("binary"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        static bool ShouldStoreBodyInMessageMetadata(int bodySize, string contentType)
+        {
+            if (bodySize > Settings.MaxBodySizeToStore)
+            {
+                return false;
+            }
+
+            if (contentType.Contains("binary"))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        static int GetContentLength(ImportMessage message)
+        {
+            if (message.PhysicalMessage.Body == null)
+            {
+                return 0;
+            }
+            return message.PhysicalMessage.Body.Length;
+        }
+
+        static string GetContentType(ImportMessage message, string defaultContentType)
+        {
             string contentType;
 
             if (!message.PhysicalMessage.Headers.TryGetValue(Headers.ContentType, out contentType))
             {
-                contentType = "text/xml"; //default to xml for now
+                contentType = defaultContentType;
             }
 
-            message.Metadata.Add("ContentType", contentType);
-
-            var bodySize = message.PhysicalMessage.Body.Length;
-
-            var bodyId = message.MessageId;
-
-            if (message is ImportFailedMessage || bodySize <= Settings.MaxBodySizeToStore)
-            {
-                StoreBody(message, bodyId, contentType, bodySize);  
-            }
-            else
-            {
-                var bodyUrl = string.Format("/messages/{0}/body", bodyId);
-                message.Metadata.Add("BodyUrl", bodyUrl);
-                message.Metadata.Add("BodyNotStored", true);
-            }
-
-            // Issue #296 Body Storage Enricher config
-            if (!contentType.Contains("binary") && bodySize <= Settings.MaxBodySizeToStore)
-            {
-                message.Metadata.Add("Body", System.Text.Encoding.UTF8.GetString(message.PhysicalMessage.Body));
-            }
-          
-            message.Metadata.Add("ContentLength", bodySize);
+            return contentType;
         }
 
-        void StoreBody(ImportMessage message, string bodyId, string contentType, int bodySize)
+        string StoreBodyInBodyStorage(ImportMessage message, string bodyId, string contentType, int bodySize)
         {
             using (var bodyStream = new MemoryStream(message.PhysicalMessage.Body))
             {
                 var bodyUrl = BodyStorage.Store(bodyId, contentType, bodySize, bodyStream);
-                message.Metadata.Add("BodyUrl", bodyUrl);
+                return bodyUrl;
             }
         }
     }


### PR DESCRIPTION
### Symptoms
When an audit message is ingested it's body is stored as a Raven attachment. When the Audit message expires after `HoursToKeepMessagesBeforeExpiring` the audit message was not being removed as well. This results in an ever expanding ServiceControl database.

### Fix
ServiceControl will now clear out message bodies when expiring related Audit messages. Additionally, as non-binary messages are already being stored as metadata in the document, these message bodies will not be placed into attachment storage when they are initially ingested.  

### Who's Affected
All users of ServiceControl 1.6 or 1.6.1