### PR TITLE
WIP - Not use callbacks when using SqlServer transport.

### DIFF
--- a/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
@@ -32,6 +32,9 @@ namespace ServiceBus.Management.Infrastructure
             configuration.DisableFeature<TimeoutManager>();
             configuration.DisableFeature<Outbox>();
 
+            // Disable Callback queue creation for SQL Transport so it doesn't create the ServiceControl.MachineName queue.
+            configuration.ScaleOut().UseSingleBrokerQueue();
+
             configuration.UseSerialization<JsonSerializer>();
 
             configuration.Transactions()


### PR DESCRIPTION
Relates to a customer case. 

This will work for Sql according to:
https://github.com/Particular/NServiceBus.sqlserver/issues/2#issuecomment-24493875

TODO:
Find a way where we can do this in an agnostic way for RabbitMQ as well. 
