### PR TITLE
ServiceControl Management and ServiceControl report different license status

### DIFF
--- a/src/ServicControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServicControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />

--- a/src/ServiceControl.AcceptanceTesting/ServiceControl.AcceptanceTesting.csproj
+++ b/src/ServiceControl.AcceptanceTesting/ServiceControl.AcceptanceTesting.csproj
@@ -24,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,6 +35,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,7 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">

--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -25,7 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -36,7 +36,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/ServiceControl.IntegrationDemo/ServiceControl.IntegrationDemo.csproj
+++ b/src/ServiceControl.IntegrationDemo/ServiceControl.IntegrationDemo.csproj
@@ -22,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,7 +32,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -22,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,7 +32,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/ActiveLicense.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/ActiveLicense.cs
@@ -1,0 +1,48 @@
+namespace Particular.Licensing
+{
+    using System.Globalization;
+    using System.Linq;
+
+    class ActiveLicense
+    {
+        /// <summary>
+        /// Compare a bunch of license sources and choose an active license
+        /// </summary>
+        public static ActiveLicenseFindResult Find(string applicationName, params LicenseSource[] licenseSources )
+        {
+            var results = licenseSources.Select(licenseSource => licenseSource.Find(applicationName)).ToList();
+            var activeLicense = new ActiveLicenseFindResult();
+            foreach (var result in results.Where(p => !string.IsNullOrWhiteSpace(p.Result)).Select(p => p.Result))
+            {
+                activeLicense.Report.Add(result);
+            }
+
+            var licenseSourceResultToUse = LicenseSourceResult.DetermineBestLicenseSourceResult(results.ToArray());
+            if (licenseSourceResultToUse != null)
+            { 
+                activeLicense.Report.Add($"Selected active license from {licenseSourceResultToUse.Location}");
+                var details = licenseSourceResultToUse.License;
+                if (details.ExpirationDate.HasValue)
+                {
+                    activeLicense.Report.Add(string.Format(CultureInfo.InvariantCulture, "License Expiration: {0:dd MMMM yyyy}", details.ExpirationDate.Value));
+
+                    if (details.UpgradeProtectionExpiration.HasValue)
+                    {
+                        activeLicense.Report.Add(string.Format(CultureInfo.InvariantCulture, "Upgrade Protection Expiration: {0:dd MMMM yyyy}", details.UpgradeProtectionExpiration.Value));
+                    }
+                }
+                activeLicense.License = details;
+                activeLicense.Location = licenseSourceResultToUse.Location;
+            }
+
+            if (activeLicense.License == null)
+            {
+                activeLicense.Report.Add("No valid license could be found, falling back to trial license");
+                activeLicense.License = License.TrialLicense(TrialStartDateStore.GetTrialStartDate());
+                activeLicense.Location = "Trial License";
+            }
+            activeLicense.HasExpired = LicenseExpirationChecker.HasLicenseExpired(activeLicense.License);
+            return activeLicense;
+        }
+    }
+}

--- a/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/ActiveLicenseFindResult.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/ActiveLicenseFindResult.cs
@@ -1,0 +1,12 @@
+﻿namespace Particular.Licensing
+{
+    using System.Collections.Generic;
+
+    class ActiveLicenseFindResult
+    {
+        internal License License { get; set; }
+        internal bool HasExpired { get; set; }
+        internal string Location { get; set; }
+        internal List<string> Report = new List<string>();
+    }
+}

