### PR TITLE
Powershell cmdlet validation of Timespan is broken

### DIFF
--- a/src/ServiceControlInstaller.Engine/Services/WindowsServiceController.cs
+++ b/src/ServiceControlInstaller.Engine/Services/WindowsServiceController.cs
@@ -29,7 +29,7 @@ namespace ServiceControlInstaller.Engine.Services
             }
             set
             {
-                WriteValue("Description", value);
+                WriteValue("Description", value ?? string.Empty);
             }
         }
 

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/Instances/InvokeServiceControlInstanceUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/Instances/InvokeServiceControlInstanceUpgrade.cs
@@ -20,12 +20,10 @@ namespace ServiceControlInstaller.PowerShell
         public bool? ForwardErrorMessages;
 
         [Parameter(HelpMessage = "Specify the timespan to keep Audit Data")]
-        [ValidateNotNull]
         [ValidateTimeSpanRange(MinimumHours = 1, MaximumHours = 8760)] //1 hour to 365 days
         public TimeSpan? AuditRetentionPeriod { get; set; }
 
         [Parameter(HelpMessage = "Specify the timespan to keep Error Data")]
-        [ValidateNotNull]
         [ValidateTimeSpanRange(MinimumHours = 240, MaximumHours = 1080)] //10 to 45 days
         public TimeSpan? ErrorRetentionPeriod { get; set; }
 

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/Instances/NewServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/Instances/NewServiceControlInstance.cs
@@ -127,6 +127,8 @@ namespace ServiceControlInstaller.PowerShell
                 ErrorLogQueue = string.IsNullOrWhiteSpace(ErrorLogQueue) ? null : ErrorLogQueue,
                 ForwardAuditMessages = ForwardAuditMessages,
                 ForwardErrorMessages = ForwardErrorMessages,
+                AuditRetentionPeriod = AuditRetentionPeriod,
+                ErrorRetentionPeriod = ErrorRetentionPeriod,
                 ConnectionString = ConnectionString,
                 TransportPackage = Transport
             };

--- a/src/ServiceControlInstaller.PowerShell/Validation/ValidateTimeSpanAttribute.cs
+++ b/src/ServiceControlInstaller.PowerShell/Validation/ValidateTimeSpanAttribute.cs
@@ -16,8 +16,8 @@ namespace ServiceControlInstaller.PowerShell
             if (span.TotalHours < MinimumHours)
                 throw new Exception(string.Format("Timespan value is lower than the minimum of {0} hours", MinimumHours));
 
-            if (span.TotalHours > MinimumHours)
-                throw new Exception(string.Format("Timespan value is lower than the minimum of {0} hours", MinimumHours));
+            if (span.TotalHours > MaximumHours)
+                throw new Exception(string.Format("Timespan value is greater than the maximum of {0} hours", MaximumHours));
         }
     }
 }


### PR DESCRIPTION
### Symptoms

The powershell cmdlets for adding and upgrading ServiceControl instances are not correctly validating TimeSpan arguments and cannot be executed

###  Who's affected 

Anyone attempting to update or add a ServiceControl instance using ServiceControl 1.13
from the supplied ServiceControl Powershell Module


 