### PR TITLE
Avoid the extra byte array allocation

### DIFF
--- a/src/ServiceControl/Recoverability/Retries/RetryProcessor.cs
+++ b/src/ServiceControl/Recoverability/Retries/RetryProcessor.cs
@@ -178,6 +178,17 @@ namespace ServiceControl.Recoverability
 
         static byte[] ReadFully(Stream input)
         {
+            var memoryStream = input as MemoryStream;
+            if (memoryStream != null)
+            {
+                var outArray = new byte[memoryStream.Length];
+
+                Array.Copy(memoryStream.GetBuffer(), outArray, outArray.Length);
+
+                return outArray;
+            }
+
+
             var buffer = new byte[16 * 1024];
             using (var ms = new MemoryStream())
             {


### PR DESCRIPTION
Raven majority of time uses `MemoryStream`, so we can shortcut the process when we are copying Streams to byte arrays and instead call the `GetBuffer()`.