### PR TITLE
Tool to detect messages which may have been affected for issue 558

### DIFF
--- a/tools/Issue558Detector/Issue558Detector.Tests/Issue558Detector.Tests.csproj
+++ b/tools/Issue558Detector/Issue558Detector.Tests/Issue558Detector.Tests.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6411725A-8B6F-4CE8-9547-B3827601F70A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Issue558Detector.Tests</RootNamespace>
+    <AssemblyName>Issue558Detector.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="ScenarioTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Issue558Detector\Issue558Detector.csproj">
+      <Project>{3910f90c-2216-4d03-a10a-b6fe2ab06379}</Project>
+      <Name>Issue558Detector</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tools/Issue558Detector/Issue558Detector.Tests/Properties/AssemblyInfo.cs
+++ b/tools/Issue558Detector/Issue558Detector.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Issue558Detector.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Issue558Detector.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("19e6cf10-4bcb-4ae4-bbbd-799cc081c0da")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/Issue558Detector/Issue558Detector.Tests/ScenarioTests.cs
+++ b/tools/Issue558Detector/Issue558Detector.Tests/ScenarioTests.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Issue558Detector.Tests
+{
+    [TestClass]
+    public class ScenarioTests
+    {
+        static string Failed = "MessageFailed";
+        static string NewRetry = "MessagesSubmittedForRetry";
+        static string OldRetry = "MessageSubmittedForRetry";
+        static string Resolved = "MessageFailureResolvedByRetry";
+        static string Archived = "FailedMessageArchived";
+        static string ArchivedAsPartOfAGroup = "FailedMessageGroupArchived";
+
+        [TestMethod]
+        public void NewRetryDirectlyAfterFailureIsOk()
+        {
+            var timeline = CreateTimeline(Failed, NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline.ToArray()).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+            Assert.IsTrue(results.All(x => x.Classification == EventClassification.Ok), "All events should be OK");
+        }
+
+        [TestMethod]
+        public void NewRetryAfterArchivedIsNotOk()
+        {
+            var timeline = CreateTimeline(Failed, Archived, NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[1].Classification, "Archiving should be OK");
+            Assert.AreEqual(EventClassification.NotOk, results[2].Classification, "Retrying an Archived message is Not OK");
+        }
+
+        [TestMethod]
+        public void NewRetryAfterArchivedAsGroupNotOk()
+        {
+            var timeline = CreateTimeline(Failed, ArchivedAsPartOfAGroup, NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[1].Classification, "Archiving failed message should be OK");
+            Assert.AreEqual(EventClassification.NotOk, results[2].Classification, "Retrying an Archived message is Not OK");
+        }
+
+        [TestMethod]
+        public void NewRetryAfterResolvedByOldRetryIsNotOk()
+        {
+            var timeline = CreateTimeline(Failed, OldRetry, Resolved, NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[1].Classification, "Retrying failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[2].Classification, "Resolved message is OK");
+            Assert.AreEqual(EventClassification.NotOk, results[3].Classification, "Retrying an resolved message is Not OK");
+        }
+
+
+        [TestMethod]
+        public void NewRetryAfterOldRetryIssuedNotOk()
+        {
+            // This will happen for one of two reasons. Both are not OK
+            // a) Audit Ingestion is switched off and the message was successful.
+            // b) The Retry is still in flight at the time the new new retry is attempted.
+            var timeline = CreateTimeline(Failed, OldRetry, NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[1].Classification, "Retrying failed message should be OK");
+            Assert.AreEqual(EventClassification.NotOk, results[2].Classification, "Retrying a message which is already being retried is Not OK");
+        }
+
+        [TestMethod]
+        public void NewRetryAfterOldRetryFailedOk()
+        {
+            var timeline = CreateTimeline(Failed, OldRetry, Failed, NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[1].Classification, "Retrying failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[2].Classification, "Failure of Retried Message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[3].Classification, "Retrying a message which has failed a previous retry should be OK");
+        }
+
+        [TestMethod]
+        public void NewRetryAfterNewRetryIsNotOk()
+        {
+            var timeline = CreateTimeline(Failed, NewRetry, NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+            
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[1].Classification, "Retrying failed message should be OK");
+            Assert.AreEqual(EventClassification.NotOk, results[2].Classification, "Retrying a message which is already being retried is Not OK");
+        }
+
+        [TestMethod]
+        public void NewRetryAfterNewRetryFailsIsOk()
+        {
+            var timeline = CreateTimeline(Failed, NewRetry, Failed, NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[1].Classification, "Retrying failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[2].Classification, "Message failing retry is OK");
+            Assert.AreEqual(EventClassification.Ok, results[3].Classification, "Retrying a message which failed a previous retry is OK");
+        }
+
+        [TestMethod]
+        public void NewRetryAfterNewRetrySucceedsIsNotOk()
+        {
+            var timeline = CreateTimeline(Failed, NewRetry, Resolved, NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[1].Classification, "Retrying failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[2].Classification, "Message resolved by retry is OK");
+            Assert.AreEqual(EventClassification.NotOk, results[3].Classification, "Retrying a message which was resolved by a previous retry is Not OK");
+        }
+
+        [TestMethod]
+        public void OnceTimelineIsPoisonedAllFurtherEventsAreUnknown()
+        {
+            var timeline = CreateTimeline(Failed, Archived, NewRetry, Resolved).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[1].Classification, "Archiving failed message should be OK");
+            Assert.AreEqual(EventClassification.NotOk, results[2].Classification, "Retrying a message which is archived is Not OK");
+            Assert.AreEqual(EventClassification.Unknown, results[3].Classification, "A message resolving after an invalid retry is Unknown");
+        }
+
+        [TestMethod]
+        public void AnInvalidRetryWhenTimelineIsAlreadyPoisonedIsUnknown()
+        {
+            var timeline = CreateTimeline(Failed, Archived, NewRetry, Resolved, NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed message should be OK");
+            Assert.AreEqual(EventClassification.Ok, results[1].Classification, "Archiving failed message should be OK");
+            Assert.AreEqual(EventClassification.NotOk, results[2].Classification, "Retrying a message which is archived is Not OK");
+            Assert.AreEqual(EventClassification.Unknown, results[3].Classification, "A message resolving after an invalid retry should be Unknown");
+            Assert.AreEqual(EventClassification.Unknown, results[4].Classification, "An invalid retry on a poisoned timeline is still Unknown");
+        }
+
+        [TestMethod]
+        public void IfANewRetryIsTheFirstThingInAMessageTimelineThenTheStatusIsUnknown()
+        {
+            var timeline = CreateTimeline(NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Unknown, results[0].Classification, "Retry as first timeline entry is unknown");
+        }
+
+        [TestMethod]
+        public void AnUnexpectedEventCannotBeClassified()
+        {
+            var timeline = CreateTimeline(Failed, "Unexpected Event").ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed Message should be OK");
+            Assert.AreEqual(EventClassification.Unknown, results[1].Classification, "Unexpected Event should be Unknown");
+        }
+
+        [TestMethod]
+        public void AfterAnUnexpectedEventTheTimelineIsPosioned()
+        {
+            var timeline = CreateTimeline(Failed, "Unexpected Event", NewRetry).ToArray();
+
+            var results = TimelineAnalyzer.AnalyzeTimeline(timeline).ToArray();
+
+            Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
+
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Initial Failed Message should be OK");
+            Assert.AreEqual(EventClassification.Unknown, results[1].Classification, "Unknown Event should be Unknown");
+            Assert.AreEqual(EventClassification.Unknown, results[2].Classification, "Status of Retry directly after Unknown Event is Unknown");
+        }
+
+
+        private static IEnumerable<TimelineEntry> CreateTimeline(params string[] events)
+        {
+            var yesterday = DateTime.UtcNow.AddDays(-1);
+
+            var time = yesterday;
+
+            foreach (var evt in events)
+            {
+                yield return new TimelineEntry {Event = evt, When = time};
+                time = time.AddMinutes(5);
+            }
+        }
+    }
+}

--- a/tools/Issue558Detector/Issue558Detector.Tests/ScenarioTests.cs
+++ b/tools/Issue558Detector/Issue558Detector.Tests/ScenarioTests.cs
@@ -178,7 +178,7 @@ namespace Issue558Detector.Tests
         }
 
         [TestMethod]
-        public void IfANewRetryIsTheFirstThingInAMessageTimelineThenTheStatusIsUnknown()
+        public void IfANewRetryIsTheFirstThingInAMessageTimelineThenTheStatusIsOk()
         {
             var timeline = CreateTimeline(NewRetry).ToArray();
 
@@ -186,7 +186,7 @@ namespace Issue558Detector.Tests
 
             Assert.AreEqual(timeline.Length, results.Length, "Analyzed Timeline should have the same number of events as the Ingested Timeline");
 
-            Assert.AreEqual(EventClassification.Unknown, results[0].Classification, "Retry as first timeline entry is unknown");
+            Assert.AreEqual(EventClassification.Ok, results[0].Classification, "Retry as first timeline entry is Ok");
         }
 
         [TestMethod]

--- a/tools/Issue558Detector/Issue558Detector.sln
+++ b/tools/Issue558Detector/Issue558Detector.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Issue558Detector", "Issue558Detector\Issue558Detector.csproj", "{3910F90C-2216-4D03-A10A-B6FE2AB06379}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Issue558Detector.Tests", "Issue558Detector.Tests\Issue558Detector.Tests.csproj", "{6411725A-8B6F-4CE8-9547-B3827601F70A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{3910F90C-2216-4D03-A10A-B6FE2AB06379}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3910F90C-2216-4D03-A10A-B6FE2AB06379}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3910F90C-2216-4D03-A10A-B6FE2AB06379}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6411725A-8B6F-4CE8-9547-B3827601F70A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6411725A-8B6F-4CE8-9547-B3827601F70A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6411725A-8B6F-4CE8-9547-B3827601F70A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6411725A-8B6F-4CE8-9547-B3827601F70A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/Issue558Detector/Issue558Detector.sln
+++ b/tools/Issue558Detector/Issue558Detector.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Issue558Detector", "Issue558Detector\Issue558Detector.csproj", "{3910F90C-2216-4D03-A10A-B6FE2AB06379}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3910F90C-2216-4D03-A10A-B6FE2AB06379}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3910F90C-2216-4D03-A10A-B6FE2AB06379}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3910F90C-2216-4D03-A10A-B6FE2AB06379}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3910F90C-2216-4D03-A10A-B6FE2AB06379}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tools/Issue558Detector/Issue558Detector/App.config
+++ b/tools/Issue558Detector/Issue558Detector/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/tools/Issue558Detector/Issue558Detector/Issue558Detector.csproj
+++ b/tools/Issue558Detector/Issue558Detector/Issue558Detector.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3910F90C-2216-4D03-A10A-B6FE2AB06379}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Issue558Detector</RootNamespace>
+    <AssemblyName>Issue558Detector</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Raven.Abstractions">
+      <HintPath>..\packages\RavenDB.Client.2.5.2970\lib\net45\Raven.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Raven.Client.Lightweight">
+      <HintPath>..\packages\RavenDB.Client.2.5.2970\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TimelineModel.cs" />
+    <Compile Include="ServiceControlModel\EventLogItem.cs" />
+    <Compile Include="MessageHistories.cs" />
+    <Compile Include="ServiceControlModel\FailedMessageModel.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tools/Issue558Detector/Issue558Detector/Issue558Detector.csproj
+++ b/tools/Issue558Detector/Issue558Detector/Issue558Detector.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TimelineAnalyzer.cs" />
     <Compile Include="TimelineModel.cs" />
     <Compile Include="ServiceControlModel\EventLogItem.cs" />
     <Compile Include="MessageHistories.cs" />

