### PR TITLE
Update bundled NServiceBus RabbitMQ Transport

### DIFF
--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -115,7 +115,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Transports.RabbitMQ, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.RabbitMQ.3.5.0\lib\net451\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.RabbitMQ.3.5.1\lib\net451\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Transports.SQLServer, Version=2.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">

--- a/src/ServiceControl.AcceptanceTests/packages.config
+++ b/src/ServiceControl.AcceptanceTests/packages.config
@@ -18,7 +18,7 @@
   <package id="NServiceBus.Azure.Transports.WindowsAzureServiceBus" version="6.4.0" targetFramework="net452" />
   <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="6.2.1" targetFramework="net452" />
   <package id="NServiceBus.NLog" version="1.1.0" targetFramework="net452" />
-  <package id="NServiceBus.RabbitMQ" version="3.5.0" targetFramework="net452" />
+  <package id="NServiceBus.RabbitMQ" version="3.5.1" targetFramework="net452" />
   <package id="NServiceBus.SqlServer" version="2.2.4" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -81,7 +81,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Transports.RabbitMQ, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.RabbitMQ.3.5.0\lib\net451\NServiceBus.Transports.RabbitMQ.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.RabbitMQ.3.5.1\lib\net451\NServiceBus.Transports.RabbitMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Transports.SQLServer, Version=2.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">

--- a/src/ServiceControlInstaller.Packaging/packages.config
+++ b/src/ServiceControlInstaller.Packaging/packages.config
@@ -9,7 +9,7 @@
   <package id="NServiceBus" version="5.2.19" targetFramework="net452" />
   <package id="NServiceBus.Azure.Transports.WindowsAzureServiceBus" version="6.4.0" targetFramework="net452" />
   <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="6.2.1" targetFramework="net452" />
-  <package id="NServiceBus.RabbitMQ" version="3.5.0" targetFramework="net452" />
+  <package id="NServiceBus.RabbitMQ" version="3.5.1" targetFramework="net452" />
   <package id="NServiceBus.SqlServer" version="2.2.4" targetFramework="net452" />
   <package id="RabbitMQ.Client" version="4.1.0" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net452" />


### PR DESCRIPTION
Update NServiceBus Rabbit Transport from 3.5.0 to 3.5.1 - See the NServiceBus RabbitMQ [release notes](https://github.com/Particular/NServiceBus.RabbitMQ/releases/tag/3.5.1) for details 