### PR TITLE
DO NOT MERGE - Added additional logging to RetryAllInGroup handler

### DIFF
--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -256,5 +256,8 @@
       <Name>ServiceControl</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -134,6 +134,9 @@
   <ItemGroup>
     <Folder Include="AuditImport\" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/ServiceControl/Recoverability/Retries/RetriesGateway.cs
+++ b/src/ServiceControl/Recoverability/Retries/RetriesGateway.cs
@@ -6,6 +6,7 @@ namespace ServiceControl.Recoverability
     using System.Linq;
     using System.Linq.Expressions;
     using System.Threading.Tasks;
+    using NServiceBus.Logging;
     using Raven.Abstractions.Data;
     using Raven.Client;
     using Raven.Client.Indexes;
@@ -69,24 +70,28 @@ namespace ServiceControl.Recoverability
             var currentBatch = new List<string>(BatchSize);
 
             using (var session = Store.OpenSession())
-            using (var stream = request.GetDocuments(session))
             {
-                while (stream.MoveNext())
+                Logger.Info("Retry group: Loading documents for request");
+                using (var stream = request.GetDocuments(session))
                 {
-                    currentBatch.Add(stream.Current.Document.UniqueMessageId);
-                    if (currentBatch.Count == BatchSize)
+                    while (stream.MoveNext())
+                    {
+                        currentBatch.Add(stream.Current.Document.UniqueMessageId);
+                        if (currentBatch.Count == BatchSize)
+                        {
+                            batches.Add(currentBatch.ToArray());
+                            currentBatch.Clear();
+                        }
+                    }
+
+                    if (currentBatch.Any())
                     {
                         batches.Add(currentBatch.ToArray());
-                        currentBatch.Clear();
                     }
-                }
-
-                if (currentBatch.Any())
-                {
-                    batches.Add(currentBatch.ToArray());
                 }
             }
 
+            Logger.InfoFormat("Retry group: Loaded {0} new messages to retry", batches.Count);
             return batches;
         }
 
@@ -94,8 +99,10 @@ namespace ServiceControl.Recoverability
             where TIndex : AbstractIndexCreationTask, new()
             where TType : IHaveStatus
         {
+            Logger.InfoFormat("Retry group: Starting retry for index with context: {0}", context ?? "null");
             var request = new IndexBasedBulkRetryRequest<TType, TIndex>(context, filter);
 
+            Logger.Info("Retry group: Enqueuing IndexBasedBulkRetryRequest");
             _bulkRequests.Enqueue(request);
         }
 
@@ -103,10 +110,14 @@ namespace ServiceControl.Recoverability
         {
             if (messageIds == null || !messageIds.Any())
             {
+            Logger.Info("Retry group: No messages to retry");
                 return;
             }
 
+            Logger.InfoFormat("Retry group: Retrying messages '{0}'", string.Join(", ", messageIds));
+
             var batchDocumentId = RetryDocumentManager.CreateBatchDocument(context);
+            Logger.InfoFormat("Retry group: Retrying batch document with Id {0}", batchDocumentId);
 
             var retryIds = new ConcurrentSet<string>();
             Parallel.ForEach(
@@ -118,24 +129,31 @@ namespace ServiceControl.Recoverability
 
         internal bool ProcessNextBulkRetry()
         {
+            Logger.Info("Retry group: Processing next bulk retry");
             IBulkRetryRequest request;
             if (!_bulkRequests.TryDequeue(out request))
             {
                 return false;
             }
 
+            Logger.Info("Retry group: Bulk retry found");
             ProcessRequest(request);
             return true;
         }
 
         void ProcessRequest(IBulkRetryRequest request)
         {
+            Logger.Info("Retry group: Processing IBulkRetryRequest");
             var batches = GetRequestedBatches(request);
 
             for (var i = 0; i < batches.Count; i++)
             {
                 StageRetryByUniqueMessageIds(batches[i], request.GetBatchName(i + 1, batches.Count));
             }
+
+            Logger.Info("Retry group: Finished processing IBulkRetryRequest");
         }
+
+        static readonly ILog Logger = LogManager.GetLogger(typeof(RetriesGateway));
     }
 }

--- a/src/ServiceControlInstaller.CustomActions.UnitTests/ServiceControlInstaller.CustomActions.UnitTests.csproj
+++ b/src/ServiceControlInstaller.CustomActions.UnitTests/ServiceControlInstaller.CustomActions.UnitTests.csproj
@@ -74,6 +74,9 @@
       <Name>ServiceControlInstaller.CustomActions</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
@@ -94,6 +94,9 @@
       <Name>ServiceControlInstaller.Engine</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
This is a hotfix for LightSail to investigate why their RetryAllInGroup messages fail silently.