### PR TITLE
Endpoint Started message presents date in UTC

### DIFF
--- a/src/ServiceControl/EventLog/Definitions/EndpointStartedDefinition.cs
+++ b/src/ServiceControl/EventLog/Definitions/EndpointStartedDefinition.cs
@@ -6,7 +6,7 @@
     {
         public EndpointStartedDefinition()
         {
-            Description(m => string.Format("Endpoint '{0}' started at {1} on host {2}", m.EndpointDetails.Name, m.StartedAt, m.EndpointDetails.Host));
+            Description(m => string.Format("Endpoint '{0}' started on host {2}", m.EndpointDetails.Name, m.EndpointDetails.Host));
 
             RelatesToEndpoint(m => m.EndpointDetails.Name);
             RelatesToHost(m => m.EndpointDetails.HostId);

--- a/src/ServiceControl/EventLog/Definitions/EndpointStartedDefinition.cs
+++ b/src/ServiceControl/EventLog/Definitions/EndpointStartedDefinition.cs
@@ -6,7 +6,7 @@
     {
         public EndpointStartedDefinition()
         {
-            Description(m => string.Format("Endpoint '{0}' started on host {2}", m.EndpointDetails.Name, m.EndpointDetails.Host));
+            Description(m => string.Format("Endpoint '{0}' started on host {1}", m.EndpointDetails.Name, m.EndpointDetails.Host));
 
             RelatesToEndpoint(m => m.EndpointDetails.Name);
             RelatesToHost(m => m.EndpointDetails.HostId);


### PR DESCRIPTION
## Symptoms
Dates shown in the Endpoint Started message are presented in UTC time.

## Who's affected
All users of ServiceControl that are currently running v1.11.1.

## Plan of attack

#### Service Control  

- [x] Remove the date from the message. The other messages in the list use the raised_at time. raised_at is in local time and is consistent with the other messages in the event log

#### Update documentation

There isn't any reference to this item in documentation

---

From a customer case endpoint start times are wrong

![endpoint utc](https://cloud.githubusercontent.com/assets/1644481/13829763/c4180812-ec1c-11e5-8c91-9e5e3ba7d608.PNG)

Endpoint 'SmokeTest.Client' started at 16/03/2016 9:37:56 PM on host DESKTOP-GRTSUTV 6 minutes ago

ServiceControl send the UTC date (in my case I'm UTC+11) which means the date given is 11 hrs behind the actual time of the event. But I also get told that it happened 6 minutes ago.

The call that gets this data is http://localhost:33333/api/eventlogitems

``` javascript
{

    "id": "EventLogItem/EndpointControl/EndpointStarted/3cfff3b8-fa31-4e93-8e10-a5cc008e41d0",
    "description": "Endpoint 'SmokeTest.Client' started at 16/03/2016 9:37:56 PM on host DESKTOP-GRTSUTV",
    "severity": "info",
    "raised_at": "2016-03-16T21:37:56.2911856Z",
    "related_to": 

    [
        "/endpoint/SmokeTest.Client",
        "/host/166792ae-9378-4707-5fec-70f7c5d96c4e"
    ],
    "category": "EndpointControl",
    "event_type": "EndpointStarted"

}
```
