### PR TITLE
Added support for MessageType groups for failure messages

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_ServiceControl_has_started.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_ServiceControl_has_started.cs
@@ -1,0 +1,28 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.Recoverability.Groups
+{
+    using System.Collections.Generic;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+    using ServiceControl.Recoverability;
+
+    public class When_ServiceControl_has_started : AcceptanceTest
+    {
+        [Test]
+        public void All_classifiers_should_be_retrievable()
+        {
+            List<string> classifiers = null;
+
+            Define<Context>()
+                .Done(x => TryGetMany("/api/recoverability/classifiers", out classifiers))
+                .Run();
+
+            Assert.IsNotNull(classifiers, "classifiers is null");
+            Assert.IsNotEmpty(classifiers, "No classifiers retrieved");
+            Assert.Contains(ExceptionTypeAndStackTraceFailureClassifier.Id, classifiers, "ExceptionTypeAndStackTraceFailureClassifier was not found");
+            Assert.Contains(MessageTypeFailureClassifier.Id, classifiers, "MessageTypeFailureClassifier was not found");
+        }
+
+        class Context : ScenarioContext
+        { }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_message_has_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_message_has_failed.cs
@@ -10,6 +10,7 @@
     using ServiceBus.Management.AcceptanceTests.Contexts;
     using ServiceControl.Infrastructure;
     using ServiceControl.MessageFailures;
+    using ServiceControl.Recoverability;
 
     class When_a_message_has_failed : AcceptanceTest
     {
@@ -35,6 +36,9 @@
 
             Assert.AreEqual(context.UniqueMessageId, failedMessage.UniqueMessageId);
             Assert.IsNotEmpty(failedMessage.FailureGroups, "The returned message should have failure groups");
+
+            Assert.AreEqual(1, failedMessage.FailureGroups.Count(g => g.Type == ExceptionTypeAndStackTraceFailureClassifier.Id), $"{ExceptionTypeAndStackTraceFailureClassifier.Id} FailureGroup was not created");
+            Assert.AreEqual(1, failedMessage.FailureGroups.Count(g => g.Type == MessageTypeFailureClassifier.Id), $"{MessageTypeFailureClassifier.Id} FailureGroup was not created");
         }
 
         public class Receiver : EndpointConfigurationBuilder

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_message_has_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_message_has_failed.cs
@@ -1,44 +1,95 @@
 ﻿namespace ServiceBus.Management.AcceptanceTests.Recoverability.Groups
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
+    using Newtonsoft.Json;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.Features;
     using NServiceBus.Settings;
     using NUnit.Framework;
     using ServiceBus.Management.AcceptanceTests.Contexts;
+    using ServiceBus.Management.Infrastructure.Settings;
+    using ServiceControl.Contracts.Operations;
     using ServiceControl.Infrastructure;
     using ServiceControl.MessageFailures;
     using ServiceControl.Recoverability;
 
-    class When_a_message_has_failed : AcceptanceTest
+    class When_a_messages_have_failed : AcceptanceTest
     {
         [Test]
         public void Should_be_grouped()
         {
             var context = new MyContext();
 
-            FailedMessage failedMessage = null;
+            List<FailureGroupView> defaultGroups = null;
+            List<FailureGroupView> exceptionTypeAndStackTraceGroups = null;
+            List<FailureGroupView> messageTypeGroups = null;
+
+            FailedMessage failedMessageA = null;
+            FailedMessage failedMessageB = null;
 
             Define(context)
-                .WithEndpoint<Receiver>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                .WithEndpoint<Receiver>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new MyMessageA());
+                    bus.SendLocal(new MyMessageB());
+                }))
                 .Done(c =>
                 {
-                    if (c.MessageId == null)
+                    if (c.MessageIdA == null || c.MessageIdB == null)
                     {
                         return false;
                     }
 
-                    return TryGet("/api/errors/" + c.UniqueMessageId, out failedMessage, msg => msg.FailureGroups.Any());
+                    if (!TryGetMany("/api/recoverability/groups/", out defaultGroups))
+                    {
+                        return false;
+                    }
+
+                    if (defaultGroups.Count != 2)
+                    {
+                        Thread.Sleep(1000);
+                        return false;
+                    }
+
+                    TryGetMany("/api/recoverability/groups/Message%20Type", out messageTypeGroups);
+                    TryGetMany("/api/recoverability/groups/Exception%20Type%20and%20Stack%20Trace", out exceptionTypeAndStackTraceGroups);
+
+                    if (!TryGet("/api/errors/" + c.UniqueMessageIdA, out failedMessageA, msg => msg.FailureGroups.Any()) || !TryGet("/api/errors/" + c.UniqueMessageIdB, out failedMessageB, msg => msg.FailureGroups.Any()))
+                    {
+                        return false;
+                    }
+
+
+
+                    return true;
                 })
                 .Run();
 
