### PR TITLE
Removing the drop shadow for tooltips

### DIFF
--- a/src/ServiceControl.Config/Styles/Button.xaml
+++ b/src/ServiceControl.Config/Styles/Button.xaml
@@ -330,6 +330,7 @@
     <Style x:Key="IconButtonToolTipStyle" TargetType="{x:Type ToolTip}">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="HasDropShadow" Value="False" />
         <Setter Property="Foreground" Value="{StaticResource ThemeBrush}" />
         <Setter Property="Placement" Value="Center" />
     </Style>


### PR DESCRIPTION
Addresses issue #665 on Windows 7