### PR TITLE
Allows overriding retry address in failed messages

### DIFF
--- a/src/ServiceControl.UnitTests/Recoverability/ReturnToSenderDequeuerTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/ReturnToSenderDequeuerTests.cs
@@ -1,0 +1,148 @@
+﻿namespace ServiceControl.UnitTests.Operations
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using NServiceBus;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+    using NUnit.Framework;
+    using ServiceControl.Operations.BodyStorage;
+    using ServiceControl.Recoverability;
+
+    [TestFixture]
+    public class ReturnToSenderDequeuerTests
+    {
+        [Test]
+        public void It_removes_staging_id_header()
+        {
+            var sender = new FakeSender();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["ServiceControl.Retry.StagingId"] = "SomeId",
+                ["ServiceControl.TargetEndpointAddress"] = "TargetEndpoint"
+            };
+            var message = new TransportMessage(Guid.NewGuid().ToString(), headers);
+
+            ReturnToSenderDequeuer.HandleMessage(message, new FakeBodyStorage(), sender);
+
+            Assert.IsFalse(sender.Message.Headers.ContainsKey("ServiceControl.Retry.StagingId"));
+        }
+
+        [Test]
+        public void It_fetches_the_body_if_provided()
+        {
+            var sender = new FakeSender();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["ServiceControl.Retry.StagingId"] = "SomeId",
+                ["ServiceControl.TargetEndpointAddress"] = "TargetEndpoint",
+                ["ServiceControl.Retry.Attempt.MessageId"] = "MessageBodyId"
+            };
+            var message = new TransportMessage(Guid.NewGuid().ToString(), headers);
+
+            ReturnToSenderDequeuer.HandleMessage(message, new FakeBodyStorage(), sender);
+
+            Assert.AreEqual("MessageBodyId", Encoding.UTF8.GetString(sender.Message.Body));
+        }
+
+        [Test]
+        public void It_uses_retry_to_if_provided()
+        {
+            var sender = new FakeSender();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["ServiceControl.Retry.StagingId"] = "SomeId",
+                ["ServiceControl.TargetEndpointAddress"] = "TargetEndpoint",
+                ["ServiceControl.RetryTo"] = "Proxy"
+            };
+            var message = new TransportMessage(Guid.NewGuid().ToString(), headers);
+
+            ReturnToSenderDequeuer.HandleMessage(message, new FakeBodyStorage(), sender);
+
+            Assert.AreEqual("Proxy", sender.Options.Destination.Queue);
+            Assert.AreEqual("TargetEndpoint", sender.Message.Headers["ServiceControl.TargetEndpointAddress"]);
+        }
+
+        [Test]
+        public void It_sends_directly_to_target_if_retry_to_is_not_provided()
+        {
+            var sender = new FakeSender();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["ServiceControl.Retry.StagingId"] = "SomeId",
+                ["ServiceControl.TargetEndpointAddress"] = "TargetEndpoint",
+            };
+            var message = new TransportMessage(Guid.NewGuid().ToString(), headers);
+
+            ReturnToSenderDequeuer.HandleMessage(message, new FakeBodyStorage(), sender);
+
+            Assert.AreEqual("TargetEndpoint", sender.Options.Destination.Queue);
+            Assert.IsFalse(sender.Message.Headers.ContainsKey("ServiceControl.TargetEndpointAddress"));
+        }
+
+        [Test]
+        public void It_restores_body_id_and_target_addres_after_failure()
+        {
+            var sender = new FaultySender();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["ServiceControl.Retry.StagingId"] = "SomeId",
+                ["ServiceControl.TargetEndpointAddress"] = "TargetEndpoint",
+                ["ServiceControl.Retry.Attempt.MessageId"] = "MessageBodyId",
+            };
+            var message = new TransportMessage(Guid.NewGuid().ToString(), headers);
+
+            try
+            {
+                ReturnToSenderDequeuer.HandleMessage(message, new FakeBodyStorage(), sender);
+            }
+            catch (Exception)
+            {
+                //Intentionally empty catch
+            }
+            Assert.IsTrue(message.Headers.ContainsKey("ServiceControl.TargetEndpointAddress"));
+            Assert.IsTrue(message.Headers.ContainsKey("ServiceControl.Retry.Attempt.MessageId"));
+        }
+
+        class FaultySender : ISendMessages
+        {
+            public void Send(TransportMessage message, SendOptions sendOptions)
+            {
+                throw new Exception("Simulated");
+            }
+        }
+
+        class FakeSender : ISendMessages
+        {
+            public TransportMessage Message { get; private set; }
+            public SendOptions Options { get; private set; }
+
+            public void Send(TransportMessage message, SendOptions sendOptions)
+            {
+                Message = message;
+                Options = sendOptions;
+            }
+        }
+
+        class FakeBodyStorage : IBodyStorage
+        {
+            public string Store(string bodyId, string contentType, int bodySize, Stream bodyStream)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool TryFetch(string bodyId, out Stream stream)
+            {
+                stream = new MemoryStream(Encoding.UTF8.GetBytes(bodyId)); //Echo back the body ID.
+                return true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Operations\UpdateLicenseEnricherTest.cs" />
     <Compile Include="Recoverability\ExceptionTypeAndStackTraceFailureClassifierTest.cs" />
     <Compile Include="Recoverability\MessageTypeFailureClassifierTest.cs" />
+    <Compile Include="Recoverability\ReturnToSenderDequeuerTests.cs" />
     <Compile Include="SagaAudit\SagaDetailsIndexTests.cs" />
     <Compile Include="SagaAudit\SagaListIndexTests.cs" />
   </ItemGroup>

--- a/src/ServiceControl/Recoverability/Retries/Infrastructure/ReturnToSenderDequeuer.cs
+++ b/src/ServiceControl/Recoverability/Retries/Infrastructure/ReturnToSenderDequeuer.cs
@@ -56,7 +56,7 @@ namespace ServiceControl.Recoverability
         {
             if (shouldProcess(message))
             {
-                HandleMessage(message);
+                HandleMessage(message, bodyStorage, sender);
 
                 if (IsCounting)
                 {
@@ -84,7 +84,7 @@ namespace ServiceControl.Recoverability
             }
         }
 
-        void HandleMessage(TransportMessage message)
+        public static void HandleMessage(TransportMessage message, IBodyStorage bodyStorage, ISendMessages sender) //Public for testing
         {
             message.Headers.Remove("ServiceControl.Retry.StagingId");
             

--- a/src/ServiceControl/Recoverability/Retries/Infrastructure/ReturnToSenderDequeuer.cs
+++ b/src/ServiceControl/Recoverability/Retries/Infrastructure/ReturnToSenderDequeuer.cs
@@ -25,7 +25,7 @@ namespace ServiceControl.Recoverability
         bool endedPrematurelly;
         int? targetMessageCount;
         int actualMessageCount;
-        Predicate<TransportMessage> shouldProcess; 
+        Predicate<TransportMessage> shouldProcess;
         readonly ISendMessages sender;
         CaptureIfMessageSendingFails faultManager;
         IBodyStorage bodyStorage;
@@ -86,11 +86,8 @@ namespace ServiceControl.Recoverability
 
         void HandleMessage(TransportMessage message)
         {
-            var destination = message.Headers["ServiceControl.TargetEndpointAddress"];
-
-            message.Headers.Remove("ServiceControl.TargetEndpointAddress");
             message.Headers.Remove("ServiceControl.Retry.StagingId");
-
+            
             string attemptMessageId;
             if (message.Headers.TryGetValue("ServiceControl.Retry.Attempt.MessageId", out attemptMessageId))
             {
@@ -104,10 +101,17 @@ namespace ServiceControl.Recoverability
                 }
                 message.Headers.Remove("ServiceControl.Retry.Attempt.MessageId");
             }
-
+            var destination = message.Headers["ServiceControl.TargetEndpointAddress"];
             try
             {
-                sender.Send(message, new SendOptions(destination));
+                string retryTo;
+                if (!message.Headers.TryGetValue("ServiceControl.RetryTo", out retryTo))
+                {
+                    retryTo = destination;
+                    message.Headers.Remove("ServiceControl.TargetEndpointAddress");
+                }
+
+                sender.Send(message, new SendOptions(retryTo));
             }
             catch (Exception)
             {


### PR DESCRIPTION
Adds handling of `ServiceControl.RetryTo` header when retrying a failed message. If a failed message contains that header, it is used instead of `ServiceControl.TargetEndpointAddress` as a destination. In that case the `ServiceControl.TargetEndpointAddress` is preserved on the message so that the adapter can actually forward the message to the ultimate destination