--- a/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSource.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSource.cs
@@ -1,0 +1,55 @@
+﻿namespace Particular.Licensing
+{
+    using System;
+    
+    abstract class LicenseSource 
+    {
+        protected string Location;
+        
+        protected LicenseSource(string location)
+        {
+            Location = location;
+        }
+
+        public abstract LicenseSourceResult Find(string applicationName);
+
+        protected LicenseSourceResult ValidateLicense(string licenseText, string applicationName)
+        {
+            if (string.IsNullOrWhiteSpace(applicationName))
+            {
+                throw new ArgumentException("No application name specified");
+            }
+
+            var result = new LicenseSourceResult{Location = Location};
+
+            Exception validationFailure;
+            if (!LicenseVerifier.TryVerify(licenseText, out validationFailure))
+            {
+                result.Result = $"License found at '{Location}' is not valid - {validationFailure.Message}";
+                return result;
+            }
+
+            License license;
+            try
+            {
+                license = LicenseDeserializer.Deserialize(licenseText);
+            }
+            catch
+            {
+                result.Result = $"License found at '{Location}' could not be deserialized";
+                return result;
+            }
+
+            if (license.ValidForApplication(applicationName))
+            {
+                result.License = license;
+                result.Result = $"License found at '{Location}'";
+            }
+            else
+            {
+                result.Result = $"License found at '{Location}' was not valid for '{applicationName}'. Valid apps: '{string.Join(",", license.ValidApplications)}'";
+            }
+            return result;
+        }
+    }
+}

--- a/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSourceConfigFile.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSourceConfigFile.cs
@@ -1,0 +1,49 @@
+﻿namespace Particular.Licensing.FindActiveLicense
+{
+    using System.Configuration;
+    using System.IO;
+
+    class LicenseSourceConfigFile : LicenseSource
+    {
+        
+        public LicenseSourceConfigFile() : base("App config file")
+        {
+
+        }
+        
+        public override LicenseSourceResult Find(string applicationName)
+        {
+            var embeddedLicense = ReadLicenseFromAppConfig(applicationName);
+            var externalLicense = ReadExternalLicense(applicationName);
+
+            return LicenseSourceResult.DetermineBestLicenseSourceResult(embeddedLicense, externalLicense) ?? new LicenseSourceResult
+            {
+                Location = Location,
+                Result = $"License not found in {Location}"
+            };
+        }
+
+        LicenseSourceResult ReadLicenseFromAppConfig(string applicationName)
+        {
+            return ValidateLicense(ConfigurationManager.AppSettings["NServiceBus/License"], applicationName);
+        }
+
+        LicenseSourceResult ReadExternalLicense(string applicationName)
+        {
+            var appConfigLicenseFile = ConfigurationManager.AppSettings["NServiceBus/LicensePath"];
+
+            if (!string.IsNullOrEmpty(appConfigLicenseFile))
+            {
+                if (File.Exists(appConfigLicenseFile))
+                {
+                    return ValidateLicense(NonBlockingReader.ReadAllTextWithoutLocking(appConfigLicenseFile), applicationName);
+                }
+            }
+            return new LicenseSourceResult
+            {
+                Location = Location,
+                Result = $"License file not found in path supplied by app config file setting 'NServiceBus/LicensePath'.  Value was {appConfigLicenseFile}"
+            };
+        }
+    }
+}

--- a/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSourceFilePath.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSourceFilePath.cs
@@ -1,0 +1,27 @@
+﻿namespace Particular.Licensing
+{
+    using System.IO;
+
+    class LicenseSourceFilePath : LicenseSource
+    {
+        public LicenseSourceFilePath(string path) : base(path)
+        {
+            
+        }
+
+        public override LicenseSourceResult Find(string applicationName)
+        {
+            if (File.Exists(Location))
+            {
+                return ValidateLicense(NonBlockingReader.ReadAllTextWithoutLocking(Location), applicationName);
+            }
+
+            return new LicenseSourceResult
+            {
+                Location = Location,
+                Result = $"License not found in {Location}"
+            };
+        }
+    }
+}
+

