### PR TITLE
Support GMSA accounts

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddView.xaml
@@ -42,17 +42,16 @@
                             </Grid.RowDefinitions>
                             <controls:FormTextBox Grid.Row="1"
                                                   Header="SERVICE ACCOUNT"
-                                                  IsEnabled="{Binding UseProvidedAccount}"
                                                   Text="{Binding ServiceAccount}"
                                                   Visibility="{Binding UseProvidedAccount,
                                                                        Converter={StaticResource boolToVis}}" />
 
                             <controls:FormPasswordBox Grid.Row="2"
                                                       Header="PASSWORD"
-                                                      IsEnabled="{Binding UseProvidedAccount}"
                                                       Text="{Binding Password}"
-                                                      Visibility="{Binding UseProvidedAccount,
-                                                                           Converter={StaticResource boolToVis}}" />
+                                                      Visibility="{Binding PasswordEnabled, Converter={StaticResource boolToVis}}"
+                                                      />
+                            <TextBlock Grid.Row="2" Visibility="{Binding ManagedAccount, Converter={StaticResource boolToVis}}" Text="No password is required for an AD Group Managed Service Account" />
                         </Grid>
                     </StackPanel>
                 </GroupBox>

--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditView.xaml
@@ -71,17 +71,17 @@
 
                             <controls:FormTextBox Grid.Row="1"
                                                   Header="SERVICE ACCOUNT"
-                                                  IsEnabled="{Binding UseProvidedAccount}"
                                                   Text="{Binding ServiceAccount}"
                                                   Visibility="{Binding UseProvidedAccount,
                                                                        Converter={StaticResource boolToVis}}" />
 
                             <controls:FormPasswordBox Grid.Row="2"
                                                       Header="PASSWORD"
-                                                      IsEnabled="{Binding UseProvidedAccount}"
                                                       Text="{Binding Password}"
-                                                      Visibility="{Binding UseProvidedAccount,
-                                                                           Converter={StaticResource boolToVis}}" />
+                                                      Visibility="{Binding PasswordEnabled, Converter={StaticResource boolToVis}}"
+                                                      />
+                            <TextBlock Grid.Row="2" Visibility="{Binding ManagedAccount, Converter={StaticResource boolToVis}}" Text="No password is required for an AD Group Managed Service Account" />
+
                         </Grid>
                     </StackPanel>
                 </GroupBox>

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorViewModel.cs
@@ -114,6 +114,35 @@
 
         public bool UseProvidedAccount { get; set; }
 
