### PR TITLE
Also expire SagaHistories

### DIFF
--- a/src/ServiceControl.UnitTests/Expiration/CustomExpirationBundleTests.cs
+++ b/src/ServiceControl.UnitTests/Expiration/CustomExpirationBundleTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Threading;
@@ -9,141 +10,173 @@
     using MessageFailures;
     using NUnit.Framework;
     using Raven.Client.Embedded;
-    using ServiceBus.Management.Infrastructure.Settings;
     using ServiceControl.Infrastructure.RavenDB.Expiration;
     using ServiceControl.Operations.BodyStorage.RavenAttachments;
+    using ServiceControl.SagaAudit;
 
     [TestFixture]
     public class CustomExpirationBundleTests
     {
         [Test]
-        public void Processed_messages_are_being_expired()
+        public void Old_documents_are_being_expired()
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = InMemoryStoreBuilder.GetInMemoryStore())
             {
+                var expiredDate = DateTime.UtcNow.AddDays(-3);
+                var thresholdDate = DateTime.UtcNow.AddDays(-2);
                 var processedMessage = new ProcessedMessage
                 {
                     Id = "1",
-                    ProcessedAt = DateTime.UtcNow.AddHours(-(Settings.HoursToKeepMessagesBeforeExpiring*3)),
                 };
 
-                var processedMessage2 = new ProcessedMessage
+                var sagaHistoryId = Guid.NewGuid();
+                var sagaHistory = new SagaHistory
                 {
-                    Id = "2",
-                    ProcessedAt = DateTime.UtcNow.AddHours(-(Settings.HoursToKeepMessagesBeforeExpiring*2)),
+                    Id = sagaHistoryId,
                 };
-                processedMessage2.MessageMetadata["IsSystemMessage"] = true;
 
+                using (new RavenLastModifiedScope(expiredDate))
                 using (var session = documentStore.OpenSession())
                 {
                     session.Store(processedMessage);
-                    session.Store(processedMessage2);
+                    session.Store(sagaHistory);
                     session.SaveChanges();
                 }
-
-                documentStore.WaitForIndexing();
-                Thread.Sleep(Settings.ExpirationProcessTimerInSeconds*1000*2);
+                RunExpiry(documentStore, thresholdDate);
 
                 using (var session = documentStore.OpenSession())
                 {
-                    var msg = session.Load<ProcessedMessage>(processedMessage.Id);
-                    Assert.Null(msg);
-
-                    msg = session.Load<ProcessedMessage>(processedMessage2.Id);
-                    Assert.Null(msg);
+                    Assert.IsEmpty(session.Query<ProcessedMessage>());
+                    Assert.IsEmpty(session.Query<SagaHistory>());
                 }
             }
         }
 
         [Test]
-        public void Many_processed_messages_are_being_expired()
+        public void Many_documents_are_being_expired()
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = InMemoryStoreBuilder.GetInMemoryStore())
             {
-                new ExpiryProcessedMessageIndex().Execute(documentStore);
-
-                var processedMessage = new ProcessedMessage
+                var expiredDate = DateTime.UtcNow.AddDays(-3);
+                var thresholdDate = DateTime.UtcNow.AddDays(-2);
+                var recentDate = DateTime.UtcNow.AddDays(-1);
+                var expiredMessages = BuilExpiredMessaged().ToList();
+                using (new RavenLastModifiedScope(expiredDate))
                 {
-                    Id = Guid.NewGuid().ToString(),
-                    ProcessedAt = DateTime.UtcNow.AddMinutes(-DateTime.UtcNow.Millisecond%30).AddDays(-(Settings.HoursToKeepMessagesBeforeExpiring*3)),
-                };
+                    using (var session = documentStore.OpenSession())
+                    {
+                        foreach (var message in expiredMessages)
+                        {
+                            session.Store(message);
+                        }
+                        session.SaveChanges();
+                    }
+                }
 
