### PR TITLE
Disabling monitoring of endpoints does not persist changes

### DIFF
--- a/src/ServiceControl/CompositeViews/Endpoints/KnownEndpointUpdateHandler.cs
+++ b/src/ServiceControl/CompositeViews/Endpoints/KnownEndpointUpdateHandler.cs
@@ -57,7 +57,7 @@ namespace ServiceControl.CompositeViews.Endpoints
 
                 knownEndpoint.Monitored = false;
 
-                session.Store(knownEndpoint);
+                session.SaveChanges();
             }
 
             bus.Publish(new MonitoringDisabledForEndpoint


### PR DESCRIPTION
### Symptoms
When disabling monitoring of endpoints, the command does not work because the changes are not persisted to RavenDB. 

### Who's Affected
Users that are running ServiceControl v1.25.0.