### PR TITLE
Add failing endpoint address classifier

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_ServiceControl_has_started.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_ServiceControl_has_started.cs
@@ -20,6 +20,7 @@
             Assert.IsNotEmpty(classifiers, "No classifiers retrieved");
             Assert.Contains(ExceptionTypeAndStackTraceFailureClassifier.Id, classifiers, "ExceptionTypeAndStackTraceFailureClassifier was not found");
             Assert.Contains(MessageTypeFailureClassifier.Id, classifiers, "MessageTypeFailureClassifier was not found");
+            Assert.Contains(AddressOfFailingEndpointClassifier.Id, classifiers, "AddressOfFailingEndpointClassifier was not found");
         }
 
         class Context : ScenarioContext

--- a/src/ServiceControl/Recoverability/Grouping/FailedMessageClassification.cs
+++ b/src/ServiceControl/Recoverability/Grouping/FailedMessageClassification.cs
@@ -17,6 +17,7 @@
             context.Container.ConfigureComponent<ExceptionTypeAndStackTraceFailureClassifier>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<MessageTypeFailureClassifier>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<ClassifyFailedMessageEnricher>(DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent<AddressOfFailingEndpointClassifier>(DependencyLifecycle.SingleInstance);
         }
 
         class ReclassifyErrorsAtStartup : FeatureStartupTask

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/AddressOfFailingEndpointClassifier.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/AddressOfFailingEndpointClassifier.cs
@@ -1,0 +1,13 @@
+namespace ServiceControl.Recoverability
+{
+    public class AddressOfFailingEndpointClassifier : IFailureClassifier
+    {
+        public const string Id = "Endpoint Address";
+        public string Name => Id;
+
+        public string ClassifyFailure(ClassifiableMessageDetails failureDetails)
+        {
+            return failureDetails.Details?.AddressOfFailingEndpoint;
+        }
+    }
+}

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -396,6 +396,7 @@
     <Compile Include="Recoverability\Grouping\Api\EtagHelper.cs" />
     <Compile Include="Recoverability\Grouping\DomainHandlers\PublishAllHandler.cs" />
     <Compile Include="Recoverability\Grouping\DomainHandlers\StoreHistoryHandler.cs" />
+    <Compile Include="Recoverability\Grouping\Groupers\AddressOfFailingEndpointClassifier.cs" />
     <Compile Include="Recoverability\Grouping\GroupRetries.cs" />
     <Compile Include="Recoverability\Grouping\IFailedMessageEnricher.cs" />
     <Compile Include="MessageFailures\Handlers\UnArchiveMessagesByRangeHandler.cs" />


### PR DESCRIPTION
## Who's affected

* Any user using Service Control to manage errors

## Symptoms

Adds an additional classifier to group errors based on the address of the endpoint.

## Original request 

https://github.com/Particular/ServicePulse/issues/427