### PR TITLE
Allow an external ServiceControl.Contracts.MessageFailed event with a Status of MessageStatus.ArchivedFailure to be published per the documentation

### DIFF
--- a/src/ServiceControl/ExternalIntegrations/FailedMessageArchivedPublisher.cs
+++ b/src/ServiceControl/ExternalIntegrations/FailedMessageArchivedPublisher.cs
@@ -1,0 +1,29 @@
+﻿namespace ServiceControl.ExternalIntegrations
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Contracts.MessageFailures;
+    using Raven.Client;
+
+    public class FailedMessageArchivedPublisher : EventPublisher<FailedMessageArchived, MessageFailedPublisher.DispatchContext>
+    {
+        protected override MessageFailedPublisher.DispatchContext CreateDispatchRequest(FailedMessageArchived @event)
+        {
+            return new MessageFailedPublisher.DispatchContext
+            {
+                FailedMessageId = new Guid(@event.FailedMessageId)
+            };
+        }
+
+        protected override IEnumerable<object> PublishEvents(IEnumerable<MessageFailedPublisher.DispatchContext> contexts, IDocumentSession session)
+        {
+            // FailedMessageArchived events are published externally as ServiceControl.Contracts.MessageFailed events
+            // with the Status property set to MessageStatus.ArchivedFailure. This is handled by the PublishEvents
+            // method in the MessageFailedPublisher class. Returning an empty collection here to avoid multiple 
+            // external events from being published.
+
+            return Enumerable.Empty<object>();
+        }
+    }
+}

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -283,6 +283,7 @@
     <Compile Include="DbMigrations\MigrationsManager.cs" />
     <Compile Include="DbMigrations\MigrationsModule.cs" />
     <Compile Include="DbMigrations\1.27\SplitFailedMessageDocumentsMigration.cs" />
+    <Compile Include="ExternalIntegrations\FailedMessageArchivedPublisher.cs" />
     <Compile Include="Hosting\MaintenanceHost.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
We are unable to receive a ServiceControl.Contracts.MessageFailed event with a Status of MessageStatus.ArchivedFailure per the documentation linked below. We engaged support to review this issue (in conjunction with another issue) and uncovered the root cause when reviewing the ServiceControl code during our troubleshooting. A fix is contained in this pull request.

https://docs.particular.net/servicepulse/event-types#messagefailed