-                var processedMessage2 = new ProcessedMessage
-                {
-                    Id = "2",
-                    ProcessedAt = DateTime.UtcNow,
-                };
-
+                using (new RavenLastModifiedScope(recentDate))
                 using (var session = documentStore.OpenSession())
                 {
-                    for (var i = 0; i < 100; i++)
+                    var recentMessage = new ProcessedMessage
                     {
-                        processedMessage = new ProcessedMessage
-                        {
-                            Id = Guid.NewGuid().ToString(),
-                            ProcessedAt = DateTime.UtcNow.AddMinutes(-DateTime.UtcNow.Millisecond%30).AddDays(-(Settings.HoursToKeepMessagesBeforeExpiring*3)),
-                        };
-
-                        session.Store(processedMessage);
-                    }
-
-                    session.Store(processedMessage2);
+                        Id = "recentMessageId",
+                    };
+                    session.Store(recentMessage);
+                    var recentSagaHistory = new SagaHistory
+                    {
+                        Id = Guid.NewGuid(),
+                    };
+                    session.Store(recentSagaHistory);
                     session.SaveChanges();
                 }
+                RunExpiry(documentStore, thresholdDate);
+                foreach (dynamic message in expiredMessages)
+                {
+                    using (var session = documentStore.OpenSession())
+                    {
+                        Assert.Null(session.Load<ProcessedMessage>(message.Id));
+                    }
+                }
 
-                documentStore.WaitForIndexing();
-                Thread.Sleep(Settings.ExpirationProcessTimerInSeconds*1000*10);
                 using (var session = documentStore.OpenSession())
                 {
-                    var results = session.Query<ProcessedMessage, ExpiryProcessedMessageIndex>().Customize(x => x.WaitForNonStaleResults()).ToArray();
-                    Assert.AreEqual(1, results.Length);
-
-                    var msg = session.Load<ProcessedMessage>(processedMessage.Id);
-                    Assert.Null(msg, "Message with datestamp {0} and ID {1} was found", processedMessage.ProcessedAt, processedMessage.Id);
-
-                    msg = session.Load<ProcessedMessage>(processedMessage2.Id);
-                    Assert.NotNull(msg);
+                    Assert.AreEqual(1, session.Query<ProcessedMessage>().Count());
+                    Assert.AreEqual(1, session.Query<SagaHistory>().Count());
                 }
             }
+        }
+
+        IEnumerable<object> BuilExpiredMessaged()
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                yield return new ProcessedMessage
+                {
+                    Id = Guid.NewGuid().ToString(),
+                };
+                yield return new SagaHistory
+                {
+                    Id = Guid.NewGuid(),
+                };
+            }
+        }
+
+        static void RunExpiry(EmbeddableDocumentStore documentStore, DateTime expiryThreshold)
+        {
+            new ExpiryProcessedMessageIndex().Execute(documentStore);
+            documentStore.WaitForIndexing();
+            ExpiredDocumentsCleaner.InnerCleanup(100, documentStore.DocumentDatabase, expiryThreshold);
+            documentStore.WaitForIndexing();
         }
 
         [Test]
         public void Only_processed_messages_are_being_expired()
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = InMemoryStoreBuilder.GetInMemoryStore())
             {
-                new ExpiryProcessedMessageIndex().Execute(documentStore);
-
-                var processedMessage = new ProcessedMessage
+                var expiredDate = DateTime.UtcNow.AddDays(-3);
+                var thresholdDate = DateTime.UtcNow.AddDays(-2);
+                var recentDate = DateTime.UtcNow.AddDays(-1);
+                var expiredMessage = new ProcessedMessage
                 {
                     Id = "1",
-                    ProcessedAt = DateTime.UtcNow.AddHours(-(Settings.HoursToKeepMessagesBeforeExpiring*3)),
                 };
 
-                var processedMessage2 = new ProcessedMessage
+                var expiredSagaHistory = new SagaHistory
                 {
-                    Id = "2",
-                    ProcessedAt = DateTime.UtcNow,
+                    Id = Guid.NewGuid(),
                 };
-                processedMessage2.MessageMetadata["IsSystemMessage"] = true;
 
+                using (new RavenLastModifiedScope(expiredDate))
                 using (var session = documentStore.OpenSession())
                 {
-                    session.Store(processedMessage);
-                    session.Store(processedMessage2);
+                    session.Store(expiredMessage);
+                    session.Store(expiredSagaHistory);
                     session.SaveChanges();
                 }
 
-                documentStore.WaitForIndexing();
-                Thread.Sleep(Settings.ExpirationProcessTimerInSeconds*1000*2);
+                var recentMessage = new ProcessedMessage
+                {
+                    Id = "2",
+                };
+                var recentSagaHistory = new SagaHistory
+                {
+                    Id = Guid.NewGuid(),
+                };
+                using (new RavenLastModifiedScope(recentDate))
+                using (var session = documentStore.OpenSession())
+                {
+                    session.Store(recentMessage);
+                    session.Store(recentSagaHistory);
+                    session.SaveChanges();
+                }
+                RunExpiry(documentStore, thresholdDate);
 
                 using (var session = documentStore.OpenSession())
                 {
-                    var msg = session.Load<ProcessedMessage>(processedMessage.Id);
-                    Assert.Null(msg);
-
-                    msg = session.Load<ProcessedMessage>(processedMessage2.Id);
-                    Assert.NotNull(msg);
+                    Assert.Null(session.Load<ProcessedMessage>(expiredMessage.Id));
+                    Assert.Null(session.Load<SagaHistory>(expiredSagaHistory.Id));
+                    Assert.NotNull(session.Load<ProcessedMessage>(recentMessage.Id));
+                    Assert.NotNull(session.Load<SagaHistory>(recentSagaHistory.Id));
                 }
             }
         }
