### PR TITLE
When retrying failed messages, previously archived failed messages are also retried

### DIFF
--- a/src/ServiceControl.AcceptanceTests/MessageFailures/When_all_messages_are_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageFailures/When_all_messages_are_retried.cs
@@ -1,0 +1,142 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.Recoverability.Groups
+{
+    using System;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Config;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+    using ServiceBus.Management.AcceptanceTests.Contexts;
+    using ServiceControl.Infrastructure;
+    using ServiceControl.MessageFailures;
+
+    public class When_all_messages_are_retried : AcceptanceTest
+    {
+        [Test]
+        public void Only_unresolved_issues_should_be_retried()
+        {
+            var context = new MyContext();
+
+            FailedMessage messageToBeRetriedAsPartOfRetryAll = null;
+            FailedMessage messageToBeArchived = null;
+
+            Scenario.Define(context)
+                .WithEndpoint<ManagementEndpoint>(c => c.AppConfig(PathToAppConfig))
+                .WithEndpoint<Receiver>(b => b.Given(bus =>
+                {
+                    bus.SendLocal<MyMessage>(m => m.MessageNumber = 1);
+                    bus.SendLocal<MyMessage>(m => m.MessageNumber = 2);
+                }))
+                .Done(c =>
+                {
+                    if (c.MessageToBeRetriedAsPartOfRetryAllId == null || c.MessageToBeArchivedId == null)
+                    {
+                        return false;
+                    }
+
+                    //First we are going to issue an archive to one of the messages
+                    if (!c.ArchiveIssued)
+                    {
+                        if (!TryGet("/api/errors/" + c.MessageToBeArchivedId, out messageToBeArchived, e => e.Status == FailedMessageStatus.Unresolved))
+                        {
+                            return false;
+                        }
+
+                        Patch<object>(String.Format("/api/errors/{0}/archive", messageToBeArchived.UniqueMessageId));
+
+                        c.ArchiveIssued = true;
+
+                        return false;
+                    }
+
+                    //We are now going to issue a retry group
+                    if (!c.RetryAllIssued)
+                    {
+                        // Ensure message is being retried
+                        if (!TryGet("/api/errors/" + c.MessageToBeRetriedAsPartOfRetryAllId, out messageToBeRetriedAsPartOfRetryAll, e => e.Status == FailedMessageStatus.Unresolved))
+                        {
+                            return false;
+                        }
+
+                        c.RetryAllIssued = true;
+                        
+                        Post<object>("/api/errors/retry/all");
+
+                        return false;
+                    }
+
+                    if (!TryGet("/api/errors/" + c.MessageToBeRetriedAsPartOfRetryAllId, out messageToBeRetriedAsPartOfRetryAll, e => e.Status == FailedMessageStatus.Resolved))
+                    {
+                        return false;
+                    }
+
+                    if (!TryGet("/api/errors/" + c.MessageToBeArchivedId, out messageToBeArchived, e => e.Status == FailedMessageStatus.Archived))
+                    {
+                        return false;
+                    }
+
+                    return true;
+                })
+                .Run(TimeSpan.FromMinutes(2));
+
+            Assert.AreEqual(FailedMessageStatus.Archived, messageToBeArchived.Status, "Non retried message should be archived");
+            Assert.AreEqual(FailedMessageStatus.Resolved, messageToBeRetriedAsPartOfRetryAll.Status, "Retried Message should not be set to Archived when group is retried");
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<SecondLevelRetries>())
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 1;
+                    })
+                    .AuditTo(Address.Parse("audit"));
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyContext Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    var messageId = Bus.CurrentMessageContext.Id.Replace(@"\", "-");
+
+                    var uniqueMessageId = DeterministicGuid.MakeId(messageId, Configure.EndpointName).ToString();
+
+                    if (message.MessageNumber == 1)
+                    {
+                        Context.MessageToBeRetriedAsPartOfRetryAllId = uniqueMessageId;
+                    }
+                    else
+                    {
+                        Context.MessageToBeArchivedId = uniqueMessageId;
+                    }
+
+                    if (!Context.RetryAllIssued)
+                    {
+                        throw new Exception("Simulated exception");
+                    }
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+            public int MessageNumber { get; set; }
+        }
+
+        public class MyContext : ScenarioContext
+        {
+            public string MessageToBeRetriedAsPartOfRetryAllId { get; set; }
+            public string MessageToBeArchivedId { get; set; }
+
+            public bool ArchiveIssued { get; set; }
+            public bool RetryAllIssued { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_archived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_archived.cs
@@ -59,7 +59,7 @@
         }
 
         [Test]
-        public void Only_unresolved_issues_should_be_retried()
+        public void Only_unresolved_issues_should_be_archived()
         {
             var context = new MyContext();
 
@@ -124,7 +124,7 @@
         {
             public Receiver()
             {
-                EndpointSetup<DefaultServerWithoutAudit>(c => Configure.Features.Disable<SecondLevelRetries>())
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<SecondLevelRetries>())
                     .WithConfig<TransportConfig>(c =>
                     {
                         c.MaxRetries = 1;
@@ -140,7 +140,6 @@
 
                 public void Handle(MyMessage message)
                 {
-
                     var messageId = Bus.CurrentMessageContext.Id.Replace(@"\", "-");
 
                     var uniqueMessageId = DeterministicGuid.MakeId(messageId, Configure.EndpointName).ToString();
@@ -172,11 +171,8 @@
         {
             public string FirstMessageId { get; set; }
             public string SecondMessageId { get; set; }
-
-
             public bool ArchiveIssued { get; set; }
             public bool RetryIssued { get; set; }
         }
-
     }
 }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_retried.cs
@@ -1,0 +1,142 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.Recoverability.Groups
+{
+    using System;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Config;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+    using ServiceBus.Management.AcceptanceTests.Contexts;
+    using ServiceControl.Infrastructure;
+    using ServiceControl.MessageFailures;
+
+    public class When_a_group_is_retried : AcceptanceTest
+    {
+        [Test]
+        public void Only_unresolved_issues_should_be_retried()
+        {
+            var context = new MyContext();
+
+            FailedMessage messageToBeRetriedAsPartOfGroupRetry = null;
+            FailedMessage messageToBeArchived = null;
+
+            Scenario.Define(context)
+                .WithEndpoint<ManagementEndpoint>(c => c.AppConfig(PathToAppConfig))
+                .WithEndpoint<Receiver>(b => b.Given(bus =>
+                {
+                    bus.SendLocal<MyMessage>(m => m.MessageNumber = 1);
+                    bus.SendLocal<MyMessage>(m => m.MessageNumber = 2);
+                }))
+                .Done(c =>
+                {
+                    if (c.MessageToBeRetriedByGroupId == null || c.MessageToBeArchivedId == null)
+                    {
+                        return false;
+                    }
+
+                    //First we are going to issue an archive to one of the messages
+                    if (!c.ArchiveIssued)
+                    {
+                        if (!TryGet("/api/errors/" + c.MessageToBeArchivedId, out messageToBeArchived, e => e.Status == FailedMessageStatus.Unresolved))
+                        {
+                            return false;
+                        }
+
+                        Patch<object>(String.Format("/api/errors/{0}/archive", messageToBeArchived.UniqueMessageId));
+
+                        c.ArchiveIssued = true;
+
+                        return false;
+                    }
+
+                    //We are now going to issue a retry group
+                    if (!c.RetryIssued)
+                    {
+                        // Ensure message is being retried
+                        if (!TryGet("/api/errors/" + c.MessageToBeRetriedByGroupId, out messageToBeRetriedAsPartOfGroupRetry, e => e.Status == FailedMessageStatus.Unresolved))
+                        {
+                            return false;
+                        }
+
+                        c.RetryIssued = true;
+                        
+                        Post<object>(String.Format("/api/recoverability/groups/{0}/errors/retry", messageToBeRetriedAsPartOfGroupRetry.FailureGroups[0].Id));
+
+                        return false;
+                    }
+
+                    if (!TryGet("/api/errors/" + c.MessageToBeRetriedByGroupId, out messageToBeRetriedAsPartOfGroupRetry, e => e.Status == FailedMessageStatus.Resolved))
+                    {
+                        return false;
+                    }
+
+                    if (!TryGet("/api/errors/" + c.MessageToBeArchivedId, out messageToBeArchived, e => e.Status == FailedMessageStatus.Archived))
+                    {
+                        return false;
+                    }
+
+                    return true;
+                })
+                .Run(TimeSpan.FromMinutes(2));
+
+            Assert.AreEqual(FailedMessageStatus.Archived, messageToBeArchived.Status, "Non retried message should be archived");
+            Assert.AreEqual(FailedMessageStatus.Resolved, messageToBeRetriedAsPartOfGroupRetry.Status, "Retried Message should not be set to Archived when group is retried");
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c => Configure.Features.Disable<SecondLevelRetries>())
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 1;
+                    })
+                    .AuditTo(Address.Parse("audit"));
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyContext Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    var messageId = Bus.CurrentMessageContext.Id.Replace(@"\", "-");
+
+                    var uniqueMessageId = DeterministicGuid.MakeId(messageId, Configure.EndpointName).ToString();
+
+                    if (message.MessageNumber == 1)
+                    {
+                        Context.MessageToBeRetriedByGroupId = uniqueMessageId;
+                    }
+                    else
+                    {
+                        Context.MessageToBeArchivedId = uniqueMessageId;
+                    }
+
+                    if (!Context.RetryIssued)
+                    {
+                        throw new Exception("Simulated exception");
+                    }
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+            public int MessageNumber { get; set; }
+        }
+
+        public class MyContext : ScenarioContext
+        {
+            public string MessageToBeRetriedByGroupId { get; set; }
+            public string MessageToBeArchivedId { get; set; }
+
+            public bool ArchiveIssued { get; set; }
+            public bool RetryIssued { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -187,6 +187,7 @@
     <Compile Include="HeartbeatMonitoring\When_endpoints_heartbeats_are_received_in_a_timely_manner.cs" />
     <Compile Include="MessageFailures\ErrorImportPerformanceTests.cs" />
     <Compile Include="MessageFailures\Is_System_Message_Tests.cs" />
+    <Compile Include="MessageFailures\When_all_messages_are_retried.cs" />
     <Compile Include="MessageFailures\When_a_message_has_failed.cs" />
     <Compile Include="MessageFailures\When_a_message_has_failed_from_send_only_endpoint.cs" />
     <Compile Include="MessageFailures\When_a_message_sent_from_third_party_endpoint_with_missing_metadata_failed.cs" />
@@ -198,6 +199,7 @@
     <Compile Include="Contexts\DefaultServer.cs" />
     <Compile Include="Contexts\ManagementEndpoint.cs" />
     <Compile Include="Contexts\ManagementEndpointSetup.cs" />
+    <Compile Include="Recoverability\Groups\When_a_group_is_retried.cs" />
     <Compile Include="Recoverability\Groups\When_a_group_is_archived.cs" />
     <Compile Include="Recoverability\Groups\When_a_message_fails_twice_with_different_exceptions.cs" />
     <Compile Include="Recoverability\Groups\When_a_message_has_failed.cs" />

--- a/src/ServiceControl/MessageFailures/Api/FailedMessageViewIndex.cs
+++ b/src/ServiceControl/MessageFailures/Api/FailedMessageViewIndex.cs
@@ -8,7 +8,7 @@ namespace ServiceControl.MessageFailures.Api
 
     public class FailedMessageViewIndex : AbstractIndexCreationTask<FailedMessage>
     {
-        public class SortAndFilterOptions
+        public class SortAndFilterOptions: IHaveStatus
         {
             public string MessageId { get; set; }
             public DateTime TimeSent { get; set; }

--- a/src/ServiceControl/MessageFailures/FailedMessage.cs
+++ b/src/ServiceControl/MessageFailures/FailedMessage.cs
@@ -5,7 +5,7 @@
     using Contracts.Operations;
     using NServiceBus;
 
-    public class FailedMessage
+    public class FailedMessage: IHaveStatus
     {
         public static string MakeDocumentId(string messageUniqueId)
         {

--- a/src/ServiceControl/MessageFailures/IHaveStatus.cs
+++ b/src/ServiceControl/MessageFailures/IHaveStatus.cs
@@ -1,0 +1,7 @@
+﻿namespace ServiceControl.MessageFailures
+{
+    public interface IHaveStatus
+    {
+        FailedMessageStatus Status { get; }
+    }
+}

--- a/src/ServiceControl/Recoverability/Grouping/Raven/FailureGroupMessageView.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Raven/FailureGroupMessageView.cs
@@ -2,7 +2,7 @@ namespace ServiceControl.Recoverability
 {
     using ServiceControl.MessageFailures;
 
-    public class FailureGroupMessageView
+    public class FailureGroupMessageView: IHaveStatus
     {
         public string Id { get; set; }
         public string FailureGroupId { get; set; }

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -314,6 +314,7 @@
     <Compile Include="Infrastructure\SubscribeToAllEvents.cs" />
     <Compile Include="MessageFailures\FailedMessageViewIndexNotifications.cs" />
     <Compile Include="MessageFailures\Handlers\IFailedMessageEnricher.cs" />
+    <Compile Include="MessageFailures\IHaveStatus.cs" />
     <Compile Include="MessageFailures\InternalMessages\ReclassificationOfErrorMessageComplete.cs" />
     <Compile Include="MessageFailures\InternalMessages\ReclassifyErrors.cs" />
     <Compile Include="Operations\EndpointDetailsParser.cs" />


### PR DESCRIPTION
## Who's affected

- Anyone using ServiceControl version 1.6.0 and up

## Symptoms

When retrying failed messages at `Error Group` page using `Retry a Group` or `Retry All Failed Messages`, incorrect number of messages is retried (failed and archived messages are retried all together).

---

## Steps to Repro

1. Run the ErrorHandling sample to have two messages to fail
2. Archive the 2 messages in ServiceControl via ServicePulse
3. Have another 2 messages error out. 
4. Invoke the RetryAll method in ServiceControl via the RetryAll button in the FailedMessages page in ServicePulse. 
5. Instead of retrying just the 2 recently failed messages, ServiceControl will retries all messages including those that were archived before. 

Related Desk Case: https://nservicebus.desk.com/agent/case/13323

--

**Customer Communication**
## Notice of a Critical Bug in the Retry Failed Messages Functionality in Service Pulse / Service Control version 1.6.x
When we released the new version of 1.6.0 of ServiceControl, we introduced a new feature where error messages can be grouped together based on the exception type in Service Pulse. This allowed the retry all functionality to become simpler. However, we discovered a bug today with our new error grouping functionality. When retrying either all messages or error messages within the same error group in ServicePulse, ServiceControl also incorrectly includes the previously archived failed messages as well. 

We wanted to make sure you knew what the situation was, if you were affected, and how to handle things in the meantime while we work to provide you with a fix.

## How to know if you're affected
If you are using ServiceControl versions 1.6.0 and above.
This bug does not affect if you are using ServiceControl version 1.5.3 and below. 
In Service Pulse, you can verify the version by looking at the bottom of the dashboard in ServicePulse. For example:
![version](https://cloud.githubusercontent.com/assets/854553/9969099/50bddaa8-5e01-11e5-8bad-e02b37104aff.png)

## What to do if you are affected 
If you are using version 1.6.0 and above, 
   - Do not use the `Retry All Failed Messages` button
   - Do not use the `Retry Group` button within each failure group under the Action column 
   - If you’ve previously used these functions, please review the endpoint’s logs to ensure that those messages did not cause any adverse side-effects. If that’s the case, please contact us via support (http://particular.net/support) and we will work with you to get your situation remedied. 

## The plan going forwards
We are actively working on a hot fix for this, and we will release it as soon as we have this bug fixed. We rely heavily on our automated unit tests before we release new features. And we are very sorry that our acceptance test suite, had missed this use case. We will be adding this test to our suite of existing tests.
We appreciate your understanding and patience while we work through this. 

With thanks for all your support.

The Particular Engineering team
