### PR TITLE
Unable to start Particular.ServiceControl service after upgrading to 1.13.0

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddViewModel.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Windows.Input;
     using ServiceControl.Config.Commands;
+    using ServiceControlInstaller.Engine.Configuration;
     using ServiceControlInstaller.Engine.Instances;
     using SharedInstanceEditor;
     using Validar;
@@ -39,8 +40,8 @@
                 }
             }
 
-            AuditRetentionPeriod = TimeSpan.FromDays(30);
-            ErrorRetentionPeriod = TimeSpan.FromDays(15);
+            AuditRetentionPeriod = TimeSpan.FromHours(SettingConstants.AuditRetentionPeriodDefaultInHoursForUI);
+            ErrorRetentionPeriod = TimeSpan.FromDays(SettingConstants.ErrorRetentionPeriodDefaultInDaysForUI);
             Description = "A ServiceControl Instance";
             HostName = "localhost"; 
             AuditQueueName = "audit";

--- a/src/ServiceControl.Config/UI/MessageBox/SliderDialogViewModel.cs
+++ b/src/ServiceControl.Config/UI/MessageBox/SliderDialogViewModel.cs
@@ -32,11 +32,7 @@
             PeriodLargeStep = periodLargeStep;
             Cancel = Command.Create(() =>{Result = null;((IDeactivate)this).Deactivate(true);});
             Save = Command.Create(() =>{Result = true; ((IDeactivate)this).Deactivate(true);});
-
-            
         }
-        
-        
 
         public string PeriodHeader { get; set; }
         public string PeriodExplanation { get; set; }

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorViewModel.cs
@@ -7,6 +7,7 @@
     using ServiceControl.Config.Framework.Rx;
     using ServiceControl.Config.Validation;
     using ServiceControl.Config.Xaml.Controls;
+    using ServiceControlInstaller.Engine.Configuration;
     using ServiceControlInstaller.Engine.Instances;
 
     public class ForwardingOption
@@ -109,12 +110,12 @@
         public ForwardingOption AuditForwarding { get; set; }
         public ForwardingOption ErrorForwarding { get; set; }
 
-        public int MaximumErrorRetentionPeriod {get { return 45; }}
-        public int MinimumErrorRetentionPeriod { get { return 10; }}
+        public int MaximumErrorRetentionPeriod {get { return SettingConstants.ErrorRetentionPeriodMaxInDays; }}
+        public int MinimumErrorRetentionPeriod { get { return SettingConstants.ErrorRetentionPeriodMinInDays; }}
         public TimeSpanUnits ErrorRetentionUnits { get { return TimeSpanUnits.Days; }}
 
-        public int MinimumAuditRetentionPeriod  {get { return 1;}}
-        public int MaximumAuditRetentionPeriod { get { return 8760; }}  //365 days
+        public int MinimumAuditRetentionPeriod  {get { return SettingConstants.AuditRetentionPeriodMinInHours;}}
+        public int MaximumAuditRetentionPeriod { get { return SettingConstants.AuditRetentionPeriodMaxInHours; }}  
         public TimeSpanUnits AuditRetentionUnits { get { return TimeSpanUnits.Hours; }}
 
         public IEnumerable<ForwardingOption> AuditForwardingOptions{ get; private set;}

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -220,31 +220,29 @@
                 Logger.Fatal(message);
                 throw new Exception(message);
             }
-            try
-            {
-                result = TimeSpan.Parse(valueRead);
 
-                if (result < TimeSpan.FromDays(10))
+            if (TimeSpan.TryParse(valueRead, out result))
+            { 
+                if (errorRetentionPeriod < TimeSpan.FromDays(10))
                 {
                     message = "ErrorRetentionPeriod settings is invalid, value should be minimum 10 days.";
                     Logger.Fatal(message);
                     throw new Exception(message);
                 }
 
-                if (result > TimeSpan.FromDays(45))
+                if (errorRetentionPeriod > TimeSpan.FromDays(45))
                 {
                     message = "ErrorRetentionPeriod settings is invalid, value should be maximum 45 days.";
                     Logger.Fatal(message);
                     throw new Exception(message);
                 }
-            }
-            catch (Exception)
-            {
+            } 
+            else
+            { 
                 message = "ErrorRetentionPeriod settings is invalid, please make sure it is a TimeSpan.";
                 Logger.Fatal(message);
                 throw new Exception(message);
             }
-
             return result;
         }
 
@@ -259,31 +257,29 @@
                 Logger.Fatal(message);
                 throw new Exception(message);
             }