--- a/tools/Issue558Detector/Issue558Detector/MessageHistories.cs
+++ b/tools/Issue558Detector/Issue558Detector/MessageHistories.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq;
+using Raven.Client.Indexes;
+
+namespace Issue558Detector
+{
+    public class MessageHistories : AbstractIndexCreationTask<EventLogItem, MessageHistories.Result>
+    {
+        public class Result
+        {
+            public string MessageId { get; set; }
+            public TimelineEntry[] Events { get; set; }
+        }
+
+        public MessageHistories()
+        {
+            Map = docs => from doc in docs
+                from message in doc.RelatedTo.Where(x => x.StartsWith("/message/"))
+                select new
+                {
+                    MessageId = message,
+                    Events = new[] { 
+                        new
+                        {
+                            Id = doc.Id, 
+                            When = doc.RaisedAt, 
+                            Event = doc.EventType
+                        }
+                    }
+                };
+
+            Reduce = results => from result in results
+                group result by result.MessageId into g
+                select new
+                {
+                    MessageId = g.Key,
+                    Events = g.SelectMany(x => x.Events).OrderBy(x => x.When).ToArray()
+                };
+        }
+    }
+}

--- a/tools/Issue558Detector/Issue558Detector/Program.cs
+++ b/tools/Issue558Detector/Issue558Detector/Program.cs
@@ -12,12 +12,14 @@ namespace Issue558Detector
         {
             var store = new DocumentStore
             {
-                Url = "http://localhost:33333/storage",
+                Url = (args.Length == 1 ? args[0] : "http://localhost:33333/storage"),
             };
 
             store.Initialize();
 
-            Console.Write("Creating Temp Index (this may take some time)...");
+            Console.WriteLine("This tool is going to examine ServiceControl for potential messages affected by issue  https://github.com/Particular/ServiceControl/pull/558\n");
+            
+            Console.WriteLine("Creating Temp Index (this may take some time)...");
 
             var index = new MessageHistories();
 
@@ -31,32 +33,40 @@ namespace Issue558Detector
                 }
 
                 Console.WriteLine(" DONE");