-            Assert.AreEqual(context.UniqueMessageId, failedMessage.UniqueMessageId);
-            Assert.IsNotEmpty(failedMessage.FailureGroups, "The returned message should have failure groups");
+            Assert.AreEqual(2, exceptionTypeAndStackTraceGroups.Count, "There should be 2 Exception Type and Stack Trace Groups");
+            Assert.AreEqual(2, messageTypeGroups.Count, "There should be 2 Message Type Groups");
 
-            Assert.AreEqual(1, failedMessage.FailureGroups.Count(g => g.Type == ExceptionTypeAndStackTraceFailureClassifier.Id), $"{ExceptionTypeAndStackTraceFailureClassifier.Id} FailureGroup was not created");
-            Assert.AreEqual(1, failedMessage.FailureGroups.Count(g => g.Type == MessageTypeFailureClassifier.Id), $"{MessageTypeFailureClassifier.Id} FailureGroup was not created");
+            defaultGroups.ForEach(g => Console.WriteLine(JsonConvert.SerializeObject(g)));
+
+            Assert.IsEmpty(exceptionTypeAndStackTraceGroups.Select(g => g.Id).Except(defaultGroups.Select(g => g.Id)), "/api/recoverability/groups did not retrieve Exception Type and Stack Trace Group");
+
+            Assert.Contains(DeterministicGuid.MakeId(MessageTypeFailureClassifier.Id, typeof(MyMessageA).FullName).ToString(), messageTypeGroups.Select(g => g.Id).ToArray());
+            Assert.Contains(DeterministicGuid.MakeId(MessageTypeFailureClassifier.Id, typeof(MyMessageB).FullName).ToString(), messageTypeGroups.Select(g => g.Id).ToArray());
+
+            Assert.AreEqual(context.UniqueMessageIdA, failedMessageA.UniqueMessageId);
+            Assert.AreEqual(context.UniqueMessageIdB, failedMessageB.UniqueMessageId);
+
+            Assert.IsNotEmpty(failedMessageA.FailureGroups, "MyMessageA should have failure groups");
+            Assert.IsNotEmpty(failedMessageB.FailureGroups, "MyMessageB should have failure groups");
+
+            Assert.AreEqual(1, failedMessageA.FailureGroups.Count(g => g.Type == ExceptionTypeAndStackTraceFailureClassifier.Id), $"{ExceptionTypeAndStackTraceFailureClassifier.Id} FailureGroup was not created");
+            Assert.AreEqual(1, failedMessageA.FailureGroups.Count(g => g.Type == MessageTypeFailureClassifier.Id), $"{MessageTypeFailureClassifier.Id} FailureGroup was not created");
+
+            Assert.AreEqual(1, failedMessageB.FailureGroups.Count(g => g.Type == ExceptionTypeAndStackTraceFailureClassifier.Id), $"{ExceptionTypeAndStackTraceFailureClassifier.Id} FailureGroup was not created");
+            Assert.AreEqual(1, failedMessageB.FailureGroups.Count(g => g.Type == MessageTypeFailureClassifier.Id), $"{MessageTypeFailureClassifier.Id} FailureGroup was not created");
         }
 
         public class Receiver : EndpointConfigurationBuilder
@@ -48,7 +99,9 @@
                 EndpointSetup<DefaultServerWithoutAudit>(c => c.DisableFeature<SecondLevelRetries>());
             }
 
