### PR TITLE
Event broadcast not working

### DIFF
--- a/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
@@ -44,7 +44,7 @@
 
         protected Dictionary<string, string> AppConfigurationSettings = new Dictionary<string, string>();
         string pathToAppConfig;
-        int port;
+        protected int port;
         string ravenPath;
         [NonSerialized]
         ITransportIntegration transportToUse;

--- a/src/ServiceControl.AcceptanceTests/CustomChecks/When_a_custom_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/CustomChecks/When_a_custom_check_fails.cs
@@ -24,7 +24,7 @@
                 .Done(c => TryGetSingle("/api/eventlogitems/", out entry, e => e.EventType == typeof(CustomCheckFailed).Name))
                 .Run();
 
-            Assert.AreEqual(Severity.Error, entry.Severity, "Failed custom checks should be treated as info");
+            Assert.AreEqual(Severity.Error, entry.Severity, "Failed custom checks should be treated as error");
             Assert.IsTrue(entry.RelatedTo.Any(item => item == "/customcheck/MyCustomCheckId"));
             Assert.IsTrue(entry.RelatedTo.Any(item => item.StartsWith("/endpoint/CustomChecks.EndpointWithFailingCustomCheck")));
         }

--- a/src/ServiceControl.AcceptanceTests/CustomChecks/When_a_periodic_custom_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/CustomChecks/When_a_periodic_custom_check_fails.cs
@@ -1,12 +1,19 @@
 ﻿namespace ServiceBus.Management.AcceptanceTests.CustomChecks
 {
     using System;
+    using System.Globalization;
     using System.Linq;
+    using System.Net;
     using Contexts;
+    using Microsoft.AspNet.SignalR.Client;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using NServiceBus;
     using NServiceBus.AcceptanceTesting;
     using NUnit.Framework;
     using ServiceControl.Contracts.CustomChecks;
     using ServiceControl.EventLog;
+    using ServiceControl.Infrastructure.SignalR;
     using ServiceControl.Plugin.CustomChecks;
 
     [TestFixture]
@@ -25,16 +32,106 @@
                 .Done(c => TryGetSingle("/api/eventlogitems/", out entry, e => e.EventType == typeof(CustomCheckFailed).Name))
                 .Run();
 
-            Assert.AreEqual(Severity.Error, entry.Severity, "Failed custom checks should be treated as info");
+            Assert.AreEqual(Severity.Error, entry.Severity, "Failed custom checks should be treated as error");
             Assert.IsTrue(entry.RelatedTo.Any(item => item == "/customcheck/MyCustomCheckId"));
             Assert.IsTrue(entry.RelatedTo.Any(item => item.StartsWith("/endpoint/CustomChecks.EndpointWithFailingCustomCheck")));
-           
         }
 
+        [Test]
+        public void Should_raise_a_signalr_event()
+        {
+            var context = new MyContext
+            {
+                SCPort = port
+            };
 
+            Scenario.Define(context)
+                .WithEndpoint<ManagementEndpoint>(c => c.AppConfig(PathToAppConfig))
+                .WithEndpoint<EndpointWithFailingCustomCheck>()
+                .WithEndpoint<EndpointThatUsesSignalR>()
+                .Done(c => c.SignalrEventReceived)
+                .Run();
+
+            Assert.IsNotNull(context.SignalrData);
+        }
+        
         public class MyContext : ScenarioContext
         {
-            public string CustomCheckId { get; set; }
+            public bool SignalrEventReceived { get; set; }
+            public string SignalrData { get; set; }
+            public int SCPort { get; set; }
+        }
+
+        public class EndpointThatUsesSignalR : EndpointConfigurationBuilder
+        {
+            public EndpointThatUsesSignalR()
+            {
+                EndpointSetup<DefaultServerWithoutAudit>();
+            }
+
+            class SignalrStarter : IWantToRunWhenBusStartsAndStops
+            {
+                private readonly MyContext context;
+                Connection connection;
+
+                public SignalrStarter(MyContext context)
+                {
+                    this.context = context;
+                    connection = new Connection(string.Format("http://localhost:{0}/api/messagestream", context.SCPort));
+                }
+
+                public void Start()
+                {
+                    var serializerSettings = new JsonSerializerSettings
+                    {
+                        ContractResolver = new CustomSignalRContractResolverBecauseOfIssue500InSignalR(),
+                        Formatting = Formatting.None,
+                        NullValueHandling = NullValueHandling.Ignore,
+                        Converters = { new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.RoundtripKind } }
+                    };
+
+                    connection.JsonSerializer = Newtonsoft.Json.JsonSerializer.Create(serializerSettings);
+                    connection.Received += ConnectionOnReceived;
+
+                    while (true)
+                    {
+                        try
+                        {
+                            connection.Start().Wait();
+                            break;
+                        }
+                        catch (AggregateException ex)
+                        {
+                            var exception = ex.GetBaseException();
+                            var webException = exception as WebException;
+
+                            if (webException == null)
+                            {
+                                continue;
+                            }
+                            var statusCode = ((HttpWebResponse)webException.Response).StatusCode;
+                            if (statusCode != HttpStatusCode.NotFound && statusCode != HttpStatusCode.ServiceUnavailable)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                private void ConnectionOnReceived(string s)
+                {
+                    if (s.IndexOf("\"CustomCheckFailed\"") > 0)
+                    {
+                        context.SignalrData = s;
+                        context.SignalrEventReceived = true;
+                    }
+                }
+
+                public void Stop()
+                {
+                    connection.Stop();
+                }
+            }
         }
 
         public class EndpointWithFailingCustomCheck : EndpointConfigurationBuilder
@@ -47,13 +144,23 @@
 
             class FailingCustomCheck : PeriodicCheck
             {
-                public FailingCustomCheck() : base("MyCustomCheckId", "MyCategory", TimeSpan.FromHours(1))
+                bool executed;
+                
+                public FailingCustomCheck() : base("MyCustomCheckId", "MyCategory", TimeSpan.FromSeconds(5))
                 {
                 }
 
                 public override CheckResult PerformCheck()
                 {
-                    return CheckResult.Failed("Some reason");
+                    if (executed)
+                    {
+                        return CheckResult.Failed("Some reason");
+                    }
+
+                    executed = true;
+
+                    return CheckResult.Pass;
+
                 }
             }
         }

--- a/src/ServiceControl/Infrastructure/OWIN/Startup.cs
+++ b/src/ServiceControl/Infrastructure/OWIN/Startup.cs
@@ -27,13 +27,17 @@
 
                 return func();
             });
+
+            var resolver = new AutofacDependencyResolver();
             
             app.MapConnection<MessageStreamerConnection>("/messagestream",
                 new ConnectionConfiguration
                 {
                     EnableCrossDomain = true,
-                    Resolver = new AutofacDependencyResolver()
+                    Resolver = resolver
                 });
+
+            GlobalHost.DependencyResolver = resolver;
 
             app.UseNancy(new NancyOptions { Bootstrapper = new NServiceBusContainerBootstrapper() });
         }


### PR DESCRIPTION
Connects to #590

SignalR was resolving a separate connection when broadcasting messages. This meant that successfully connected clients were not receiving messages.