### PR TITLE
Keep original UniqueMessageId for Retried Messages

### DIFF
--- a/src/ServiceControl.AcceptanceTests/MessageRedirects/When_a_message_fails_a_retry_with_a_redirect.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageRedirects/When_a_message_fails_a_retry_with_a_redirect.cs
@@ -1,0 +1,138 @@
+﻿namespace ServiceBus.Management.AcceptanceTests.MessageRedirects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Config;
+    using NServiceBus.Features;
+    using NServiceBus.Settings;
+    using NUnit.Framework;
+    using ServiceBus.Management.AcceptanceTests.Contexts;
+    using ServiceControl.Infrastructure;
+    using ServiceControl.MessageFailures;
+    using ServiceControl.MessageFailures.Api;
+
+    class When_a_message_fails_a_retry_with_a_redirect : AcceptanceTest
+    {
+        [Test]
+        public void The_original_failed_message_record_is_updated()
+        {
+            FailedMessage failedMessage;
+            List<FailedMessageView> failedMessages = null;
+
+            Define<Context>()
+                .WithEndpoint<OriginalEndpoint>(b =>
+                        b.Given(bus => bus.SendLocal(new MessageToRetry()))
+                            .When( // Failed Message Received
+                                ctx => ctx.UniqueMessageId != null && TryGet($"/api/errors/{ctx.UniqueMessageId}", out failedMessage),
+                                (bus, ctx) =>
+                                {
+                                    // Create Redirect
+                                    Post("/api/redirects", new RedirectRequest
+                                    {
+                                        fromphysicaladdress = ctx.FromAddress,
+                                        tophysicaladdress = ctx.ToAddress
+                                    }, status => status != HttpStatusCode.Created);
+
+                                    // Retry Failed Message
+                                    Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry");
+                                })
+                )
+                .WithEndpoint<NewEndpoint>()
+                .Done(ctx => ctx.ProcessedAgain
+                             && TryGetMany("/api/errors",
+                                 out failedMessages,
+                                 msg => msg.Exception.Message.Contains("Message Failed In New Endpoint Too")
+                             )
+                )
+                .Run();
+
+            Assert.IsNotNull(failedMessages);
+            Assert.IsNotEmpty(failedMessages);
+            Assert.AreEqual(1, failedMessages.Count);
+
+            var failedMessageView = failedMessages.Single();
+            Assert.AreEqual(2, failedMessageView.NumberOfProcessingAttempts);
+            Assert.AreEqual(FailedMessageStatus.Unresolved, failedMessageView.Status);
+        }
+
+        class OriginalEndpoint : EndpointConfigurationBuilder
+        {
+            public OriginalEndpoint()
+            {
+                EndpointSetup<DefaultServerWithoutAudit>(c => c.DisableFeature<SecondLevelRetries>())
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 1;
+                    });
+            }
+
+            public class MessageToRetryHandler : IHandleMessages<MessageToRetry>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+                public ReadOnlySettings Settings { get; set; }
+
+                public void Handle(MessageToRetry message)
+                {
+                    Context.FromAddress = Settings.LocalAddress().ToString();
+                    Context.UniqueMessageId = DeterministicGuid.MakeId(Bus.CurrentMessageContext.Id.Replace(@"\", "-"), Settings.LocalAddress().Queue).ToString();
+                    throw new Exception("Message Failed");
+                }
+            }
+        }
+
+        class NewEndpoint : EndpointConfigurationBuilder
+        {
+            public NewEndpoint()
+            {
+                EndpointSetup<DefaultServerWithoutAudit>(c => c.DisableFeature<SecondLevelRetries>())
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 1;
+                    });
+            }
+
+            public class EndpointDiscovery : IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
+                public ReadOnlySettings Settings { get; set; }
+
+                public void Start()
+                {
+                    Context.ToAddress = Settings.LocalAddress().ToString();
+                }
+
+                public void Stop() { }
+            }
+
+            public class MessageToRetryHandler : IHandleMessages<MessageToRetry>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageToRetry message)
+                {
+                    Context.ProcessedAgain = true;
+                    throw new Exception("Message Failed In New Endpoint Too");
+                }
+            }
+        }
+
+        class Context : ScenarioContext
+        {
+            public string FromAddress { get; set; }
+            public string ToAddress { get; set; }
+            public string UniqueMessageId { get; set; }
+            public bool ProcessedAgain { get; set; }
+        }
+
+        [Serializable]
+        class MessageToRetry : ICommand
+        {
+
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Contexts\ConfigureExtensions.cs" />
     <Compile Include="MessageRedirects\MessageRedirect.cs" />
     <Compile Include="MessageRedirects\RedirectRequest.cs" />
+    <Compile Include="MessageRedirects\When_a_message_fails_a_retry_with_a_redirect.cs" />
     <Compile Include="MessageRedirects\When_a_message_is_retried.cs" />
     <Compile Include="MessageRedirects\When_a_redirect_is_changed.cs" />
     <Compile Include="MessageRedirects\When_a_redirect_is_created.cs" />

--- a/src/ServiceControl.UnitTests/Migrations/1.27/SplitFailedMessageDocumentsMigrationTests.cs
+++ b/src/ServiceControl.UnitTests/Migrations/1.27/SplitFailedMessageDocumentsMigrationTests.cs
@@ -196,6 +196,42 @@
         }
 
         [Test]