-            public class MyMessageHandler : IHandleMessages<MyMessage>
+            public class MyMessageHandler :
+                IHandleMessages<MyMessageA>,
+                IHandleMessages<MyMessageB>
             {
                 public MyContext Context { get; set; }
 
@@ -56,26 +109,40 @@
 
                 public ReadOnlySettings Settings { get; set; }
 
-                public void Handle(MyMessage message)
+                public void Handle(MyMessageA message)
                 {
                     Context.EndpointNameOfReceivingEndpoint = Settings.EndpointName();
-                    Context.MessageId = Bus.CurrentMessageContext.Id.Replace(@"\", "-");
+                    Context.MessageIdA = Bus.CurrentMessageContext.Id.Replace(@"\", "-");
+                    throw new Exception("Simulated exception");
+                }
+
+                public void Handle(MyMessageB message)
+                {
+                    Context.MessageIdB = Bus.CurrentMessageContext.Id.Replace(@"\", "-");
                     throw new Exception("Simulated exception");
                 }
             }
         }
 
         [Serializable]
-        public class MyMessage : ICommand
+        public class MyMessageA : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MyMessageB : ICommand
         {
         }
 
         public class MyContext : ScenarioContext
         {
-            public string MessageId { get; set; }
+            public string MessageIdA { get; set; }
+            public string MessageIdB { get; set; }
+
             public string EndpointNameOfReceivingEndpoint { get; set; }
 
-            public string UniqueMessageId => DeterministicGuid.MakeId(MessageId, EndpointNameOfReceivingEndpoint).ToString();
+            public string UniqueMessageIdA => DeterministicGuid.MakeId(MessageIdA, EndpointNameOfReceivingEndpoint).ToString();
+            public string UniqueMessageIdB => DeterministicGuid.MakeId(MessageIdB, EndpointNameOfReceivingEndpoint).ToString();
         }
     }
 }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_messages_have_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_messages_have_failed.cs
@@ -11,13 +11,11 @@
     using NServiceBus.Settings;
     using NUnit.Framework;
     using ServiceBus.Management.AcceptanceTests.Contexts;
-    using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Contracts.Operations;
     using ServiceControl.Infrastructure;
     using ServiceControl.MessageFailures;
     using ServiceControl.Recoverability;
 
