### PR TITLE
Fix NRE in Mgmt Util Add Instance screen

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/InstanceAddViewModelValidator.cs
@@ -65,7 +65,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
                 .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
                 .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted && x.AuditForwarding.Value);
+                .When(x => x.SubmitAttempted && (x.AuditForwarding?.Value ?? false ));
 
             RuleFor(x => x.ConnectionString)
                 .NotEmpty().WithMessage(Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)


### PR DESCRIPTION
Related to #883 

Validation on Add Instance screen throws NRE in Audit Forwarding in not set to On or Off when Submitted
Corrected to show the validation message when not selected.

Initial report of the issue was through the unhandled exception screen logged by an end user through Raygun