### PR TITLE
Add new instance dialog should auto-scroll to the error fields

### DIFF
--- a/src/ServiceControl.Config/Extensions/VisualTreeExtensions.cs
+++ b/src/ServiceControl.Config/Extensions/VisualTreeExtensions.cs
@@ -1,0 +1,61 @@
+﻿namespace ServiceControl.Config.Extensions
+{
+    using System.Windows;
+    using System.Windows.Controls;
+    using System.Windows.Media;
+
+    public static class VisualTreeExtensions
+    {
+        public static Control FindControlWithError(this DependencyObject parent)
+        {
+            // Confirm parent and childName are valid.
+            if (parent == null)
+            {
+                return null;
+            }
+
+            Control foundChild = null;
+
+            var childrenCount = VisualTreeHelper.GetChildrenCount(parent);
+            for (var i = 0; i < childrenCount; i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                // If the child is not of the request child type child
+                var childType = child;
+                if (childType == null)
+                {
+                    // recursively drill down the tree
+                    foundChild = FindControlWithError(child);
+
+                    // If the child is found, break so we do not overwrite the found child.
+                    if (foundChild != null)
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    var frameworkElement = child as FrameworkElement;
+
+                    // If the child is in error
+                    if (frameworkElement != null && Validation.GetHasError(frameworkElement))
+                    {
+                        foundChild = (Control)child;
+                        break;
+                    }
+
+                    // recursively drill down the tree
+                    foundChild = FindControlWithError(child);
+
+                    // If the child is found, break so we do not overwrite the found child.
+                    if (foundChild != null)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return foundChild;
+        }
+    }
+}

--- a/src/ServiceControl.Config/Framework/WindowManagerEx.cs
+++ b/src/ServiceControl.Config/Framework/WindowManagerEx.cs
@@ -9,9 +9,7 @@ using ServiceControlInstaller.Engine.ReportCard;
 
 namespace ServiceControl.Config.Framework
 {
-    using System.Linq;
-    using System.Windows.Controls;
-    using System.Windows.Media;
+    using ServiceControl.Config.Extensions;
 
     public interface IWindowManagerEx : IWindowManager
     {
@@ -29,7 +27,7 @@ namespace ServiceControl.Config.Framework
 
         bool ShowActionReport(ReportCard reportcard, string title, string errorsMessage, string warningsMessage);
 
-        void ScrollFirstErrorIntoView();
+        void ScrollFirstErrorIntoView(object viewModel, object context = null);
     }
 
     class WindowManagerEx : WindowManager, IWindowManagerEx
@@ -111,63 +109,11 @@ namespace ServiceControl.Config.Framework
             return result ?? false;
         }
 
-        public void ScrollFirstErrorIntoView()
+        public void ScrollFirstErrorIntoView(object viewModel, object context = null)
         {
-            var controlInError = FindChild(Application.Current.MainWindow);
+            var view = ViewLocator.LocateForModel(viewModel, null, context);
+            var controlInError = view?.FindControlWithError();
             controlInError?.BringIntoView();
-        }
-
-        static Control FindChild(DependencyObject parent)
-        {
-            // Confirm parent and childName are valid.
-            if (parent == null)
-            {
-                return null;
-            }
-
-            Control foundChild = null;
-
-            var childrenCount = VisualTreeHelper.GetChildrenCount(parent);
-            for (var i = 0; i < childrenCount; i++)
-            {
-                var child = VisualTreeHelper.GetChild(parent, i);
-                // If the child is not of the request child type child
-                var childType = child;
-                if (childType == null)
-                {
-                    // recursively drill down the tree
-                    foundChild = FindChild(child);
-
-                    // If the child is found, break so we do not overwrite the found child.
-                    if (foundChild != null)
-                    {
-                        break;
-                    }
-                }
-                else
-                {
-                    var frameworkElement = child as FrameworkElement;
-
-                    // If the child is in error
-                    if (frameworkElement != null && Validation.GetHasError(frameworkElement))
-                    {
-                        foundChild = (Control)child;
-                        break;
-                    }
-                    
-                    // recursively drill down the tree
-                    foundChild = FindChild(child);
-
-                    // If the child is found, break so we do not overwrite the found child.
-                    if (foundChild != null)
-                    {
-                        break;
-                    }
-                    
-                }
-            }
-
-            return foundChild;
         }
 
         private ShellViewModel GetShell()

--- a/src/ServiceControl.Config/Framework/WindowManagerEx.cs
+++ b/src/ServiceControl.Config/Framework/WindowManagerEx.cs
@@ -29,7 +29,7 @@ namespace ServiceControl.Config.Framework
 
         bool ShowActionReport(ReportCard reportcard, string title, string errorsMessage, string warningsMessage);
 
-        void ScrollIntoView();
+        void ScrollFirstErrorIntoView();
     }
 
     class WindowManagerEx : WindowManager, IWindowManagerEx
@@ -111,7 +111,7 @@ namespace ServiceControl.Config.Framework
             return result ?? false;
         }
 
