### PR TITLE
Fixes the problem of showing endpoints with no HB plugin as "inactive"

### DIFF
--- a/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
@@ -183,7 +183,14 @@ namespace ServiceBus.Management.AcceptanceTests
 
         protected IScenarioWithEndpointBehavior<T> Define<T>(Func<T> contextFactory) where T : ScenarioContext, new()
         {
-            scenarioContext = contextFactory();
+            var ctx = contextFactory();
+
+            if (ctx == scenarioContext)
+            {
+                //We have already SC running
+                return new ScenarioWithContext<T>(() => (T)scenarioContext);
+            }
+            scenarioContext = ctx;
             scenarioContext.SessionId = Guid.NewGuid().ToString();
 
             InitializeServiceControl(scenarioContext);

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_endpoint_with_audit_enabled_without_heartbeat_plugin_starts_up.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_endpoint_with_audit_enabled_without_heartbeat_plugin_starts_up.cs
@@ -1,0 +1,78 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.HeartbeatMonitoring
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Contexts;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+    using ServiceControl.CompositeViews.Endpoints;
+    using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+    public class When_an_endpoint_with_audit_enabled_without_heartbeat_plugin_starts_up : AcceptanceTest
+    {
+        static string EndpointName => Conventions.EndpointNamingConvention(typeof(StartingEndpoint));
+
+        [Test]
+        public void Should_not_be_monitored()
+        {
+            var context = new MyContext();
+            List<EndpointsView> endpoints = null;
+
+            Define(context)
+                .WithEndpoint<StartingEndpoint>()
+                .Done(c => TryGetMany("/api/endpoints/", out endpoints, e => e.Name == EndpointName))
+                .Run();
+
+            var myEndpoint = endpoints.FirstOrDefault(e => e.Name == EndpointName);
+            Assert.NotNull(myEndpoint);
+            Assert.IsFalse(myEndpoint.Monitored);
+        }
+
+        public class MyContext : ScenarioContext
+        {
+        }
+
+        public class StartingEndpoint : EndpointConfigurationBuilder
+        {
+            public StartingEndpoint()
+            {
+                EndpointSetup<DefaultServerWithoutAudit>(c =>
+                {
+                    c.EnableFeature<Audit>();
+                });
+            }
+
+            class SendMessage : IWantToRunWhenBusStartsAndStops
+            {
+                readonly IBus bus;
+
+                public SendMessage(IBus bus)
+                {
+                    this.bus = bus;
+                }
+
+                public void Start()
+                {
+                    bus.SendLocal(new MyMessage());
+                }
+
+                public void Stop()
+                {
+                }
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public void Handle(MyMessage message)
+                {
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_endpoint_with_audit_enabled_without_heartbeat_plugin_starts_up.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_endpoint_with_audit_enabled_without_heartbeat_plugin_starts_up.cs
@@ -5,7 +5,6 @@
     using Contexts;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.Features;
     using NUnit.Framework;
     using ServiceControl.CompositeViews.Endpoints;
     using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
@@ -38,10 +37,7 @@
         {
             public StartingEndpoint()
             {
-                EndpointSetup<DefaultServerWithoutAudit>(c =>
-                {
-                    c.EnableFeature<Audit>();
-                });
+                EndpointSetup<DefaultServerWithAudit>();
             }
 
             class SendMessage : IWantToRunWhenBusStartsAndStops

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_endpoint_with_heartbeat_plugin_starts_up.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_endpoint_with_heartbeat_plugin_starts_up.cs
@@ -1,0 +1,80 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.HeartbeatMonitoring
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Contexts;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+    using ServiceControl.CompositeViews.Endpoints;
+    using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+    public class When_an_endpoint_with_heartbeat_plugin_starts_up : AcceptanceTest
+    {
+        static string EndpointName => Conventions.EndpointNamingConvention(typeof(StartingEndpoint));
+
+        [Test]
+        public void Should_be_monitored_and_active()
+        {
+            var context = new MyContext();
+            List<EndpointsView> endpoints = null;
+
+            Define(context)
+                .WithEndpoint<StartingEndpoint>()
+                .Done(c => TryGetMany("/api/endpoints/", out endpoints, e => e.Name == EndpointName && e.Monitored && e.MonitorHeartbeat && e.IsSendingHeartbeats))
+                .Run();
+
+            var myEndpoint = endpoints.FirstOrDefault(e => e.Name == EndpointName);
+            Assert.NotNull(myEndpoint);
+            Assert.IsTrue(myEndpoint.Monitored);
+            Assert.IsTrue(myEndpoint.IsSendingHeartbeats);
+        }
+
+        public class MyContext : ScenarioContext
+        {
+        }
+
+        public class StartingEndpoint : EndpointConfigurationBuilder
+        {
+            public StartingEndpoint()
+            {
+                EndpointSetup<DefaultServerWithoutAudit>(c =>
+                {
+                    c.EnableFeature<Audit>();
+                }).IncludeAssembly(Assembly.LoadFrom("ServiceControl.Plugin.Nsb5.Heartbeat.dll"));
+            }
+
+            class SendMessage : IWantToRunWhenBusStartsAndStops
+            {
+                readonly IBus bus;
+
+                public SendMessage(IBus bus)
+                {
+                    this.bus = bus;
+                }
+
+                public void Start()
+                {
+                    bus.SendLocal(new MyMessage());
+                }
+
+                public void Stop()
+                {
+                }
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public void Handle(MyMessage message)
+                {
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_endpoint_with_heartbeat_plugin_starts_up.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_endpoint_with_heartbeat_plugin_starts_up.cs
@@ -6,7 +6,6 @@
     using Contexts;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.Features;
     using NUnit.Framework;
     using ServiceControl.CompositeViews.Endpoints;
     using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
@@ -40,10 +39,8 @@
         {
             public StartingEndpoint()
             {
-                EndpointSetup<DefaultServerWithoutAudit>(c =>
-                {
-                    c.EnableFeature<Audit>();
-                }).IncludeAssembly(Assembly.LoadFrom("ServiceControl.Plugin.Nsb5.Heartbeat.dll"));
+                EndpointSetup<DefaultServerWithAudit>()
+                    .IncludeAssembly(Assembly.LoadFrom("ServiceControl.Plugin.Nsb5.Heartbeat.dll"));
             }
 
             class SendMessage : IWantToRunWhenBusStartsAndStops

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_is_marked_as_monitored.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_is_marked_as_monitored.cs
@@ -1,0 +1,105 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.HeartbeatMonitoring
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Contexts;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+    using ServiceControl.CompositeViews.Endpoints;
+    using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+    public class When_an_unmonitored_endpoint_is_marked_as_monitored : AcceptanceTest
+    {
+        enum State
+        {
+            WaitingForEndpointDetection,
+            WaitingForHeartbeatFailure
+        }
+
+        static string EndpointName => Conventions.EndpointNamingConvention(typeof(MyEndpoint));
+
+        [Test]
+        public void It_is_shown_as_inactive_if_it_does_not_send_heartbeats()
+        {
+            var context = new MyContext();
+            List<EndpointsView> endpoints = null;
+            var state = State.WaitingForEndpointDetection;
+            Define(context)
+                .WithEndpoint<MyEndpoint>()
+                .Done(c =>
+                {
+                    if (state == State.WaitingForEndpointDetection)
+                    {
+                        var found = TryGetMany("/api/endpoints/", out endpoints, e => e.Name == EndpointName && !e.Monitored);
+                        if (found)
+                        {
+                            var endpointId = endpoints.First(e => e.Name == EndpointName).Id;
+                            Patch($"/api/endpoints/{endpointId}",new EndpointUpdateModel
+                            {
+                                MonitorHeartbeat = true
+                            });
+                            state = State.WaitingForHeartbeatFailure;
+                            Console.WriteLine("Patch successful");
+                        }
+                        return false;
+                    }
+                    return state == State.WaitingForHeartbeatFailure && TryGetMany("/api/endpoints/", out endpoints, e => e.Name == EndpointName && e.MonitorHeartbeat && e.Monitored && !e.IsSendingHeartbeats);
+                })
+                .Run();
+
+            var myEndpoint = endpoints.FirstOrDefault(e => e.Name == EndpointName);
+            Assert.NotNull(myEndpoint);
+            Assert.IsTrue(myEndpoint.Monitored);
+            Assert.IsTrue(myEndpoint.MonitorHeartbeat);
+            Assert.IsFalse(myEndpoint.IsSendingHeartbeats);
+        }
+
+        public class MyContext : ScenarioContext
+        {
+        }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServerWithoutAudit>(c =>
+                {
+                    c.EnableFeature<Audit>();
+                });
+            }
+
+            class SendMessage : IWantToRunWhenBusStartsAndStops
+            {
+                readonly IBus bus;
+
+                public SendMessage(IBus bus)
+                {
+                    this.bus = bus;
+                }
+
+                public void Start()
+                {
+                    bus.SendLocal(new MyMessage());
+                }
+
+                public void Stop()
+                {
+                }
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public void Handle(MyMessage message)
+                {
+                }
+            }
+        }
+        
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_is_marked_as_monitored.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_is_marked_as_monitored.cs
@@ -6,7 +6,6 @@
     using Contexts;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.Features;
     using NUnit.Framework;
     using ServiceControl.CompositeViews.Endpoints;
     using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
@@ -65,10 +64,7 @@
         {
             public MyEndpoint()
             {
-                EndpointSetup<DefaultServerWithoutAudit>(c =>
-                {
-                    c.EnableFeature<Audit>();
-                });
+                EndpointSetup<DefaultServerWithAudit>();
             }
 
             class SendMessage : IWantToRunWhenBusStartsAndStops

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_starts_sending_heartbeats.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_starts_sending_heartbeats.cs
@@ -1,0 +1,101 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.HeartbeatMonitoring
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Contexts;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+    using ServiceControl.CompositeViews.Endpoints;
+    using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+    public class When_an_unmonitored_endpoint_starts_sending_heartbeats : AcceptanceTest
+    {
+        static string EndpointName => Conventions.EndpointNamingConvention(typeof(MyEndpoint));
+
+        [Test]
+        public void Should_be_marked_as_monitored()
+        {
+            var context = new MyContext();
+            List<EndpointsView> endpoints = null;
+
+            Define(context)
+                .WithEndpoint<MyEndpoint>()
+                .Done(c => TryGetMany("/api/endpoints/", out endpoints, e => e.Name == EndpointName))
+                .Run();
+
+            var myEndpoint = endpoints.FirstOrDefault(e => e.Name == EndpointName);
+            Assert.NotNull(myEndpoint);
+            Assert.IsFalse(myEndpoint.Monitored);
+
+            Define(context)
+                .WithEndpoint<MyEndpointWithHeartbeat>()
+                .Done(c => TryGetMany("/api/endpoints/", out endpoints, e => e.Name == EndpointName && e.Monitored && e.MonitorHeartbeat && e.IsSendingHeartbeats))
+                .Run();
+
+            myEndpoint = endpoints.FirstOrDefault(e => e.Name == EndpointName);
+            Assert.NotNull(myEndpoint);
+            Assert.IsTrue(myEndpoint.Monitored);
+            Assert.IsTrue(myEndpoint.IsSendingHeartbeats);
+        }
+
+        public class MyContext : ScenarioContext
+        {
+        }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServerWithoutAudit>(c =>
+                {
+                    c.EnableFeature<Audit>();
+                });
+            }
+
+            class SendMessage : IWantToRunWhenBusStartsAndStops
+            {
+                readonly IBus bus;
+
+                public SendMessage(IBus bus)
+                {
+                    this.bus = bus;
+                }
+
+                public void Start()
+                {
+                    bus.SendLocal(new MyMessage());
+                }
+
+                public void Stop()
+                {
+                }
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public void Handle(MyMessage message)
+                {
+                }
+            }
+        }
+
+        public class MyEndpointWithHeartbeat : EndpointConfigurationBuilder
+        {
+            public MyEndpointWithHeartbeat()
+            {
+                EndpointSetup<DefaultServerWithoutAudit>(c =>
+                {
+                    c.EndpointName(EndpointName);
+                }).IncludeAssembly(Assembly.LoadFrom("ServiceControl.Plugin.Nsb5.Heartbeat.dll"));
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_starts_sending_heartbeats.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_starts_sending_heartbeats.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceBus.Management.AcceptanceTests.HeartbeatMonitoring
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_starts_sending_heartbeats.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_starts_sending_heartbeats.cs
@@ -34,7 +34,7 @@
                 .Done(c => TryGetMany("/api/endpoints/", out endpoints, e => e.Name == EndpointName && e.Monitored && e.MonitorHeartbeat && e.IsSendingHeartbeats))
                 .Run();
 
-            myEndpoint = endpoints.FirstOrDefault(e => e.Name == EndpointName);
+            myEndpoint = endpoints.SingleOrDefault(e => e.Name == EndpointName);
             Assert.NotNull(myEndpoint);
             Assert.IsTrue(myEndpoint.Monitored);
             Assert.IsTrue(myEndpoint.IsSendingHeartbeats);

--- a/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_starts_sending_heartbeats.cs
+++ b/src/ServiceControl.AcceptanceTests/HeartbeatMonitoring/When_an_unmonitored_endpoint_starts_sending_heartbeats.cs
@@ -6,7 +6,6 @@
     using Contexts;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.Features;
     using NUnit.Framework;
     using ServiceControl.CompositeViews.Endpoints;
     using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
@@ -49,10 +48,7 @@
         {
             public MyEndpoint()
             {
-                EndpointSetup<DefaultServerWithoutAudit>(c =>
-                {
-                    c.EnableFeature<Audit>();
-                });
+                EndpointSetup<DefaultServerWithAudit>();
             }
 
             class SendMessage : IWantToRunWhenBusStartsAndStops

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -221,6 +221,10 @@
     <Compile Include="ExternalIntegrations\When_heartbeat_is_restored.cs" />
     <Compile Include="ExternalIntegrations\When_encountered_an_error.cs" />
     <Compile Include="ExternalIntegrations\When_heartbeat_loss_is_detected.cs" />
+    <Compile Include="HeartbeatMonitoring\When_an_unmonitored_endpoint_is_marked_as_monitored.cs" />
+    <Compile Include="HeartbeatMonitoring\When_an_unmonitored_endpoint_starts_sending_heartbeats.cs" />
+    <Compile Include="HeartbeatMonitoring\When_an_endpoint_with_heartbeat_plugin_starts_up.cs" />
+    <Compile Include="HeartbeatMonitoring\When_an_endpoint_with_audit_enabled_without_heartbeat_plugin_starts_up.cs" />
     <Compile Include="HeartbeatMonitoring\When_an_endpoint_starts_up.cs" />
     <Compile Include="MessageFailures\ErrorImportPerformanceTests.cs" />
     <Compile Include="MessageFailures\Is_System_Message_Tests.cs" />

--- a/src/ServiceControl/EndpointControl/Handlers/DetectEndpointsFromHeartbeats.cs
+++ b/src/ServiceControl/EndpointControl/Handlers/DetectEndpointsFromHeartbeats.cs
@@ -3,9 +3,12 @@
     using Infrastructure;
     using InternalMessages;
     using NServiceBus;
+    using ServiceControl.CompositeViews.Endpoints;
     using ServiceControl.Contracts.HeartbeatMonitoring;
 
-    class DetectEndpointsFromHeartbeats : IHandleMessages<HeartbeatingEndpointDetected>
+    class DetectEndpointsFromHeartbeats : 
+        IHandleMessages<HeartbeatingEndpointDetected>,
+        IHandleMessages<EndpointHeartbeatRestored>
     {
         public IBus Bus { get; set; }
 
@@ -24,6 +27,20 @@
                     DetectedAt = message.DetectedAt
                 });
             }
+
+            Bus.SendLocal(new EnableEndpointMonitoring
+            {
+                EndpointId = id
+            });
+        }
+
+        public void Handle(EndpointHeartbeatRestored message)
+        {
+            var id = DeterministicGuid.MakeId(message.Endpoint.Name, message.Endpoint.HostId.ToString());
+            Bus.SendLocal(new EnableEndpointMonitoring
+            {
+                EndpointId = id
+            });
         }
     }
 }

--- a/src/ServiceControl/EndpointControl/Handlers/DetectEndpointsFromHeartbeats.cs
+++ b/src/ServiceControl/EndpointControl/Handlers/DetectEndpointsFromHeartbeats.cs
@@ -24,14 +24,17 @@
                 {
                     EndpointInstanceId = id,
                     Endpoint = message.Endpoint,
-                    DetectedAt = message.DetectedAt
+                    DetectedAt = message.DetectedAt,
+                    EnableMonitoring = true
                 });
             }
-
-            Bus.SendLocal(new EnableEndpointMonitoring
+            else
             {
-                EndpointId = id
-            });
+                Bus.SendLocal(new EnableEndpointMonitoring
+                {
+                    EndpointId = id
+                });
+            }
         }
 
         public void Handle(EndpointHeartbeatRestored message)

--- a/src/ServiceControl/EndpointControl/Handlers/RegisterEndpointHandler.cs
+++ b/src/ServiceControl/EndpointControl/Handlers/RegisterEndpointHandler.cs
@@ -54,6 +54,7 @@
                     {
                         EndpointDetails = message.Endpoint,
                         HostDisplayName = message.Endpoint.Host,
+                        Monitored = message.EnableMonitoring
                     };
 
                     if (id == Guid.Empty)
@@ -78,8 +79,10 @@
                             Id = id,
                             EndpointDetails = message.Endpoint,
                             HostDisplayName = message.Endpoint.Host,
+                            Monitored = knownEndpoint.Monitored || message.EnableMonitoring
                         });
                     }
+                    knownEndpoint.Monitored |= message.EnableMonitoring;
                 }
 
                 session.SaveChanges();