-
-                Console.WriteLine("\nSearching for messages which may have been affected by issue https://github.com/Particular/ServiceControl/pull/558\n");
+                Console.WriteLine("\nScanning for messages that were sent for reprocessing and require your attention.\n");
 
                 var dangerLevel = CheckForMessagesAffectedByIssue(store);
+
+                var noralColor = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.Cyan;
 
                 switch (dangerLevel)
                 {
                     case 0: // Not affected
                         Console.WriteLine("You are NOT affected by issue https://github.com/Particular/ServiceControl/pull/558");
-                        Console.WriteLine("However, we ask all users of ServiceControl using 1.6.x to update to 1.6.3 immediately.");
+                        Console.WriteLine("However, we ask all users of ServiceControl using 1.6.x to update to the latest version immediately.");
+                        Console.WriteLine("Latest release:  https://github.com/Particular/ServiceControl/releases");
                         break;
                     case 1: // Maybe affected
                         Console.WriteLine("You may be affected by issue https://github.com/Particular/ServiceControl/pull/558");
-                        Console.WriteLine("Please upgrade ServiceControl to 1.6.3 immediately.");
+                        Console.WriteLine("Please upgrade ServiceControl to the latest version immediately.");
+                        Console.WriteLine("Latest release:  https://github.com/Particular/ServiceControl/releases");
                         Console.WriteLine("Contact us via support (http://particular.net/support) and we will work with you to get your situation sorted out.");
                         break;
                     case 2: // Definitely affected
                         Console.WriteLine("You are affected by issue https://github.com/Particular/ServiceControl/pull/558");
-                        Console.WriteLine("Please upgrade ServiceControl to 1.6.3 immediately.");
+                        Console.WriteLine("Please upgrade ServiceControl to the latest version immediately.");
+                        Console.WriteLine("Latest release:  https://github.com/Particular/ServiceControl/releases");
                         Console.WriteLine("Contact us via support (http://particular.net/support) and we will work with you to get your situation sorted out.");
                         break;
                 }
+
+                Console.ForegroundColor = noralColor;
             }
             finally
             {
-                Console.WriteLine("Removing Temp Index");
+                Console.WriteLine("\nRemoving Temp Index...");
+                Console.WriteLine(" DONE");
                 store.DatabaseCommands.DeleteIndex(index.IndexName);
             }
         }
@@ -83,9 +93,9 @@ namespace Issue558Detector
                             var attempt = failedMessage.ProcessingAttempts.Last();
 
                             Console.WriteLine("Message Id:         {0}", attempt.MessageId);
-                            Console.WriteLine("Receiving Endpoint: {0}", attempt.FailureDetails.AddressOfFailingEndpoint);
                             Console.WriteLine("Message Type:       {0}", attempt.MessageMetadata.MessageType);
-                            Console.WriteLine("Timeline: ");
+                            Console.WriteLine("Receiving Endpoint: {0}", attempt.FailureDetails.AddressOfFailingEndpoint);
+                            Console.WriteLine("Message History: ");
 
                             foreach (var item in classifiedTimeline)
                             {

--- a/tools/Issue558Detector/Issue558Detector/Program.cs
+++ b/tools/Issue558Detector/Issue558Detector/Program.cs
@@ -16,6 +16,7 @@ namespace Issue558Detector
             };
 
             store.Initialize();
+            store.Conventions.MaxNumberOfRequestsPerSession = 2048;
 
             Console.WriteLine("This tool is going to examine ServiceControl for potential messages affected by issue  https://github.com/Particular/ServiceControl/pull/558\n");
             