@@ -151,23 +184,25 @@
         [Test]
         public void Stored_bodies_are_being_removed_when_message_expires()
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = InMemoryStoreBuilder.GetInMemoryStore())
             {
+                var expiredDate = DateTime.UtcNow.AddDays(-3);
+                var thresholdDate = DateTime.UtcNow.AddDays(-2);
                 // Store expired message with associated body
                 var messageId = "21";
-                var bodyStorage = new RavenAttachmentsBodyStorage
-                {
-                    DocumentStore = documentStore
-                };
 
                 var processedMessage = new ProcessedMessage
                 {
                     Id = "1",
-                    ProcessedAt = DateTime.UtcNow.AddHours(-(Settings.HoursToKeepMessagesBeforeExpiring*2))
+                    MessageMetadata = new Dictionary<string, object>
+                    {
+                        {
+                            "MessageId", messageId
+                        }
+                    }
                 };
 
-            processedMessage.SetMessageId(messageId);
-
+                using (new RavenLastModifiedScope(expiredDate))
                 using (var session = documentStore.OpenSession())
                 {
                     session.Store(processedMessage);
@@ -183,53 +218,56 @@
                     5
                 };
 
+                var bodyStorage = new RavenAttachmentsBodyStorage
+                {
+                    DocumentStore = documentStore
+                };
                 using (var stream = new MemoryStream(body))
+                {
                     bodyStorage.Store(messageId, "binary", 5, stream);
-
-                // Wait for expiry
-                documentStore.WaitForIndexing();
-                Thread.Sleep(Settings.ExpirationProcessTimerInSeconds*1000*2);
+                }
+                RunExpiry(documentStore, thresholdDate);
 
                 // Verify message expired
                 using (var session = documentStore.OpenSession())
                 {
-                    var msg = session.Load<ProcessedMessage>(processedMessage.Id);
-                    Assert.Null(msg, "Audit document should be deleted");
+                    Assert.Null(session.Load<ProcessedMessage>(processedMessage.Id));
                 }
 
                 // Verify body expired
                 Stream dummy;
-                var bodyFound = bodyStorage.TryFetch(messageId, out dummy);
-                Assert.False(bodyFound, "Audit document body should be deleted");
+                Assert.False(bodyStorage.TryFetch(messageId, out dummy), "Audit document body should be deleted");
             }
         }
 
         [Test]
         public void Recent_processed_messages_are_not_being_expired()
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = InMemoryStoreBuilder.GetInMemoryStore())
             {
-                new ExpiryProcessedMessageIndex().Execute(documentStore);
-
-                var processedMessage = new ProcessedMessage
+                var thresholdDate = DateTime.UtcNow.AddDays(-2);
+                var recentDate = DateTime.UtcNow.AddDays(-1);
+                var message = new ProcessedMessage
                 {
                     Id = "1",
-                    ProcessedAt = DateTime.UtcNow,
+                };
+                var sagaHistory = new SagaHistory
+                {
+                    Id = Guid.NewGuid(),
                 };
 
+                using (new RavenLastModifiedScope(recentDate))
                 using (var session = documentStore.OpenSession())
                 {
-                    session.Store(processedMessage);
+                    session.Store(sagaHistory);
+                    session.Store(message);
                     session.SaveChanges();
                 }
-
-                documentStore.WaitForIndexing();
-                Thread.Sleep(Settings.ExpirationProcessTimerInSeconds*1000*2);
-
+                RunExpiry(documentStore, thresholdDate);
                 using (var session = documentStore.OpenSession())
                 {
-                    var msg = session.Load<ProcessedMessage>(processedMessage.Id);
-                    Assert.NotNull(msg);
+                    Assert.AreEqual(1, session.Query<ProcessedMessage>().Count());
+                    Assert.AreEqual(1, session.Query<SagaHistory>().Count());
                 }
             }
         }