-            try
-                {
-                    result = TimeSpan.Parse(valueRead);
 
-                    if (result < TimeSpan.FromHours(1))
-                    {
-                        message = "AuditRetentionPeriod settings is invalid, value should be minimum 1 hour.";
-                        InternalLogger.Fatal(message);
-                        throw new Exception(message);
-                    }
-
-                    if (result > TimeSpan.FromDays(365))
-                    {
-                        message = "AuditRetentionPeriod settings is invalid, value should be maximum 365 days.";
-                        InternalLogger.Fatal(message);
-                        throw new Exception(message);
-                    }
-                }
-                catch (Exception)
+            if (TimeSpan.TryParse(valueRead, out result))
+            { 
+                if (result < TimeSpan.FromHours(1))
                 {
-                    message = "AuditRetentionPeriod settings is invalid, please make sure it is a TimeSpan.";
+                    message = "AuditRetentionPeriod settings is invalid, value should be minimum 1 hour.";
                     InternalLogger.Fatal(message);
                     throw new Exception(message);
                 }
-            
+
+                if (result > TimeSpan.FromDays(365))
+                {
+                    message = "AuditRetentionPeriod settings is invalid, value should be maximum 365 days.";
+                    InternalLogger.Fatal(message);
+                    throw new Exception(message);
+                }
+            }
+            else
+            {
+                message = "AuditRetentionPeriod settings is invalid, please make sure it is a TimeSpan.";
+                InternalLogger.Fatal(message);
+                throw new Exception(message);
+            }
             return result;
         }
 

--- a/src/ServiceControlInstaller.Engine/Configuration/SettingConstants.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/SettingConstants.cs
@@ -1,0 +1,13 @@
+﻿namespace ServiceControlInstaller.Engine.Configuration
+{
+    public class SettingConstants
+    {
+        public const int ErrorRetentionPeriodMaxInDays = 45;
+        public const int ErrorRetentionPeriodMinInDays = 10;
+        public const int ErrorRetentionPeriodDefaultInDaysForUI = 15;
+
+        public const int AuditRetentionPeriodMaxInHours = 8760;
+        public const int AuditRetentionPeriodMinInHours = 1;
+        public const int AuditRetentionPeriodDefaultInHoursForUI = 720;
+    }
+}

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Api\ServiceControlManager.cs" />
     <Compile Include="Api\TokenPrivileges.cs" />
     <Compile Include="Configuration\RegistryReader.cs" />
+    <Compile Include="Configuration\SettingConstants.cs" />
     <Compile Include="Configuration\SettingList.cs" />
     <Compile Include="Configuration\SettingInfo.cs" />
     <Compile Include="Instances\InstanceUpgradeOptions.cs" />


### PR DESCRIPTION
### Symptom

In ServiceControl Managment Utility released with ServiceControl 1.13 asks for a ErrorRetentionPeriod  during upgrade.  The slider control allows a range from 10 days to 50 days,
This is incorrect as the maximum value the ServiceContriol service will accept is 45 days,
When a incorrect value is set the upgrade succeeds but the service fails to start afterwards.

### Workaround

- Open the edit screen in ServiceControl Management Utility and change the value.
- Start the service

### Who's Affected

Users uograding from older versions to ServiceControl 1.13 can be affected if they change the Error Retention Period slider above 45 days

----
When I upgraded to 1.13.0, I chose to use 50 days as the retention period for archived & resolved error messages. After the upgrade installed, I was unable to start the Particular.ServiceControl service, and I could see that following exception was being thrown:

`
Service cannot be started. System.TypeInitializationException: The type initializer for 'ServiceBus.Management.Infrastructure.Settings.Settings' threw an exception. ---> System.Exception: ErrorRetentionPeriod settings is invalid, please make sure it is a TimeSpan.
   at ServiceBus.Management.Infrastructure.Settings.Settings.GetErrorRetentionPeriod() in C:\BuildAgent\work\7189a56f9f44affc\src\ServiceControl\Infrastructure\Settings\Settings.cs:line 248
   at ServiceBus.Management.Infrastructure.Settings.Settings..cctor() in C:\BuildAgent\work\7189a56f9f44affc\src\ServiceControl\Infrastructure\Settings\Settings.cs:line 23
   --- End of inner exception stack trace ---
   at Particular.ServiceControl.Bootstrapper..ctor(ServiceBase host, HostArguments hostArguments, BusConfiguration configuration) in C:\BuildAgent\work\7189a56f9f44affc\src\ServiceControl\Bootstrapper.cs:line 41
   at Particular.ServiceControl.Hosting.Host.OnStart(String[] args) in C:\BuildAgent\work\7189a56f9f44affc\src\ServiceControl\Hosting\Host.cs:line 21
   at S...
`

This is what was in the ServiceControl.exe.config file:
`<add key="ServiceControl/ErrorRetentionPeriod" value="50.00:00:00" />`

When I changed the config entry to what's shown below, everything started working:
`<add key="ServiceControl/ErrorRetentionPeriod" value="30.00:00:00" />`