### PR TITLE
Improvements to data being served to ServicePulse

### DIFF
--- a/src/ServiceControl/EventLog/EventLogApiModule.cs
+++ b/src/ServiceControl/EventLog/EventLogApiModule.cs
@@ -5,6 +5,7 @@
     using Raven.Client;
     using ServiceBus.Management.Infrastructure.Extensions;
     using ServiceBus.Management.Infrastructure.Nancy.Modules;
+    using ServiceControl.Infrastructure.Extensions;
 
     public class EventLogApiModule : BaseModule
     {
@@ -16,9 +17,11 @@
                 {
                     RavenQueryStatistics stats;
                     var results = session.Query<EventLogItem>().Statistics(out stats).OrderByDescending(p => p.RaisedAt)
-                        .ToArray();
+                    .Paging(Request)
+                    .ToArray();
 
                     return Negotiate.WithModel(results)
+                        .WithPagingLinksAndTotalCount(stats, Request)
                         .WithEtagAndLastModified(stats);
                 }
             };

--- a/src/ServiceControl/EventLog/GenericAuditHandler.cs
+++ b/src/ServiceControl/EventLog/GenericAuditHandler.cs
@@ -40,7 +40,11 @@
                 m.Description = logItem.Description;
                 m.Id = logItem.Id;
                 m.Category = logItem.Category;
-                m.RelatedTo = EmptyArray;
+                // Yes this is on purpose.
+                // The reason is because this data is not useful for end users, so for now we just empty it.
+                // At the moment too much data is being populated in this field, and this has significant down sides to the amount of data we are sending down to ServicePulse (it actually crashes it).
+                m.RelatedTo = EmptyArray; 
+
             });
         }
     }

--- a/src/ServiceControl/EventLog/GenericAuditHandler.cs
+++ b/src/ServiceControl/EventLog/GenericAuditHandler.cs
@@ -14,6 +14,8 @@
         public IDocumentSession Session { get; set; }
         public IBus Bus { get; set; }
 
+        static string[] EmptyArray = new string[0];
+
         public void Handle(IEvent message)
         {
             //to prevent a infinite loop
@@ -38,7 +40,7 @@
                 m.Description = logItem.Description;
                 m.Id = logItem.Id;
                 m.Category = logItem.Category;
-                m.RelatedTo = logItem.RelatedTo;
+                m.RelatedTo = EmptyArray;
             });
         }
     }

--- a/src/ServiceControl/Infrastructure/Extensions/QueryableExtensions.cs
+++ b/src/ServiceControl/Infrastructure/Extensions/QueryableExtensions.cs
@@ -183,7 +183,39 @@ namespace ServiceControl.Infrastructure.Extensions
 
             return source;
         }
-     
+
+        public static IOrderedQueryable<TSource> Paging<TSource>(this IOrderedQueryable<TSource> source, Request request)
+        {
+            var maxResultsPerPage = 50;
+
+            if (request.Query.per_page.HasValue)
+            {
+                maxResultsPerPage = request.Query.per_page;
+            }
+
+            if (maxResultsPerPage < 1)
+            {
+                maxResultsPerPage = 50;
+            }
+
+            var page = 1;
+
+            if (request.Query.page.HasValue)
+            {
+                page = request.Query.page;
+            }
+
+            if (page < 1)
+            {
+                page = 1;
+            }
+
+            var skipResults = (page - 1) * maxResultsPerPage;
+
+            return (IOrderedQueryable<TSource>)source.Skip(skipResults)
+                .Take(maxResultsPerPage);
+        }
+
         public static IRavenQueryable<TSource> Paging<TSource>(this IRavenQueryable<TSource> source, Request request)
         {
             var maxResultsPerPage = 50;


### PR DESCRIPTION
So far the improvements are:
- `/eventlogitems` REST call was unbounded, and ServicePulse really only needs the top 10 documents.  
  I have added paging to the REST api call
- Stop populating related_to field for `EventLogItemAdded`, this data at the moment does not make sense for an end user and can cause a lot of data to sent out to ServicePulse