--- a/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSourceHKCURegKey.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSourceHKCURegKey.cs
@@ -1,0 +1,63 @@
+﻿namespace Particular.Licensing
+{
+    using Microsoft.Win32;
+
+    class LicenseSourceHKCURegKey : LicenseSource
+    {
+        string keyPath;
+
+        public LicenseSourceHKCURegKey(string path = @"SOFTWARE\ParticularSoftware") : base(LocationFriendlyName(path))
+        {
+            keyPath = path;
+        }
+
+        static string LocationFriendlyName(string path)
+        {
+            var fixedPath = path.StartsWith(@"\") ? path : @"\" + path;
+            return string.Concat("HKEY_CURRENT_USER", fixedPath);
+        }
+
+        public override LicenseSourceResult Find(string applicationName)
+        {
+           var regLicense = ReadLicenseFromRegistry(RegistryView.Default);
+            
+            if (!string.IsNullOrWhiteSpace(regLicense))
+            {
+                return ValidateLicense(regLicense, applicationName);
+            }
+
+            return new LicenseSourceResult
+            {
+                Location = Location,
+                Result = $"License not found in {Location}"
+            };
+        }
+
+        string ReadLicenseFromRegistry(RegistryView view)
+        {
+            try
+            {
+                using (var rootKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, view))
+                using (var registryKey = rootKey.OpenSubKey(keyPath))
+                {
+                    if (registryKey == null)
+                    {
+                        return null;
+                    }
+
+                    var licenseValue = registryKey.GetValue("License", null);
+
+                    if (licenseValue is string[])
+                    {
+                        return string.Join(" ", (string[])licenseValue);
+                    }
+                    return (string)licenseValue;
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSourceHKLMRegKey.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSourceHKLMRegKey.cs
@@ -1,0 +1,65 @@
+﻿namespace Particular.Licensing
+{
+    using System.Security;
+    using Microsoft.Win32;
+
+    class LicenseSourceHKLMRegKey : LicenseSource
+    {
+        string keyPath;
+        
+        public LicenseSourceHKLMRegKey(string path = @"SOFTWARE\ParticularSoftware") : base(LocationFriendlyName(path))
+        {
+            keyPath = path;
+        }
+
+        static string LocationFriendlyName(string path)
+        {
+            var fixedPath = path.StartsWith(@"\") ? path : @"\" + path;
+            return string.Concat("HKEY_LOCAL_MACHINE", fixedPath);
+        }
+
+        public override LicenseSourceResult Find(string applicationName)
+        {
+            var reg32Result = ReadFromRegistry(RegistryView.Registry32, applicationName);
+            var reg64Result = ReadFromRegistry(RegistryView.Registry64, applicationName);
+
+            return LicenseSourceResult.DetermineBestLicenseSourceResult(reg32Result, reg64Result) ?? new LicenseSourceResult
+            {
+                Location = Location,
+                Result = $"License not found in {Location}"
+            };
+        }
+
+        LicenseSourceResult ReadFromRegistry(RegistryView view, string applicationName)
+        {
+            try
+            {
+                using(var rootKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, view ))
+                using (var registryKey = rootKey.OpenSubKey(keyPath))
+                {
+                    if (registryKey == null)
+                    {
+                        return ValidateLicense(null, applicationName);
+                    }
+
+                    var regValue = registryKey.GetValue("License", null);
+
+                    var licenseText = (regValue is string[]) 
+                        ? string.Join(" ", (string[]) regValue)
+                        : (string) regValue;
+
+                    return ValidateLicense(licenseText , applicationName);
+                }
+            }
+            catch (SecurityException)
+            {
+                return new LicenseSourceResult
+                {
+                    Location = Location,
+                    Result = $"Insufficent rights to read license from {Location}"
+                };
+                
+            }
+        }
+    }
+}

--- a/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSourceResult.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/LicenseSourceResult.cs
@@ -1,0 +1,25 @@
+﻿namespace Particular.Licensing
+{
+    using System.Linq;
+
+    class LicenseSourceResult
+    {
+        internal License License { get; set; }
+        internal string Location { get; set; }
+        internal string Result { get; set; }
+        
+        public static LicenseSourceResult DetermineBestLicenseSourceResult(params LicenseSourceResult[] sourceResults)
+        {
+            if (sourceResults.All(p => p.License == null))
+            {
+                return null;
+            }
+            var sourcesResultsWithLicenseOrderedByDate = sourceResults.Where(p => p.License != null).OrderByDescending(p => p.License.ExpirationDate).ToList();
+
+            // Can't rely on just expiry date as running on a build that was produced after the upgrade protection expiration is the same as unlicensed. 
+            var unexpiredResult = sourcesResultsWithLicenseOrderedByDate.FirstOrDefault(p => !LicenseExpirationChecker.HasLicenseExpired(p.License));
+
+            return unexpiredResult ?? sourcesResultsWithLicenseOrderedByDate.First();
+        }
+    }
+}

--- a/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/NonBlockingReader.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/FindActiveLicense/NonBlockingReader.cs
@@ -1,0 +1,16 @@
+namespace Particular.Licensing
+{
+    using System.IO;
+
+    class NonBlockingReader
+    {
+        public static string ReadAllTextWithoutLocking(string path)
+        {
+            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var textReader = new StreamReader(fileStream))
+            {
+                return textReader.ReadToEnd();
+            }
+        }
+    }
+}

--- a/src/ServiceControl/App_Packages/Particular.Licensing/License.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/License.cs
@@ -23,17 +23,11 @@
 
         public DateTime? ExpirationDate { get; set; }
 
-        public bool IsTrialLicense
-        {
-            get { return !IsCommercialLicense; }
-        }
+        public bool IsTrialLicense => !IsCommercialLicense;
 
         public bool IsExtendedTrial { get; set; }
 
-        public bool IsCommercialLicense
-        {
-            get { return LicenseType.ToLower() != "trial"; }
-        }
+        public bool IsCommercialLicense => LicenseType.ToLower() != "trial";
 
         public string LicenseType { get; set; }
 

--- a/src/ServiceControl/App_Packages/Particular.Licensing/RegistryLicenseStore.cs
+++ b/src/ServiceControl/App_Packages/Particular.Licensing/RegistryLicenseStore.cs
@@ -49,7 +49,7 @@
             }
             catch (SecurityException exception)
             {
-                throw new Exception(string.Format("Failed to access '{0}'. Do you have permission to read this key?", FullPath), exception);
+                throw new Exception($"Failed to access '{FullPath}'. Do you have permission to read this key?", exception);
             }
         }
 
@@ -62,7 +62,7 @@
                 {
                     if (registryKey == null)
                     {
-                        throw new Exception(string.Format("CreateSubKey for '{0}' returned null. Do you have permission to write to this key", keyPath));
+                        throw new Exception($"CreateSubKey for '{keyPath}' returned null. Do you have permission to write to this key");
                     }
 
                     registryKey.SetValue(keyName, license, RegistryValueKind.String);
@@ -70,14 +70,11 @@
             }
             catch (UnauthorizedAccessException exception)
             {
-                throw new Exception(string.Format("Failed to access '{0}'. Do you have permission to write to this key?", FullPath), exception);
+                throw new Exception($"Failed to access '{FullPath}'. Do you have permission to write to this key?", exception);
             }
         }
 
-        string FullPath
-        {
-            get { return string.Format("{0} : {1} : {2}", regKey.Name, keyPath, keyName); }
-        }
+        string FullPath => $"{regKey.Name} : {keyPath} : {keyName}";
 
         string keyPath;
         string keyName;

--- a/src/ServiceControl/Licensing/LicenseDetector.cs
+++ b/src/ServiceControl/Licensing/LicenseDetector.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.IO;
-    using Microsoft.Win32;
     using NServiceBus;
     using NServiceBus.Logging;
     using Particular.Licensing;
@@ -12,100 +11,35 @@
         public void Customize(BusConfiguration configuration)
         {
             var activeLicense = DetermineActiveLicense();
-
             configuration.RegisterComponents(c => c.RegisterSingleton(activeLicense));
         }
 
         static ActiveLicense DetermineActiveLicense()
         {
-            var activeLicense = new ActiveLicense
+
+            var result = Particular.Licensing.ActiveLicense.Find("ServiceControl",
+                new LicenseSourceHKLMRegKey(),
+                new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "License", "License.xml")),
+                new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ParticularPlatformLicense.xml")));
+
+            foreach (var report in result.Report)
             {
-                IsValid = false
+                Logger.Info(report);
+            }
+
+            if (result.HasExpired)
+            {
+                Logger.Warn("License has expired");
+            }
+
+            //Return the class ServicePulse expects
+            return new ActiveLicense
+            {
+                Details = result.License,
+                IsValid = !result.HasExpired,
+                HasExpired = result.HasExpired
             };
-
-            var licenseText = TryFindLicense();
-
-            if (string.IsNullOrEmpty(licenseText))
-            {
-                Logger.Warn("No valid license could be found, falling back to trial license");
-
-                activeLicense.Details = License.TrialLicense(TrialStartDateStore.GetTrialStartDate());
-            }
-            else
-            {
-                Exception validationFailure;
-
-                if (!LicenseVerifier.TryVerify(licenseText, out validationFailure))
-                {
-                    Logger.WarnFormat("Found license was not valid: {0}", validationFailure);
-                    return activeLicense;
-                }
-
-
-                var licenseDetails = LicenseDeserializer.Deserialize(licenseText);
-
-                if (!licenseDetails.ValidForApplication("ServiceControl"))
-                {
-                    Logger.WarnFormat("Found license was is not valid for ServiceControl. Valid apps: '{0}'", string.Join(",", licenseDetails.ValidApplications));
-                    return activeLicense;
-                }
-
-                activeLicense.Details = licenseDetails;                
-            }
-
-            activeLicense.HasExpired = LicenseExpirationChecker.HasLicenseExpired(activeLicense.Details);
-
-            if (activeLicense.HasExpired)
-            {
-                Logger.WarnFormat("Found license has expired");
-            }
-            else
-            {
-                activeLicense.IsValid = true;
-            }
-
-            return activeLicense;
         }