--- a/tools/Issue558Detector/Issue558Detector/Program.cs
+++ b/tools/Issue558Detector/Issue558Detector/Program.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Raven.Client.Document;
+
+namespace Issue558Detector
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var store = new DocumentStore
+            {
+                Url = "http://localhost:33333/storage",
+            };
+
+            store.Initialize();
+
+            Console.Write("Creating Temp Index (this may take some time)...");
+
+            var index = new MessageHistories();
+
+            try
+            {
+                store.ExecuteIndex(index);
+
+                while (store.DatabaseCommands.GetStatistics().StaleIndexes.Length != 0)
+                {
+                    Thread.Sleep(10);
+                }
+
+                Console.WriteLine(" DONE");
+
+                Console.WriteLine("\nSearching for messages which may have been affected by issue https://github.com/Particular/ServiceControl/pull/558\n");
+
+                var dangerLevel = CheckForMessagesAffectedByIssue(store);
+
+                switch (dangerLevel)
+                {
+                    case 0: // Not affected
+                        Console.WriteLine("You are NOT affected by issue https://github.com/Particular/ServiceControl/pull/558");
+                        Console.WriteLine("However, we ask all users of ServiceControl using 1.6.x to update to 1.6.3 immediately.");
+                        break;
+                    case 1: // Maybe affected
+                        Console.WriteLine("You may be affected by issue https://github.com/Particular/ServiceControl/pull/558");
+                        Console.WriteLine("Please upgrade ServiceControl to 1.6.3 immediately.");
+                        Console.WriteLine("Contact us via support (http://particular.net/support) and we will work with you to get your situation sorted out.");
+                        break;
+                    case 2: // Definitely affected
+                        Console.WriteLine("You are affected by issue https://github.com/Particular/ServiceControl/pull/558");
+                        Console.WriteLine("Please upgrade ServiceControl to 1.6.3 immediately.");
+                        Console.WriteLine("Contact us via support (http://particular.net/support) and we will work with you to get your situation sorted out.");
+                        break;
+                }
+            }
+            finally
+            {
+                Console.WriteLine("Removing Temp Index");
+                store.DatabaseCommands.DeleteIndex(index.IndexName);
+            }
+        }
+
+        private static int CheckForMessagesAffectedByIssue(DocumentStore store)
+        {
+            var dangerLevel = 0;
+
+            using (var session = store.OpenSession())
+            {
+                var query = session.Query<MessageHistories.Result, MessageHistories>();
+
+                using (var stream = session.Advanced.Stream(query))
+                {
+                    while (stream.MoveNext())
+                    {
+                        var classifiedTimeline = AnalyseTimeline(stream.Current.Document.Events).ToArray();
+                        if (classifiedTimeline.Any(x => x.Classification != EventClassification.Ok))
+                        {
+                            var failedMessageId = stream.Current.Document.MessageId.Replace("/message/", "FailedMessages/");
+
+                            var failedMessage = session.Load<FailedMessage>(failedMessageId);
+
+                            var attempt = failedMessage.ProcessingAttempts.Last();
+
+                            Console.WriteLine("Message Id:         {0}", attempt.MessageId);
+                            Console.WriteLine("Receiving Endpoint: {0}", attempt.FailureDetails.AddressOfFailingEndpoint);
+                            Console.WriteLine("Message Type:       {0}", attempt.MessageMetadata.MessageType);
+                            Console.WriteLine("Timeline: ");
+
+                            foreach (var item in classifiedTimeline)
+                            {
+                                Console.WriteLine("\t{0:dd-MMM-yy HH:mm:ss K}: [{2,7}] {1}", item.Entry.When, item.Entry.Event, item.Classification);
+                                if (item.Classification == EventClassification.NotOk)
+                                {
+                                    dangerLevel = 2;
+                                }
+                                else if (item.Classification == EventClassification.Unknown)
+                                {
+                                    dangerLevel = Math.Max(dangerLevel, 1);
+                                }
+                            }
+                            Console.WriteLine();
+                            Console.WriteLine();
+                        }
+                    }
+                }
+            }
+
+            return dangerLevel;
+        }
+
+        private static IEnumerable<ClassifiedTimelineEntry> AnalyseTimeline(TimelineEntry[] entries)
+        {
+            bool? canRetry = null;
+
+            foreach (var entry in entries.OrderBy(e => e.When))
+            {
+                var status = EventClassification.Ok;
+
+                switch (entry.Event)
+                {
+                    case "MessageFailed":
+                        canRetry = true;
+                        break;
+                    case "MessagesSubmittedForRetry":
+                        if (canRetry.HasValue)
+                        {
+                            if (canRetry.Value == false)
+                            {
+                                status = EventClassification.NotOk;
+                            }
+                        }
+                        else
+                        {
+                            status = EventClassification.Unknown;
+                        }
+                        canRetry = false;
+                        break;
+                    case "MessageSubmittedForRetry": // Event for Retries before SC 1.6
+                    case "MessageFailureResolvedByRetry": // Only is audit ingestion is on
+                    case "FailedMessageArchived": // Single message archived
+                    case "FailedMessageGroupArchived": // SC1.6 group archived
+                        canRetry = false;
+                        break;
+                    default: // An event we didn't account for. A Retry following this is suspect
+                        canRetry = null;
+                        Console.WriteLine("Unexpected event for message: {0}", entry.Event);
+                        break;
+                }
+
+                yield return new ClassifiedTimelineEntry
+                {
+                    Entry = entry,
+                    Classification = status
+                };
+
+            }
+        }
+    }
+}

--- a/tools/Issue558Detector/Issue558Detector/Program.cs
+++ b/tools/Issue558Detector/Issue558Detector/Program.cs
@@ -95,11 +95,28 @@ namespace Issue558Detector
                             Console.WriteLine("Message Id:         {0}", attempt.MessageId);
                             Console.WriteLine("Message Type:       {0}", attempt.MessageMetadata.MessageType);
                             Console.WriteLine("Receiving Endpoint: {0}", attempt.FailureDetails.AddressOfFailingEndpoint);
+                            Console.Write("Status:             ");
+
+                            var definitelyAffected = classifiedTimeline.Any(x => x.Classification == EventClassification.NotOk);
+
+                            if (definitelyAffected)
+                            {
+                                Console.WriteLine("Definitely affected");
+                            }
+                            else
+                            {
+                                var maybeAffected = classifiedTimeline.Any(x => x.Classification == EventClassification.Unknown);
+                                if (maybeAffected)
+                                {
+                                    Console.WriteLine("May be affected");
+                                }
+                            }
+
                             Console.WriteLine("Message History: ");
 
                             foreach (var item in classifiedTimeline)
                             {
-                                Console.WriteLine("\t{0:dd-MMM-yy HH:mm:ss K}: [{2,7}] {1}", item.Entry.When, item.Entry.Event, item.Classification);
+                                Console.WriteLine("\t{0:dd-MMM-yy HH:mm:ss K}: [{2,15}] {1}", item.Entry.When, item.Entry.Event, FormatClassification(item.Classification));
                                 if (item.Classification == EventClassification.NotOk)
                                 {
                                     dangerLevel = 2;
@@ -117,6 +134,21 @@ namespace Issue558Detector
             }
 
             return dangerLevel;
+        }
+
+        private static string FormatClassification(EventClassification classification)
+        {
+            switch (classification)
+            {
+                case EventClassification.Ok:
+                    return "";
+                case EventClassification.NotOk:
+                    return "Affected";
+                case EventClassification.Unknown:
+                    return "May be affected";
+                default:
+                    return "Unknown";
+            }
         }
     }
 }

