### PR TITLE
Request tracing for tests

### DIFF
--- a/src/ServiceControl.AcceptanceTesting/ScenarioContext.cs
+++ b/src/ServiceControl.AcceptanceTesting/ScenarioContext.cs
@@ -1,10 +1,22 @@
 ﻿namespace NServiceBus.AcceptanceTesting
 {
+    using System;
+    using System.Collections.Concurrent;
+
     public abstract class ScenarioContext
     {
+        private ConcurrentQueue<string> traceMessages = new ConcurrentQueue<string>();
+
         public bool EndpointsStarted { get; set; }
         public string Exceptions { get; set; }
         public string SessionId { get; set; }
         public bool HasNativePubSubSupport { get; set; }
+
+        public string Trace => string.Join(Environment.NewLine, traceMessages);
+
+        public void AddTrace(string trace)
+        {
+            traceMessages.Enqueue(trace);
+        }
     }
 }

--- a/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
@@ -557,7 +557,9 @@ namespace ServiceBus.Management.AcceptanceTests
                 typeof(MessageMapperInterceptor),
                 typeof(RegisterWrappers),
                 typeof(SessionCopInBehavior),
-                typeof(SessionCopInBehaviorForMainPipe)
+                typeof(SessionCopInBehaviorForMainPipe),
+                typeof(TraceIncomingBehavior),
+                typeof(TraceOutgoingBehavior)
             }));
             configuration.EnableInstallers();
 
@@ -577,6 +579,8 @@ namespace ServiceBus.Management.AcceptanceTests
 
             configuration.Pipeline.Register<SessionCopInBehavior.Registration>();
             configuration.Pipeline.Register<SessionCopInBehaviorForMainPipe.Registration>();
+            configuration.Pipeline.Register<TraceIncomingBehavior.Registration>();
+            configuration.Pipeline.Register<TraceOutgoingBehavior.Registration>();
 
             CustomConfiguration(configuration);
 

--- a/src/ServiceControl.AcceptanceTests/Contexts/DefaultServerWithAudit.cs
+++ b/src/ServiceControl.AcceptanceTests/Contexts/DefaultServerWithAudit.cs
@@ -37,7 +37,9 @@
             {
                 typeof(RegisterWrappers),
                 typeof(SessionCopInBehavior),
-                typeof(SessionCopInBehaviorForMainPipe)
+                typeof(SessionCopInBehaviorForMainPipe),
+                typeof(TraceIncomingBehavior),
+                typeof(TraceOutgoingBehavior)
             });
             var builder = new BusConfiguration();
 
@@ -59,6 +61,8 @@
             });
             builder.Pipeline.Register<SessionCopInBehavior.Registration>();
             builder.Pipeline.Register<SessionCopInBehaviorForMainPipe.Registration>();
+            builder.Pipeline.Register<TraceIncomingBehavior.Registration>();
+            builder.Pipeline.Register<TraceOutgoingBehavior.Registration>();
 
             var serializer = settings.GetOrNull("Serializer");
 

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -268,6 +268,8 @@
     <Compile Include="SessionCopBehavior.cs" />
     <Compile Include="SignalRHttpClient.cs" />
     <Compile Include="SubscriptionBehavior.cs" />
+    <Compile Include="TraceIncomingBehavior.cs" />
+    <Compile Include="TraceOutgoingBehavior.cs" />
     <Compile Include="When_a_message_is_imported_twice.cs" />
     <Compile Include="Audit\When_a_message_has_been_successfully_processed.cs" />
     <Compile Include="AcceptanceTest.cs" />

--- a/src/ServiceControl.AcceptanceTests/TraceIncomingBehavior.cs
+++ b/src/ServiceControl.AcceptanceTests/TraceIncomingBehavior.cs
@@ -1,0 +1,36 @@
+﻿namespace ServiceBus.Management.AcceptanceTests
+{
+    using System;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NServiceBus.Settings;
+
+    internal class TraceIncomingBehavior : IBehavior<IncomingContext>
+    {
+        private ScenarioContext scenarioContext;
+        private ReadOnlySettings settings;
+
+        public TraceIncomingBehavior(ScenarioContext scenarioContext, ReadOnlySettings settings)
+        {
+            this.scenarioContext = scenarioContext;
+            this.settings = settings;
+        }
+
+        public void Invoke(IncomingContext context, Action next)
+        {
+            scenarioContext.AddTrace($"<- {settings.LocalAddress()} got [{context.PhysicalMessage.Id}] {context.IncomingLogicalMessage.MessageType.Name}");
+            next();
+        }
+
+        internal class Registration : RegisterStep
+        {
+            public Registration()
+                : base("TraceIncomingBehavior", typeof(TraceIncomingBehavior), "Adds incoming messages to the acceptance test trace")
+            {
+                InsertBefore(WellKnownStep.LoadHandlers);
+            }
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/TraceOutgoingBehavior.cs
+++ b/src/ServiceControl.AcceptanceTests/TraceOutgoingBehavior.cs
@@ -1,0 +1,36 @@
+﻿namespace ServiceBus.Management.AcceptanceTests
+{
+    using System;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NServiceBus.Settings;
+
+    internal class TraceOutgoingBehavior : IBehavior<OutgoingContext>
+    {
+        private ScenarioContext scenarioContext;
+        private ReadOnlySettings settings;
+
+        public TraceOutgoingBehavior(ScenarioContext scenarioContext, ReadOnlySettings settings)
+        {
+            this.scenarioContext = scenarioContext;
+            this.settings = settings;
+        }
+
+        public void Invoke(OutgoingContext context, Action next)
+        {
+            scenarioContext.AddTrace($"-> {context.OutgoingMessage.MessageIntent} from {settings.LocalAddress()} [{context.OutgoingMessage.Id}] {context.OutgoingLogicalMessage.MessageType.Name}");
+            next();
+        }
+
+        internal class Registration : RegisterStep
+        {
+            public Registration()
+                : base("TraceOutgoingBehavior", typeof(TraceOutgoingBehavior), "Adds outgoing messages to the acceptance test trace")
+            {
+                InsertBefore(WellKnownStep.DispatchMessageToTransport);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Traces outgoing and incoming messages to acceptance test log. This may be useful when tests fail intermittently on the build server as it will show the order that messages were sent and received.