### PR TITLE
Change raven logging

### DIFF
--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -123,6 +123,7 @@ namespace Particular.ServiceControl
 
         static void ConfigureLogging()
         {
+            const long MegaByte = 1073741824;
             if (NLog.LogManager.Configuration != null)
             {
                 return;
@@ -139,6 +140,7 @@ namespace Particular.ServiceControl
                 ArchiveNumbering = ArchiveNumberingMode.Rolling,
                 Layout = simpleLayout,
                 MaxArchiveFiles = 14,
+                ArchiveAboveSize =  30 * MegaByte
             };
 
             var consoleTarget = new ColoredConsoleTarget

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -136,9 +136,9 @@ namespace Particular.ServiceControl
             var fileTarget = new FileTarget
             {
                 ArchiveEvery = FileArchivePeriod.Day,
-                FileName = Path.Combine(Settings.LogPath, "logfile.txt"),
-                ArchiveFileName = Path.Combine(Settings.LogPath, "log.{#}.txt"),
-                ArchiveNumbering = ArchiveNumberingMode.Rolling,
+                FileName = Path.Combine(Settings.LogPath, "logfile.${shortdate}.txt"),
+                ArchiveFileName = Path.Combine(Settings.LogPath, "logfile.{#}.txt"),
+                ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
                 Layout = simpleLayout,
                 MaxArchiveFiles = 14,
                 ArchiveAboveSize =  30 * megaByte
@@ -147,9 +147,9 @@ namespace Particular.ServiceControl
             var ravenFileTarget = new FileTarget
             {
                 ArchiveEvery = FileArchivePeriod.Day,
-                FileName = Path.Combine(Settings.LogPath, "ravenlog.txt"),
+                FileName = Path.Combine(Settings.LogPath, "ravenlog.${shortdate}.txt"),
                 ArchiveFileName = Path.Combine(Settings.LogPath, "ravenlog.{#}.txt"),
-                ArchiveNumbering = ArchiveNumberingMode.Rolling,
+                ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
                 Layout = simpleLayout,
                 MaxArchiveFiles = 14,
                 ArchiveAboveSize = 30 * megaByte

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -29,7 +29,7 @@ namespace Particular.ServiceControl
             
             // ServiceName is required to determine the default logging path
             Settings.ServiceName = DetermineServiceName(host, hostArguments);
-            ConfigureLogging();
+            ConfigureLogging(enableConsoleLogging: host == null);
             
             // .NET default limit is 10. RavenDB in conjunction with transports that use HTTP exceeds that limit.
             ServicePointManager.DefaultConnectionLimit = Settings.HttpDefaultConnectionLimit;
@@ -121,7 +121,7 @@ namespace Particular.ServiceControl
             Bus.Dispose();
         }
 
-        static void ConfigureLogging()
+        static void ConfigureLogging(bool enableConsoleLogging)
         {
             const long MegaByte = 1073741824;
             if (NLog.LogManager.Configuration != null)
@@ -152,7 +152,12 @@ namespace Particular.ServiceControl
             var nullTarget = new NullTarget();
 
             nlogConfig.AddTarget("debugger", fileTarget);
-            nlogConfig.AddTarget("console", consoleTarget);
+
+            if (enableConsoleLogging)
+            {
+                nlogConfig.AddTarget("console", consoleTarget);
+            }
+
             nlogConfig.AddTarget("bitbucket", nullTarget);
             
             // Only want to see raven errors

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -159,7 +159,7 @@
                 var level = NLog.LogLevel.Warn;
                 try
                 {
-                    level = NLog.LogLevel.FromString(SettingsReader<string>.Read("LogLevel"));
+                    level = NLog.LogLevel.FromString(SettingsReader<string>.Read("LogLevel", NLog.LogLevel.Warn.Name));
                 }
                 catch
                 {
@@ -176,7 +176,7 @@
                 var level = NLog.LogLevel.Warn;
                 try
                 {
-                    level = NLog.LogLevel.FromString(SettingsReader<string>.Read("RavenDBLogLevel"));
+                    level = NLog.LogLevel.FromString(SettingsReader<string>.Read("RavenDBLogLevel", NLog.LogLevel.Warn.Name));
                 }
                 catch
                 {

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -169,6 +169,24 @@
             }
         }
 
+        public static NLog.LogLevel RavenDBLogLevel
+        {
+            get
+            {
+                var level = NLog.LogLevel.Warn;
+                try
+                {
+                    level = NLog.LogLevel.FromString(SettingsReader<string>.Read("RavenDBLogLevel"));
+                }
+                catch
+                {
+                    NLog.Common.InternalLogger.Warn("Failed to parse RavenDBLogLevel setting. Defaulting to Warn");
+                }
+                return level;
+            }
+        }
+
+
         public static string LogPath
         {
             get


### PR DESCRIPTION
Relates to #654 and #641

- Raven Logging separated out to a different file
- New Setting RavenDBLogLevel to control the level of data written to the separate log.
- Console Target is no longer used when running as a service
- Logs now roll at 30MB
- Log file names and  archived logs names are date based for easier sorting

