### PR TITLE
Don't create forwarding queues if option is disabled

### DIFF
--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -254,6 +254,7 @@
     <Compile Include="Xaml\Controls\AppHeader.xaml.cs">
       <DependentUpon>AppHeader.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Xaml\Controls\FormWarningTextBlock.cs" />
     <Compile Include="Xaml\Controls\FormSlider.cs" />
     <Compile Include="Xaml\Controls\FormPasswordBox.cs" />
     <Compile Include="Xaml\Controls\FormPathTextBox.cs" />

--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -196,6 +196,7 @@
     </Compile>
     <Compile Include="UI\MessageBox\YesNoCancelDialogViewModel.cs" />
     <Compile Include="UI\MessageBox\ReportCardViewModel.cs" />
+    <Compile Include="UI\SharedInstanceEditor\ForwardingOption.cs" />
     <Compile Include="UI\SharedInstanceEditor\SharedInstanceEditorView.xaml.cs">
       <DependentUpon>SharedInstanceEditorView.xaml</DependentUpon>
     </Compile>

--- a/src/ServiceControl.Config/Styles/Converters.xaml
+++ b/src/ServiceControl.Config/Styles/Converters.xaml
@@ -11,5 +11,6 @@
                                           IsHidden="True" />
     <converters:SelectedIndexToVisibilityConverter  x:Key="HasSelectedIndex"  />
     <converters:StringNullOrEmptyToVisibilityConverter x:Key="nullOrEmptyToVis" />
+    <converters:StringNullOrEmptyToVisibilityConverter x:Key="nullOrEmptyToVisInverted" Invert="True" />
     <converters:NegaterConverter x:Key="negate" />
 </ResourceDictionary>

--- a/src/ServiceControl.Config/Themes/Generic.xaml
+++ b/src/ServiceControl.Config/Themes/Generic.xaml
@@ -36,7 +36,7 @@
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="auto" />
-                                <RowDefinition Height="*" />
+                                <RowDefinition Height="auto" />
                                 <RowDefinition Height="auto" />
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
@@ -179,12 +179,12 @@
         <Border x:Name="PART_ContentHost"
                 Background="{TemplateBinding Background}"
                 Focusable="False"
-                Padding="3" />
+                Padding="2,1.5" />
     </ControlTemplate>
 
     <Style TargetType="{x:Type controls:FormComboBox}">
         <Setter Property="MinWidth" Value="120" />
-        <Setter Property="MinHeight" Value="20" />
+        <Setter Property="MinHeight" Value="18" />
         <Setter Property="Padding" Value="3" />
         <Setter Property="Margin" Value="0,5" />
         <Setter Property="SnapsToDevicePixels" Value="true" />
@@ -205,10 +205,10 @@
                             Padding="{TemplateBinding Padding}">
                         <Grid HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                              TextElement.FontSize="14">
+                              TextElement.FontSize="13">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="auto" />
-                                <RowDefinition Height="*" />
+                                <RowDefinition Height="auto" />
                                 <RowDefinition Height="auto" />
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
@@ -240,6 +240,7 @@
                             <TextBlock Grid.Row="1" Margin="3,3,23,3" 
                                        Text="Please Select..." 
                                        Foreground="{StaticResource Gray50Brush}" 
+                                       FontSize="13px"
                                        Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(SelectedIndex), Converter={StaticResource HasSelectedIndex}}" />
                             <TextBox x:Name="PART_EditableTextBox"
                                      Grid.Row="1"
@@ -790,4 +791,39 @@
         </Setter>
     </Style>
 
+    <Style TargetType="{x:Type controls:FormWarningTextBlock}">
+        <Setter Property="Text" Value="" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{StaticResource Gray70Brush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="3" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FontSize" Value="14px" />
+        <Setter Property="Foreground" Value="{StaticResource BlackBrush}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type controls:FormWarningTextBlock}">
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                        <Control x:Name="errorIcon"
+                                             Width="16"
+                                             Height="16"
+                                             Margin="5,0"
+                                             Foreground="{StaticResource WarningBrush}"
+                                             Template="{StaticResource WarningIcon}"
+                                             Visibility="{TemplateBinding  Text, Converter={StaticResource nullOrEmptyToVis}}"/>
+
+                        <TextBlock x:Name="PART_TextBlock" 
+                               Foreground="{TemplateBinding Foreground}"
+                               FontSize="{TemplateBinding FontSize}" 
+                               FontFamily="{TemplateBinding FontFamily}" 
+                               FontWeight="{TemplateBinding FontWeight}"
+                               VerticalAlignment="Top" 
+                               HorizontalAlignment="Left"
+                               Text="{TemplateBinding Text}" />
+                    </StackPanel>
+                   </ControlTemplate>
+            </Setter.Value>
+            </Setter>
+    </Style>
+    
 </ResourceDictionary>

--- a/src/ServiceControl.Config/Themes/Generic.xaml
+++ b/src/ServiceControl.Config/Themes/Generic.xaml
@@ -800,6 +800,7 @@
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="FontSize" Value="13px" />
         <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:FormWarningTextBlock}">
@@ -818,7 +819,7 @@
                                              VerticalAlignment="Top" 
                                              Template="{StaticResource WarningIcon}"
                                              Visibility="{TemplateBinding  Text, Converter={StaticResource nullOrEmptyToVis}}"
-                                             IsTabStop="False"
+                                             IsTabStop="{TemplateBinding IsTabStop}"
                                  />
 
                         <TextBlock x:Name="PART_TextBlock" 

--- a/src/ServiceControl.Config/Themes/Generic.xaml
+++ b/src/ServiceControl.Config/Themes/Generic.xaml
@@ -796,32 +796,44 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="{StaticResource Gray70Brush}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="Padding" Value="3" />
+        <Setter Property="Padding" Value="0" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-        <Setter Property="FontSize" Value="14px" />
-        <Setter Property="Foreground" Value="{StaticResource BlackBrush}" />
+        <Setter Property="FontSize" Value="13px" />
+        <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:FormWarningTextBlock}">
-                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="28"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
                         <Control x:Name="errorIcon"
+                                             Grid.Column="0"
                                              Width="16"
                                              Height="16"
                                              Margin="5,0"
                                              Foreground="{StaticResource WarningBrush}"
+                                             VerticalAlignment="Top" 
                                              Template="{StaticResource WarningIcon}"
-                                             Visibility="{TemplateBinding  Text, Converter={StaticResource nullOrEmptyToVis}}"/>
+                                             Visibility="{TemplateBinding  Text, Converter={StaticResource nullOrEmptyToVis}}"
+                                             IsTabStop="False"
+                                 />
 
                         <TextBlock x:Name="PART_TextBlock" 
+                               Width="Auto"
+                               Grid.Column="1"
                                Foreground="{TemplateBinding Foreground}"
                                FontSize="{TemplateBinding FontSize}" 
                                FontFamily="{TemplateBinding FontFamily}" 
                                FontWeight="{TemplateBinding FontWeight}"
                                VerticalAlignment="Top" 
                                HorizontalAlignment="Left"
+                               TextWrapping="Wrap"
                                Text="{TemplateBinding Text}" />
-                    </StackPanel>
-                   </ControlTemplate>
+                    </Grid>
+                </ControlTemplate>
             </Setter.Value>
             </Setter>
     </Style>

--- a/src/ServiceControl.Config/Themes/Generic.xaml
+++ b/src/ServiceControl.Config/Themes/Generic.xaml
@@ -801,6 +801,7 @@
         <Setter Property="FontSize" Value="13px" />
         <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
         <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Margin" Value="0,-10,0,0" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:FormWarningTextBlock}">
@@ -814,7 +815,6 @@
                                              Grid.Column="0"
                                              Width="16"
                                              Height="16"
-                                             Margin="5,0"
                                              Foreground="{StaticResource WarningBrush}"
                                              VerticalAlignment="Top" 
                                              Template="{StaticResource WarningIcon}"

