### PR TITLE
Acknowledge Retries as well as Archive operations

### DIFF
--- a/src/ServiceControl/Recoverability/API/UnacknowledgedGroupsApi.cs
+++ b/src/ServiceControl/Recoverability/API/UnacknowledgedGroupsApi.cs
@@ -13,11 +13,31 @@ namespace ServiceControl.Recoverability
         private dynamic AcknowledgeOperation(dynamic parameters)
         {
             var groupId = parameters.groupId;
+            if (ArchiveOperationManager.IsArchiveInProgressFor(groupId))
+            {
+                ArchiveOperationManager.DismissArchiveOperation(groupId, ArchiveType.FailureGroup);
+                return HttpStatusCode.OK;
+            }
+           
+            using (var session = Store.OpenSession())
+            {
+                var retryHistory = session.Load<RetryHistory>(RetryHistory.MakeId());
+                if (retryHistory != null)
+                {
+                    if (retryHistory.Acknowledge(groupId, RetryType.FailureGroup))
+                    {
+                        session.Store(retryHistory);
+                        session.SaveChanges();
 
-            ArchiveOperationManager.DismissArchiveOperation(groupId, ArchiveType.FailureGroup);
+                        return HttpStatusCode.OK;
+                    }
+                }
+            }
 
-            return HttpStatusCode.OK;
+            return HttpStatusCode.NotFound;
         }
+
 		public ArchivingManager ArchiveOperationManager { get; set; }
+		public RetryingManager RetryingOperationManager { get; set; }
     }
 }

--- a/src/ServiceControl/Recoverability/Retrying/History/RetryHistory.cs
+++ b/src/ServiceControl/Recoverability/Retrying/History/RetryHistory.cs
@@ -50,9 +50,9 @@
             return UnacknowledgedOperations.Where(x => x.Classifier == classifier).ToArray();
         }
         
-        public void Acknowledge(string requestId, RetryType type)
+        public bool Acknowledge(string requestId, RetryType type)
         {
-            UnacknowledgedOperations.RemoveAll(x => x.RequestId == requestId && x.RetryType == type);
+            return UnacknowledgedOperations.RemoveAll(x => x.RequestId == requestId && x.RetryType == type) > 0;
         }
     }
 }


### PR DESCRIPTION
Connects to https://github.com/Particular/ServiceControl/issues/944

Changes the acknowledgement operation to try and acknowledge archive operations first, followed by retry operations. There can only be one of those per group at a time.

Returns `404` if a group is provided that is either not archived or retried.