-
-        static string TryFindLicense()
-        {
-            //look for a license file in /bin/license/license.xml
-            var localLicenseFileInLicenseDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,"License", @"License.xml");
-            if (File.Exists(localLicenseFileInLicenseDir))
-            {
-                Logger.InfoFormat(@"Using license in current folder ({0}).", localLicenseFileInLicenseDir);
-                return NonLockingFileReader.ReadAllTextWithoutLocking(localLicenseFileInLicenseDir);
-            }
-
-
-            //look for a license file in /bin
-            var localLicenseFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"ParticularPlatformLicense.xml");
-            if (File.Exists(localLicenseFile))
-            {
-                Logger.InfoFormat(@"Using license in current folder ({0}).", localLicenseFile);
-                return NonLockingFileReader.ReadAllTextWithoutLocking(localLicenseFile);
-            }
-
-            
-            string regLicense;
-
-            //try HKCU
-            if (new RegistryLicenseStore().TryReadLicense(out regLicense))
-            {
-                Logger.InfoFormat("Using license in HKCU");
-                return regLicense;
-            }
-
-            //try HKLM
-            if (new RegistryLicenseStore(Registry.LocalMachine).TryReadLicense(out regLicense))
-            {
-                Logger.InfoFormat("Using license in HKLM");
-                return regLicense;
-            }
-
-            return null;
-        }
-
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(LicenseDetector));
     }

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -39,7 +39,7 @@
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -49,7 +49,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>Particular.ServiceControl.Program</StartupObject>
@@ -196,10 +196,20 @@
       <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="App_Packages\Particular.Licensing\FindActiveLicense\ActiveLicense.cs" />