--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddAttachment.cs
@@ -67,11 +67,11 @@
                 HostName = viewModel.HostName,
                 Port = Convert.ToInt32(viewModel.PortNumber),
                 VirtualDirectory = null, // TODO
-                AuditLogQueue = viewModel.AuditForwardingQueueName,
+                AuditLogQueue = viewModel.AuditForwarding.Value ? viewModel.AuditForwardingQueueName  : null,
                 AuditQueue = viewModel.AuditQueueName,
                 ForwardAuditMessages = viewModel.AuditForwarding.Value,
                 ErrorQueue = viewModel.ErrorQueueName,
-                ErrorLogQueue = viewModel.ErrorForwardingQueueName,
+                ErrorLogQueue = viewModel.ErrorForwarding.Value ? viewModel.ErrorForwardingQueueName : null ,
                 TransportPackage = viewModel.SelectedTransport.Name,
                 ConnectionString = viewModel.ConnectionString,
                 ErrorRetentionPeriod = viewModel.ErrorRetentionPeriod,

--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddView.xaml
@@ -155,26 +155,75 @@
                                Text="QUEUES CONFIGURATION" />
                 </Border>
 
-                <controls:FormTextBox Header="ERROR QUEUE NAME" Text="{Binding ErrorQueueName}" />
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <controls:FormTextBox  Grid.Column="0" 
+                                           Grid.Row="0"
+                                           Grid.ColumnSpan="2"
+                                           Header="ERROR QUEUE NAME"
+                                           Text="{Binding ErrorQueueName}" />
 
-                <controls:FormComboBox HorizontalAlignment="Stretch"
-                                       DisplayMemberPath="Name"
-                                       Header="ERROR FORWARDING"
-                                       ItemsSource="{Binding ErrorForwardingOptions}"
-                                       SelectedValue="{Binding ErrorForwarding}"
-                                       Warning="{Binding ErrorForwardingWarning}" />
+                    <controls:FormComboBox Grid.Column="0" 
+                                           Grid.Row="1"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Top" 
+                                           DisplayMemberPath="Name"
+                                           Header="ERROR FORWARDING"
+                                           ItemsSource="{Binding ErrorForwardingOptions}"
+                                           SelectedValue="{Binding ErrorForwarding}" />
+                    
+                    <controls:FormTextBox Grid.Column="1" 
+                                          Grid.Row="1"
+                                          Header="ERROR FORWARDING QUEUE NAME" 
+                                          Text="{Binding ErrorForwardingQueueName}" 
+                                          Visibility="{Binding ShowErrorForwardingQueue, Converter={StaticResource boolToVis}}"/>
 
-                <controls:FormTextBox Header="ERROR FORWARDING QUEUE NAME" Text="{Binding ErrorForwardingQueueName}" />
-                <controls:FormTextBox Header="AUDIT QUEUE NAME" Text="{Binding AuditQueueName}" />
-                <controls:FormComboBox HorizontalAlignment="Stretch"
-                                       DisplayMemberPath="Name"
-                                       Header="AUDIT FORWARDING"
-                                       ItemsSource="{Binding AuditForwardingOptions}"
-                                       SelectedValue="{Binding AuditForwarding}"
-                                       Warning="{Binding AuditForwardingWarning}" />
-                <controls:FormTextBox Header="AUDIT FORWARDING QUEUE NAME"
-                                      Text="{Binding AuditForwardingQueueName}"
-                                      ToolTip="The audit forwarding queue will be created even if Audit Forwarding is not enabled." />
+                    <controls:FormWarningTextBlock Grid.Column="0" 
+                                           Grid.ColumnSpan="2"
+                                           Grid.Row="2"
+                                           Text="{Binding ErrorForwardingWarning}" 
+                                           Visibility="{Binding Path=(cm:IDataErrorInfo.Error), Converter={StaticResource nullOrEmptyToVisInverted}}" />
+                    
+                    <controls:FormTextBox Grid.Column="0" 
+                                          Grid.ColumnSpan="2" 
+                                          Grid.Row="3"
+                                          Header="AUDIT QUEUE NAME" 
+                                          Text="{Binding AuditQueueName}" />
+
+                    <controls:FormComboBox Grid.Column="0" 
+                                           Grid.Row="4"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Top" 
+                                           DisplayMemberPath="Name"
+                                           Header="AUDIT FORWARDING"
+                                           ItemsSource="{Binding AuditForwardingOptions}"
+                                           SelectedValue="{Binding AuditForwarding}" 
+                                           />
+
+                    <controls:FormTextBox Grid.Column="1" 
+                                          Grid.Row="4"
+                                          Header="AUDIT FORWARDING QUEUE NAME"
+                                          Text="{Binding AuditForwardingQueueName}"
+                                          Visibility="{Binding ShowAuditForwardingQueue, Converter={StaticResource boolToVis}}"/>
+
+                    <controls:FormWarningTextBlock Grid.Column="0" 
+                                           Grid.ColumnSpan="2"
+                                           Grid.Row="5"
+                                           Text="{Binding AuditForwardingWarning}" 
+                                           Visibility="{Binding Path=(cm:IDataErrorInfo.Error), Converter={StaticResource nullOrEmptyToVisInverted}}" />
+
+                </Grid>
             </StackPanel>
         </sie:SharedInstanceEditorView.SharedContent>
     </sie:SharedInstanceEditorView>

--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddViewModel.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Windows.Input;
     using ServiceControl.Config.Commands;
+    using ServiceControl.Config.Framework.Modules;
     using ServiceControlInstaller.Engine.Configuration;
     using ServiceControlInstaller.Engine.Instances;
     using SharedInstanceEditor;
@@ -13,7 +14,7 @@
     [InjectValidation]
     public class InstanceAddViewModel : SharedInstanceEditorViewModel
     {
-        public InstanceAddViewModel()
+        public InstanceAddViewModel(Installer installer) : base (installer)
         {
             DisplayName = "Add new instance";
 
@@ -50,6 +51,7 @@
             ErrorForwardingQueueName = "error.log";
             ErrorForwarding = ErrorForwardingOptions.First(p => !p.Value); //Default to Off.
             UseSystemAccount = true;
+            Version = installer.ZipInfo.Version;
         }
 
         public string DestinationPath { get; set; }

--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddViewModel.cs
@@ -4,8 +4,8 @@
     using System.IO;
     using System.Linq;
     using System.Windows.Input;
+    using PropertyChanged;
     using ServiceControl.Config.Commands;
-    using ServiceControl.Config.Framework.Modules;
     using ServiceControlInstaller.Engine.Configuration;
     using ServiceControlInstaller.Engine.Instances;
     using SharedInstanceEditor;
@@ -14,7 +14,7 @@
     [InjectValidation]
     public class InstanceAddViewModel : SharedInstanceEditorViewModel
     {
-        public InstanceAddViewModel(Installer installer) : base (installer)
+        public InstanceAddViewModel()
         {
             DisplayName = "Add new instance";
 
@@ -51,7 +51,6 @@
             ErrorForwardingQueueName = "error.log";
             ErrorForwarding = ErrorForwardingOptions.First(p => !p.Value); //Default to Off.
             UseSystemAccount = true;
-            Version = installer.ZipInfo.Version;
         }
 
         public string DestinationPath { get; set; }
@@ -66,5 +65,42 @@
             DatabasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Particular", "ServiceControl", InstanceName, "DB");
             LogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Particular", "ServiceControl", InstanceName, "Logs");
         }
+
+        public string ErrorQueueName { get; set; }
+        public string ErrorForwardingQueueName { get; set; }
+        public string AuditQueueName { get; set; }
+        public string AuditForwardingQueueName { get; set; }
+        public ForwardingOption AuditForwarding { get; set; }
+        public ForwardingOption ErrorForwarding { get; set; }
+
+        [AlsoNotifyFor("AuditForwarding")]
+        public string AuditForwardingWarning => (AuditForwarding != null && AuditForwarding.Value) ? "Only enable if another application is processing messages from the Audit Forwarding Queue" : null;
+
+        [AlsoNotifyFor("ErrorForwarding")]
+        public string ErrorForwardingWarning => (ErrorForwarding != null && ErrorForwarding.Value) ? "Only enable if another application is processing messages from the Error Forwarding Queue" : null;
+
+        public bool ShowAuditForwardingQueue => AuditForwarding?.Value ?? false;
+        public bool ShowErrorForwardingQueue => ErrorForwarding?.Value ?? false;
+                    
+        TransportInfo selectedTransport;
+
+        [AlsoNotifyFor("ConnectionString", "ErrorQueueName", "AuditQueueName", "ErrorForwardingQueueName", "AuditForwardingQueueName")]
+        public TransportInfo SelectedTransport
+        {
+            get { return selectedTransport; }
+            set
+            {
+                ConnectionString = null;
+                selectedTransport = value;
+            }
+        }
+
+        public string ConnectionString { get; set; }
+
+        // ReSharper disable once UnusedMember.Global
+        public string SampleConnectionString => SelectedTransport != null ? SelectedTransport.SampleConnectionString : String.Empty;
+
+        // ReSharper disable once UnusedMember.Global
+        public bool ShowConnectionString => !string.IsNullOrEmpty(SelectedTransport?.SampleConnectionString);
     }
 }

