### PR TITLE
Don't treat sibling paths as nested (#733)

### DIFF
--- a/src/ServiceControlInstaller.Engine.UnitTests/Validation/PathsValidationTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Validation/PathsValidationTests.cs
@@ -164,6 +164,23 @@
         }
 
         [Test]
+        public void CheckNoNestedSiblingPaths_ShouldSucceed()
+        {
+            var newInstance = new ServiceControlInstanceMetadata
+            {
+                InstallPath = @"c:\test\1\servicecontrol",
+                LogPath = @"c:\test\1\servicecontrollog",
+                DBPath = @"c:\test\1\servicecontroldb"
+            };
+
+            var p = new PathsValidator(newInstance)
+            {
+                Instances = instances
+            };
+            Assert.DoesNotThrow(() => p.CheckNoNestedPaths());
+        }
+
+        [Test]
         public void CheckNoNestedPaths_ShouldSucceed()
         {
             var newInstance = new ServiceControlInstanceMetadata

--- a/src/ServiceControlInstaller.Engine/Validation/PathsValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/PathsValidator.cs
@@ -108,7 +108,8 @@
                 {
                     if (path.Name == possibleChild.Name)
                         continue;
-                    if (possibleChild.Path.IndexOf(path.Path, StringComparison.OrdinalIgnoreCase) > -1)
+
+                    if (Path.GetDirectoryName(possibleChild.Path).IndexOf(path.Path, StringComparison.OrdinalIgnoreCase) > -1)
                     {
                         throw new EngineValidationException(string.Format("Nested paths are not supported. The {0} is nested under {1}", possibleChild.Name, path.Name));
                     }


### PR DESCRIPTION
Fixes the issue described in #733, and adds a test for it.