### PR TITLE
Instance refresh fails 

### DIFF
--- a/src/ServiceControl.Config/UI/ListInstances/ListInstancesViewModel.cs
+++ b/src/ServiceControl.Config/UI/ListInstances/ListInstancesViewModel.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Net;
     using Caliburn.Micro;
     using ServiceControl.Config.Events;

--- a/src/ServiceControl.Config/UI/ListInstances/ListInstancesViewModel.cs
+++ b/src/ServiceControl.Config/UI/ListInstances/ListInstancesViewModel.cs
@@ -34,26 +34,11 @@
 
         private void RefreshInstances()
         {
-            var currentInstances = ServiceControlInstance.Instances();
-
-            var addedInstances = currentInstances.Where(i => Instances.All(i2 => i2.Name != i.Name)).ToList();
-            var removedInstances = Instances.Where(i => currentInstances.All(i2 => i2.Name != i.Name)).ToList();
-
-            foreach (var item in addedInstances)
+            Instances.Clear();
+            foreach (var item in ServiceControlInstance.Instances())
             {
                 Instances.Add(instanceDetailsFunc(item));
             }
-
-            foreach (var item in removedInstances)
-            {
-                Instances.Remove(item);
-            }
-
-            foreach (var instance in Instances)
-            {
-                instance.ServiceControlInstance.Reload();
-            }
-            // Existing instances are updated in the InstanceDetailsViewModel
         }
 
         public void Handle(LicenseUpdated licenseUpdatedEvent)


### PR DESCRIPTION
Connects to #964

When changing values in the SC Management app like port the update is sometimes not reflected in the UI until restart. Simplified the refresh to clear and reload the data completely