-    class When_a_messages_have_failed : AcceptanceTest
+    public class When_messages_have_failed : AcceptanceTest
     {
         [Test]
         public void Should_be_grouped()
@@ -30,6 +28,9 @@
 
             FailedMessage failedMessageA = null;
             FailedMessage failedMessageB = null;
+
+            List<FailedMessage> exceptionTypeAndStackTraceFailedMessages;
+            List<FailedMessage> messageTypeFailedMessages;
 
             Define(context)
                 .WithEndpoint<Receiver>(b => b.Given(bus =>
@@ -62,8 +63,6 @@
                     {
                         return false;
                     }
-
-
 
                     return true;
                 })

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_two_similar_messages_have_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_two_similar_messages_have_failed.cs
@@ -64,7 +64,7 @@
 
             var failureGroup = groups.First();
             Assert.AreEqual(2, failureGroup.Count, "Group should have both messages in it");
-            
+
             var failureTimes = firstFailure.ProcessingAttempts
                         .Union(secondFailure.ProcessingAttempts)
                         .Where(x => x.FailureDetails != null)

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -250,6 +250,7 @@
     <Compile Include="Recoverability\Groups\When_a_message_fails_twice_with_different_exceptions.cs" />
     <Compile Include="Recoverability\Groups\When_a_message_has_failed.cs" />
     <Compile Include="Recoverability\Groups\When_message_groups_are_sorted_by_a_web_api_call.cs" />
+    <Compile Include="Recoverability\Groups\When_ServiceControl_has_started.cs" />
     <Compile Include="Recoverability\Groups\When_two_similar_messages_have_failed.cs" />
     <Compile Include="Recoverability\When_a_message_is_retried_and_succeeds_with_a_reply.cs" />
     <Compile Include="SagaAudit\When_multiple_messages_are_emitted_by_a_saga.cs" />

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -248,7 +248,7 @@
     <Compile Include="Recoverability\Groups\When_a_group_is_retried.cs" />
     <Compile Include="Recoverability\Groups\When_a_group_is_archived.cs" />
     <Compile Include="Recoverability\Groups\When_a_message_fails_twice_with_different_exceptions.cs" />
-    <Compile Include="Recoverability\Groups\When_a_message_has_failed.cs" />
+    <Compile Include="Recoverability\Groups\When_messages_have_failed.cs" />
     <Compile Include="Recoverability\Groups\When_message_groups_are_sorted_by_a_web_api_call.cs" />
     <Compile Include="Recoverability\Groups\When_ServiceControl_has_started.cs" />
     <Compile Include="Recoverability\Groups\When_two_similar_messages_have_failed.cs" />

--- a/src/ServiceControl.UnitTests/Recoverability/ExceptionTypeAndStackTraceFailureClassifierTest.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/ExceptionTypeAndStackTraceFailureClassifierTest.cs
@@ -5,14 +5,13 @@
     using ServiceControl.Recoverability;
 
     [TestFixture]
-    public class ExceptionTypeAndStackTraceMessageGrouperTest
+    public class ExceptionTypeAndStackTraceFailureClassifierTest
     {
         [Test]
         public void Failure_Without_ExceptionDetails_should_not_group()
         {
-            var grouper = new ExceptionTypeAndStackTraceFailureClassifier();
-            var failureWithoutExceptionDetails =  new FailureDetails();
-            var classification = grouper.ClassifyFailure(failureWithoutExceptionDetails);
+            var classifier = new ExceptionTypeAndStackTraceFailureClassifier();
+            var classification = classifier.ClassifyFailure(new ClassifiableMessageDetails());
 
             Assert.IsNull(classification);
         }
@@ -20,9 +19,9 @@
         [Test]
         public void Empty_stack_trace_should_group_by_exception_type()
         {
-            var grouper = new ExceptionTypeAndStackTraceFailureClassifier();
+            var classifier = new ExceptionTypeAndStackTraceFailureClassifier();
             var failureWithEmptyStackTrace = CreateFailureDetailsWithStackTrace(string.Empty);
-            var classification = grouper.ClassifyFailure(failureWithEmptyStackTrace);
+            var classification = classifier.ClassifyFailure(failureWithEmptyStackTrace);
 
             Assert.AreEqual("exceptionType: 0", classification);
         }
@@ -30,9 +29,9 @@
         [Test]
         public void Null_stack_trace_should_group_by_exception_type()
         {
-            var grouper = new ExceptionTypeAndStackTraceFailureClassifier();
+            var classifier = new ExceptionTypeAndStackTraceFailureClassifier();
             var failureWithNullStackTrace = CreateFailureDetailsWithStackTrace(null);
-            var classification = grouper.ClassifyFailure(failureWithNullStackTrace);
+            var classification = classifier.ClassifyFailure(failureWithNullStackTrace);
 
             Assert.AreEqual("exceptionType: 0", classification);
         }
@@ -40,9 +39,9 @@
         [Test]
         public void Non_standard_stack_trace_format_should_group_by_exception_type()
         {
-            var grouper = new ExceptionTypeAndStackTraceFailureClassifier();
+            var classifier = new ExceptionTypeAndStackTraceFailureClassifier();
             var failureWithNonStandardStackTrace = CreateFailureDetailsWithStackTrace("something other than a normal stack trace");
-            var classification = grouper.ClassifyFailure(failureWithNonStandardStackTrace);
+            var classification = classifier.ClassifyFailure(failureWithNonStandardStackTrace);
 
             Assert.AreEqual("exceptionType: 0", classification);
         }
@@ -55,15 +54,15 @@
    at System.Environment.get_StackTrace()
    at Sample.Main()";
 
-            var grouper = new ExceptionTypeAndStackTraceFailureClassifier();
+            var classifier = new ExceptionTypeAndStackTraceFailureClassifier();
             var standardStackTrace = CreateFailureDetailsWithStackTrace(stackTrace);
 
-            var classification = grouper.ClassifyFailure(standardStackTrace);
+            var classification = classifier.ClassifyFailure(standardStackTrace);
             Assert.AreEqual(@"exceptionType: System.Environment.GetStackTrace(Exception e)", classification);
 
         }
 
-        static FailureDetails CreateFailureDetailsWithStackTrace(string stackTrace)
+        static ClassifiableMessageDetails CreateFailureDetailsWithStackTrace(string stackTrace)
         {
             var failureWithEmptyStackTrace = new FailureDetails
             {
@@ -73,7 +72,10 @@
                     ExceptionType = "exceptionType"
                 }
             };
-            return failureWithEmptyStackTrace;
+            return new ClassifiableMessageDetails
+            {
+                Details = failureWithEmptyStackTrace
+            };
         }
     }
 }

--- a/src/ServiceControl.UnitTests/Recoverability/ExceptionTypeAndStackTraceFailureClassifierTest.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/ExceptionTypeAndStackTraceFailureClassifierTest.cs
@@ -72,10 +72,7 @@
                     ExceptionType = "exceptionType"
                 }
             };
-            return new ClassifiableMessageDetails
-            {
-                Details = failureWithEmptyStackTrace
-            };
+            return new ClassifiableMessageDetails(null, failureWithEmptyStackTrace);
         }
     }
 }