--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddViewModelValidator.cs
@@ -27,6 +27,49 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 .MustNotBeIn(x => UsedPaths(x.InstanceName))
                 .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Paths")
                 .When(x => x.SubmitAttempted);
+
+            RuleFor(x => x.AuditForwarding)
+                .NotNull().WithMessage(Validations.MSG_SELECTAUDITFORWARDING);
+
+            RuleFor(x => x.ErrorForwarding)
+                .NotNull().WithMessage(Validations.MSG_SELECTERRORFORWARDING);
+
+            
+            RuleFor(x => x.ErrorQueueName)
+                .NotEmpty()
+                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit")
+                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Error Forwarding")
+                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit Forwarding")
+                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .When(x => x.SubmitAttempted);
+
+            RuleFor(x => x.ErrorForwardingQueueName)
+                .NotEmpty()
+                .NotEqual(x => x.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
+                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
+                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .When(x => x.SubmitAttempted && x.ErrorForwarding.Value);
+
+            RuleFor(x => x.AuditQueueName)
+                .NotEmpty()
+                .NotEqual(x => x.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
+                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
+                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
+                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .When(x => x.SubmitAttempted);
+
+            RuleFor(x => x.AuditForwardingQueueName).NotEmpty()
+                .NotEmpty().When(t => t.AuditForwarding != null)
+                .NotEqual(x => x.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
+                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
+                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .When(x => x.SubmitAttempted && x.ErrorForwarding.Value);
+
+            RuleFor(x => x.ConnectionString)
+                .NotEmpty().WithMessage(Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
+                .When(x => !string.IsNullOrWhiteSpace(x.SelectedTransport?.SampleConnectionString) && x.SubmitAttempted);
         }
     }
 }

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
@@ -122,7 +122,7 @@
 
         <GroupBox Grid.Row="6"
                   Grid.ColumnSpan="2"
-                  Header="HOST">
+                  Header="URL">
             <Hyperlink Command="{Binding OpenUrl}" CommandParameter="{Binding BrowsableUrl}">
                 <Hyperlink.ContextMenu>
                     <ContextMenu>

--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditView.xaml
@@ -220,9 +220,12 @@
                                            DisplayMemberPath="Name"
                                            Header="ERROR FORWARDING"
                                            ItemsSource="{Binding ErrorForwardingOptions}"
-                                           SelectedValue="{Binding ErrorForwarding}" />
+                                           SelectedValue="{Binding ErrorForwarding}"
+                                           Visibility="{Binding ShowErrorForwardingCombo, Converter={StaticResource boolToVis}}"
+                                           />
 
-                    <controls:FormTextBox Grid.Column="1" 
+                    <controls:FormTextBox Grid.Column="{Binding ErrorForwardingQueueColumn}" 
+                                          Grid.ColumnSpan="{Binding ErrorForwardingQueueColumnSpan}"
                                           Grid.Row="1"
                                           Header="ERROR FORWARDING QUEUE NAME" 
                                           Text="{Binding ErrorForwardingQueueName}" 

--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditView.xaml
@@ -194,32 +194,74 @@
                                FontWeight="Bold"
                                Text="QUEUES CONFIGURATION" />
                 </Border>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <controls:FormTextBox  Grid.Column="0" 
+                                           Grid.Row="0"
+                                           Grid.ColumnSpan="2"
+                                           Header="ERROR QUEUE NAME"
+                                           Text="{Binding ErrorQueueName}" />
 
+                    <controls:FormComboBox Grid.Column="0" 
+                                           Grid.Row="1"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Top" 
+                                           DisplayMemberPath="Name"
+                                           Header="ERROR FORWARDING"
+                                           ItemsSource="{Binding ErrorForwardingOptions}"
+                                           SelectedValue="{Binding ErrorForwarding}" />
 
-                <controls:FormTextBox Header="ERROR QUEUE NAME" Text="{Binding ErrorQueueName}" />
+                    <controls:FormTextBox Grid.Column="1" 
+                                          Grid.Row="1"
+                                          Header="ERROR FORWARDING QUEUE NAME" 
+                                          Text="{Binding ErrorForwardingQueueName}" 
+                                          Visibility="{Binding ShowErrorForwardingQueue, Converter={StaticResource boolToVis}}"/>
 
-                <controls:FormComboBox HorizontalAlignment="Stretch"
-                                       DisplayMemberPath="Name"
-                                       Header="ERROR FORWARDING"
-                                       ItemsSource="{Binding ErrorForwardingOptions}"
-                                       SelectedValue="{Binding ErrorForwarding}"
-                                       Visibility="{Binding ErrorForwardingVisible,
-                                                            Converter={StaticResource boolToVis}}"
-                                       Warning="{Binding ErrorForwardingWarning}" />
+                    <controls:FormWarningTextBlock Grid.Column="0" 
+                                           Grid.ColumnSpan="2"
+                                           Grid.Row="2"
+                                           Text="{Binding ErrorForwardingWarning}" 
+                                           Visibility="{Binding Path=(cm:IDataErrorInfo.Error), Converter={StaticResource nullOrEmptyToVisInverted}}" />
 
-                <controls:FormTextBox Header="ERROR FORWARDING QUEUE NAME" Text="{Binding ErrorForwardingQueueName}" />
+                    <controls:FormTextBox Grid.Column="0" 
+                                          Grid.ColumnSpan="2" 
+                                          Grid.Row="3"
+                                          Header="AUDIT QUEUE NAME" 
+                                          Text="{Binding AuditQueueName}" />
 
-                <controls:FormTextBox Header="AUDIT QUEUE NAME" Text="{Binding AuditQueueName}" />
+                    <controls:FormComboBox Grid.Column="0" 
+                                           Grid.Row="4"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Top" 
+                                           DisplayMemberPath="Name"
+                                           Header="AUDIT FORWARDING"
+                                           ItemsSource="{Binding AuditForwardingOptions}"
+                                           SelectedValue="{Binding AuditForwarding}" 
+                                           />
 
