### PR TITLE
Fix archive operation document id

### DIFF
--- a/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/AcceptanceTest.cs
@@ -37,6 +37,7 @@ namespace ServiceBus.Management.AcceptanceTests
     using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
     using JsonSerializer = Newtonsoft.Json.JsonSerializer;
     using LogManager = NServiceBus.Logging.LogManager;
+    using ServiceControl.Recoverability;
 
     [TestFixture]
     public abstract class AcceptanceTest
@@ -634,6 +635,9 @@ namespace ServiceBus.Management.AcceptanceTests
             {
                 bus = bootstrapper.Start(true);
             }
+
+            ArchivingManager.ArchiveOperations = new Dictionary<string, InMemoryArchive>();
+            RetryingManager.RetryOperations = new Dictionary<string, InMemoryRetry>();
         }
 
         private class MessageMapperInterceptor : Feature

--- a/src/ServiceControl/Properties/AssemblyInfo.cs
+++ b/src/ServiceControl/Properties/AssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCompany("NServiceBus Ltd.")]
 [assembly: AssemblyDescription("Management extension to NServiceBus.")]
 [assembly: InternalsVisibleTo("ServiceControl.UnitTests")]
+[assembly: InternalsVisibleTo("ServiceBus.Management.AcceptanceTests")]

--- a/src/ServiceControl/Recoverability/API/GroupFetcher.cs
+++ b/src/ServiceControl/Recoverability/API/GroupFetcher.cs
@@ -28,11 +28,11 @@
             var closedGroups = MapClosedGroups(classifier, closedRetryAcknowledgements);
             closedGroups = closedGroups.Union(MapClosedGroups(classifier, archivingManager.GetArchivalOperations().Where(archiveOp => archiveOp.NeedsAcknowledgement())));
 
-            var openGroups = MapOpenGroups(dbGroups, retryHistory, openRetryAcknowledgements);
-            openGroups = MapOpenGroups(openGroups, archivingManager.GetArchivalOperations());
-            openGroups = openGroups.Where(group => !closedGroups.Any(closedGroup => closedGroup.Id == group.Id));
+            var openGroups = MapOpenGroups(dbGroups, retryHistory, openRetryAcknowledgements).ToList();
+            openGroups = MapOpenGroups(openGroups, archivingManager.GetArchivalOperations()).ToList();
+            openGroups = openGroups.Where(group => !closedGroups.Any(closedGroup => closedGroup.Id == group.Id)).ToList();
 
-            MakeSureForwardingBatchIsIncludedAsOpen(classifier, GetCurrentForwardingBatch(session), openGroups.ToList());
+            MakeSureForwardingBatchIsIncludedAsOpen(classifier, GetCurrentForwardingBatch(session), openGroups);
 
             var groups = openGroups.Union(closedGroups);
 

--- a/src/ServiceControl/Recoverability/Archiving/Raven/ArchiveBatch.cs
+++ b/src/ServiceControl/Recoverability/Archiving/Raven/ArchiveBatch.cs
@@ -9,7 +9,7 @@
 
         public static string MakeId(string requestId, ArchiveType archiveType, int batchNumber)
         {
-            return $"ArchiveBatch/{(int)archiveType}/{requestId}/{batchNumber}";
+            return $"ArchiveOperations/{(int)archiveType}/{requestId}/{batchNumber}";
         }
     }
 }


### PR DESCRIPTION
Archiving messages is not working because the expected document Id does not match the persisted one.

This change fixes that.