### PR TITLE
Modify `GetErrorById` to return data in similar format as `GetAllErrors`

### DIFF
--- a/src/ServiceControl/MessageFailures/Api/GetErrorById.cs
+++ b/src/ServiceControl/MessageFailures/Api/GetErrorById.cs
@@ -1,8 +1,11 @@
 ﻿namespace ServiceControl.MessageFailures.Api
 {
     using System;
+    using System.Linq;
     using Nancy;
+    using Raven.Client;
     using ServiceBus.Management.Infrastructure.Nancy.Modules;
+    using ServiceControl.Contracts.Operations;
 
     public class GetErrorById : BaseModule
     {
@@ -21,8 +24,32 @@
                         return HttpStatusCode.NotFound;
                     }
 
-                    return Negotiate.WithModel(message);
+                    var result = Map(message, session);
+
+                    return Negotiate.WithModel(result);
                 }
+            };
+        }
+
+        private static FailedMessageView Map(FailedMessage message, IDocumentSession session)
+        {
+            var processingAttempt = message.ProcessingAttempts.Last();
+
+            return new FailedMessageView()
+            {
+                Id = message.UniqueMessageId,
+                MessageType = processingAttempt.MessageMetadata["MessageType"].ToString(),
+                IsSystemMessage = (bool)processingAttempt.MessageMetadata["IsSystemMessage"],
+                SendingEndpoint = (EndpointDetails)processingAttempt.MessageMetadata["SendingEndpoint"],
+                ReceivingEndpoint = (EndpointDetails)processingAttempt.MessageMetadata["ReceivingEndpoint"],
+                TimeSent = DateTime.Parse(processingAttempt.MessageMetadata["TimeSent"].ToString()),
+                MessageId = processingAttempt.MessageMetadata["MessageId"].ToString(),
+                Exception = processingAttempt.FailureDetails.Exception,
+                QueueAddress = processingAttempt.FailureDetails.AddressOfFailingEndpoint,
+                NumberOfProcessingAttempts = message.ProcessingAttempts.Count,
+                Status = message.Status,
+                TimeOfFailure = processingAttempt.FailureDetails.TimeOfFailure,
+                LastModified = session.Advanced.GetMetadataFor(message)["Last-Modified"].Value<DateTime>()
             };
         }
 


### PR DESCRIPTION
Modify `GetErrorById` to return data in similar format as `GetAllErrors`