### PR TITLE
Circuit-breaker in EventDispatcher is not being reset

### DIFF
--- a/src/ServiceControl/ExternalIntegrations/EventDispatcher.cs
+++ b/src/ServiceControl/ExternalIntegrations/EventDispatcher.cs
@@ -23,7 +23,7 @@
         {
             tokenSource = new CancellationTokenSource();
             circuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("EventDispatcher",
-                TimeSpan.FromMinutes(2),
+                TimeSpan.FromMinutes(5),
                 ex => CriticalError.Raise("Repeated failures when dispatching external integration events.", ex),
                 TimeSpan.FromSeconds(20));
             StartDispatcher();
@@ -65,6 +65,8 @@
                 {
                     token.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
                 }
+
+                circuitBreaker.Success();
             }
         }
 


### PR DESCRIPTION
## Symptoms
Once the circuit-break triggers, example an intermittent break in comms to the broker, the circuit-breaker will never be reset and therefore ServiceControl will shutdown at the end of the circuit-breaker timeout.

## Who's Affected
All versions of ServiceControl prior to v1.15