+        public void Should_split_retryissued_failuremessages_from_two_logical_subscribers_after_retrying()
+        {
+            // Arrange
+            var scenarioInfo = new PreSplitScenario(FailedMessageStatus.RetryIssued);
+            scenarioInfo.AddV5ProcessingAttempt(PreSplitScenario.Subscriber1InputQueue, PreSplitScenario.Subscriber1Endpoint);
+            scenarioInfo.AddV5ProcessingAttempt(PreSplitScenario.Subscriber2InputQueue, PreSplitScenario.Subscriber2Endpoint);
+            scenarioInfo.AddV5ProcessingAttempt(PreSplitScenario.Subscriber1InputQueue, PreSplitScenario.Subscriber1Endpoint, true);
+            using (var session = documentStore.OpenSession())
+            {
+                session.Store(scenarioInfo.FailedMessage);
+                session.SaveChanges();
+            }
+
+            // Act
+            var migration = CreateMigration();
+            migration.Apply(documentStore);
+
+            // Assert
+            using (var session = documentStore.OpenSession())
+            {
+                var failedMessages = session.Query<FailedMessage>().ToArray();
+
+                Assert.AreEqual(2, failedMessages.Length, "There should be 2 failed messages");
+
+                var firstAttemptFailure = failedMessages.SingleOrDefault(f => f.UniqueMessageId == scenarioInfo.ProcessingAttempts[0].ExpectedUniqueMessageId);
+                Assert.IsNotNull(firstAttemptFailure, "Attempt for Subscriber 1 not found");
+                Assert.AreEqual(firstAttemptFailure.Status, FailedMessageStatus.Unresolved, "Attempt for Subscriber 1 is not marked Unresolved");
+
+
+                var secondAttemptFailure = failedMessages.SingleOrDefault(f => f.UniqueMessageId == scenarioInfo.ProcessingAttempts[1].ExpectedUniqueMessageId);
+                Assert.IsNotNull(secondAttemptFailure, "Attempt for Subscriber 2 not found");
+                Assert.AreEqual(secondAttemptFailure.Status, FailedMessageStatus.Unresolved, "Attempt for Subscriber 2 is not marked Unresolved");
+            }
+        }
+
+        [Test]
         public void Should_split_resolved_failuremessages_from_two_logical_subscribers()
         {
             // Arrange
@@ -430,7 +466,7 @@
 
                 if (isRetry)
                 {
-                    Attempt.Headers.Add(V4RetryUniqueMessageIdHeader, ExpectedUniqueMessageId);
+                    Attempt.Headers.Add(V4RetryUniqueMessageIdHeader, scenario.UniqueMessageId);
                 }
             }
 
@@ -442,7 +478,7 @@
                 if (isRetry)
                 {
                     Attempt.Headers.Remove(V4RetryUniqueMessageIdHeader);
-                    Attempt.Headers.Add(V5RetryUniqueMessageIdHeader, ExpectedUniqueMessageId);
+                    Attempt.Headers.Add(V5RetryUniqueMessageIdHeader, scenario.UniqueMessageId);
                 }
             }
         }

--- a/src/ServiceControl.UnitTests/Migrations/1.27/SplitFailedMessageDocumentsMigrationTests.cs
+++ b/src/ServiceControl.UnitTests/Migrations/1.27/SplitFailedMessageDocumentsMigrationTests.cs
@@ -436,7 +436,32 @@
             public ProcessingAttemptInfo(PreSplitScenario scenario, string failedQ, bool isRetry)
             {
                 FailedQ = failedQ;
-                Attempt = new FailedMessage.ProcessingAttempt
+                Attempt = CreateAttempt(scenario, failedQ);
+                ExpectedUniqueMessageId = Attempt.Headers.UniqueId();
+
+                if (isRetry)
+                {
+                    Attempt.Headers.Add(V4RetryUniqueMessageIdHeader, scenario.UniqueMessageId);
+                }
+            }
+
+            public ProcessingAttemptInfo(PreSplitScenario scenario, string failedQ, string endpointName, bool isRetry) 
+            {
+                FailedQ = failedQ;
+                Attempt = CreateAttempt(scenario, failedQ);
+                EndpoingName = endpointName;
+                Attempt.Headers.Add(Headers.ProcessingEndpoint, endpointName);
+
+                ExpectedUniqueMessageId = Attempt.Headers.UniqueId();
+                if (isRetry)
+                {
+                    Attempt.Headers.Add(V5RetryUniqueMessageIdHeader, scenario.UniqueMessageId);
+                }
+            }
+
+            static FailedMessage.ProcessingAttempt CreateAttempt(PreSplitScenario scenario, string failedQ)
+            {
+                return new FailedMessage.ProcessingAttempt
                 {
                     MessageId = scenario.MessageId,
                     AttemptedAt = DateTime.UtcNow.AddDays(-1),
@@ -462,24 +487,6 @@
                         { "MessageType",  MessageType }
                     }
                 };