@@ -237,50 +275,28 @@
         [Test]
         public void Errors_are_not_being_expired()
         {
-            using (var documentStore = GetDocumentStore())
+            using (var documentStore = InMemoryStoreBuilder.GetInMemoryStore())
             {
                 var failedMsg = new FailedMessage
                 {
                     Id = "1",
-                    ProcessingAttempts = new List<FailedMessage.ProcessingAttempt>
-                    {
-                        new FailedMessage.ProcessingAttempt
-                        {
-                            AttemptedAt = DateTime.UtcNow.AddHours(-(Settings.HoursToKeepMessagesBeforeExpiring * 3))
-                        },
-                        new FailedMessage.ProcessingAttempt
-                        {
-                            AttemptedAt = DateTime.UtcNow.AddHours(-(Settings.HoursToKeepMessagesBeforeExpiring * 2)),
-                        }
-                    },
-                    Status = FailedMessageStatus.Unresolved,
                 };
 
                 using (var session = documentStore.OpenSession())
                 {
                     session.Store(failedMsg);
                     session.SaveChanges();
-                }
 
-                documentStore.WaitForIndexing();
-                Thread.Sleep(Settings.ExpirationProcessTimerInSeconds * 1000 * 2);
+                    Debug.WriteLine(session.Advanced.GetMetadataFor(failedMsg)["Last-Modified"]);
+                }
+                Thread.Sleep(100);
+                RunExpiry(documentStore, DateTime.UtcNow);
 
                 using (var session = documentStore.OpenSession())
                 {
-                    var msg = session.Load<FailedMessage>(failedMsg.Id);
-                    Assert.NotNull(msg);
+                    Assert.NotNull(session.Load<FailedMessage>(failedMsg.Id));
                 }
             }
-        }
-
-
-        EmbeddableDocumentStore GetDocumentStore()
-        {
-            var documentStore = InMemoryStoreBuilder.GetInMemoryStore(withExpiration: true);
-
-            var customIndex = new ExpiryProcessedMessageIndex();
-            customIndex.Execute(documentStore);
-            return documentStore;
         }
 
     }