-                <controls:FormComboBox HorizontalAlignment="Stretch"
-                                       DisplayMemberPath="Name"
-                                       Header="AUDIT FORWARDING"
-                                       ItemsSource="{Binding AuditForwardingOptions}"
-                                       SelectedValue="{Binding AuditForwarding}"
-                                       Warning="{Binding AuditForwardingWarning}" />
-                <controls:FormTextBox Header="AUDIT FORWARDING QUEUE NAME"
-                                      Text="{Binding AuditForwardingQueueName}"
-                                      ToolTip="The audit forwarding queue will be created even if Audit Forwarding is not enabled." />
+                    <controls:FormTextBox Grid.Column="1" 
+                                          Grid.Row="4"
+                                          Header="AUDIT FORWARDING QUEUE NAME"
+                                          Text="{Binding AuditForwardingQueueName}"
+                                          Visibility="{Binding ShowAuditForwardingQueue, Converter={StaticResource boolToVis}}"/>
+
+                    <controls:FormWarningTextBlock Grid.Column="0" 
+                                           Grid.ColumnSpan="2"
+                                           Grid.Row="5"
+                                           Text="{Binding AuditForwardingWarning}" 
+                                           Visibility="{Binding Path=(cm:IDataErrorInfo.Error), Converter={StaticResource nullOrEmptyToVisInverted}}" />
+                    </Grid>
             </StackPanel>
         </sie:SharedInstanceEditorView.SharedContent>
     </sie:SharedInstanceEditorView>

--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditViewModel.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using Commands;
+    using ServiceControl.Config.Framework.Modules;
     using ServiceControlInstaller.Engine.Accounts;
     using ServiceControlInstaller.Engine.Configuration;
     using ServiceControlInstaller.Engine.Instances;
@@ -12,7 +13,7 @@
     [InjectValidation]
     public class InstanceEditViewModel : SharedInstanceEditorViewModel
     {
-        public InstanceEditViewModel(ServiceControlInstance instance)
+        public InstanceEditViewModel(ServiceControlInstance instance, Installer installer) : base (installer)
         {
             DisplayName = "Edit Instance";
             SelectLogPath = new SelectPathCommand(p => LogPath = p, isFolderPicker: true, defaultPath: LogPath);
@@ -53,7 +54,7 @@
             ErrorForwardingVisible = instance.Version >= SettingsList.ForwardErrorMessages.SupportedFrom;
 
             //Both Audit and Error Retention Property was introduced in same version
-            RetentionPeriodsVisible = instance.Version >= SettingsList.ErrorRetentionPeriod.SupportedFrom; 
+            RetentionPeriodsVisible = instance.Version >= SettingsList.ErrorRetentionPeriod.SupportedFrom;
         }
 
         public bool ErrorForwardingVisible { get; set; }

--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditViewModel.cs
@@ -86,9 +86,9 @@
             {
                 if (ServiceControlInstance.Version >= Compatibility.ForwardingQueuesAreOptional.SupportedFrom)
                 {
-                    return true;
+                    return AuditForwarding?.Value ?? false;
                 }
-                return AuditForwarding?.Value ?? false;
+                return true;
             }
         }
 

--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditViewModel.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Linq;
     using Commands;
-    using ServiceControl.Config.Framework.Modules;
+    using PropertyChanged;
     using ServiceControlInstaller.Engine.Accounts;
     using ServiceControlInstaller.Engine.Configuration;
     using ServiceControlInstaller.Engine.Instances;
@@ -13,7 +13,7 @@
     [InjectValidation]
     public class InstanceEditViewModel : SharedInstanceEditorViewModel
     {
-        public InstanceEditViewModel(ServiceControlInstance instance, Installer installer) : base (installer)
+        public InstanceEditViewModel(ServiceControlInstance instance) 
         {
             DisplayName = "Edit Instance";
             SelectLogPath = new SelectPathCommand(p => LogPath = p, isFolderPicker: true, defaultPath: LogPath);
@@ -34,9 +34,9 @@
 
             HostName = instance.HostName;
             PortNumber = instance.Port.ToString();
-            
+
             LogPath = instance.LogPath;
-            
+
             AuditForwardingQueueName = instance.AuditLogQueue;
             AuditQueueName = instance.AuditQueue;
             AuditForwarding = AuditForwardingOptions.FirstOrDefault(p => p.Value == instance.ForwardAuditMessages);
@@ -59,7 +59,70 @@
 
         public bool ErrorForwardingVisible { get; set; }
         public bool RetentionPeriodsVisible { get; set; }
-        
+
         public ServiceControlInstance ServiceControlInstance { get; set; }
+
+
+        public string ErrorQueueName { get; set; }
+        public string ErrorForwardingQueueName { get; set; }
+        public string AuditQueueName { get; set; }
+        public string AuditForwardingQueueName { get; set; }
+        public ForwardingOption AuditForwarding { get; set; }
+        public ForwardingOption ErrorForwarding { get; set; }
+
+        [AlsoNotifyFor("AuditForwarding")]
+        public string AuditForwardingWarning => (AuditForwarding != null && AuditForwarding.Value) ? "Only enable if another application is processing messages from the Audit Forwarding Queue" : null;
+
+        [AlsoNotifyFor("ErrorForwarding")]
+        public string ErrorForwardingWarning => (ErrorForwarding != null && ErrorForwarding.Value) ? "Only enable if another application is processing messages from the Error Forwarding Queue" : null;
+        
+        public bool ShowErrorForwardingCombo => ServiceControlInstance.Version >= SettingsList.ForwardErrorMessages.SupportedFrom;
+        public int ErrorForwardingQueueColumn => ServiceControlInstance.Version >= SettingsList.ForwardErrorMessages.SupportedFrom ? 1 : 0;
+        public int ErrorForwardingQueueColumnSpan => ServiceControlInstance.Version >= SettingsList.ForwardErrorMessages.SupportedFrom ? 1 : 2;
+
+        public bool ShowAuditForwardingQueue
+        {
+            get
+            {
+                if (ServiceControlInstance.Version >= Compatibility.ForwardingQueuesAreOptional.SupportedFrom)
+                {
+                    return true;
+                }
+                return AuditForwarding?.Value ?? false;
+            }
+        }
+
+        public bool ShowErrorForwardingQueue
+        {
+            get
+            {
+                if (ServiceControlInstance.Version >= Compatibility.ForwardingQueuesAreOptional.SupportedFrom)
+                {
+                    return ErrorForwarding?.Value ?? false;
+                }
+                return true;
+            }
+        }
+        
+        TransportInfo selectedTransport;
+
+        [AlsoNotifyFor("ConnectionString", "ErrorQueueName", "AuditQueueName", "ErrorForwardingQueueName", "AuditForwardingQueueName")]
+        public TransportInfo SelectedTransport
+        {
+            get { return selectedTransport; }
+            set
+            {
+                ConnectionString = null;
+                selectedTransport = value;
+            }
+        }
+
+        public string ConnectionString { get; set; }
+
+        // ReSharper disable once UnusedMember.Global
+        public string SampleConnectionString => SelectedTransport != null ? SelectedTransport.SampleConnectionString : string.Empty;
+
+        // ReSharper disable once UnusedMember.Global
+        public bool ShowConnectionString => !string.IsNullOrEmpty(SelectedTransport?.SampleConnectionString);
     }
 }

--- a/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/InstanceEditViewModelValidator.cs
@@ -12,7 +12,49 @@ namespace ServiceControl.Config.UI.InstanceEdit
                 .When(x => x.SubmitAttempted); 
 
             RuleFor(x => x.SelectedTransport)