--- a/tools/Issue558Detector/Issue558Detector/Properties/AssemblyInfo.cs
+++ b/tools/Issue558Detector/Issue558Detector/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Issue558Detector")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Issue558Detector")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("da3e482f-42be-4a73-9fab-f688195666eb")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/Issue558Detector/Issue558Detector/ServiceControlModel/EventLogItem.cs
+++ b/tools/Issue558Detector/Issue558Detector/ServiceControlModel/EventLogItem.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Issue558Detector
+{
+    public class EventLogItem
+    {
+        public string Id { get; set; }
+        public string Description { get; set; }
+        public int Severity { get; set; }
+        public DateTime RaisedAt { get; set; }
+        public string[] RelatedTo { get; set; }
+        public string Category { get; set; }
+        public string EventType { get; set; }
+    }
+}

--- a/tools/Issue558Detector/Issue558Detector/ServiceControlModel/FailedMessageModel.cs
+++ b/tools/Issue558Detector/Issue558Detector/ServiceControlModel/FailedMessageModel.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+
+namespace Issue558Detector
+{
+    class FailedMessage
+    {
+        public string Id { get; set; }
+        public List<ProcessingAttempt> ProcessingAttempts { get; set; }
+
+        public FailedMessage()
+        {
+            ProcessingAttempts = new List<ProcessingAttempt>();
+        }
+    }
+
+    public class ProcessingAttempt
+    {
+        public string MessageId { get; set; }
+        public FailureDetails FailureDetails { get; set; }
+        public MessageMetadata MessageMetadata { get; set; }
+    }
+
+    public class MessageMetadata
+    {
+        public string MessageType { get; set; }
+    }
+
+    public class FailureDetails
+    {
+        public string AddressOfFailingEndpoint { get; set; }
+    }
+
+}

--- a/tools/Issue558Detector/Issue558Detector/TimelineAnalyzer.cs
+++ b/tools/Issue558Detector/Issue558Detector/TimelineAnalyzer.cs
@@ -8,7 +8,8 @@ namespace Issue558Detector
     {
         public static IEnumerable<ClassifiedTimelineEntry> AnalyzeTimeline(TimelineEntry[] entries)
         {
-            bool? canRetry = null;
+            // Until we see the first event it is OK to Retry
+            var canRetry = true;
             var status = EventClassification.Ok;
             var timelinePoisoned = false;
 
@@ -22,17 +23,10 @@ namespace Issue558Detector
                             canRetry = true;
                             break;
                         case "MessagesSubmittedForRetry":
-                            if (canRetry.HasValue)
+                            if (canRetry == false)
                             {
-                                if (canRetry.Value == false)
-                                {
-                                    status = EventClassification.NotOk;
-                                    timelinePoisoned = true;
-                                }
-                            }
-                            else
-                            {
-                                status = EventClassification.Unknown;
+                                status = EventClassification.NotOk;
+                                timelinePoisoned = true;
                             }
                             canRetry = false;
                             break;
@@ -63,8 +57,6 @@ namespace Issue558Detector
                 {
                     status = EventClassification.Unknown;
                 }
-
-
             }
         }
     }

--- a/tools/Issue558Detector/Issue558Detector/TimelineAnalyzer.cs
+++ b/tools/Issue558Detector/Issue558Detector/TimelineAnalyzer.cs
@@ -46,7 +46,8 @@ namespace Issue558Detector
                             canRetry = false;
                             break;
                         default: // An event we didn't account for. A Retry following this is suspect
-                            canRetry = null;
+                            status = EventClassification.Unknown;
+                            timelinePoisoned = true;
                             Console.WriteLine("Unexpected event for message: {0}", entry.Event);
                             break;
                     }

--- a/tools/Issue558Detector/Issue558Detector/TimelineAnalyzer.cs
+++ b/tools/Issue558Detector/Issue558Detector/TimelineAnalyzer.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Issue558Detector
+{
+    public static class TimelineAnalyzer
+    {
+        public static IEnumerable<ClassifiedTimelineEntry> AnalyzeTimeline(TimelineEntry[] entries)
+        {
+            bool? canRetry = null;
+            var status = EventClassification.Ok;
+            var timelinePoisoned = false;
+
+            foreach (var entry in entries.OrderBy(e => e.When))
+            {
+                if (!timelinePoisoned)
+                {
+                    switch (entry.Event)
+                    {
+                        case "MessageFailed":
+                            canRetry = true;
+                            break;
+                        case "MessagesSubmittedForRetry":
+                            if (canRetry.HasValue)
+                            {
+                                if (canRetry.Value == false)
+                                {
+                                    status = EventClassification.NotOk;
+                                    timelinePoisoned = true;
+                                }
+                            }
+                            else
+                            {
+                                status = EventClassification.Unknown;
+                            }
+                            canRetry = false;
+                            break;
+
+                        // If a message is retried successfully with audit ingestion off then there won't be a resolved message. 
+                        // But if a message fails a retry with audit ingestion off then there should be another Message Failed event.
+                        case "MessageSubmittedForRetry": // Event for Retries before SC 1.6
+                        case "MessageFailureResolvedByRetry": // Only if audit ingestion is on
+                        case "FailedMessageArchived": // Single message archived
+                        case "FailedMessageGroupArchived": // SC1.6 group archived
+                            canRetry = false;
+                            break;
+                        default: // An event we didn't account for. A Retry following this is suspect
+                            canRetry = null;
+                            Console.WriteLine("Unexpected event for message: {0}", entry.Event);
+                            break;
+                    }
+                }
+
+                yield return new ClassifiedTimelineEntry
+                {
+                    Entry = entry,
+                    Classification = status
+                };
+
+                if (timelinePoisoned)
+                {
+                    status = EventClassification.Unknown;
+                }
+
+
+            }
+        }
+    }
+}