--- a/src/ServiceControl.UnitTests/Recoverability/ExceptionTypeAndStackTraceMessageGrouperTest.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/ExceptionTypeAndStackTraceMessageGrouperTest.cs
@@ -10,7 +10,7 @@
         [Test]
         public void Failure_Without_ExceptionDetails_should_not_group()
         {
-            var grouper = new ExceptionTypeAndStackTraceMessageGrouper();
+            var grouper = new ExceptionTypeAndStackTraceFailureClassifier();
             var failureWithoutExceptionDetails =  new FailureDetails();
             var classification = grouper.ClassifyFailure(failureWithoutExceptionDetails);
 
@@ -20,7 +20,7 @@
         [Test]
         public void Empty_stack_trace_should_group_by_exception_type()
         {
-            var grouper = new ExceptionTypeAndStackTraceMessageGrouper();
+            var grouper = new ExceptionTypeAndStackTraceFailureClassifier();
             var failureWithEmptyStackTrace = CreateFailureDetailsWithStackTrace(string.Empty);
             var classification = grouper.ClassifyFailure(failureWithEmptyStackTrace);
 
@@ -30,20 +30,20 @@
         [Test]
         public void Null_stack_trace_should_group_by_exception_type()
         {
-            var grouper = new ExceptionTypeAndStackTraceMessageGrouper();
+            var grouper = new ExceptionTypeAndStackTraceFailureClassifier();
             var failureWithNullStackTrace = CreateFailureDetailsWithStackTrace(null);
             var classification = grouper.ClassifyFailure(failureWithNullStackTrace);
 
             Assert.AreEqual("exceptionType: 0", classification);
         }
-        
+
         [Test]
         public void Non_standard_stack_trace_format_should_group_by_exception_type()
         {
-            var grouper = new ExceptionTypeAndStackTraceMessageGrouper();
+            var grouper = new ExceptionTypeAndStackTraceFailureClassifier();
             var failureWithNonStandardStackTrace = CreateFailureDetailsWithStackTrace("something other than a normal stack trace");
             var classification = grouper.ClassifyFailure(failureWithNonStandardStackTrace);
-            
+
             Assert.AreEqual("exceptionType: 0", classification);
         }
 
@@ -54,8 +54,8 @@
    at System.Environment.GetStackTrace(Exception e)
    at System.Environment.get_StackTrace()
    at Sample.Main()";
-            
-            var grouper = new ExceptionTypeAndStackTraceMessageGrouper();
+
+            var grouper = new ExceptionTypeAndStackTraceFailureClassifier();
             var standardStackTrace = CreateFailureDetailsWithStackTrace(stackTrace);
 
             var classification = grouper.ClassifyFailure(standardStackTrace);

--- a/src/ServiceControl.UnitTests/Recoverability/MessageTypeFailureClassifierTest.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/MessageTypeFailureClassifierTest.cs
@@ -1,0 +1,30 @@
+﻿namespace ServiceControl.UnitTests.Operations
+{
+    using NUnit.Framework;
+    using ServiceControl.Recoverability;
+
+    [TestFixture]
+    public class MessageTypeFailureClassifierTest
+    {
+        [Test]
+        public void Failure_With_MessageType_should_group()
+        {
+            var classifier = new MessageTypeFailureClassifier();
+            var classification = classifier.ClassifyFailure(new ClassifiableMessageDetails
+            {
+                MessageType = GetType().ToString()
+            });
+
+            Assert.IsNotNull(classification);
+        }
+
+        [Test]
+        public void Failure_Without_MessageType_should_not_group()
+        {
+            var classifier = new MessageTypeFailureClassifier();
+            var classification = classifier.ClassifyFailure(new ClassifiableMessageDetails());
+
+            Assert.IsNull(classification);
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/Recoverability/MessageTypeFailureClassifierTest.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/MessageTypeFailureClassifierTest.cs
@@ -10,10 +10,7 @@
         public void Failure_With_MessageType_should_group()
         {
             var classifier = new MessageTypeFailureClassifier();
-            var classification = classifier.ClassifyFailure(new ClassifiableMessageDetails
-            {
-                MessageType = GetType().ToString()
-            });
+            var classification = classifier.ClassifyFailure(new ClassifiableMessageDetails(GetType().ToString(), null));
 
             Assert.IsNotNull(classification);
         }

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -136,7 +136,8 @@
     <Compile Include="RavenIndexAwaiter.cs" />
     <Compile Include="Infrastructure\TransportMessageExtensionsTests.cs" />
     <Compile Include="Operations\UpdateLicenseEnricherTest.cs" />
-    <Compile Include="Recoverability\ExceptionTypeAndStackTraceMessageGrouperTest.cs" />
+    <Compile Include="Recoverability\ExceptionTypeAndStackTraceFailureClassifierTest.cs" />
+    <Compile Include="Recoverability\MessageTypeFailureClassifierTest.cs" />
     <Compile Include="SagaAudit\SagaDetailsIndexTests.cs" />
     <Compile Include="SagaAudit\SagaListIndexTests.cs" />
   </ItemGroup>

--- a/src/ServiceControl/Recoverability/Grouping/ClassifyFailedMessageEnricher.cs
+++ b/src/ServiceControl/Recoverability/Grouping/ClassifyFailedMessageEnricher.cs
@@ -14,13 +14,15 @@ namespace ServiceControl.Recoverability
         {
             var classifications = new List<FailedMessage.FailureGroup>();
 
+            var details = new ClassifiableMessageDetails
+            {
+                MessageType = source.Metadata["MessageType"],
+                Details = source.FailureDetails
+            };
+
             foreach (var classifier in Classifiers)
             {
-                var classification = classifier.ClassifyFailure(new ClassifiableMessageDetails
-                {
-                    MessageType = source.Metadata["MessageType"],
-                    Details = source.FailureDetails
-                });
+                var classification = classifier.ClassifyFailure(details);
 
                 if (classification == null)
                     continue;

--- a/src/ServiceControl/Recoverability/Grouping/ClassifyFailedMessageEnricher.cs
+++ b/src/ServiceControl/Recoverability/Grouping/ClassifyFailedMessageEnricher.cs
@@ -14,11 +14,7 @@ namespace ServiceControl.Recoverability
         {
             var classifications = new List<FailedMessage.FailureGroup>();
 
-            var details = new ClassifiableMessageDetails
-            {
-                MessageType = source.Metadata["MessageType"],
-                Details = source.FailureDetails
-            };
+            var details = new ClassifiableMessageDetails((string)source.Metadata["MessageType"], source.FailureDetails);
 
             foreach (var classifier in Classifiers)
             {

--- a/src/ServiceControl/Recoverability/Grouping/ClassifyFailedMessageEnricher.cs
+++ b/src/ServiceControl/Recoverability/Grouping/ClassifyFailedMessageEnricher.cs
@@ -16,7 +16,12 @@ namespace ServiceControl.Recoverability
 
             foreach (var classifier in Classifiers)
             {
-                var classification = classifier.ClassifyFailure(source.FailureDetails);
+                var classification = classifier.ClassifyFailure(new ClassifiableMessageDetails
+                {
+                    MessageType = source.Metadata["MessageType"],
+                    Details = source.FailureDetails
+                });
+
                 if (classification == null)
                     continue;
 

--- a/src/ServiceControl/Recoverability/Grouping/FailedMessageClassification.cs
+++ b/src/ServiceControl/Recoverability/Grouping/FailedMessageClassification.cs
@@ -14,7 +14,8 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            context.Container.ConfigureComponent<ExceptionTypeAndStackTraceMessageGrouper>(DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent<ExceptionTypeAndStackTraceFailureClassifier>(DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent<MessageTypeFailureClassifier>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<ClassifyFailedMessageEnricher>(DependencyLifecycle.SingleInstance);
         }
 

--- a/src/ServiceControl/Recoverability/Grouping/FailureGroupsApi.cs
+++ b/src/ServiceControl/Recoverability/Grouping/FailureGroupsApi.cs
@@ -84,8 +84,9 @@ namespace ServiceControl.Recoverability
 
                 var results = session
                     .Query<FailureGroupView, FailureGroupsViewIndex>()
+                    .Where(v => v.Type == classifier)
                     .Statistics(out stats)
-                    .Count(v => v.Type == classifier);
+                    .Count();
 
                 return Negotiate
                     .WithTotalCount(results)

--- a/src/ServiceControl/Recoverability/Grouping/FailureGroupsApi.cs
+++ b/src/ServiceControl/Recoverability/Grouping/FailureGroupsApi.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Recoverability
 {
+    using System.Collections.Generic;
     using System.Linq;
     using Nancy;
     using NServiceBus;
@@ -15,16 +16,21 @@ namespace ServiceControl.Recoverability
     {
         public IBus Bus { get; set; }
 
+        public IEnumerable<IFailureClassifier> Classifiers { get; set; }
+
         public FailureGroupsApi()
         {
-            Post["/recoverability/groups/reclassify"] = 
+            Get["/recoverability/classifiers"] =
+                _ => GetSupportedClassifiers();
+
+            Post["/recoverability/groups/reclassify"] =
                 _ => ReclassifyErrors();
 
-            Get["/recoverability/groups"] =
-                _ => GetAllGroups();
+            Get["/recoverability/groups/{classifier?Exception Type and Stack Trace}"] =
+                parameters => GetAllGroups(parameters.Classifier);
 
-            Head["/recoverability/groups"] =
-                 _ => GetAllGroupsCount();
+            Head["/recoverability/groups/{classifier?Exception Type and Stack Trace}"] =
+                parameters => GetAllGroupsCount(parameters.Classifier);
 
             Get["/recoverability/groups/{groupId}/errors"] =
                 parameters => GetGroupErrors(parameters.GroupId);
@@ -43,7 +49,15 @@ namespace ServiceControl.Recoverability
             return HttpStatusCode.Accepted;
         }
 
-        dynamic GetAllGroups()
+        dynamic GetSupportedClassifiers()
+        {
+            var classifiers = Classifiers.Select(c => c.Name).ToArray();
+
+            return Negotiate.WithModel(classifiers)
+                .WithTotalCount(classifiers.Length);
+        }
+
+        dynamic GetAllGroups(string classifier)
         {
             using (var session = Store.OpenSession())
             {
@@ -51,6 +65,7 @@ namespace ServiceControl.Recoverability
 
                 var results = session.Query<FailureGroupView, FailureGroupsViewIndex>()
                     .Statistics(out stats)
+                    .Where(v => v.Type == classifier)
                     .OrderByDescending(x => x.Last)
                     .Take(200)
                     .ToArray();
@@ -61,15 +76,17 @@ namespace ServiceControl.Recoverability
             }
         }
 
-        dynamic GetAllGroupsCount()
+        dynamic GetAllGroupsCount(string classifier)
         {
             using (var session = Store.OpenSession())
             {
                 RavenQueryStatistics stats;
-                var results = session.Query<FailureGroupView, FailureGroupsViewIndex>()
+
+                var results = session
+                    .Query<FailureGroupView, FailureGroupsViewIndex>()
                     .Statistics(out stats)
-                    .Count();
-                   
+                    .Count(v => v.Type == classifier);
+
                 return Negotiate
                     .WithTotalCount(results)
                     .WithEtagAndLastModified(stats);

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/ClassifiableMessageDetails.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/ClassifiableMessageDetails.cs
@@ -4,20 +4,24 @@ namespace ServiceControl.Recoverability
     using ServiceControl.Contracts.Operations;
     using ServiceControl.MessageFailures;
 
-    public class ClassifiableMessageDetails
+    public struct ClassifiableMessageDetails
     {
-        public FailureDetails Details { get; set; }
-        public object MessageType { get; set; }
-
-        public ClassifiableMessageDetails()
-        { }
+        public FailureDetails Details { get; private set; }
+        public string MessageType { get; private set; }
 
         public ClassifiableMessageDetails(FailedMessage message)
         {
             var last = message.ProcessingAttempts.Last();
 
             Details = last.FailureDetails;
-            MessageType = last.MessageMetadata["MessageType"];
+            MessageType = (string)last.MessageMetadata["MessageType"];
+        }
+
+        public ClassifiableMessageDetails(string messageType, FailureDetails failureDetails)
+        {
+            Details = failureDetails;
+
+            MessageType = messageType;
         }
     }
 }

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/ClassifiableMessageDetails.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/ClassifiableMessageDetails.cs
@@ -1,0 +1,23 @@
+namespace ServiceControl.Recoverability
+{
+    using System.Linq;
+    using ServiceControl.Contracts.Operations;
+    using ServiceControl.MessageFailures;
+
+    public class ClassifiableMessageDetails
+    {
+        public FailureDetails Details { get; set; }
+        public object MessageType { get; set; }
+
+        public ClassifiableMessageDetails()
+        { }
+
+        public ClassifiableMessageDetails(FailedMessage message)
+        {
+            var last = message.ProcessingAttempts.Last();
+
+            Details = last.FailureDetails;
+            MessageType = last.MessageMetadata["MessageType"];
+        }
+    }
+}

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/ExceptionTypeAndStackTraceFailureClassifier.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/ExceptionTypeAndStackTraceFailureClassifier.cs
@@ -1,16 +1,17 @@
 namespace ServiceControl.Recoverability
 {
     using System.Linq;
-    using ServiceControl.Contracts.Operations;
 
-    public class ExceptionTypeAndStackTraceMessageGrouper : IFailureClassifier
+    public class ExceptionTypeAndStackTraceFailureClassifier : IFailureClassifier
     {
-        public string Name => "Exception Type and Stack Trace";
+        public const string Id = "Exception Type and Stack Trace";
 
-        public string ClassifyFailure(FailureDetails failureDetails)
+        public string Name => Id;
+
+        public string ClassifyFailure(ClassifiableMessageDetails failure)
         {
-            var exception = failureDetails.Exception;
-            
+            var exception = failure.Details.Exception;
+
             if (exception == null)
                 return null;
 

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/ExceptionTypeAndStackTraceFailureClassifier.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/ExceptionTypeAndStackTraceFailureClassifier.cs
@@ -10,7 +10,7 @@ namespace ServiceControl.Recoverability
 
         public string ClassifyFailure(ClassifiableMessageDetails failure)
         {
-            var exception = failure.Details.Exception;
+            var exception = failure.Details?.Exception;
 
             if (exception == null)
                 return null;

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/IFailureClassifier.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/IFailureClassifier.cs
@@ -1,10 +1,8 @@
 namespace ServiceControl.Recoverability
 {
-    using ServiceControl.Contracts.Operations;
-
-    interface IFailureClassifier
+    public interface IFailureClassifier
     {
         string Name { get; }
-        string ClassifyFailure(FailureDetails failureDetails);
+        string ClassifyFailure(ClassifiableMessageDetails failureDetails);
     }
 }

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/MessageTypeFailureClassifier.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/MessageTypeFailureClassifier.cs
@@ -7,7 +7,7 @@ namespace ServiceControl.Recoverability
 
         public string ClassifyFailure(ClassifiableMessageDetails failureDetails)
         {
-            return failureDetails.MessageType.ToString();
+            return failureDetails.MessageType?.ToString();
         }
     }
 }

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/MessageTypeFailureClassifier.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/MessageTypeFailureClassifier.cs
@@ -7,7 +7,7 @@ namespace ServiceControl.Recoverability
 
         public string ClassifyFailure(ClassifiableMessageDetails failureDetails)
         {
-            return failureDetails.MessageType?.ToString();
+            return failureDetails.MessageType;
         }
     }
 }

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/MessageTypeFailureClassifier.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/MessageTypeFailureClassifier.cs
@@ -1,0 +1,13 @@
+namespace ServiceControl.Recoverability
+{
+    public class MessageTypeFailureClassifier : IFailureClassifier
+    {
+        public const string Id = "Message Type";
+        public string Name => Id;
+
+        public string ClassifyFailure(ClassifiableMessageDetails failureDetails)
+        {
+            return failureDetails.MessageType.ToString();
+        }
+    }
+}

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/ReclassifyErrorsHandler.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/ReclassifyErrorsHandler.cs
@@ -12,7 +12,6 @@ namespace ServiceControl.Recoverability
     using Raven.Client;
     using Raven.Client.Linq;
     using Raven.Json.Linq;
-    using ServiceControl.Contracts.Operations;
     using ServiceControl.Infrastructure;
     using ServiceControl.MessageFailures;
     using ServiceControl.MessageFailures.Api;

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -499,10 +499,12 @@
     <Compile Include="Recoverability\Grouping\Archiving\ArchiveAllInGroupHandler.cs" />
     <Compile Include="Recoverability\Grouping\ClassifyFailedMessageEnricher.cs" />
     <Compile Include="Recoverability\Grouping\Archiving\FailureGroupsArchiveApi.cs" />
+    <Compile Include="Recoverability\Grouping\Groupers\ClassifiableMessageDetails.cs" />
+    <Compile Include="Recoverability\Grouping\Groupers\MessageTypeFailureClassifier.cs" />
     <Compile Include="Recoverability\Grouping\Groupers\ReclassifyErrorsHandler.cs" />
     <Compile Include="Recoverability\Grouping\Raven\ReclassifyErrorSettings.cs" />
     <Compile Include="Recoverability\Grouping\Retries\FailureGroupsRetryApi.cs" />
-    <Compile Include="Recoverability\Grouping\Groupers\ExceptionTypeAndStackTraceMessageGrouper.cs" />
+    <Compile Include="Recoverability\Grouping\Groupers\ExceptionTypeAndStackTraceFailureClassifier.cs" />
     <Compile Include="Recoverability\Grouping\FailedMessageClassification.cs" />
     <Compile Include="Recoverability\Grouping\Archiving\FailedMessageGroupArchived.cs" />
     <Compile Include="Recoverability\Grouping\Raven\FailedMessages_ByGroup.cs" />


### PR DESCRIPTION
### Feature
This release adds support for viewing failed messages grouped by Message Type.

I modified the existing `GET/HEAD /recoverability/groups/{classifier?Exception Type and Stack Trace}` actions to support a new parameter to set the classifier. The existing `Exception Type and Stack Trace` is set as the default grouping to maintain compatibility with the current version of ServicePulse. The new classifier is `Message Type`.

I have also added `GET /recoverability/classifiers` to retrieve a list of the currently implemented classifiers to make it easier for ServicePulse to implement this feature.

### Should You Upgrade Immediately
Nope.