-                .NotEmpty(); 
+                .NotEmpty();
+
+            RuleFor(x => x.AuditForwarding)
+                .NotNull().WithMessage(Validations.MSG_SELECTAUDITFORWARDING);
+
+            RuleFor(x => x.ErrorForwarding)
+                .NotNull().WithMessage(Validations.MSG_SELECTERRORFORWARDING);
+
+            RuleFor(x => x.ErrorQueueName)
+                .NotEmpty()
+                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit")
+                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Error Forwarding")
+                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit Forwarding")
+                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .When(x => x.SubmitAttempted);
+
+            RuleFor(x => x.ErrorForwardingQueueName)
+                .NotEmpty()
+                .NotEqual(x => x.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
+                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
+                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .When(x => x.SubmitAttempted && x.ErrorForwarding.Value);
+
+            RuleFor(x => x.AuditQueueName)
+                .NotEmpty()
+                .NotEqual(x => x.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
+                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
+                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
+                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .When(x => x.SubmitAttempted);
+
+            RuleFor(x => x.AuditForwardingQueueName).NotEmpty()
+                .NotEmpty().When(t => t.AuditForwarding != null)
+                .NotEqual(x => x.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
+                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
+                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .When(x => x.SubmitAttempted && x.ErrorForwarding.Value);
+
+            RuleFor(x => x.ConnectionString)
+               .NotEmpty().WithMessage(Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
+               .When(x => !string.IsNullOrWhiteSpace(x.SelectedTransport?.SampleConnectionString) && x.SubmitAttempted);
         }
     }
 }

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/ForwardingOption.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/ForwardingOption.cs
@@ -1,0 +1,8 @@
+﻿namespace ServiceControl.Config.UI.SharedInstanceEditor
+{
+    public class ForwardingOption
+    {
+        public string Name { get; set; }
+        public bool Value { get; set; }
+    }
+}

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/ServiceInstanceViewlValidator.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/ServiceInstanceViewlValidator.cs
@@ -76,57 +76,12 @@ namespace ServiceControl.Config.Validation
                 .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports")
                 .When(x => x.SubmitAttempted);
 
-            RuleFor(x => x.ConnectionString)
-                .TransportConnectionStringValid()
-                .When(x => x.SubmitAttempted);
-
-            RuleFor(x => x.AuditForwarding)
-                .NotNull().WithMessage(Validations.MSG_SELECTAUDITFORWARDING);
-
-
-            RuleFor(x => x.ErrorForwarding)
-                .NotNull().WithMessage(Validations.MSG_SELECTERRORFORWARDING);
-                
-
-
             RuleFor(x => x.LogPath)
                 .NotEmpty()
                 .ValidPath()
                 .MustNotBeIn(x => UsedPaths(x.InstanceName))
                 .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Paths")
                 .When(x => x.SubmitAttempted);
-
-            RuleFor(x => x.ErrorQueueName)
-                .NotEmpty()
-                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit")
-                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Error Forwarding")
-                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit Forwarding")
-                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted);
-
-            RuleFor(x => x.ErrorForwardingQueueName)
-                .NotEmpty()
-                .NotEqual(x => x.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
-                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
-                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
-                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted && x.ErrorForwarding.Value);
-
-            RuleFor(x => x.AuditQueueName)
-                .NotEmpty()
-                .NotEqual(x => x.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
-                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
-                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
-                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted);
-
-            RuleFor(x => x.AuditForwardingQueueName).NotEmpty()
-                .NotEmpty().When(t => t.AuditForwarding != null)
-                .NotEqual(x => x.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
-                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
-                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
-                .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted && x.ErrorForwarding.Value);
         }
     }
 }

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/ServiceInstanceViewlValidator.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/ServiceInstanceViewlValidator.cs
@@ -83,9 +83,10 @@ namespace ServiceControl.Config.Validation
             RuleFor(x => x.AuditForwarding)
                 .NotNull().WithMessage(Validations.MSG_SELECTAUDITFORWARDING);
 
+
             RuleFor(x => x.ErrorForwarding)
                 .NotNull().WithMessage(Validations.MSG_SELECTERRORFORWARDING);
-
+                
 
 
             RuleFor(x => x.LogPath)
@@ -109,7 +110,7 @@ namespace ServiceControl.Config.Validation
                 .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
                 .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
                 .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted);
+                .When(x => x.SubmitAttempted && x.ErrorForwarding.Value);
 
             RuleFor(x => x.AuditQueueName)
                 .NotEmpty()
@@ -125,7 +126,7 @@ namespace ServiceControl.Config.Validation
                 .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
                 .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
                 .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted);
+                .When(x => x.SubmitAttempted && x.ErrorForwarding.Value);
         }
     }
 }

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorViewModel.cs
@@ -206,6 +206,11 @@
         // ReSharper disable once UnusedMember.Global
         public bool ShowConnectionString => SelectedTransport != null && !string.IsNullOrEmpty(SelectedTransport.SampleConnectionString);
 
+        public bool ShowAuditForwardingQueue => AuditForwarding?.Value ?? false;
+
+        public bool ShowErrorForwardingQueue => ErrorForwarding?.Value ?? false;
+
+
         public string LogPath { get; set; }
         public ICommand SelectLogPath { get; set; }
 

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorViewModel.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Windows.Forms;
     using System.Windows.Input;
     using PropertyChanged;
     using ServiceControl.Config.Framework.Modules;
@@ -12,22 +11,14 @@
     using ServiceControlInstaller.Engine.Configuration;
     using ServiceControlInstaller.Engine.Instances;
 
-    public class ForwardingOption
-    {
-        public string Name { get; set; }
-        public bool Value { get; set; }
-    }
-
     public class SharedInstanceEditorViewModel : RxProgressScreen
     {
         string hostName;
         string serviceAccount;
         string password;
-        TransportInfo selectedTransport;
-
-        public SharedInstanceEditorViewModel(Installer installer)
+      
+        public SharedInstanceEditorViewModel()
         {
-            this.installer = installer;
             Transports = ServiceControlInstaller.Engine.Instances.Transports.All;
             AuditForwardingOptions = new[]
             {
@@ -57,15 +48,11 @@
             };
         }
 
-        private Installer installer;
-
-
+        
         [DoNotNotify]
         public ValidationTemplate ValidationTemplate { get; set; }
 
         public string InstanceName { get; set; }
-
-
 
         public string HostName
         {
@@ -116,8 +103,6 @@
             set { password = value; }
         }
 
-        public Version Version { get; set; }
-
         public bool UseSystemAccount { get; set; }
 
         public bool UseServiceAccount { get; set; }
@@ -153,50 +138,6 @@
             }
         }
 
-        public string ErrorQueueName { get; set; }
-        public string ErrorForwardingQueueName { get; set; }
-        public string AuditQueueName { get; set; }
-        public string AuditForwardingQueueName { get; set; }
-
-        public ForwardingOption AuditForwarding { get; set; }
-
-        public ForwardingOption ErrorForwarding { get; set; }
-
-        [AlsoNotifyFor("AuditForwarding")]
-        public string AuditForwardingWarning => (AuditForwarding != null && AuditForwarding.Value) ? "Only enable if another application is processing messages from the Audit Forwarding Queue" : null;
-
-        [AlsoNotifyFor("ErrorForwarding")]
-        public string ErrorForwardingWarning => (ErrorForwarding != null && ErrorForwarding.Value) ? "Only enable if another application is processing messages from the Error Forwarding Queue" : null;
-
-        public bool ShowAuditForwardingQueue
-        {
-            get
-            {
-                if (Compatibility.ForwardingQueuesAreOptional.SupportedFrom > Version)
-                {
-                    return true;
-                }
-                return AuditForwarding?.Value ?? false; 
-            }
-        }
-
-        public bool ShowErrorForwardingQueue
-        {
-            get
-            {
-                
-                if (Version >= SettingsList.ForwardErrorMessages.SupportedFrom)
-                {
-                    if (Compatibility.ForwardingQueuesAreOptional.SupportedFrom > Version)
-                    {
-                        return ErrorForwarding?.Value ?? false;
-                    }
-                    return true;
-                }
-                return false;
-            }
-        }
-
         public int MaximumErrorRetentionPeriod => SettingConstants.ErrorRetentionPeriodMaxInDays;
         public int MinimumErrorRetentionPeriod => SettingConstants.ErrorRetentionPeriodMinInDays;
         public TimeSpanUnits ErrorRetentionUnits => TimeSpanUnits.Days;
@@ -225,26 +166,7 @@
         {
             ErrorRetention = ErrorRetentionUnits == TimeSpanUnits.Days ? value.TotalDays : value.TotalHours;
         }
