### PR TITLE
Provide information to visitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
 ServiceControl
 =====================
 
-Management extension to ServiceBus
+ServiceControl is the monitoring brain in the Particular Service Platform. It collects data on every single message flowing through the system (Audit Queue), errors (Error Queue), as well as additional information regarding sagas, endpoints heartbeats and custom checks (Control Queue). The information is then exposed to [ServicePulse](https://particular.net/servicepulse) and [ServiceInsight](https://particular.net/serviceinsight) via an HTTP API and SignalR notifications.
+
+License
+=====================
+
+ServiceControl requires an Advanced or higher license to operate. Visit https://particular.net/licensing for more details.
 
 Where to Download
 =====================
 
-https://particular.net/downloads
+The easiest way to download and install ServiceControl is through the Particular Service Platform Installer, available at https://particular.net/start-platform-download.
+
+If you would like to download ServiceControl directly you can visit https://particular.net/downloads.
 
 User Documentation
 =====================
+
+Documentation for ServiceControl is located on the Particular Docs website at following address:
 
 https://docs.particular.net/servicecontrol/

--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@ ServiceControl
 =====================
 
 Management extension to ServiceBus
+
+Where to Download
+=====================
+
+https://particular.net/downloads
+
+User Documentation
+=====================
+
+https://docs.particular.net/servicecontrol/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
-ServiceControl
+ServiceControl ![Current Version](https://img.shields.io/github/release/particular/servicecontrol.svg?style=flat&label=current%20version)
 =====================
 
 ServiceControl is the monitoring brain in the Particular Service Platform. It collects data on every single message flowing through the system (Audit Queue), errors (Error Queue), as well as additional information regarding sagas, endpoints heartbeats and custom checks (Control Queue). The information is then exposed to [ServicePulse](https://particular.net/servicepulse) and [ServiceInsight](https://particular.net/serviceinsight) via an HTTP API and SignalR notifications.
-
-License
-=====================
-
-ServiceControl requires an Advanced or higher license to operate. Visit https://particular.net/licensing for more details.
 
 Where to Download
 =====================


### PR DESCRIPTION
Looking at https://github.com/Particular/ServiceControl/graphs/traffic most of our visitors come to the main page, and many from searches. We should have some basic links to help them find what they may be looking for.