+        public bool PasswordEnabled
+        {
+            get
+            {
+                if (!UseProvidedAccount)
+                {
+                    return false;
+                }
+                if ((ServiceAccount != null) && ServiceAccount.EndsWith("$"))
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        public bool ManagedAccount
+        {
+            get
+            {
+                var managedAccount = UseProvidedAccount && ServiceAccount != null && ServiceAccount.Trim().EndsWith("$");
+                if (managedAccount)
+                {
+                    Password = null;
+                }
+                return managedAccount;
+            }
+        }
+
         public string ErrorQueueName { get; set; }
         public string ErrorForwardingQueueName { get; set; }
         public string AuditQueueName { get; set; }
@@ -163,7 +192,7 @@
         }
 
         public string ConnectionString { get; set; }
-        
+
         // ReSharper disable once UnusedMember.Global
         public string SampleConnectionString => SelectedTransport != null ? SelectedTransport.SampleConnectionString : String.Empty;
 
@@ -175,7 +204,7 @@
 
         public ICommand Save { get; set; }
         public ICommand Cancel { get; set; }
-        
+
         public bool SubmitAttempted { get; set; }
 
         protected virtual void OnInstanceNameChanged()

--- a/src/ServiceControlInstaller.Engine/Accounts/UserAccount.cs
+++ b/src/ServiceControlInstaller.Engine/Accounts/UserAccount.cs
@@ -58,11 +58,18 @@
 
         public bool CheckPassword(string password)
         {
-
             if (Domain.Equals(LocalizedNTAuthority(), StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
+
+            // AD Group Managed Service Account are always named with a trailing $ 
+            // In this case the installing user does not provide a password and Windows handles the password management
+            if (Name.EndsWith("$"))  
+            {
+                return true;
+            }
+
             if (password == null)
             {
                 throw new EngineValidationException("A password is required for this service account");

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/Instances/NewServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/Instances/NewServiceControlInstance.cs
@@ -83,10 +83,10 @@ namespace ServiceControlInstaller.PowerShell
         [Parameter(Mandatory = true, HelpMessage = "Specify if error messages are forwarded to the queue specified by ErrorLogQueue")]
         public bool ForwardErrorMessages { get; set; }
         
-        [Parameter(HelpMessage = "The Account to run the Windows service. If no specified LocalSystem is used")]
+        [Parameter(HelpMessage = "The Account to run the Windows service. If not specified then LocalSystem is used")]
         public string ServiceAccount { get; set; }
 
-        [Parameter(HelpMessage = "The password for the ServiceAccount.  Do not use for LocalSystem or NetworkService")]
+        [Parameter(HelpMessage = "The password for the ServiceAccount.  Do not use for builtin accounts or managed serviceaccount")]
         public string ServiceAccountPassword { get; set; }
 
         [Parameter(Mandatory = true, HelpMessage = "Specify the timespan to keep Audit Data")]

--- a/src/ServiceControlInstaller.PowerShell/ServiceControlInstaller.Powershell.dll-help.xml
+++ b/src/ServiceControlInstaller.PowerShell/ServiceControlInstaller.Powershell.dll-help.xml
@@ -959,7 +959,7 @@ Get-SecurityIdentifier MyDomain\Foo</dev:code>
 			<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
 				<maml:name>ServiceAccountPassword</maml:name>
 				<maml:description>
-					<maml:para>The password for the Windows account used as the service account. If the Service Account was not specified then the account chosen is localsystem and no password is required.</maml:para>
+					<maml:para>The password for the Windows account used as the service account. If the Service Account was not specified then the account chosen is localsystem and no password is required.  For Active Directory Group Managed Service Accounts no password should be specified.</maml:para>
 				</maml:description>
 				<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 			</command:parameter>
@@ -1185,7 +1185,7 @@ Get-SecurityIdentifier MyDomain\Foo</dev:code>
 		<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="named">
 			<maml:name>ServiceAccountPassword</maml:name>
 			<maml:description>
-				<maml:para>The password for the Windows account used as the service account. If the Service Account was not specified then the account chosen is localsystem and no password is required.</maml:para>
+				<maml:para>The password for the Windows account used as the service account. If the Service Account was not specified then the account chosen is localsystem and no password is required. For Active Directory Group Managed Service Accounts no password should be specified</maml:para>
 			</maml:description>
 			<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 			<dev:type>
@@ -1271,8 +1271,10 @@ Get-SecurityIdentifier MyDomain\Foo</dev:code>
 			<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="2">
 				<maml:name>Password</maml:name>
 				<maml:description>
-					<maml:para>The Password for the Service Account.  When no account is specified then LocalSystem is used. 
-LocalSystem does not require a password</maml:para>
+					<maml:para>
+            The Password for the Service Account.  When no account is specified then LocalSystem is used.
+            LocalSystem does not require a password. For Active Directory Group Managed Service Accounts no password should be specified.
+          </maml:para>
 				</maml:description>
 				<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 			</command:parameter>
@@ -1306,8 +1308,10 @@ LocalSystem does not require a password</maml:para>
 		<command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false" position="2">
 			<maml:name>Password</maml:name>
 			<maml:description>
-				<maml:para>The Password for the Service Account.  When no account is specified then LocalSystem is used. 
-LocalSystem does not require a password</maml:para>
+				<maml:para>
+          The Password for the Service Account.  When no account is specified then LocalSystem is used.
+          LocalSystem does not require a password. For Active Directory Group Managed Service Accounts no password should be specified.
+        </maml:para>
 			</maml:description>
 			<command:parameterValue required="true" variableLength="false">String</command:parameterValue>
 			<dev:type>


### PR DESCRIPTION
Customer request:

> Description: I want the Windows Service that NServiceBus.Host.exe creates
> to be executed as a Group Managed Service Account. In Windows Server 2012,
> you can create a special account in Active Directory called a Group Managed
> Service Account (gMSA). You can use this account to host Windows Services,
> IIS App Pools, Scheduled Tasks, and more. The advantage of using a gMSA is
> that you don't have to know the password. In fact, no one knows the
> password. When an administrator of a server creates a Windows Service
> using services.msc, he (or she) can click on the login tab, type the gMSA's
> UPN and leave the password blank. The server (if it is permitted to do so)
> will retrieve the managed password from Active Directory. The password is
> automatically changed and refreshed on a scheduled basis.
> 
> 
> 
> We run as many services as we can using gMSA's.
> 
> 
> 
> You can read more about gMSA's here:
> https://blogs.technet.microsoft.com/askpfeplat/2012/12/16/windows-server-2012-group-managed-service-accounts/
> 

See also https://github.com/Particular/NServiceBus.Host/issues/93