-        public void ScrollIntoView()
+        public void ScrollFirstErrorIntoView()
         {
             var controlInError = FindChild(Application.Current.MainWindow);
             controlInError?.BringIntoView();

--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Extensions\DeactivateExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\ValidatorExtensions.cs" />
+    <Compile Include="Extensions\VisualTreeExtensions.cs" />
     <Compile Include="Framework\Commands\AwaitableAbstractCommand.cs" />
     <Compile Include="Framework\IProgressViewModel.cs" />
     <Compile Include="Framework\Modules\InstallerModule.cs" />

--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddAttachment.cs
@@ -48,7 +48,7 @@
             {
                 viewModel.NotifyOfPropertyChange(string.Empty);
                 viewModel.SubmitAttempted = false;
-                windowManager.ScrollFirstErrorIntoView();
+                windowManager.ScrollFirstErrorIntoView(viewModel);
                 
                 return;
             }

--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddAttachment.cs
@@ -48,6 +48,8 @@
             {
                 viewModel.NotifyOfPropertyChange(string.Empty);
                 viewModel.SubmitAttempted = false;
+                windowManager.ScrollIntoView();
+                
                 return;
             }
 

--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddAttachment.cs
@@ -48,7 +48,7 @@
             {
                 viewModel.NotifyOfPropertyChange(string.Empty);
                 viewModel.SubmitAttempted = false;
-                windowManager.ScrollIntoView();
+                windowManager.ScrollFirstErrorIntoView();
                 
                 return;
             }

--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditAttachment.cs
@@ -49,6 +49,8 @@ namespace ServiceControl.Config.UI.InstanceEdit
             {
                 viewModel.NotifyOfPropertyChange(string.Empty);
                 viewModel.SubmitAttempted = false;
+                windowManager.ScrollFirstErrorIntoView();
+                
                 return;
             }
 

--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditAttachment.cs
@@ -49,7 +49,7 @@ namespace ServiceControl.Config.UI.InstanceEdit
             {
                 viewModel.NotifyOfPropertyChange(string.Empty);
                 viewModel.SubmitAttempted = false;
-                windowManager.ScrollFirstErrorIntoView();
+                windowManager.ScrollFirstErrorIntoView(viewModel);
                 
                 return;
             }

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorView.xaml
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorView.xaml
@@ -16,12 +16,11 @@
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
 
-        <ScrollViewer IsTabStop="False">
+        <ScrollViewer x:Name="ContentScroller" IsTabStop="False">
             <ContentPresenter Content="{Binding SharedContent, ElementName=uc}" />
         </ScrollViewer>
 
-        <Border x:Name="progressOverlay"
-                Grid.RowSpan="2"
+        <Border Grid.RowSpan="2"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
                 Background="#CCFFFFFF"

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorView.xaml.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorView.xaml.cs
@@ -4,6 +4,7 @@ namespace ServiceControl.Config.UI.SharedInstanceEditor
 {
     public partial class SharedInstanceEditorView
     {
+
         public SharedInstanceEditorView()
         {
             InitializeComponent();
@@ -11,7 +12,7 @@ namespace ServiceControl.Config.UI.SharedInstanceEditor
 
         public string SaveText
         {
-            get { return (string)GetValue(SaveTextProperty); }
+            get { return (string) GetValue(SaveTextProperty); }
             set { SetValue(SaveTextProperty, value); }
         }
 


### PR DESCRIPTION
When adding a new instance, what's immediately visible is just the first 'page', it's not immediately obvious there's a scrollbar.
If clicking 'Add' at this point, it will say "There are errors", and it's up to the user to try and figure out what's wrong...

![image](https://cloud.githubusercontent.com/assets/601206/13201981/2aee2fa2-d891-11e5-9c07-18670700a2f9.png)

There should be a subtle scrolling animation down to the first error. The error text should also possibly say: **There are X errors**, until all errors are fixed.