--- a/src/ServiceControl/EndpointControl/InternalMessages/RegisterEndpoint.cs
+++ b/src/ServiceControl/EndpointControl/InternalMessages/RegisterEndpoint.cs
@@ -9,5 +9,6 @@
         public Guid EndpointInstanceId { get; set; }
         public EndpointDetails Endpoint { get; set; }
         public DateTime DetectedAt { get; set; }
+        public bool EnableMonitoring { get; set; }
     }
 }

--- a/src/ServiceControl/EndpointControl/KnownEndpoint.cs
+++ b/src/ServiceControl/EndpointControl/KnownEndpoint.cs
@@ -5,11 +5,6 @@
 
     public class KnownEndpoint
     {
-        public KnownEndpoint()
-        {
-            Monitored = true;
-        }
-
         public Guid Id { get; set; }
         public string HostDisplayName { get; set; }
         public bool Monitored { get; set; }

--- a/src/ServiceControl/HeartbeatMonitoring/RaiseHeartbeatChanges.cs
+++ b/src/ServiceControl/HeartbeatMonitoring/RaiseHeartbeatChanges.cs
@@ -1,12 +1,10 @@
 ﻿namespace ServiceControl.HeartbeatMonitoring
 {
-    using Contracts.EndpointControl;
     using Contracts.HeartbeatMonitoring;
     using NServiceBus;
 
     public class RaiseHeartbeatChanges :
-        IHandleMessages<HeartbeatStatusChanged>,
-        IHandleMessages<NewEndpointDetected>
+        IHandleMessages<HeartbeatStatusChanged>
     {
         public IBus Bus { get; set; }
 
@@ -16,14 +14,7 @@
         {
             PublishUpdate(StatusProvider.GetHeartbeatsStats());
         }
-
-        public void Handle(NewEndpointDetected message)
-        {
-            //this call is non intuitive, we just call it since endpoints without the heartbeat plugin installed should count as "failing"
-            // we need to revisit the requirements for this
-            PublishUpdate(StatusProvider.RegisterNewEndpoint(message.Endpoint));
-        }
-
+        
         void PublishUpdate(HeartbeatsStats stats)
         {
             Bus.Publish(new HeartbeatsUpdated


### PR DESCRIPTION
This includes the original problem in #726 which was related to satellite receivers (which by definition don't send heartbeats) showing as "inactive" if there was a failure in processing that resulted in moving a message to the error queue.

There are two changes:
 * Remove the behavior which caused endpoints to be added to the monitored group immediately after they were detected (regardless of the detection source: HB, audit, error)
 * Enabling adding of endpoints to the monitored group when a HB is first detected or is restored

Fixes #726 