### PR TITLE
Adding ExposeRavenDB can cause service to fail on startup

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditViewModel.cs
@@ -23,10 +23,12 @@
             var userAccount = UserAccount.ParseAccountName(instance.ServiceAccount);
             UseSystemAccount = userAccount.IsLocalSystem();
             UseServiceAccount = userAccount.IsLocalService();
+
+            UseProvidedAccount = !(UseServiceAccount || UseServiceAccount);
+
             if (UseProvidedAccount)
             {
                 ServiceAccount = instance.ServiceAccount;
-                Password = instance.ServiceAccountPwd;
             }
 
             HostName = instance.HostName;

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -90,7 +90,7 @@ namespace ServiceControlInstaller.Engine.Instances
             }
         }
 
-        public string RavenStudioUrl
+        public string StorageUrl
         {
             get
             {
@@ -109,21 +109,8 @@ namespace ServiceControlInstaller.Engine.Instances
                 {
                     return $"http://{host}:{Port}/storage/";
                 }
-                var virt = VirtualDirectory.Replace("/", "");
-                return $"http://{host}:{Port}/{virt}/storage/";
-            }
-        }
-
-        public string StorageUrl
-        {
-            get
-            {
-                var baseUrl = $"http://localhost:{Port}/";
-                if (string.IsNullOrWhiteSpace(VirtualDirectory))
-                {
-                    return $"{baseUrl}storage/";
-                }
-                return $"{baseUrl}{VirtualDirectory}{(VirtualDirectory.EndsWith("/") ? String.Empty : "/")}storage/";
+                var virt = $"{VirtualDirectory}{(VirtualDirectory.EndsWith("/") ? String.Empty : "/")}";
+                return $"http://{host}:{Port}/{virt}storage/";
             }
         }
 
@@ -213,7 +200,7 @@ namespace ServiceControlInstaller.Engine.Instances
                 oldSettings.RemoveUrlAcl();
                 var reservation = new UrlReservation(Url, new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null));
                 reservation.Create();
-                var ravenStorageReservation = new UrlReservation(RavenStudioUrl, new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null));
+                var ravenStorageReservation = new UrlReservation(StorageUrl, new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null));
                 ravenStorageReservation.Create();
             }
 
@@ -342,7 +329,7 @@ namespace ServiceControlInstaller.Engine.Instances
 
         public void RemoveUrlAcl()
         {
-            foreach (var urlReservation in UrlReservation.GetAll().Where(p => p.Url.Equals(Url, StringComparison.OrdinalIgnoreCase) || p.Url.Equals(RavenStudioUrl, StringComparison.OrdinalIgnoreCase)))
+            foreach (var urlReservation in UrlReservation.GetAll().Where(p => p.Url.Equals(Url, StringComparison.OrdinalIgnoreCase) || p.Url.Equals(StorageUrl, StringComparison.OrdinalIgnoreCase)))
             {
                 try
                 {

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstanceMetadata.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstanceMetadata.cs
@@ -71,7 +71,7 @@ namespace ServiceControlInstaller.Engine.Instances
             }
         }
 
-        public string RavenStudioUrl
+        public string StorageUrl
         {
             get
             {
@@ -90,8 +90,8 @@ namespace ServiceControlInstaller.Engine.Instances
                 {
                     return $"http://{host}:{Port}/storage/";
                 }
-                var virt = VirtualDirectory.Replace("/", "");
-                return $"http://{host}:{Port}/{virt}/storage/";
+                var virt = $"{VirtualDirectory}{(VirtualDirectory.EndsWith("/") ? String.Empty : "/")}";
+                return $"http://{host}:{Port}/{virt}storage/";
             }
         }
 
@@ -161,7 +161,7 @@ namespace ServiceControlInstaller.Engine.Instances
             var reservation = new UrlReservation(Url, new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null));
             reservation.Create();
 
-            var ravenReservation = new UrlReservation(RavenStudioUrl, new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null));
+            var ravenReservation = new UrlReservation(StorageUrl, new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null));
             ravenReservation.Create();
         }
 

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstanceMetadata.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstanceMetadata.cs
@@ -62,13 +62,36 @@ namespace ServiceControlInstaller.Engine.Instances
         {
             get
             {
-                //TODO: Introduce option for https?
-                var baseUrl = $"http://{HostName}:{Port}/api/";
                 if (string.IsNullOrWhiteSpace(VirtualDirectory))
                 {
-                    return baseUrl;
+                    return $"http://{HostName}:{Port}/api/";
                 }
-                return $"{baseUrl}{VirtualDirectory}{(VirtualDirectory.EndsWith("/") ? String.Empty : "/")}api/";
+                var virt = VirtualDirectory.Replace("/", "");
+                return $"http://{HostName}:{Port}/{virt}/api/";
+            }
+        }
+
+        public string RavenStudioUrl
+        {
+            get
+            {
+                string host;
+                switch (HostName)
+                {
+                    case "*":
+                    case "+":
+                        host = "localhost";
+                        break;
+                    default:
+                        host = HostName;
+                        break;
+                }
+                if (string.IsNullOrWhiteSpace(VirtualDirectory))
+                {
+                    return $"http://{host}:{Port}/storage/";
+                }
+                var virt = VirtualDirectory.Replace("/", "");
+                return $"http://{host}:{Port}/{virt}/storage/";
             }
         }
 
@@ -137,7 +160,12 @@ namespace ServiceControlInstaller.Engine.Instances
         {
             var reservation = new UrlReservation(Url, new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null));
             reservation.Create();
+
+            var ravenReservation = new UrlReservation(RavenStudioUrl, new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null));
+            ravenReservation.Create();
         }
+
+
 
         public void SetupInstance()
         {


### PR DESCRIPTION
### Symptom 

If the service account is not a local administrator or localsystem enabling the ExposeRavenDB setting can cause the server to fail on startup.  This is because A URLACL is required to allow the Raven Management Studio to be exposed on the `/storage` virtual directory.  Raven will create this automatically if the service account has the privileges.

### Who's affected 

Anyone using a low privilege service account that decides to expose the raven studio.  This setup is typically used by client using the SQL transport and integrated authentication so they are more likely to be affected.

### Workaround 

Until this is fixed the workaround is to manually create the required URLACL as covered in [docs ](http://docs.particular.net/servicecontrol/troubleshooting#unable-to-start-service-after-exposing-ravendb) 