+    <Compile Include="App_Packages\Particular.Licensing\FindActiveLicense\ActiveLicenseFindResult.cs" />
+    <Compile Include="App_Packages\Particular.Licensing\FindActiveLicense\LicenseSource.cs" />
+    <Compile Include="App_Packages\Particular.Licensing\FindActiveLicense\LicenseSourceConfigFile.cs" />
+    <Compile Include="App_Packages\Particular.Licensing\FindActiveLicense\LicenseSourceFilePath.cs" />
+    <Compile Include="App_Packages\Particular.Licensing\FindActiveLicense\LicenseSourceHKCURegKey.cs" />
+    <Compile Include="App_Packages\Particular.Licensing\FindActiveLicense\LicenseSourceHKLMRegKey.cs" />
+    <Compile Include="App_Packages\Particular.Licensing\FindActiveLicense\LicenseSourceResult.cs" />
+    <Compile Include="App_Packages\Particular.Licensing\FindActiveLicense\NonBlockingReader.cs" />
     <Compile Include="App_Packages\Particular.Licensing\License.cs" />
     <Compile Include="App_Packages\Particular.Licensing\LicenseDeserializer.cs" />
     <Compile Include="App_Packages\Particular.Licensing\LicenseExpirationChecker.cs" />

--- a/src/ServiceControl/ServiceControl.csproj.DotSettings
+++ b/src/ServiceControl/ServiceControl.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>