-
-        [AlsoNotifyFor("ConnectionString", "ErrorQueueName", "AuditQueueName", "ErrorForwardingQueueName", "AuditForwardingQueueName")]
-        public TransportInfo SelectedTransport
-        {
-            get { return selectedTransport; }
-            set
-            {
-                ConnectionString = null;
-                selectedTransport = value;
-            }
-        }
-
-        public string ConnectionString { get; set; }
-
-        // ReSharper disable once UnusedMember.Global
-        public string SampleConnectionString => SelectedTransport != null ? SelectedTransport.SampleConnectionString : String.Empty;
-
-        // ReSharper disable once UnusedMember.Global
-        public bool ShowConnectionString => SelectedTransport != null && !string.IsNullOrEmpty(SelectedTransport.SampleConnectionString);
-
+        
         public string LogPath { get; set; }
         public ICommand SelectLogPath { get; set; }
 

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedInstanceEditorViewModel.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Windows.Input;
     using PropertyChanged;
-    using ServiceControl.Config.Framework.Modules;
     using ServiceControl.Config.Framework.Rx;
     using ServiceControl.Config.Validation;
     using ServiceControl.Config.Xaml.Controls;

--- a/src/ServiceControl.Config/Validation/Validations.cs
+++ b/src/ServiceControl.Config/Validation/Validations.cs
@@ -4,13 +4,12 @@
     using System.Collections.Generic;
     using System.Linq;
     using FluentValidation;
-    using UI.SharedInstanceEditor;
-
+    
     public static class Validations
     {
         public const string MSG_EMAIL_NOT_VALID = "Not Valid.";
 
-        public const string MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING = "Transport '{0}' requires a connection string.";
+        public const string MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING = "This transport requires a connection string.";
         public const string MSG_CANTCONTAINWHITESPACE = "Cannot contain white space.";
 
         public const string MSG_SELECTAUDITFORWARDING = "Must select audit forwarding.";
@@ -54,17 +53,7 @@
             })
             .WithMessage(MSG_ILLEGAL_PATH_CHAR, string.Join(" ", ILLEGAL_PATH_CHARS));
         }
-
-        public static IRuleBuilderOptions<T, string> TransportConnectionStringValid<T>(this IRuleBuilder<T, string> ruleBuilder) where T : SharedInstanceEditorViewModel
-        {
-            return ruleBuilder.Must((model, connectionString) =>
-            {
-                if (string.IsNullOrEmpty(model.SelectedTransport?.SampleConnectionString)) return true;
-                return !string.IsNullOrWhiteSpace(connectionString);
-            })
-            .WithMessage(MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING, model => model.SelectedTransport.Name);
-        }
-
+        
         public static IRuleBuilderOptions<T, TProperty> MustNotBeIn<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<T, IEnumerable<TProperty>> list) where TProperty : class
         {
             return ruleBuilder.Must((t, p) => p != null && !list(t).Contains(p));

--- a/src/ServiceControl.Config/Xaml/Controls/FormWarningTextBlock.cs
+++ b/src/ServiceControl.Config/Xaml/Controls/FormWarningTextBlock.cs
@@ -1,0 +1,22 @@
+﻿namespace ServiceControl.Config.Xaml.Controls
+{
+    using System.Windows;
+    using System.Windows.Controls;
+
+    public class FormWarningTextBlock : Control
+    {
+        static FormWarningTextBlock()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(FormWarningTextBlock), new FrameworkPropertyMetadata(typeof(FormWarningTextBlock)));
+        }
+
+        public string Text
+        {
+            get { return (string)GetValue(TextProperty); }
+            set { SetValue(TextProperty, value); }
+        }
+
+        public static readonly DependencyProperty TextProperty = 
+            DependencyProperty.Register("Text", typeof(string), typeof(FormWarningTextBlock), new PropertyMetadata(string.Empty));
+    }
+}

--- a/src/ServiceControl.Config/Xaml/Converters/BoolToVisibilityConverter.cs
+++ b/src/ServiceControl.Config/Xaml/Converters/BoolToVisibilityConverter.cs
@@ -10,7 +10,7 @@ namespace ServiceControl.Config.Xaml.Converters
         public bool Invert { get; set; }
 
         public bool IsHidden { get; set; }
-
+        
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var flag = false;

--- a/src/ServiceControl.Config/Xaml/Converters/StringNullOrEmptyToVisibilityConverter.cs
+++ b/src/ServiceControl.Config/Xaml/Converters/StringNullOrEmptyToVisibilityConverter.cs
@@ -7,10 +7,11 @@
 
     public class StringNullOrEmptyToVisibilityConverter : System.Windows.Markup.MarkupExtension, IValueConverter
     {
+        public bool Invert { get; set; }
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return string.IsNullOrEmpty(value as string)
-                ? Visibility.Collapsed : Visibility.Visible;
+            return  Invert ^ string.IsNullOrEmpty(value as string) ? Visibility.Collapsed : Visibility.Visible;
         }
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {

--- a/src/ServiceControl/Infrastructure/Installers/AuditLogQueueInstaller.cs
+++ b/src/ServiceControl/Infrastructure/Installers/AuditLogQueueInstaller.cs
@@ -10,7 +10,7 @@ namespace ServiceBus.Management.Infrastructure.Installers
 
         public bool ShouldCreateQueue()
         {
-            return Settings.AuditLogQueue != Address.Undefined;
+            return Settings.ForwardAuditMessages && Settings.AuditLogQueue != Address.Undefined;
         }
 
         public Address Address => Settings.AuditLogQueue;

--- a/src/ServiceControl/Infrastructure/Installers/ErrorLogQueueInstaller.cs
+++ b/src/ServiceControl/Infrastructure/Installers/ErrorLogQueueInstaller.cs
@@ -10,7 +10,7 @@
 
         public bool ShouldCreateQueue()
         {
-            return Settings.ErrorLogQueue != Address.Undefined;
+            return Settings.ForwardErrorMessages && Settings.ErrorLogQueue != Address.Undefined;
         }
 
         public Address Address => Settings.ErrorLogQueue;

--- a/src/ServiceControlInstaller.Engine/Configuration/Compatibility.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/Compatibility.cs
@@ -1,0 +1,17 @@
+﻿namespace ServiceControlInstaller.Engine.Configuration
+{
+    using System;
+
+    // For Removing and Adding Setting use SettingsList.cs
+
+    public static class Compatibility
+    {
+        public class CompatibilityInfo
+        {
+            public Version SupportedFrom { get; set; }
+            public Version RemovedFrom { get; set; }
+        }
+
+        public static CompatibilityInfo ForwardingQueuesAreOptional = new CompatibilityInfo{SupportedFrom = new Version(1, 27)};
+    }
+}

--- a/src/ServiceControlInstaller.Engine/Configuration/Compatibility.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/Compatibility.cs
@@ -12,6 +12,6 @@
             public Version RemovedFrom { get; set; }
         }
 
-        public static CompatibilityInfo ForwardingQueuesAreOptional = new CompatibilityInfo{SupportedFrom = new Version(1, 27)};
+        public static CompatibilityInfo ForwardingQueuesAreOptional = new CompatibilityInfo{SupportedFrom = new Version(1, 28)};
     }
 }

--- a/src/ServiceControlInstaller.Engine/Configuration/Compatibility.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/Compatibility.cs
@@ -12,6 +12,6 @@
             public Version RemovedFrom { get; set; }
         }
 
-        public static CompatibilityInfo ForwardingQueuesAreOptional = new CompatibilityInfo{SupportedFrom = new Version(1, 28)};
+        public static CompatibilityInfo ForwardingQueuesAreOptional = new CompatibilityInfo{SupportedFrom = new Version(1, 29)};
     }
 }

