### PR TITLE
Corrected sorting of failed messages inside an error group 

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_message_groups_are_sorted_by_a_web_api_call.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_message_groups_are_sorted_by_a_web_api_call.cs
@@ -1,0 +1,155 @@
+namespace ServiceBus.Management.AcceptanceTests.Recoverability.Groups
+{
+    using System;
+    using System.Collections.Generic;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Config;
+    using NServiceBus.Features;
+    using NServiceBus.Settings;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+    using NUnit.Framework;
+    using ServiceBus.Management.AcceptanceTests.Contexts;
+
+    using ServiceControl.MessageFailures;
+    using ServiceControl.MessageFailures.Api;
+
+    public class When_message_groups_are_sorted_by_a_web_api_call : AcceptanceTest
+    {
+        const string MessageId = "014b048-2b7b-4f94-8eda-d5be0fe50e92";
+
+        [Test]
+        public void All_messages_in_group_should_be_sorted_by_time_sent()
+        {
+            List<FailedMessageView> errors;
+
+            SortTest("time_sent", out errors);
+
+            Assert.IsTrue(errors[0].MessageId.StartsWith("1"));
+            Assert.IsTrue(errors[1].MessageId.StartsWith("2"));
+            Assert.IsTrue(errors[2].MessageId.StartsWith("3"));
+        }
+
+        [Test]
+        public void All_messages_in_group_should_be_sorted_by_message_type()
+        {
+            List<FailedMessageView> errors;
+
+            SortTest("message_type", out errors);
+
+            Assert.IsTrue(errors[0].MessageId.StartsWith("1"));
+            Assert.IsTrue(errors[1].MessageId.StartsWith("2"));
+            Assert.IsTrue(errors[2].MessageId.StartsWith("3"));
+        }
+
+        void SortTest(string sortProperty, out List<FailedMessageView> errors)
+        {
+            var context = new MyContext();
+
+            List<FailedMessageView> localErrors = null;
+
+            Scenario.Define(context)
+                .WithEndpoint<ManagementEndpoint>(c => c.AppConfig(PathToAppConfig))
+                .WithEndpoint<Receiver>()
+                .Done(c =>
+                {
+                    List<FailedMessage.FailureGroup> groups;
+
+                    if (!TryGetMany("/api/recoverability/groups", out groups))
+                    {
+                        return false;
+                    }
+
+                    if (groups.Count != 1)
+                    {
+                        return false;
+                    }
+
+                    if (!TryGetMany("/api/recoverability/groups/" + groups[0].Id + "/errors?page=1&direction=asc&sort=" + sortProperty, out localErrors))
+                    {
+                        return false;
+                    }
+
+                    if (localErrors.Count != 3)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                })
+                .Run();
+
+            errors = localErrors;
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<SecondLevelRetries>())
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 1;
+                        c.MaximumConcurrencyLevel = 1; // this should mean they get processed one at a time
+                    })
+                    .AuditTo(Address.Parse("audit"));
+            }
+
+            public class SendFailedMessage : IWantToRunWhenBusStartsAndStops
+            {
+                readonly ISendMessages sendMessages;
+                readonly ReadOnlySettings settings;
+
+                public SendFailedMessage(ISendMessages sendMessages, ReadOnlySettings settings)
+                {
+                    this.sendMessages = sendMessages;
+                    this.settings = settings;
+                }
+
+                public void Start()
+                {
+                    var msg = CreateTransportMessage(2);
+
+                    sendMessages.Send(msg, new SendOptions(Address.Parse("error")));
+
+                    msg = CreateTransportMessage(1);
+
+                    sendMessages.Send(msg, new SendOptions(Address.Parse("error")));
+
+                    msg = CreateTransportMessage(3);
+
+                    sendMessages.Send(msg, new SendOptions(Address.Parse("error")));
+                }
+
+                TransportMessage CreateTransportMessage(int i)
+                {
+                    var date = new DateTime(2015, 9 + i, 20 + i, 0, 0, 0);
+                    var msg = new TransportMessage(i + MessageId, new Dictionary<string, string>
+                    {
+                        {Headers.ProcessingEndpoint, "EndpointName"},
+                        {"NServiceBus.ExceptionInfo.ExceptionType", "System.Exception"},
+                        {"NServiceBus.ExceptionInfo.Message", "An error occurred"},
+                        {"NServiceBus.ExceptionInfo.Source", "NServiceBus.Core"},
+                        {"NServiceBus.FailedQ", settings.LocalAddress().ToString()},
+                        {"NServiceBus.TimeOfFailure", "2014-11-11 02:26:58:000462 Z"},
+                        {Headers.TimeSent, DateTimeExtensions.ToWireFormattedString(date)},
+                        {Headers.EnclosedMessageTypes, "MessageThatWillFail" + i},
+                    });
+                    return msg;
+                }
+
+                public void Stop()
+                {
+
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyContext : ScenarioContext
+        {
+            
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -216,6 +216,7 @@
     <Compile Include="Recoverability\Groups\When_a_group_is_archived.cs" />
     <Compile Include="Recoverability\Groups\When_a_message_fails_twice_with_different_exceptions.cs" />
     <Compile Include="Recoverability\Groups\When_a_message_has_failed.cs" />
+    <Compile Include="Recoverability\Groups\When_message_groups_are_sorted_by_a_web_api_call.cs" />
     <Compile Include="Recoverability\Groups\When_two_similar_messages_have_failed.cs" />
     <Compile Include="SagaAudit\When_multiple_messages_are_emitted_by_a_saga.cs" />
     <Compile Include="SagaAudit\When_a_message_emitted_by_a_saga_is_audited.cs" />

--- a/src/ServiceControl/Recoverability/Grouping/Raven/FailedMessages_ByGroup.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Raven/FailedMessages_ByGroup.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Recoverability
 {
+    using System;
     using System.Linq;
     using Raven.Abstractions.Indexing;
     using Raven.Client.Indexes;
@@ -10,14 +11,17 @@ namespace ServiceControl.Recoverability
         public FailedMessages_ByGroup()
         {
             Map = docs => from doc in docs
+                let metadata = doc.ProcessingAttempts.Last().MessageMetadata
                 from failureGroup in doc.FailureGroups
                 select new FailureGroupMessageView
                 {
-                    Id = doc.Id, 
+                    Id = doc.Id,
                     MessageId = doc.UniqueMessageId,
                     FailureGroupId = failureGroup.Id,
                     FailureGroupName = failureGroup.Title,
-                    Status = doc.Status
+                    Status = doc.Status,
+                    MessageType = (string) metadata["MessageType"],
+                    TimeSent = (DateTime) metadata["TimeSent"]
                 };
 
             StoreAllFields(FieldStorage.Yes);

--- a/src/ServiceControl/Recoverability/Grouping/Raven/FailureGroupMessageView.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Raven/FailureGroupMessageView.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Recoverability
 {
+    using System;
     using ServiceControl.MessageFailures;
 
     public class FailureGroupMessageView: IHaveStatus
@@ -9,5 +10,7 @@ namespace ServiceControl.Recoverability
         public string FailureGroupName { get; set; }
         public FailedMessageStatus Status { get; set; }
         public string MessageId { get; set; }
+        public DateTime TimeSent { get; set; }
+        public string MessageType { get; set; }
     }
 }


### PR DESCRIPTION
## Who's affected
Anyone using ServiceControl version 1.6.0 and up.

## Symptoms
When browsing failed message inside an Error Group the messages were not sorted properly.

Here is an example of messages sorted by Time Sent:
![untitled](https://cloud.githubusercontent.com/assets/8087733/10577538/5b63435c-766c-11e5-8ae4-291516d5b0f3.png)

Relates to https://github.com/Particular/ServicePulse/issues/195