--- a/src/ServiceControl.UnitTests/Expiration/RavenLastModifiedScope.cs
+++ b/src/ServiceControl.UnitTests/Expiration/RavenLastModifiedScope.cs
@@ -1,0 +1,20 @@
+﻿namespace ServiceControl.UnitTests.Expiration
+{
+    using System;
+    using Raven.Abstractions;
+
+    public class RavenLastModifiedScope : IDisposable
+    {
+        Func<DateTime> previous;
+        public RavenLastModifiedScope(DateTime dateTime)
+        {
+            previous = SystemTime.UtcDateTime;
+            SystemTime.UtcDateTime = () => dateTime;
+        }
+
+        public void Dispose()
+        {
+            SystemTime.UtcDateTime = previous;
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/Infrastructure/RavenDB/Indexes/InMemoryStoreBuilder.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/RavenDB/Indexes/InMemoryStoreBuilder.cs
@@ -1,12 +1,9 @@
-using System.ComponentModel.Composition.Hosting;
 using System.IO;
 using Raven.Client.Embedded;
-using ServiceBus.Management.Infrastructure.Settings;
-using ServiceControl.Infrastructure.RavenDB.Expiration;
 
 public class InMemoryStoreBuilder
 {
-    public static EmbeddableDocumentStore GetInMemoryStore(bool withExpiration = false)
+    public static EmbeddableDocumentStore GetInMemoryStore()
     {
         var store = new EmbeddableDocumentStore
         {
@@ -21,21 +18,7 @@ public class InMemoryStoreBuilder
             }
         };
         store.Configuration.CompiledIndexCacheDirectory = Path.GetTempPath(); // RavenDB-2236
-
-        if (withExpiration)
-        {
-            Settings.ExpirationProcessTimerInSeconds = 1; // so we don't have to wait too much in tests
-            store.Configuration.Catalog.Catalogs.Add(new AssemblyCatalog(typeof(ExpiredDocumentsCleaner).Assembly));
-            store.Configuration.Settings.Add("Raven/ActiveBundles", "CustomDocumentExpiration"); // Enable the expiration bundle
-        }
-
         store.Initialize();
-
-        if (withExpiration)
-        {
-            new ExpiryProcessedMessageIndex().Execute(store); // this index is being queried by our expiration bundle
-        }
-
         return store;
     }
 }

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -104,6 +104,7 @@
   <ItemGroup>
     <Compile Include="ArgumentParsing\OptionsTests.cs" />
     <Compile Include="CompositeViews\FailedMessageTest.cs" />
+    <Compile Include="Expiration\RavenLastModifiedScope.cs" />
     <Compile Include="Expiration\PeriodicExecutorTests.cs" />
     <Compile Include="ExternalIntegrations\MessageFailedConverterTests.cs" />
     <Compile Include="CompositeViews\MessagesViewTests.cs" />

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
@@ -3,7 +3,6 @@
 
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel.Composition;
     using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
@@ -14,151 +13,24 @@
     using Raven.Abstractions.Logging;
     using Raven.Database;
     using Raven.Database.Impl;
-    using Raven.Database.Plugins;
+    using Raven.Json.Linq;
     using ServiceBus.Management.Infrastructure.Settings;
 
-
-    [InheritedExport(typeof(IStartupTask))]
-    [ExportMetadata("Bundle", "customDocumentExpiration")]
-    public class ExpiredDocumentsCleaner : IStartupTask, IDisposable
+    public class ExpiredDocumentsCleaner 
     {
-        ILog logger = LogManager.GetLogger(typeof(ExpiredDocumentsCleaner));
-        PeriodicExecutor timer;
-        DocumentDatabase Database { get; set; }
-        string indexName;
-        int deleteFrequencyInSeconds;
-        int deletionBatchSize;
+        static ILog logger = LogManager.GetLogger(typeof(ExpiredDocumentsCleaner));
+        static string indexName = new ExpiryProcessedMessageIndex().IndexName;
 
-        public void Execute(DocumentDatabase database)
+        public static void RunCleanup(int deletionBatchSize, DocumentDatabase database)
         {
-            Database = database;
-            indexName = new ExpiryProcessedMessageIndex().IndexName;
+            var hoursToKeep = Settings.HoursToKeepMessagesBeforeExpiring;
+            var expiryThreshold = SystemTime.UtcNow.AddHours(-hoursToKeep);
 
-            deletionBatchSize = Settings.ExpirationProcessBatchSize;
-            deleteFrequencyInSeconds = Settings.ExpirationProcessTimerInSeconds;
-
-            if (deleteFrequencyInSeconds == 0)
-            {
-                return;
-            }
-
-            logger.Info("Expired Documents every {0} seconds", deleteFrequencyInSeconds);
-            logger.Info("Deletion Batch Size: {0}", deletionBatchSize);
-            logger.Info("Retention Period: {0}", Settings.HoursToKeepMessagesBeforeExpiring);
-
-            timer = new PeriodicExecutor(Delete,TimeSpan.FromSeconds(deleteFrequencyInSeconds));
-            timer.Start(true);
-        }
-
-        void Delete(PeriodicExecutor executor)
-        {
-            var currentTime = SystemTime.UtcNow;
-            var currentExpiryThresholdTime = currentTime.AddHours(-Settings.HoursToKeepMessagesBeforeExpiring);
-            logger.Debug("Trying to find expired documents to delete (with threshold {0})", currentExpiryThresholdTime.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
-            const string queryString = "Status:3 OR Status:4";
-            var query = new IndexQuery
-            {
-                Start = 0,
-                PageSize = deletionBatchSize,
-                Cutoff = currentTime,
-                Query = queryString,
-                FieldsToFetch = new[]
-                {
-                    "__document_id",
-                    "ProcessedAt", 
-                    "MessageMetadata"
-                },
-                SortedFields = new[]
-                {
-                    new SortedField("ProcessedAt")
-                    {
-                        Field = "ProcessedAt",
-                        Descending = false
-                    }
-                },
-            };
+            logger.Debug("Trying to find expired documents to delete (with threshold {0})", expiryThreshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
 
             try
             {
-                var docsToExpire = 0;
-                // we may be receiving a LOT of documents to delete, so we are going to skip
-                // the cache for that, to avoid filling it up very quickly
-                var stopwatch = Stopwatch.StartNew();
-                int deletionCount;
-                using (DocumentCacher.SkipSettingDocumentsInDocumentCache())
-                using (Database.DisableAllTriggersForCurrentThread())
-                using (var cts = new CancellationTokenSource())
-                {
-                    var documentWithCurrentThresholdTimeReached = false;
-                    var items = new List<ICommandData>(deletionBatchSize);
-                    var attachments = new List<string>(deletionBatchSize);
-                    try
-                    {
-                        Database.Query(indexName, query, CancellationTokenSource.CreateLinkedTokenSource(Database.WorkContext.CancellationToken, cts.Token).Token,
-                       null,
-                        doc =>
-                        {
-                            if (documentWithCurrentThresholdTimeReached)
-                            {
-                                return;
-                            }
-
-                            if (doc.Value<DateTime>("ProcessedAt") >= currentExpiryThresholdTime)
-                            {
-                                documentWithCurrentThresholdTimeReached = true;
-                                cts.Cancel();
-                                return;
-                            }
-
-                            var id = doc.Value<string>("__document_id");
-                            if (!string.IsNullOrEmpty(id))
-                            {
-                                items.Add(new DeleteCommandData
-                                {
-                                    Key = id
-                                });
-
-                                var bodyNotStored = doc.SelectToken("MessageMetadata.BodyNotStored", errorWhenNoMatch: false);
-                                if (bodyNotStored == null || bodyNotStored.Value<bool>() == false)
-                                {
-                                    var msgId = doc.SelectToken("MessageMetadata.MessageId", errorWhenNoMatch: false);
-                                    if (msgId != null)
-                                    {
-                                        var attachmentId = "messagebodies/" + msgId.Value<string>();
-                                        attachments.Add(attachmentId);
-                                    }
-                                }
-                            }
-                        });
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        //Ignore
-                    }
-
-                    logger.Debug("Batching deletion of {0} documents.",items.Count);
-
-                    docsToExpire += items.Count;
-                    var results = Database.Batch(items.ToArray());
-                    Database.TransactionalStorage.Batch(accessor =>
-                    {
-                        foreach (var attach in attachments)
-                        {
-                            accessor.Attachments.DeleteAttachment(attach, null);
-                        }
-                    });
-                    deletionCount = results.Count(x => x.Deleted == true);
-                    items.Clear();
-                }
-
-                if (docsToExpire == 0)
-                {
-                    logger.Debug("No expired documents found");
-                }
-                else
-                {
-                    logger.Debug("Deleted {0} out of {1} expired documents batch - Execution time:{2}ms", deletionCount, docsToExpire, stopwatch.ElapsedMilliseconds);
-                }
+                InnerCleanup(deletionBatchSize, database, expiryThreshold);
             }
             catch (Exception e)
             {
@@ -166,16 +38,120 @@
             }
         }
 
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        /// <filterpriority>2</filterpriority>
-        public void Dispose()
+        public static void InnerCleanup(int deletionBatchSize, DocumentDatabase database, DateTime expiryThreshold)
         {
-            if (timer != null)
+            var query = new IndexQuery
             {
-                timer.Stop();
+                Start = 0,
+                PageSize = deletionBatchSize,
+                Cutoff = DateTime.UtcNow,
+                FieldsToFetch = new[]
+                {
+                    "__document_id",
+                    "LastModified",
+                    "MessageMetadata"
+                },
+                SortedFields = new[]
+                {
+                    new SortedField("LastModified")
+                    {
+                        Field = "LastModified",
+                        Descending = false
+                    }
+                },
+            };
+
+            var docsToExpire = 0;
+            // we may be receiving a LOT of documents to delete, so we are going to skip
+            // the cache for that, to avoid filling it up very quickly
+            var stopwatch = Stopwatch.StartNew();
+            int deletionCount;
+            using (DocumentCacher.SkipSettingDocumentsInDocumentCache())
+            using (database.DisableAllTriggersForCurrentThread())
+            using (var cts = new CancellationTokenSource())
+            {
+                var documentWithCurrentThresholdTimeReached = false;
+                var items = new List<ICommandData>(deletionBatchSize);
+                var attachments = new List<string>(deletionBatchSize);
+                try
+                {
+                    database.Query(indexName, query, CancellationTokenSource.CreateLinkedTokenSource(database.WorkContext.CancellationToken, cts.Token).Token,
+                        null,
+                        doc =>
+                        {
+                            if (documentWithCurrentThresholdTimeReached)
+                            {
+                                return;
+                            }
+
+                            if (doc.Value<DateTime>("LastModified") >= expiryThreshold)
+                            {
+                                documentWithCurrentThresholdTimeReached = true;
+                                cts.Cancel();
+                                return;
+                            }
+
+                            var id = doc.Value<string>("__document_id");
+                            if (string.IsNullOrEmpty(id))
+                            {
+                                return;
+                            }
+                            items.Add(new DeleteCommandData
+                            {
+                                Key = id
+                            });
+
+                            string bodyId;
+                            if (TryGetBodyId(doc, out bodyId))
+                            {
+                                attachments.Add(bodyId);
+                            }
+                        });
+                }
+                catch (OperationCanceledException)
+                {
+                    //Ignore
+                }
+
+                logger.Debug("Batching deletion of {0} documents.", items.Count);
+
+                docsToExpire += items.Count;
+                var results = database.Batch(items.ToArray());
+                database.TransactionalStorage.Batch(accessor =>
+                {
+                    foreach (var attach in attachments)
+                    {
+                        accessor.Attachments.DeleteAttachment(attach, null);
+                    }
+                });
+                deletionCount = results.Count(x => x.Deleted == true);
+                items.Clear();
             }
+
+            if (docsToExpire == 0)
+            {
+                logger.Debug("No expired documents found");
+            }
+            else
+            {
+                logger.Debug("Deleted {0} out of {1} expired documents batch - Execution time:{2}ms", deletionCount, docsToExpire, stopwatch.ElapsedMilliseconds);
+            }
+        }
+        static bool TryGetBodyId(RavenJObject doc, out string bodyId)
+        {
+            bodyId = null;
+            var bodyNotStored = doc.SelectToken("MessageMetadata.BodyNotStored", errorWhenNoMatch: false);
+            if (bodyNotStored != null && bodyNotStored.Value<bool>())
+            {
+                return false;
+            }
+            var messageId = doc.SelectToken("MessageMetadata.MessageId", errorWhenNoMatch: false);
+            if (messageId == null)
+            {
+                return false;
+            }
+            bodyId = "messagebodies/" + messageId.Value<string>();
+            return true;
         }
     }
 }

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
@@ -17,19 +17,19 @@
 
         public void Execute(DocumentDatabase database)
         {
-            var deletionBatchSize = Settings.ExpirationProcessBatchSize;
             var deleteFrequencyInSeconds = Settings.ExpirationProcessTimerInSeconds;
 
             if (deleteFrequencyInSeconds == 0)
             {
                 return;
             }
+            var deletionBatchSize = Settings.ExpirationProcessBatchSize;
 
             logger.Info("Expired Documents every {0} seconds", deleteFrequencyInSeconds);
             logger.Info("Deletion Batch Size: {0}", deletionBatchSize);
-            logger.Info("Retention Period: {0}", Settings.HoursToKeepMessagesBeforeExpiring);
+            logger.Info("Retention Period: {0} hours", Settings.HoursToKeepMessagesBeforeExpiring);
 
-            timer = new PeriodicExecutor(executor => ExpiredDocumentsCleaner.RunCleanup(Settings.ExpirationProcessBatchSize, database), TimeSpan.FromSeconds(deleteFrequencyInSeconds));
+            timer = new PeriodicExecutor(executor => ExpiredDocumentsCleaner.RunCleanup(deletionBatchSize, database), TimeSpan.FromSeconds(deleteFrequencyInSeconds));
             timer.Start(true);
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
@@ -1,0 +1,44 @@
+﻿namespace ServiceControl.Infrastructure.RavenDB.Expiration
+{
+
+    using System;
+    using System.ComponentModel.Composition;
+    using Raven.Abstractions.Logging;
+    using Raven.Database;
+    using Raven.Database.Plugins;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    [InheritedExport(typeof(IStartupTask))]
+    [ExportMetadata("Bundle", "customDocumentExpiration")]
+    public class ExpiredDocumentsCleanerBundle : IStartupTask, IDisposable
+    {
+        ILog logger = LogManager.GetLogger(typeof(ExpiredDocumentsCleanerBundle));
+        PeriodicExecutor timer;
+
+        public void Execute(DocumentDatabase database)
+        {
+            var deletionBatchSize = Settings.ExpirationProcessBatchSize;
+            var deleteFrequencyInSeconds = Settings.ExpirationProcessTimerInSeconds;
+
+            if (deleteFrequencyInSeconds == 0)
+            {
+                return;
+            }
+
+            logger.Info("Expired Documents every {0} seconds", deleteFrequencyInSeconds);
+            logger.Info("Deletion Batch Size: {0}", deletionBatchSize);
+            logger.Info("Retention Period: {0}", Settings.HoursToKeepMessagesBeforeExpiring);
+
+            timer = new PeriodicExecutor(executor => ExpiredDocumentsCleaner.RunCleanup(Settings.ExpirationProcessBatchSize, database), TimeSpan.FromSeconds(deleteFrequencyInSeconds));
+            timer.Start(true);
+        }
+
+        public void Dispose()
+        {
+            if (timer != null)
+            {
+                timer.Stop();
+            }
+        }
+    }
+}

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiryProcessedMessageIndex.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiryProcessedMessageIndex.cs
@@ -1,23 +1,36 @@
 namespace ServiceControl.Infrastructure.RavenDB.Expiration
 {
     using System.Linq;
-    using Contracts.Operations;
     using MessageAuditing;
+    using Raven.Abstractions.Indexing;
     using Raven.Client.Indexes;
+    using Raven.Json.Linq;
+    using ServiceControl.SagaAudit;
 
-    public class ExpiryProcessedMessageIndex : AbstractIndexCreationTask<ProcessedMessage>
-    {  
+    public class ExpiryProcessedMessageIndex : AbstractMultiMapIndexCreationTask<ExpiryProcessedMessageIndex.Result>
+    {
+        public class Result
+        {
+            public RavenJToken LastModified { get; set; }
+        }
+
         public ExpiryProcessedMessageIndex()
         {
-            Map = (messages => from message in messages
-                select new 
-                {
-                    MessageId = (string) message.MessageMetadata["MessageId"],
-                    Status = (bool)message.MessageMetadata["IsRetried"] ? MessageStatus.ResolvedSuccessfully : MessageStatus.Successful,
-                    ProcessedAt = message.ProcessedAt,
-                });
-
+            AddMap<ProcessedMessage>(messages => from message in messages
+                                                 select new Result
+                                                 {
+                                                     LastModified = MetadataFor(message)["Last-Modified"],
+                                                 });
+            AddMap<SagaHistory>(sagaHistories => from sagaHistory in sagaHistories
+                                                 select new Result
+                                                 {
+                                                     LastModified = MetadataFor(sagaHistory)["Last-Modified"],
+                                                 });
             DisableInMemoryIndexing = true;
+
+            Sort(result => result.LastModified, SortOptions.String);
+            Stores.Add(result => result.LastModified, FieldStorage.Yes);
         }
+
     }
 }

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -295,6 +295,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Hosting\Options.cs" />
+    <Compile Include="Infrastructure\RavenDB\Expiration\ExpiredDocumentsCleaner.cs" />
     <Compile Include="Infrastructure\Settings\CheckSettingsFeature.cs" />
     <Compile Include="Infrastructure\Settings\NullableRegistryReader.cs" />
     <Compile Include="Infrastructure\RavenDB\Expiration\ExpiryProcessedMessageIndex.cs" />
@@ -360,7 +361,7 @@
     <Compile Include="Infrastructure\Installers\AuditQueueInstaller.cs" />
     <Compile Include="Infrastructure\Installers\CreateEventSource.cs" />
     <Compile Include="Infrastructure\Plugins\RegisterPluginMessages.cs" />
-    <Compile Include="Infrastructure\RavenDB\Expiration\ExpiredDocumentsCleaner.cs" />
+    <Compile Include="Infrastructure\RavenDB\Expiration\ExpiredDocumentsCleanerBundle.cs" />
     <Compile Include="Infrastructure\SubscribeToOwnEvents.cs" />
     <Compile Include="Infrastructure\RavenDB\RavenUnitOfWorkBehavior.cs" />
     <Compile Include="Licensing\ActiveLicense.cs" />


### PR DESCRIPTION
 * Use RavenLastModified date for expiring documents
 * Add a scoped raven last modified helper for testing
 * remove MessageStatus.ResolvedSuccessfully : MessageStatus.Successful
usage since those are the only statuses we query on it is redundant data
to store in the index
 * dont store MessageId in the index, we only use __document_id so
MessageId is redundant
 * simplify and speed up tests but only applying the expiry bundle to the
test that require it