--- a/src/ServiceControlInstaller.Engine/Configuration/SettingConstants.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/SettingConstants.cs
@@ -1,13 +1,19 @@
-﻿namespace ServiceControlInstaller.Engine.Configuration
+﻿// ReSharper disable InconsistentNaming
+namespace ServiceControlInstaller.Engine.Configuration
 {
     public class SettingConstants
     {
         public const int ErrorRetentionPeriodMaxInDays = 45;
+        public const int ErrorRetentionPeriodMaxInHours = 1080;
+
         public const int ErrorRetentionPeriodMinInDays = 10;
-        public const int ErrorRetentionPeriodDefaultInDaysForUI = 15;
+        public const int ErrorRetentionPeriodMinInHours = 240;
 
         public const int AuditRetentionPeriodMaxInHours = 8760;
         public const int AuditRetentionPeriodMinInHours = 1;
+
         public const int AuditRetentionPeriodDefaultInHoursForUI = 720;
+
+        public const int ErrorRetentionPeriodDefaultInDaysForUI = 15;
     }
 }

--- a/src/ServiceControlInstaller.Engine/Configuration/SettingList.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/SettingList.cs
@@ -2,6 +2,8 @@ namespace ServiceControlInstaller.Engine.Configuration
 {
     using System;
 
+    // See Compatibility.cs for version switching that isn't related to Settings
+
     public static class SettingsList
     {
         public static SettingInfo VirtualDirectory = new SettingInfo{Name = "ServiceControl/VirtualDirectory"};

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -229,8 +229,15 @@ namespace ServiceControlInstaller.Engine.Instances
 
             settings.Set(SettingsList.AuditQueue, AuditQueue);
             settings.Set(SettingsList.ErrorQueue, ErrorQueue);
+
+            if (Version >= Compatibility.ForwardingQueuesAreOptional.SupportedFrom)
+            {
+                if (!ForwardErrorMessages) ErrorLogQueue = null;
+                if (!ForwardAuditMessages) AuditLogQueue = null;
+            }
             settings.Set(SettingsList.ErrorLogQueue, ErrorLogQueue);
             settings.Set(SettingsList.AuditLogQueue, AuditLogQueue);
+            
             configuration.ConnectionStrings.ConnectionStrings.Set("NServiceBus/Transport", ConnectionString);
             configuration.Save();
 

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstanceMetadata.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstanceMetadata.cs
@@ -24,8 +24,13 @@ namespace ServiceControlInstaller.Engine.Instances
         public string LogPath { get; set; }
         public string DBPath { get; set; }
         public string HostName { get; set; }
+
+        [XmlElement(typeof(XmlTimeSpan))]
         public TimeSpan AuditRetentionPeriod { get; set; }
+
+        [XmlElement(typeof(XmlTimeSpan))]
         public TimeSpan ErrorRetentionPeriod { get; set; }
+
         public string InstallPath { get; set; }
         public int Port { get; set; }
         public string VirtualDirectory { get; set; }
@@ -66,7 +71,7 @@ namespace ServiceControlInstaller.Engine.Instances
                 {
                     return $"http://{HostName}:{Port}/api/";
                 }
-                return $"http://{HostName}:{Port}/{VirtualDirectory}{(VirtualDirectory.EndsWith("/") ? String.Empty : "/")}api/";
+                return $"http://{HostName}:{Port}/{VirtualDirectory}{(VirtualDirectory.EndsWith("/") ? string.Empty : "/")}api/";
             }
         }
 
@@ -89,7 +94,7 @@ namespace ServiceControlInstaller.Engine.Instances
                 {
                     return $"http://{host}:{Port}/storage/";
                 }
-                return $"http://{host}:{Port}/{VirtualDirectory}{(VirtualDirectory.EndsWith("/") ? String.Empty : "/")}storage/";
+                return $"http://{host}:{Port}/{VirtualDirectory}{(VirtualDirectory.EndsWith("/") ? string.Empty : "/")}storage/";
             }
         }
 
@@ -102,7 +107,7 @@ namespace ServiceControlInstaller.Engine.Instances
                 {
                     return baseUrl;
                 }
-                return $"{baseUrl}{VirtualDirectory}{(VirtualDirectory.EndsWith("/") ? String.Empty : "/")}";
+                return $"{baseUrl}{VirtualDirectory}{(VirtualDirectory.EndsWith("/") ? string.Empty : "/")}";
             }
         }
 

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -97,6 +97,7 @@
     <Compile Include="App_Packages\Particular.Licensing\TrialStartDateStore.cs" />
     <Compile Include="App_Packages\Particular.Licensing\UniversalDateParser.cs" />
     <Compile Include="App_Packages\Particular.Licensing\UserSidChecker.cs" />
+    <Compile Include="Configuration\Compatibility.cs" />
     <Compile Include="Configuration\RegistryReader.cs" />
     <Compile Include="Configuration\SettingConstants.cs" />
     <Compile Include="Configuration\SettingList.cs" />

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Configuration\SettingList.cs" />
     <Compile Include="Configuration\SettingInfo.cs" />
     <Compile Include="Instances\InstanceUpgradeOptions.cs" />
+    <Compile Include="Unattended\XmlTimeSpan.cs" />
     <Compile Include="Queues\ServiceControlQueueCreationException.cs" />
     <Compile Include="Queues\ServiceControlQueueCreationTimeoutException.cs" />
     <Compile Include="ReportCard\TruncatedStringList.cs" />

--- a/src/ServiceControlInstaller.Engine/Unattended/XmlTimeSpan.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/XmlTimeSpan.cs
@@ -1,0 +1,51 @@
+﻿namespace ServiceControlInstaller.Engine
+{
+    using System;
+    using System.Xml.Serialization;
+
+    public class XmlTimeSpan
+    {
+        private TimeSpan timeSpan;
+
+        public XmlTimeSpan(): this(TimeSpan.Zero)
+        {
+        }
+
+        public XmlTimeSpan(TimeSpan input)
+        {
+            timeSpan = input;
+        }
+
+        public static implicit operator TimeSpan(XmlTimeSpan input)
+        {
+            return input?.timeSpan ?? TimeSpan.Zero;
+        }
+
+        // Alternative to the implicit operator TimeSpan(XmlTimeSpan input)
+        public TimeSpan ToTimeSpan()
+        {
+            return timeSpan;
+        }
+
+        public static implicit operator XmlTimeSpan(TimeSpan input)
+        {
+            return new XmlTimeSpan(input);
+        }
+        
+        public void FromTimeSpan(TimeSpan input)
+        {
+            timeSpan = input;
+        }
+
+        [XmlText]
+        public string Value
+        {
+            get {
+                return timeSpan.ToString();
+            }
+            set{
+                timeSpan = TimeSpan.Parse(value);
+            }
+        }
+    }
+}

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/Instances/NewServiceControlUnattendedFile.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/Instances/NewServiceControlUnattendedFile.cs
@@ -6,87 +6,90 @@ namespace ServiceControlInstaller.PowerShell
     using System;
     using System.Management.Automation;
     using ServiceControlInstaller.Engine.Instances;
