### PR TITLE
Rerun error classifications

### DIFF
--- a/src/ServiceControl/DbMigrations/1.39/RerunClassifiersMigration.cs
+++ b/src/ServiceControl/DbMigrations/1.39/RerunClassifiersMigration.cs
@@ -1,13 +1,7 @@
 ﻿namespace Particular.ServiceControl.DbMigrations
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using global::ServiceControl;
-    using global::ServiceControl.Infrastructure;
-    using global::ServiceControl.MessageFailures;
     using global::ServiceControl.Recoverability;
     using Raven.Client;
-    using Raven.Client.Document;
 
     public class RerunClassifiersMigration : IMigration
     {

--- a/src/ServiceControl/DbMigrations/1.39/RerunClassifiersMigration.cs
+++ b/src/ServiceControl/DbMigrations/1.39/RerunClassifiersMigration.cs
@@ -1,0 +1,33 @@
+﻿namespace Particular.ServiceControl.DbMigrations
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using global::ServiceControl;
+    using global::ServiceControl.Infrastructure;
+    using global::ServiceControl.MessageFailures;
+    using global::ServiceControl.Recoverability;
+    using Raven.Client;
+    using Raven.Client.Document;
+
+    public class RerunClassifiersMigration : IMigration
+    {
+        public string Apply(IDocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            {
+                var reclassifySettings = session.Load<ReclassifyErrorSettings>(ReclassifyErrorSettings.IdentifierCase);
+
+                if (reclassifySettings != null)
+                {
+                    reclassifySettings.ReclassificationDone = false;
+                }
+
+                session.SaveChanges();
+            }
+
+            return "Reclassification settings updated.";
+        }
+
+        public string MigrationId { get; } = "Rerun error classifiers";
+    }
+}

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/ReclassifyErrorsHandler.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/ReclassifyErrorsHandler.cs
@@ -74,11 +74,6 @@ namespace ServiceControl.Recoverability
                     {
                         while (!abort && stream.MoveNext())
                         {
-                            if (stream.Current.Document.FailureGroups.Count > 0)
-                            {
-                                continue;
-                            }
-
                             currentBatch.Add(Tuple.Create(stream.Current.Document.Id, new ClassifiableMessageDetails(stream.Current.Document)));
 
                             if (currentBatch.Count == BatchSize)

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -279,6 +279,7 @@
     <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatsUpdated.cs" />
     <Compile Include="Contracts\MessageFailures\FailedMessageArchived.cs" />
     <Compile Include="Contracts\MessageFailures\FailedMessagesUnArchived.cs" />
+    <Compile Include="DbMigrations\1.39\RerunClassifiersMigration.cs" />
     <Compile Include="DbMigrations\Migrations.cs" />
     <Compile Include="DbMigrations\IMigration.cs" />
     <Compile Include="DbMigrations\MigrationsManager.cs" />


### PR DESCRIPTION
Ping @Particular/servicecontrol-maintainers 

This resets the ReclassifyErrorSettings flag to false so that the errors are reclassified. This ensures that the new dropdown we use for grouping errors will have the current messages and not just new messages.