--- a/tools/Issue558Detector/Issue558Detector/TimelineModel.cs
+++ b/tools/Issue558Detector/Issue558Detector/TimelineModel.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Issue558Detector
+{
+    public class TimelineEntry
+    {
+        public string Id { get; set; }
+        public DateTime When { get; set; }
+        public string Event { get; set; }
+    }
+
+    public enum EventClassification
+    {
+        Unknown,
+        Ok,
+        NotOk
+    }
+
+    public class ClassifiedTimelineEntry
+    {
+        public TimelineEntry Entry { get; set; }
+        public EventClassification Classification { get; set; }
+    }
+}

--- a/tools/Issue558Detector/Issue558Detector/packages.config
+++ b/tools/Issue558Detector/Issue558Detector/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="RavenDB.Client" version="2.5.2970" targetFramework="net45" />
+</packages>

--- a/tools/Issue558Detector/readme.md
+++ b/tools/Issue558Detector/readme.md
@@ -8,7 +8,7 @@ An [issue in ServiceControl 1.6](https://github.com/Particular/ServiceControl/pu
 Open the Services Panel, find the ServiceControl instance and stop it. 
 
 ### 2. Start Service Control in Maintenance Mode
-From an administrative command prompt, run `ServiceControl.exe --maint`. This will expose the embedded database of ServiceControl. No other API or processing will be started. 
+From an administrative command prompt, run `ServiceControl.exe --maint`. This will expose the embedded RavenDB database via RavenDB Studio (by default at `http://localhost:33333/storage`). ServiceControl will keep processing messages as usual.
 
 ### 3. Run the tool from the command line
 Run `Issue558Detector.exe` from the same machine that ServiceControl is running on. This assumes that the exposed RavenDB instance is available at `http://localhost:33333/storage`. If the RavenDB instance is made available at a different url then you can pass the full url in on the command line like this:

--- a/tools/Issue558Detector/readme.md
+++ b/tools/Issue558Detector/readme.md
@@ -196,7 +196,7 @@ This timeline can be the result of the following situations:
 #### What should you do?
 There are a few additional check that can help you determine which of the following scenarios took place:
   1. Find the suspicious message in ServiceInsight. If you notice two messages with the same id, it means that the message was successfully retried before the ServiceControl upgrade. If both messages are green then the incorrect retry was successful. If one of the messages is red then it means the incorrect retry attempt failed.
-  2. Navigate to the exposed Raven studio (by default it's at http://localhost:33333/storage), open Documents tab and go to FailedMessages. There you can export data to CSV file for easier search. 
+  2. Navigate to the exposed RavenDB studio (by default it's exposed at http://localhost:33333/storage, [more details](http://docs.particular.net/servicecontrol/use-ravendb-studio)), open Documents tab and go to FailedMessages. There you can export data to CSV file for easier search. 
       - If the suspicious message does not have any FailureGroup and has Status 2 (Resolved), then it means it was incorrectly retried and that retry succeeded.
       - If the suspicious message does have a FailureGroup assigned and has Status 2 (Resolved), then it was most likely correctly retried failed message.
       - If the suspicious message does have a FailureGroup and has Status 1 (Unresolved), then the last retry attempt failed, but we can't determine its previous state.

--- a/tools/Issue558Detector/readme.md
+++ b/tools/Issue558Detector/readme.md
@@ -11,7 +11,8 @@ Open the Services Panel, find the ServiceControl instance and stop it.
 From an administrative command prompt, run `ServiceControl.exe --maint`. This will expose the embedded RavenDB database via RavenDB Studio (by default at `http://localhost:33333/storage`). ServiceControl will keep processing messages as usual.
 
 ### 3. Run the tool from the command line
-Run `Issue558Detector.exe` from the same machine that ServiceControl is running on. This assumes that the exposed RavenDB instance is available at `http://localhost:33333/storage`. If the RavenDB instance is made available at a different url then you can pass the full url in on the command line like this:
+On the machine that ServiceControl is running, open a command prompt and run it in administrative mode. Navigate to directory where `Issue558Detector.exe` is stored and run it. 
+The tool assumes that RavenDB instance is exposed at the default url, i.e. `http://localhost:33333/storage`. However, if you customized configuration then you can pass the full url in on the command line like this:
 
     Issue558Detector.exe http://[machineName]:[port]/storage
 
@@ -58,7 +59,7 @@ Removing Temp Index...
 
 The first step that the tool takes is to create a temporary index. This index is created in the embedded RavenDB database that is embedded inside ServiceControl. This index is only required for tool and will be removed when the tool stops. Depending on the number of messages that you have, this step make take some time (in our testing we have seen it take 10-15 minutes). 
 
-Once the index has been created the tool will check each Failed Message in the database. Failed Messages are never deleted from ServiceControl so any message which has ever failed will still be there. The check involves looking at the series of events which have happened related to that message.
+Once the index has been created the tool will check each Failed Message in the database. Failed Messages are never deleted from ServiceControl so any message which has ever failed will still be there. The check involves looking at the series of events which have happened related to that failed message.
 
 If a message is Archived or Resolved and then subsequently retried then it has been affected by Issue 558. The tool will output the details of any message which meets this criteria.
 

--- a/tools/Issue558Detector/readme.md
+++ b/tools/Issue558Detector/readme.md
@@ -57,7 +57,7 @@ Removing Temp Index...
 ```
 ### How it works?
 
-The first step that the tool takes is to create a temporary index. This index is created in the embedded RavenDB database that is embedded inside ServiceControl. This index is only required for tool and will be removed when the tool stops. Depending on the number of messages that you have, this step make take some time (in our testing we have seen it take 10-15 minutes). 
+The first step that the tool takes is to create a temporary index. This index is created in the embedded RavenDB database that is embedded inside ServiceControl. This index is only required for the tool and will be removed when the tool done executing. Depending on the number of messages that you have, this step make take some time (in our testing we have seen it take 10-15 minutes). 
 
 Once the index has been created the tool will check each Failed Message in the database. Failed Messages are never deleted from ServiceControl so any message which has ever failed will still be there. The check involves looking at the series of events which have happened related to that failed message.
 

--- a/tools/Issue558Detector/readme.md
+++ b/tools/Issue558Detector/readme.md
@@ -64,10 +64,10 @@ Message History:
 ```
 
 Over the life of this message there have been 4 events.
-1. The message failed - This event is expected as it indicates that the message was read from the error queue
-2. The message was archived - Likely by a user of Service Pulse
-3. The message was sent for Retry - This should not have happened because the message was previously archived. This is the event that causes the message to be marked as `Affected`.
-4. The message was retried successfully - Note that although this is the outcome of the retry in step 3, which should not have happened. Any events that happen to a message after the incorrect Retry are also likely to be not what was expected.
+  1. The message failed - This event is expected as it indicates that the message was read from the error queue
+  2. The message was archived - Likely by a user of Service Pulse
+  3. The message was sent for Retry - This should not have happened because the message was previously archived. This is the event that causes the message to be marked as `Affected`.
+  4. The message was retried successfully - Note that although this is the outcome of the retry in step 3, which should not have happened. Any events that happen to a message after the incorrect Retry are also likely to be not what was expected.
 
 Using this information it is possible to examine the endpoint (in this case `Sample.Endpoint-A`) to see if the message (`Sample.Command.SendEmails`) that was sent has had any adverse effect.
 
@@ -89,11 +89,11 @@ Message History:
 ```
 
 Over the life of this message there have been 5 events.
-1. The message failed - expected
-2. The message was retried - expected
-3. The message was resolved by the retry - expected
-4. The message was sent for Retry - This should not have happened because the message was previously resolved. This is the event that causes the message to be marked as `Affected`. 
-5. The retry failed. Note that even if the incorrect retry failed, attempting to reprocess the message may still have had an effect on your system.
+  1. The message failed - expected
+  2. The message was retried - expected
+  3. The message was resolved by the retry - expected
+  4. The message was sent for Retry - This should not have happened because the message was previously resolved. This is the event that causes the message to be marked as `Affected`. 
+  5. The retry failed. Note that even if the incorrect retry failed, attempting to reprocess the message may still have had an effect on your system.
 
 ### A Bulk Retry after an Outstanding Retry
 ```
@@ -109,16 +109,16 @@ Message History:
 ```
 
 Over the life of this message there have been 4 events.
-1. The message failed - expected
-2. The message was retried - expected
-3. The message was sent for Retry - This should not have happened (see below). This is the event that causes the message to be marked as `Affected`
-4. The second retry failed.
+  1. The message failed - expected
+  2. The message was retried - expected
+  3. The message was sent for Retry - This should not have happened (see below). This is the event that causes the message to be marked as `Affected`
+  4. The second retry failed.
 
 This can happen for under two circumstances:
-1. Audit Ingestion is turned off - If this is the case then ServiceControl will not hear about it if a message is successfully resolved.
-2. The first retry is still outstanding - If this is the case then it may be possible that a `MessageFailed` or a `MessageFailureResolvedByRetry` event will appear later. 
+  1. Audit Ingestion is turned off - If this is the case then ServiceControl will not hear about it if a message is successfully resolved.
+  2. The first retry is still outstanding - If this is the case then it may be possible that a `MessageFailed` or a `MessageFailureResolvedByRetry` event will appear later. 
 
 ## Other notes
 If a failed message has been retried accidentally:
-1. It may have had an effect on your endpoint even if it failed again
-2. If the retry failed then the message may still be marked as Unresolved in ServiceControl. It needs to be archived to prevent it from being retried again in the future. 
+  1. It may have had an effect on your endpoint even if it failed again
+  2. If the retry failed then the message may still be marked as Unresolved in ServiceControl. It needs to be archived to prevent it from being retried again in the future. 

--- a/tools/Issue558Detector/readme.md
+++ b/tools/Issue558Detector/readme.md
@@ -1,0 +1,124 @@
+# Issue 558 Detector
+
+An [issue in ServiceControl 1.6](https://github.com/Particular/ServiceControl/pull/558) was identified which causes too many messages to be retried when the user performs a bulk retry operation. This tool will check the logs in your ServiceControl instance to see if any instances of this can be found.
+
+## How to run the tool
+
+### 1. Shut down Service Control
+Open the Services Panel, find the ServiceControl instance and stop it. 
+
+### 2. Start Service Control in Maintenance Mode
+From an administrative command prompt, run `ServiceControl.exe --maint`. This will expose the embedded database of ServiceControl. No other API or processing will be started. 
+
+### 3. Run the tool from the command line
+Run `Issue558Detector.exe` from the same machine that ServiceControl is running on. This assumes that the exposed RavenDB instance is available at `http://localhost:33333/storage`. If the RavenDB instance is made available at a different url then you can pass the full url in on the command line like this:
+
+    Issue558Detector.exe http://[machineName]:[port]/storage
+
+The tool outputs directly to the console window. To keep the output for examination later, pipe the output to a file using the `>` operator like this:
+
+    Issue558Detector.exe > results.txt
+
+### 4. Restart Service Control
+In the Services Control Pane, find the ServiceControl instance and restart it.
+
+## What does it do
+This is a sample output file:
+
+    Sample goes here
+
+The first step that the tool takes is to create a temporary index. This index is created in the embedded RavenDB database that is embedded inside ServiceControl. This index is only required for tool and will be removed when the tool stops. Depending on the number of messages that you have, this step make take some time (in our testing we have seen it take 10-15 minutes). 
+
+Once the index has been created the tool will check each Failed Message in the database. Failed Messages are never deleted from ServiceControl so any message which has ever failed will still be there. The check involves looking at the series of events which have happened related to that message.
+
+If a message is Archived or Resolved and then subsequently retried then it has been affected by Issue 558. The tool will output the details of any message which meets this criteria.
+
+The details include:
+* The type of the message
+* The ID of the message
+* The endpoint that the message was sent to
+* A status for the message (more on this below) AND
+* A timeline of events for the message
+
+Each message that is output by the tool will have one of two statuses:
+* `Definitely Affected` - means that the tool has detected a case where the message was sent for re-processing when it should not have been. Messages in this category require some manual intervention (see below).
+* `May be affected` - means that the tool has encountered an event in the log that it does not understand. Messages in the category require a user to interpret the timeline.
+
+Once the tool has scanned all of the messages a footer message provides an overall health statement indicating if you have or have not been affected by Issue 558.
+
+## Common Cases
+The following are a number of common cases, what they look like, and how they should be handled.
+
+### A Bulk Retry after an Archive Operation
+
+```
+Message Id:         13837004-af4f-4fef-a9a8-1e230a579c39
+Message Type:       Sample.Command.SendEmails
+Receiving Endpoint: Sample.Endpoint-A
+Status:             Definitely affected
+Message History: 
+	19-Aug-15 03:26:34 Z: [               ] MessageFailed
+	19-Aug-15 03:32:05 Z: [               ] FailedMessageArchived
+	19-Aug-15 23:02:58 Z: [       Affected] MessagesSubmittedForRetry
+	19-Aug-15 23:02:59 Z: [May be affected] MessageFailureResolvedByRetry
+```
+
+Over the life of this message there have been 4 events.
+1. The message failed - This event is expected as it indicates that the message was read from the error queue
+2. The message was archived - Likely by a user of Service Pulse
+3. The message was sent for Retry - This should not have happened because the message was previously archived. This is the event that causes the message to be marked as `Affected`.
+4. The message was retried successfully - Note that although this is the outcome of the retry in step 3, which should not have happened. Any events that happen to a message after the incorrect Retry are also likely to be not what was expected.
+
+Using this information it is possible to examine the endpoint (in this case `Sample.Endpoint-A`) to see if the message (`Sample.Command.SendEmails`) that was sent has had any adverse effect.
+
+If the message was successfully processed on the final retry then it will no longer appear in ServiceControl. If the message failed processing on the final retry then it should be archived.
+
+### A Bulk Retry after a Successful Retry
+
+```
+Message Id:         03a20f7d-bcf7-4c6a-870c-fb53a80f1544
+Message Type:       Sample.Command.SendEmails
+Receiving Endpoint: Sample.Endpoint-A
+Status:             Definitely affected
+Message History: 
+	19-Aug-15 03:45:34 Z: [               ] MessageFailed
+	19-Aug-15 03:52:05 Z: [               ] MessageSubmittedForRetry
+	19-Aug-15 03:55:06 Z: [               ] MessageFailureResolvedByRetry
+	23-Aug-15 06:07:32 Z: [       Affected] MessagesSubmittedForRetry
+	23-Aug-15 06:07:35 Z: [May be affected] MessageFailed
+```
+
+Over the life of this message there have been 5 events.
+1. The message failed - expected
+2. The message was retried - expected
+3. The message was resolved by the retry - expected
+4. The message was sent for Retry - This should not have happened because the message was previously resolved. This is the event that causes the message to be marked as `Affected`. 
+5. The retry failed. Note that even if the incorrect retry failed, attempting to reprocess the message may still have had an effect on your system.
+
+### A Bulk Retry after an Outstanding Retry
+```
+Message Id:         03a20f7d-bcf7-4c6a-870c-fb53a80f1544
+Message Type:       Sample.Command.SendEmails
+Receiving Endpoint: Sample.Endpoint-A
+Status:             Definitely affected
+Message History: 
+	20-Aug-15 05:30:12 Z: [               ] MessageFailed
+	20-Aug-15 05:31:43 Z: [               ] MessageSubmittedForRetry
+	21-Aug-15 13:09:13 Z: [       Affected] MessagesSubmittedForRetry
+	21-Aug-15 13:09:15 Z: [May be affected] MessageFailed
+```
+
+Over the life of this message there have been 4 events.
+1. The message failed - expected
+2. The message was retried - expected
+3. The message was sent for Retry - This should not have happened (see below). This is the event that causes the message to be marked as `Affected`
+4. The second retry failed.
+
+This can happen for under two circumstances:
+1. Audit Ingestion is turned off - If this is the case then ServiceControl will not hear about it if a message is successfully resolved.
+2. The first retry is still outstanding - If this is the case then it may be possible that a `MessageFailed` or a `MessageFailureResolvedByRetry` event will appear later. 
+
+## Other notes
+If a failed message has been retried accidentally:
+1. It may have had an effect on your endpoint even if it failed again
+2. If the retry failed then the message may still be marked as Unresolved in ServiceControl. It needs to be archived to prevent it from being retried again in the future. 

--- a/tools/Issue558Detector/readme.md
+++ b/tools/Issue558Detector/readme.md
@@ -150,7 +150,7 @@ Message History:
 The message in question was successfully retried in the past. However, it was picked up again during "Retry all" or "Retry group" operation and was incorrectly attempted to be processed again.
 
 #### What should you do?
-Investigate the handlers for the retried message, depending on your implementation it may or may not have a negative impact on the system. If handlers are idempotent then there should not be negative influence on the system.
+Investigate the handlers for the retried message, depending on your implementation it may or may not have a negative impact on the system. If handlers are idempotent then there should not be negative impact on the system.
  
 ### MessageSubmittedForRetry > MessagesSubmittedForRetry or MessageSubmittedForRetry > MessageSubmittedForRetry
 ```


### PR DESCRIPTION
@Particular/servicecontrol please review. 

This tool is for us to send to our customers to see if #558 has affected them. It works by examining the EventLog history looking for cases where SC 1.6 has submitted a message for Retry. If the event immediately before is not a Message Failed then the customer is (likely) affected. 

It should work even if Audit Ingestion is switched off. 