### PR TITLE
Fix handling of "The service cannot accept control messages at this time"

### DIFF
--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -344,8 +344,17 @@ namespace ServiceControlInstaller.Engine.Instances
                 return true;
             }
 
-            Service.Stop();
+            try
+            {
 
+                // Will throw with "The service cannot accept control messages at this time" message if the service is in a pending state 
+                Service.Stop();
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+            
             try
             {
                 Service.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(60));
@@ -373,7 +382,16 @@ namespace ServiceControlInstaller.Engine.Instances
                 return true;
             }
 
-            Service.Start();
+            try
+            {
+
+                // Will throw with "The service cannot accept control messages at this time" message if the service is in a pending state 
+                Service.Start();
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
 
             try
             {


### PR DESCRIPTION
Connects to #908 

Correct the handling of start and stop  services throwing "The service cannot accept control messages at this time" when the service is in a pending state.  Prior to this fix this bubbled to the unhandled exception manager and was often sent through to Raygun