### PR TITLE
Fix Expiry Processing

### DIFF
--- a/src/ServiceControl.UnitTests/Expiration/ProcessedMessageExpirationTests.cs
+++ b/src/ServiceControl.UnitTests/Expiration/ProcessedMessageExpirationTests.cs
@@ -51,7 +51,7 @@
                 var expiredDate = DateTime.UtcNow.AddDays(-3);
                 var thresholdDate = DateTime.UtcNow.AddDays(-2);
                 var recentDate = DateTime.UtcNow.AddDays(-1);
-                var expiredMessages = BuilExpiredMessaged(expiredDate).ToList();
+                var expiredMessages = BuildExpiredMessaged(expiredDate).ToList();
                 using (var session = documentStore.OpenSession())
                 {
                     foreach (var message in expiredMessages)
@@ -87,9 +87,11 @@
             }
         }
 
-        IEnumerable<object> BuilExpiredMessaged(DateTime dateTime)
+        private static int doctestrange = 999;
+
+        IEnumerable<object> BuildExpiredMessaged(DateTime dateTime)
         {
-            for (var i = 0; i < 10; i++)
+            for (var i = 0; i < doctestrange; i++)
             {
                 yield return new ProcessedMessage
                 {
@@ -103,7 +105,7 @@
         {
             new ExpiryProcessedMessageIndex().Execute(documentStore);
             documentStore.WaitForIndexing();
-            AuditMessageCleaner.Clean(100, documentStore.DocumentDatabase, expiryThreshold);
+            AuditMessageCleaner.Clean(doctestrange, documentStore.DocumentDatabase, expiryThreshold);
             documentStore.WaitForIndexing();
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/Chunker.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/Chunker.cs
@@ -27,7 +27,7 @@
 
                 start = end + 1;
                 end += CHUNK_SIZE;
-                if (end > total)
+                if (end >= total)
                 {
                     end = total - 1;
                 }


### PR DESCRIPTION
Relates to #903 

@boblangley  I took a look at #903 which you raised  and I believe I've fixed it.

Root cause was a math problem,  The "chunker" takes 500 items at a time., if the number of items is 1 less that a multiple of chunks.  ie.  999, 1499, 1599 etc then the code  incorrectly calculating the end index by 1

Please review and merge 