### PR TITLE
Allow to configure DefaultConnectionLimit for HTTP

### DIFF
--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -3,6 +3,7 @@ namespace Particular.ServiceControl
     using System;
     using System.Diagnostics;
     using System.IO;
+    using System.Net;
     using System.ServiceProcess;
     using Autofac;
     using global::ServiceControl.Infrastructure.SignalR;
@@ -29,6 +30,9 @@ namespace Particular.ServiceControl
 
         public Bootstrapper(ServiceBase host = null, HostArguments hostArguments = null, BusConfiguration configuration = null)
         {
+            // .NET default limit is 10. RavenDB in conjunction with transports that use HTTP exceeds that limit.
+            ServicePointManager.DefaultConnectionLimit = Settings.HttpDefaultConnectionLimit;
+
             Settings.ServiceName = DetermineServiceName(host, hostArguments);
             ConfigureLogging();
             var containerBuilder = new ContainerBuilder();

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -234,5 +234,7 @@
             }
             return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), string.Format("Particular\\{0}\\logs", ServiceName));
         }
+
+        public static int HttpDefaultConnectionLimit = SettingsReader<int>.Read("HttpDefaultConnectionLimit", 100);
     }
 }


### PR DESCRIPTION
## Analysis
* SC is using RavenDB client which is using HttpWebRequests. 
* Transports such ASQ is using HttpWebRequests to work as well.
* The default .NET limit is set by `DefaultConnectionLimit` is 10.
* With several satelites and transport concurrency, SC easily exceeds the maximum `DefaultConnectionLimit` when used with ASQ or ASB. 
* This causes blocking behaviour which in conjunction with default transport retry policies can cause blocking calls to stall up to several minutes.

## Solution
Solution to this is to increase `DefaultConnectionLimit` for the entire application. The default set by SC will be 100 with an option to override through configuration file using `HttpDefaultConnectionLimit` setting.

The reasoning behind making it a configurable setting is the following:

Depending on the configured concurreny setting of the transport users will need to be able to increase the `DefaultConnectionLimit`

Has to be set in ServiceControl upon start-up. Any time later the settings will not be applied.

---
https://github.com/Particular/ServiceControl/issues/308