-                ExpectedUniqueMessageId = Attempt.Headers.UniqueId();
-
-                if (isRetry)
-                {
-                    Attempt.Headers.Add(V4RetryUniqueMessageIdHeader, scenario.UniqueMessageId);
-                }
-            }
-
-            public ProcessingAttemptInfo(PreSplitScenario scenario, string failedQ, string endpointName, bool isRetry) : this(scenario, failedQ, isRetry)
-            {
-                EndpoingName = endpointName;
-                Attempt.Headers.Add(Headers.ProcessingEndpoint,endpointName);
-                ExpectedUniqueMessageId = Attempt.Headers.UniqueId();
-                if (isRetry)
-                {
-                    Attempt.Headers.Remove(V4RetryUniqueMessageIdHeader);
-                    Attempt.Headers.Add(V5RetryUniqueMessageIdHeader, scenario.UniqueMessageId);
-                }
             }
         }
 

--- a/src/ServiceControl.UnitTests/Migrations/1.27/SplitFailedMessageDocumentsMigrationTests.cs
+++ b/src/ServiceControl.UnitTests/Migrations/1.27/SplitFailedMessageDocumentsMigrationTests.cs
@@ -430,7 +430,7 @@
 
                 if (isRetry)
                 {
-                    Attempt.Headers.Add(V4RetryUniqueMessageIdHeader, scenario.UniqueMessageId);
+                    Attempt.Headers.Add(V4RetryUniqueMessageIdHeader, ExpectedUniqueMessageId);
                 }
             }
 
@@ -442,7 +442,7 @@
                 if (isRetry)
                 {
                     Attempt.Headers.Remove(V4RetryUniqueMessageIdHeader);
-                    Attempt.Headers.Add(V5RetryUniqueMessageIdHeader, scenario.UniqueMessageId);
+                    Attempt.Headers.Add(V5RetryUniqueMessageIdHeader, ExpectedUniqueMessageId);
                 }
             }
         }

--- a/src/ServiceControl/DbMigrations/1.27/SplitFailedMessageDocumentsMigration.cs
+++ b/src/ServiceControl/DbMigrations/1.27/SplitFailedMessageDocumentsMigration.cs
@@ -170,9 +170,14 @@
 
                 var headers = new Dictionary<string, string>(attempt.Headers);
 
-                UniqueMessageId = headers.UniqueId();
+                UniqueMessageId = NewUniqueId(headers);
 
                 IsRetry = headers.ContainsKey("ServiceControl.Retry.UniqueMessageId");
+            }
+
+            static string NewUniqueId(IReadOnlyDictionary<string, string> headers)
+            {
+                return DeterministicGuid.MakeId(headers.MessageId(), headers.ProcessingEndpointName()).ToString();
             }
 
             public FailedMessage.ProcessingAttempt Attempt { get; }

--- a/src/ServiceControl/Infrastructure/TransportMessageExtensions.cs
+++ b/src/ServiceControl/Infrastructure/TransportMessageExtensions.cs
@@ -43,7 +43,10 @@
 
         public static string UniqueId(this IReadOnlyDictionary<string, string> headers)
         {
-            return DeterministicGuid.MakeId(headers.MessageId(), headers.ProcessingEndpointName()).ToString();
+            string existingUniqueMessageId;
+            return headers.TryGetValue("ServiceControl.Retry.UniqueMessageId", out existingUniqueMessageId)
+                ? existingUniqueMessageId
+                : DeterministicGuid.MakeId(headers.MessageId(), headers.ProcessingEndpointName()).ToString();
         }
 
         // NOTE: Duplicated from TransportMessage


### PR DESCRIPTION
Fixes https://github.com/Particular/ServicePulse/issues/425

> When a failed message is ingested by ServiceControl it is stored in the embedded database. If the record was already in the database it's status is updated (usually from Pending to Unresolved). In order to accommodate events, the unique identifier for each failed message is a combination of the Message Id (usually a GUID) and the Processing Endpoint.
> 
> With a redirect, you are effectively changing the Processing Endpoint. When the message fails again, the resulting failed message is not matched back to the original one.
> 
> The result is two failed message records. One for the original address and one for the new address. The original one remains pending because we haven't linked it back to the incoming failed message. The new one is listed as Unresolved with only a single processing attempt.

This PR fixes the issue by retaining the original Unique Messaging Id (which was already applied as a header to all outgoing retry messages). This Id will be used for all ingested messages. If a message fails and then is retried with a redirect, when the new failure is ingested it will be correlated back to the original id and added to that document.