--- a/src/ServiceControl/packages.config
+++ b/src/ServiceControl/packages.config
@@ -23,7 +23,7 @@
   <package id="NServiceBus.NLog" version="1.1.0" targetFramework="net45" />
   <package id="NServiceBus.RavenDB" version="2.2.4" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="Particular.Licensing.Sources" version="0.1.56" targetFramework="net45" />
+  <package id="Particular.Licensing.Sources" version="0.1.58" targetFramework="net45" />
   <package id="RavenDB.Client" version="2.5.2996" targetFramework="net45" />
   <package id="RavenDB.Database" version="2.5.2996" targetFramework="net45" />
   <package id="RavenDB.Embedded" version="2.5.2996" targetFramework="net45" />

--- a/src/ServiceControlInstaller.CustomActions.UnitTests/ServiceControlInstaller.CustomActions.UnitTests.csproj
+++ b/src/ServiceControlInstaller.CustomActions.UnitTests/ServiceControlInstaller.CustomActions.UnitTests.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,7 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Packaging|AnyCPU'">
     <OutputPath>bin\Packaging\</OutputPath>

--- a/src/ServiceControlInstaller.CustomActions/ServiceControlInstaller.CustomActions.csproj
+++ b/src/ServiceControlInstaller.CustomActions/ServiceControlInstaller.CustomActions.csproj
@@ -22,7 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,7 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />

--- a/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
@@ -21,7 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -31,7 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Packaging|AnyCPU'">
@@ -40,7 +40,7 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -21,7 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,7 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Packaging|AnyCPU'">
     <OutputPath>bin\Packaging\</OutputPath>

--- a/src/ServiceControlInstaller.PowerShell/ServiceControlInstaller.PowerShell.csproj
+++ b/src/ServiceControlInstaller.PowerShell/ServiceControlInstaller.PowerShell.csproj
@@ -21,7 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,7 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Packaging|AnyCPU'">
     <OutputPath>bin\Packaging\</OutputPath>
@@ -38,7 +38,7 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>5</LangVersion>
+    <LangVersion>6</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -73,20 +75,15 @@
       <ResourceFiles Include="res\**\*.*" />
       <Prerequisites Include="Prerequisites\**\*.*" />
     </ItemGroup>
-
     <PropertyGroup>
       <SetupExeOutputFolder>$(SolutionDir)..\Assets\</SetupExeOutputFolder>
       <SetupExeName>Particular.ServiceControl-$(GfvLegacySemVerPadded).exe</SetupExeName>
     </PropertyGroup>
-
     <MakeDir Directories="$(SetupExeOutputFolder)" />
-    
     <ItemGroup>
       <ExistingExes Include="$(SetupExeOutputFolder)*.exe" />
-    </ItemGroup>  
-    
+    </ItemGroup>
     <Delete Files="@(ExistingExes)" />
-    
     <Copy SourceFiles="$(AIPFile)" DestinationFolder="$(IntermediateOutputPath)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(ResourceFiles)" DestinationFolder="$(IntermediateOutputPath)res\%(RecursiveDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(Prerequisites)" DestinationFolder="$(IntermediateOutputPath)Prerequisites\%(RecursiveDir)" SkipUnchangedFiles="true" />


### PR DESCRIPTION
### Sympton

ServiceControl Management Util reports that a valid license is installed but ServiceControl reports that there is no valid license

### Analysis 
The ServiceCotnrol Management  Util scans for licenses in multiple locations.  One of those locations is `HKEY_CURRENT_USER` registry hive.  This isn't appropriate as it is very unlikely the ServiceControl service is running as the installing user.