+    using ServiceControlInstaller.Engine.Configuration;
 
     [Cmdlet(VerbsCommon.New, "ServiceControlUnattendedFile")]
     public class NewServiceControlUnattendedFile : PSCmdlet
     {
-        [ValidateNotNullOrEmpty]
         [Parameter(Mandatory = true, HelpMessage = "Specify the name of the ServiceControl Instance")]
+        [ValidateNotNullOrEmpty]
         public string Name { get; set; }
 
+        [Parameter(Mandatory = true, HelpMessage = "Specify the directory to use for this ServiceControl Instance")]
         [ValidateNotNullOrEmpty]
         [ValidatePath]
-        [Parameter(Mandatory = true, HelpMessage = "Specify the directory to use for this ServiceControl Instance")]
         public string InstallPath { get; set; }
 
+        [Parameter(Mandatory = true, HelpMessage = "Specify the directory to use for this ServiceControl RavenDB")]
         [ValidateNotNullOrEmpty]
         [ValidatePath]
-        [Parameter(Mandatory = true, HelpMessage = "Specify the directory to use for this ServiceControl RavenDB")]
         public string DBPath { get; set; }
 
+        [Parameter(Mandatory = true, HelpMessage = "Specify the directory to use for this ServiceControl Logs")]
         [ValidateNotNullOrEmpty]
         [ValidatePath]
-        [Parameter(Mandatory = true, HelpMessage = "Specify the directory to use for this ServiceControl Logs")]
         public string LogPath { get; set; }
 
-        [ValidateNotNullOrEmpty]
         [Parameter(Mandatory = false, HelpMessage = "Specify the hostname to use in the URLACL (defaults to localhost)")]
+        [ValidateNotNullOrEmpty]
         public string HostName { get; set; }
 
-        [ValidateRange(1, 49151)]
         [Parameter(Mandatory = true, HelpMessage = "Specify the port number to listen on. If this is the only ServiceControl instance then 33333 is recommended")]
+        [ValidateRange(1, 49151)]
         public int Port { get; set; }
 
-        [ValidateNotNullOrEmpty]
         [Parameter(Mandatory = true, HelpMessage = "Specify ErrorQueue name to consume messages from. Default is error")]
+        [ValidateNotNullOrEmpty]
         public string ErrorQueue { get; set; }
 
-        [ValidateNotNullOrEmpty]
         [Parameter(Mandatory = true, HelpMessage = "Specify AuditQueue name to consume messages from. Default is audit")]
+        [ValidateNotNullOrEmpty]
         public string AuditQueue { get; set; }
 
+        [Parameter(Mandatory = false, HelpMessage = "Specify Queue name to forward error messages to. Default is errorlog")]
         [ValidateNotNullOrEmpty]
-        [Parameter(Mandatory = true, HelpMessage = "Specify Queue name to forward error messages to. Default is errorlog")]
         public string ErrorLogQueue { get; set; }
 
+        [Parameter(Mandatory = false, HelpMessage = "Specify Queue name to forward audit messages to. Default is auditlog")]
         [ValidateNotNullOrEmpty]
-        [Parameter(Mandatory = true, HelpMessage = "Specify Queue name to forward audit messages to. Default is auditlog")]
         public string AuditLogQueue { get; set; }
 
-        [ValidateSet("AzureServiceBus", "AzureStorageQueue", "MSMQ", "SQLServer", "RabbitMQ")]
         [Parameter(Mandatory = true, HelpMessage = "Specify the NServiceBus Transport to use")]
+        [ValidateSet("AzureServiceBus", "AzureStorageQueue", "MSMQ", "SQLServer", "RabbitMQ")]
         public string Transport { get; set; }
 
-        [ValidateNotNullOrEmpty]
         [Parameter(Mandatory = false, HelpMessage = "Specify the Windows Service Display name. If unspecified the instance name will be used")]
+        [ValidateNotNullOrEmpty]
         public string DisplayName { get; set; }
 
-        [ValidateNotNullOrEmpty]
         [Parameter(Mandatory = false, HelpMessage = "Specify an alternate VirtualDirectory to use. This option is not recommended")]
+        [ValidateNotNullOrEmpty]
         public string VirtualDirectory { get; set; }
 
-        [ValidateNotNullOrEmpty]
         [Parameter(Mandatory = false, HelpMessage = "Specify the connection string to use to connect to the queuing system.  Can be left blank for MSMQ")]
+        [ValidateNotNullOrEmpty]
         public string ConnectionString { get; set; }
 
-        [ValidateNotNullOrEmpty]
         [Parameter(Mandatory = false, HelpMessage = "Specify the description to use on the Windows Service for this instance")]
+        [ValidateNotNullOrEmpty]
         public string Description { get; set; }
 
         [Parameter(Mandatory = true, HelpMessage = "Specify if audit messages are forwarded to the queue specified by AuditLogQueue")]
+        [ValidateNotNull]
         public bool ForwardAuditMessages { get; set; }
 
-        [Parameter(Mandatory = true, HelpMessage = "Specify if error messages are forwarded to the queue specified by ErrorLogQueue")]
+        [Parameter(Mandatory = false, HelpMessage = "Specify if error messages are forwarded to the queue specified by ErrorLogQueue")]
+        [ValidateNotNull]
         public bool ForwardErrorMessages { get; set; }
 
         [Parameter(Mandatory = true, HelpMessage = "Specify the timespan to keep Audit Data")]
         [ValidateNotNull]
-        [ValidateTimeSpanRange(MinimumHours = 1, MaximumHours = 8760)] //1 hour to 365 days
+        [ValidateTimeSpanRange(MinimumHours = SettingConstants.AuditRetentionPeriodMinInHours, MaximumHours = SettingConstants.AuditRetentionPeriodMaxInHours)] //1 hour to 365 days
         public TimeSpan AuditRetentionPeriod {get; set;}
         
         [Parameter(Mandatory = true, HelpMessage = "Specify the timespan to keep Error Data")]
         [ValidateNotNull]
-        [ValidateTimeSpanRange(MinimumHours = 240, MaximumHours = 1080)] //10 to 45 days
+        [ValidateTimeSpanRange(MinimumHours = SettingConstants.ErrorRetentionPeriodMinInHours, MaximumHours = SettingConstants.ErrorRetentionPeriodMaxInHours)] //10 to 45 days
         public TimeSpan ErrorRetentionPeriod { get; set; }
         
         [Parameter(Mandatory = true, HelpMessage = "The path of the XML file save the output to")]
@@ -96,12 +99,18 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
-            //Set default values
+            EnsureDependentPropertyIsBoundIfSet(ForwardErrorMessages, nameof(ErrorLogQueue), "ErrorLogQueue must be specified if ForwardErrorMessages is true");
+            EnsureDependentPropertyIsBoundIfSet(ForwardAuditMessages, nameof(AuditLogQueue), "AuditLogQueue must be specified if ForwardAuditMessages is true");
+
             HostName = HostName ?? "localhost";
-            ErrorQueue = ErrorQueue ?? "error";
-            AuditQueue = AuditQueue ?? "audit";
-            ErrorLogQueue = ErrorLogQueue ?? "errorlog";
-            AuditLogQueue = AuditLogQueue ?? "auditlog";
+        }
+
+        void EnsureDependentPropertyIsBoundIfSet(bool enabled, string propertyName, string errormessage)
+        {
+            if (!MyInvocation.BoundParameters.ContainsKey(propertyName) && enabled)
+            {
+                throw new PSArgumentException(errormessage, propertyName);
+            }
         }
 
         protected override void ProcessRecord()


### PR DESCRIPTION
Related to #849

When adding a new instance and forwarding is turned off don't create the queues.  

### Mgmt UI Changes

The Add Instance UI will only ask and validate Error forwarding queue name or Audit Forwarding queue name if that related combo box is "on"

The Edit Instance screen will feature switch because of the different behavior in old versions.  
 - For version prior to 1.12 the forwarding queues are always displayed and the ErrorForwarding combo is not shown
 - For version 1.12 to the version prior to this release the ErrorForwarding combo is always shown and the  forwarding queues are always displayed and created
- For this version and above forwarding queues are only displayed 

### Mgmt PowerShell Changes.  

Cmdlets for adding ServiceControl instances no longer require the forwarding queue name if the forwarding option is off

### Config changes

For new ServiceControl instances or ServiceControl instances upgraded by this release:

- the 'ServiceBus/ErrorLogQueue' is omitted if 'ServiceControl/ForwardErrorMessages' is set to 'false'
- the 'ServiceBus/AuditLogQueue' is omitted if 'ServiceControl/ForwardAuditMessages' is set to 'false'


### ServiceControl service changes

- The queue creation for forwarding queues durign setup is only executed if the forwarding is enabled
- The empty test message sent to the forwarding queues at startup has been removed

