### PR TITLE
Console log entries which detail log filenames are not rendered with date

### DIFF
--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -215,8 +215,10 @@ namespace Particular.ServiceControl
             NLog.LogManager.Configuration = nlogConfig;
 
             var logger = LogManager.GetLogger(typeof(Bootstrapper));
-            logger.InfoFormat("Logging to {0} with LoggingLevel '{1}'", fileTarget.FileName, Settings.LoggingLevel.Name);
-            logger.InfoFormat("RavenDB logging to {0} with LoggingLevel '{1}'", ravenFileTarget.FileName, Settings.RavenDBLogLevel.Name);
+            var logEventInfo = new NLog.LogEventInfo { TimeStamp = DateTime.Now };
+            logger.InfoFormat("Logging to {0} with LoggingLevel '{1}'", fileTarget.FileName.Render(logEventInfo), Settings.LoggingLevel.Name);
+            logger.InfoFormat("RavenDB logging to {0} with LoggingLevel '{1}'", ravenFileTarget.FileName.Render(logEventInfo), Settings.RavenDBLogLevel.Name);
+            
         }
 
         string DetermineServiceName(ServiceBase host, HostArguments hostArguments)


### PR DESCRIPTION
## Symptoms
The console log entries that detail the current SC and RavenDB logs show up as 
```
Logging to 'C:\Users\Greg\AppData\Local\Particular\ServiceControl\logs\logfile.${shortdate}.txt' with LoggingLevel 'Warn'
```
The ${shortdate} should be rendered to include the actual date.  

## Who's affected
All users of ServiceControl that are currently running v1.11.1.