### PR TITLE
Handling failures when publishing to external integrations

### DIFF
--- a/src/ServiceControl.AcceptanceTests/CustomChecks/Custom_check_should_only_trigger_events_on_transition.cs
+++ b/src/ServiceControl.AcceptanceTests/CustomChecks/Custom_check_should_only_trigger_events_on_transition.cs
@@ -32,7 +32,6 @@
 
         public class MyContext : ScenarioContext
         {
-            public string CustomCheckId { get; set; }
         }
 
         public class EndpointWithFailingCustomCheck : EndpointConfigurationBuilder

--- a/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_message_has_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_message_has_failed.cs
@@ -1,13 +1,10 @@
 ﻿namespace ServiceBus.Management.AcceptanceTests
 {
     using System;
-    using System.Globalization;
     using System.Linq;
     using System.Net;
     using System.Text.RegularExpressions;
     using Contexts;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.Config;
@@ -161,21 +158,7 @@
 
                 public void Start()
                 {
-                    var serializerSettings = new JsonSerializerSettings
-                    {
-                        ContractResolver = new CustomSignalRContractResolverBecauseOfIssue500InSignalR(),
-                        Formatting = Formatting.None,
-                        NullValueHandling = NullValueHandling.Ignore,
-                        Converters =
-                        {
-                            new IsoDateTimeConverter
-                            {
-                                DateTimeStyles = DateTimeStyles.RoundtripKind
-                            }
-                        }
-                    };
-
-                    connection.JsonSerializer = Newtonsoft.Json.JsonSerializer.Create(serializerSettings);
+                    connection.JsonSerializer = Newtonsoft.Json.JsonSerializer.Create(SerializationSettingsFactoryForSignalR.CreateDefault());
                     connection.Received += ConnectionOnReceived;
 
                     while (true)

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Contexts\TransportIntegration\MsmqTransportIntegration.cs" />
     <Compile Include="Contexts\TransportIntegration\SqlServerTransportIntegration.cs" />
     <Compile Include="Contexts\TransportIntegration\RabbitMqTransportIntegration.cs" />
+    <Compile Include="CustomChecks\Custom_check_transition_should_trigger_signalr_event.cs" />
     <Compile Include="CustomChecks\Custom_check_should_only_trigger_events_on_transition.cs" />
     <Compile Include="CustomChecks\When_a_custom_check_fails.cs" />
     <Compile Include="CustomChecks\When_a_periodic_custom_check_fails.cs" />

--- a/src/ServiceControl.AcceptanceTests/When_signalr_receives_a_message.cs
+++ b/src/ServiceControl.AcceptanceTests/When_signalr_receives_a_message.cs
@@ -1,12 +1,9 @@
 ﻿namespace ServiceBus.Management.AcceptanceTests
 {
     using System;
-    using System.Globalization;
     using System.Net;
     using Contexts;
     using Microsoft.AspNet.SignalR.Client;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
     using NUnit.Framework;
@@ -31,17 +28,10 @@
                 .WithEndpoint<ManagementEndpointEx>(b => b.AppConfig(PathToAppConfig)
                     .When(_ =>
                     {
-                        var connection = new Connection("http://localhost:33333/api/messagestream");
-
-                        var serializerSettings = new JsonSerializerSettings
+                        var connection = new Connection("http://localhost:33333/api/messagestream")
                         {
-                            ContractResolver = new CustomSignalRContractResolverBecauseOfIssue500InSignalR(),
-                            Formatting = Formatting.None,
-                            NullValueHandling = NullValueHandling.Ignore,
-                            Converters = {new IsoDateTimeConverter {DateTimeStyles = DateTimeStyles.RoundtripKind}}
+                            JsonSerializer = JsonSerializer.Create(SerializationSettingsFactoryForSignalR.CreateDefault())
                         };
-
-                        connection.JsonSerializer = JsonSerializer.Create(serializerSettings);
 
                         while (true)
                         {

--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditAttachment.cs
@@ -29,7 +29,12 @@ namespace ServiceControl.Config.UI.InstanceEdit
             viewModel.ValidationTemplate = validationTemplate;
 
             viewModel.Save = new ReactiveCommand().DoAsync(Save);
-            viewModel.Cancel = Command.Create(() => viewModel.TryClose(false), IsInProgress);
+            viewModel.Cancel = Command.Create(() =>
+            {
+                viewModel.TryClose(false);
+                eventAggregator.PublishOnUIThread(new RefreshInstances());
+            }, IsInProgress);
+
         }
 
         bool IsInProgress()

--- a/src/ServiceControl/EventLog/Definitions/ExternalIntegrationEventFailedToBePublishedDefinition.cs
+++ b/src/ServiceControl/EventLog/Definitions/ExternalIntegrationEventFailedToBePublishedDefinition.cs
@@ -1,0 +1,13 @@
+namespace ServiceControl.EventLog.Definitions
+{
+    using ServiceControl.ExternalIntegrations;
+
+    class ExternalIntegrationEventFailedToBePublishedDefinition : EventLogMappingDefinition<ExternalIntegrationEventFailedToBePublished>
+    {
+        public ExternalIntegrationEventFailedToBePublishedDefinition()
+        {
+            Description(m => string.Format("'{0}' failed to be published to other integration points. Reason for failure: {1}", m.EventType, m.Reason));
+            TreatAsError();
+        }
+    }
+}

--- a/src/ServiceControl/ExternalIntegrations/ExternalIntegrationEventFailedToBePublished.cs
+++ b/src/ServiceControl/ExternalIntegrations/ExternalIntegrationEventFailedToBePublished.cs
@@ -1,0 +1,11 @@
+namespace ServiceControl.ExternalIntegrations
+{
+    using System;
+    using NServiceBus;
+
+    public class ExternalIntegrationEventFailedToBePublished : IEvent
+    {
+        public Type EventType { get; set; }
+        public string Reason { get; set; }
+    }
+}

--- a/src/ServiceControl/Infrastructure/Nancy/JsonNetSerializer.cs
+++ b/src/ServiceControl/Infrastructure/Nancy/JsonNetSerializer.cs
@@ -12,24 +12,33 @@
 
     public class JsonNetSerializer : ISerializer
     {
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="JsonNetSerializer" /> class.
-        /// </summary>
-        public JsonNetSerializer()
+        public static JsonSerializerSettings CreateDefault()
         {
-            var serializerSettings = new JsonSerializerSettings
+            return new JsonSerializerSettings
             {
                 ContractResolver = new UnderscoreMappingResolver(),
                 Formatting = Formatting.None,
                 NullValueHandling = NullValueHandling.Ignore,
                 Converters =
                 {
-                    new IsoDateTimeConverter {DateTimeStyles = DateTimeStyles.RoundtripKind}, 
-                    new StringEnumConverter{CamelCaseText = true},
-
+                    new IsoDateTimeConverter
+                    {
+                        DateTimeStyles = DateTimeStyles.RoundtripKind
+                    },
+                    new StringEnumConverter
+                    {
+                        CamelCaseText = true
+                    },
                 }
             };
-            serializer = JsonSerializer.Create(serializerSettings);
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="JsonNetSerializer" /> class.
+        /// </summary>
+        public JsonNetSerializer()
+        {
+            serializer = JsonSerializer.Create(CreateDefault());
         }
 
         /// <summary>

--- a/src/ServiceControl/Infrastructure/OWIN/ApiFeature.cs
+++ b/src/ServiceControl/Infrastructure/OWIN/ApiFeature.cs
@@ -1,12 +1,9 @@
 ﻿namespace ServiceBus.Management.Infrastructure.OWIN
 {
-    using System.Globalization;
     using System.Threading.Tasks;
     using Microsoft.AspNet.SignalR;
     using Microsoft.AspNet.SignalR.Json;
     using Microsoft.Owin.Hosting;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
     using NServiceBus.Features;
     using NServiceBus.Logging;
     using ServiceBus.Management.Infrastructure.Settings;
@@ -27,18 +24,7 @@
         {
             protected override void OnStart()
             {
-                var serializer = new JsonNetSerializer(new JsonSerializerSettings
-                {
-                    ContractResolver = new CustomSignalRContractResolverBecauseOfIssue500InSignalR(),
-                    Formatting = Formatting.None,
-                    NullValueHandling = NullValueHandling.Ignore,
-                    Converters = { 
-                    new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.RoundtripKind }, 
-                    new StringEnumConverter { CamelCaseText = true }
-                }
-                });
-
-                GlobalHost.DependencyResolver.Register(typeof(IJsonSerializer), () => serializer);
+                GlobalHost.DependencyResolver.Register(typeof(IJsonSerializer), SerializationSettingsFactoryForSignalR.CreateDefault);
             }
         }
 

--- a/src/ServiceControl/Infrastructure/OWIN/Startup.cs
+++ b/src/ServiceControl/Infrastructure/OWIN/Startup.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using global::Nancy.Owin;
     using Microsoft.AspNet.SignalR;
     using Microsoft.Owin;
@@ -12,8 +11,6 @@
     using ServiceControl.Infrastructure.SignalR;
     using Autofac;
     using Microsoft.AspNet.SignalR.Json;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
     using JsonNetSerializer = Microsoft.AspNet.SignalR.Json.JsonNetSerializer;
 
     public class Startup
@@ -50,20 +47,7 @@
 
             GlobalHost.DependencyResolver = resolver;
 
-            var serializerSettings = new JsonSerializerSettings
-            {
-                ContractResolver = new CustomSignalRContractResolverBecauseOfIssue500InSignalR(),
-                Formatting = Formatting.None,
-                NullValueHandling = NullValueHandling.Ignore,
-                Converters =
-                {
-                    new IsoDateTimeConverter
-                    {
-                        DateTimeStyles = DateTimeStyles.RoundtripKind
-                    }
-                }
-            };
-            var jsonSerializer = new JsonNetSerializer(serializerSettings);
+            var jsonSerializer = new JsonNetSerializer(SerializationSettingsFactoryForSignalR.CreateDefault());
             GlobalHost.DependencyResolver.Register(typeof(IJsonSerializer), () => jsonSerializer);
         }
     }

--- a/src/ServiceControl/Infrastructure/SignalR/SerializationSettingsFactoryForSignalR.cs
+++ b/src/ServiceControl/Infrastructure/SignalR/SerializationSettingsFactoryForSignalR.cs
@@ -1,0 +1,14 @@
+﻿namespace ServiceControl.Infrastructure.SignalR
+{
+    using Newtonsoft.Json;
+
+    public static class SerializationSettingsFactoryForSignalR
+    {
+        public static JsonSerializerSettings CreateDefault()
+        {
+            var s = ServiceBus.Management.Infrastructure.Nancy.JsonNetSerializer.CreateDefault();
+            s.ContractResolver = new CustomSignalRContractResolverBecauseOfIssue500InSignalR();
+            return s;
+        }
+    }
+}

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -249,6 +249,7 @@
     <Compile Include="CustomChecks\CustomCheckNotifications.cs" />
     <Compile Include="CustomChecks\CustomChecksFeature.cs" />
     <Compile Include="CustomChecks\InternalMessages\ReportCustomCheckResult.cs" />
+    <Compile Include="EventLog\Definitions\ExternalIntegrationEventFailedToBePublishedDefinition.cs" />
     <Compile Include="EventLog\Definitions\FailedMessageGroupArchivedDefinition.cs" />
     <Compile Include="EventLog\Definitions\MessagesSubmittedForRetryDefinition.cs" />
     <Compile Include="EventLog\Definitions\MessagesSubmittedForRetryFailedDefinition.cs" />
@@ -261,6 +262,7 @@
     <Compile Include="ExternalIntegrations\ExternalIntegrationDispatchRequest.cs" />
     <Compile Include="ExternalIntegrations\EventDispatcher.cs" />
     <Compile Include="ExternalIntegrations\EventMappingHandler.cs" />
+    <Compile Include="ExternalIntegrations\ExternalIntegrationEventFailedToBePublished.cs" />
     <Compile Include="ExternalIntegrations\ExternalIntegrationsFeature.cs" />
     <Compile Include="ExternalIntegrations\CustomCheckFailedPublisher.cs" />
     <Compile Include="ExternalIntegrations\HeartbeatRestoredPublisher.cs" />

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -297,6 +297,7 @@
     <Compile Include="Infrastructure\PeriodicExecutor.cs" />
     <Compile Include="Infrastructure\Settings\RegistryReader.cs" />
     <Compile Include="Infrastructure\Settings\NullableSettingsReader.cs" />
+    <Compile Include="Infrastructure\SignalR\SerializationSettingsFactoryForSignalR.cs" />
     <Compile Include="MessageFailures\FailedMessageViewIndexNotifications.cs" />
     <Compile Include="MessageFailures\FailedMessagesFeature.cs" />
     <Compile Include="MessageFailures\Handlers\IFailedMessageEnricher.cs" />


### PR DESCRIPTION
If the publishing of an event to external integrations fails continuosly, SC is shutdown.

This PR catches exceptions as part of the publishing, logs them in the log file and also adds them to the append log that SC keeps and is displayed in SP.