### PR TITLE
Fix grammar issue on website link

### DIFF
--- a/src/Compiler/ReleaseNotesBuilder.cs
+++ b/src/Compiler/ReleaseNotesBuilder.cs
@@ -144,7 +144,7 @@ namespace ReleaseNotesCompiler
         static void AddFooter(StringBuilder stringBuilder)
         {
             stringBuilder.AppendLine("## Where to get it");
-            stringBuilder.AppendLine("You can download this release from [website](http://particular.net/downloads).");
+            stringBuilder.AppendLine("You can download this release from our [website](http://particular.net/downloads).");
         }
 
         static void PrintHeading(string heading, StringBuilder builder)


### PR DESCRIPTION
Fixes the grammer around the website link.

Ping @Particular/servicecontrol-maintainers.

I'm not sure how this gets applied to the octopus release notes step. Does anybody know?