### PR TITLE
Throwing an exception regarding minimum error retention

### DIFF
--- a/src/ServiceControl.Config/Xaml/Controls/FormSlider.cs
+++ b/src/ServiceControl.Config/Xaml/Controls/FormSlider.cs
@@ -27,14 +27,16 @@
                 if (downButton != null)
                 {
                     downButton.Click += (sender, args) => {
-                        slider.Value = slider.Value - slider.SmallChange;
+                        var newValue = slider.Value - slider.SmallChange;
+                        slider.Value = (newValue < slider.Minimum) ? slider.Minimum : newValue;
                     };
                 }
 
                 if (upButton !=  null )
                 {
                     upButton.Click += (sender, args) => {
-                        slider.Value = slider.Value + slider.SmallChange;
+                        var newValue = slider.Value + slider.SmallChange;
+                        slider.Value = (newValue > slider.Maximum) ? slider.Maximum : newValue;
                     };
                 }
             }


### PR DESCRIPTION
When installing ServiceControl, I chose SqlServer as transport. 
Using the slider, I picked the minimum amount of days for error retention, i.e. 10 days. 

The trick is to click the slider arrow a few times after you slide it all the way to 10 days for error retention. Also, I was using SqlTransport, and running as a specific user.

I get the following error:

<img width="1150" alt="screen shot 2016-10-04 at 8 45 54 am" src="https://cloud.githubusercontent.com/assets/854553/19081506/62547318-8a0f-11e6-9fc3-a97652b38d22.png">

However, as you can see here in the UI, the appropriate value shows as 10 days:
<img width="1260" alt="screen shot 2016-10-04 at 8 46 20 am" src="https://cloud.githubusercontent.com/assets/854553/19081536/7c126e36-8a0f-11e6-8534-c534e5d34b4b.png">