### PR TITLE
Fix saga audit import

### DIFF
--- a/src/ServiceControl.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
+++ b/src/ServiceControl.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
@@ -1,0 +1,26 @@
+﻿namespace ServiceControl.UnitTests.SagaAudit
+{
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using ServiceControl.SagaAudit;
+
+    [TestFixture]
+    public class SagaRelationshipsEnricherTests
+    {
+        [Test]
+        public void It_can_process_a_message_that_invoked_the_same_saga_instance_twice()
+        {
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8;ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8",
+                ["ServiceControl.SagaStateChange"] = "51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:New;51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:Updated"
+            };
+
+            var metadata = new Dictionary<string, object>();
+
+            enricher.Enrich(headers, metadata);
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
+++ b/src/ServiceControl.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
@@ -92,35 +92,14 @@
         }
 
         [Test]
-        public void It_can_parse_malformed_headers_of_two_sagas()
-        {
-            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
-
-            var headers = new Dictionary<string, string>
-            {
-                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6;ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6",
-                ["ServiceControl.SagaStateChange"] = "d440f0b8-1716-43f3-9a00-a79900d083a6:Updated;d440f0b8-1716-43f3-9a00-a79900d083a6:New"
-            };
-
-            var metadata = new Dictionary<string, object>();
-
-            enricher.Enrich(headers, metadata);
-
-            var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
-
-            Assert.AreEqual(1, sagaData.Count);
-            Assert.AreEqual("New", sagaData[0].ChangeStatus);
-        }
-
-        [Test]
         public void It_can_parse_malformed_headers_of_three_sagas()
         {
             var enricher = new SagaAuditing.SagaRelationshipsEnricher();
 
             var headers = new Dictionary<string, string>
             {
-                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6;ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6;ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6;ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6",
-                ["ServiceControl.SagaStateChange"] = "d440f0b8-1716-43f3-9a00-a79900d083a6:Updated;d440f0b8-1716-43f3-9a00-a79900d083a6:New;d440f0b8-1716-43f3-9a00-a79900d083a6:Completed"
+                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga2:9bc8ff00-9e10-41f6-8a56-a79a0060a762ConsoleApp1.MySaga2:9bc8ff00-9e10-41f6-8a56-a79a0060a762;ConsoleApp1.MySaga3:6f46e0e9-5476-4141-a1fd-a79a0060a782ConsoleApp1.MySaga2:9bc8ff00-9e10-41f6-8a56-a79a0060a762ConsoleApp1.MySaga2:9bc8ff00-9e10-41f6-8a56-a79a0060a762;ConsoleApp1.MySaga3:6f46e0e9-5476-4141-a1fd-a79a0060a782;ConsoleApp1.MySaga:c0ed4546-ddce-42d7-9ce2-a79a0060a782",
+                ["ServiceControl.SagaStateChange"] = "c0ed4546-ddce-42d7-9ce2-a79a0060a782:Updated;6f46e0e9-5476-4141-a1fd-a79a0060a782:New;9bc8ff00-9e10-41f6-8a56-a79a0060a762:Completed"
             };
 
             var metadata = new Dictionary<string, object>();
@@ -129,8 +108,7 @@
 
             var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
 
-            Assert.AreEqual(1, sagaData.Count);
-            Assert.AreEqual("Completed", sagaData[0].ChangeStatus);
+            Assert.AreEqual(3, sagaData.Count);
         }
     }
 }

--- a/src/ServiceControl.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
+++ b/src/ServiceControl.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
@@ -90,5 +90,47 @@
             Assert.AreEqual(1, sagaData.Count);
             Assert.AreEqual("Completed", sagaData[0].ChangeStatus);
         }
+
+        [Test]
+        public void It_can_parse_malformed_headers_of_two_sagas()
+        {
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6;ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6",
+                ["ServiceControl.SagaStateChange"] = "d440f0b8-1716-43f3-9a00-a79900d083a6:Updated;d440f0b8-1716-43f3-9a00-a79900d083a6:New"
+            };
+
+            var metadata = new Dictionary<string, object>();
+
+            enricher.Enrich(headers, metadata);
+
+            var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
+
+            Assert.AreEqual(1, sagaData.Count);
+            Assert.AreEqual("New", sagaData[0].ChangeStatus);
+        }
+
+        [Test]
+        public void It_can_parse_malformed_headers_of_three_sagas()
+        {
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6;ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6;ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6;ConsoleApp1.MySaga:d440f0b8-1716-43f3-9a00-a79900d083a6",
+                ["ServiceControl.SagaStateChange"] = "d440f0b8-1716-43f3-9a00-a79900d083a6:Updated;d440f0b8-1716-43f3-9a00-a79900d083a6:New;d440f0b8-1716-43f3-9a00-a79900d083a6:Completed"
+            };
+
+            var metadata = new Dictionary<string, object>();
+
+            enricher.Enrich(headers, metadata);
+
+            var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
+
+            Assert.AreEqual(1, sagaData.Count);
+            Assert.AreEqual("Completed", sagaData[0].ChangeStatus);
+        }
     }
 }

--- a/src/ServiceControl.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
+++ b/src/ServiceControl.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
@@ -29,7 +29,7 @@
         }
 
         [Test]
-        public void Updated_does_not_verride_new()
+        public void Updated_does_not_override_new()
         {
             var enricher = new SagaAuditing.SagaRelationshipsEnricher();
 
@@ -50,7 +50,7 @@
         }
 
         [Test]
-        public void Updated_does_not_verride_completed()
+        public void Updated_does_not_override_completed()
         {
             var enricher = new SagaAuditing.SagaRelationshipsEnricher();
 
@@ -79,6 +79,27 @@
             {
                 ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8;ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8",
                 ["ServiceControl.SagaStateChange"] = "51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:New;51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:Completed"
+            };
+
+            var metadata = new Dictionary<string, object>();
+
+            enricher.Enrich(headers, metadata);
+
+            var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
+
+            Assert.AreEqual(1, sagaData.Count);
+            Assert.AreEqual("Completed", sagaData[0].ChangeStatus);
+        }
+
+        [Test]
+        public void New_does_not_override_completed()
+        {
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8;ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8",
+                ["ServiceControl.SagaStateChange"] = "51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:Completed;51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:New"
             };
 
             var metadata = new Dictionary<string, object>();

--- a/src/ServiceControl.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
+++ b/src/ServiceControl.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
@@ -8,19 +8,87 @@
     public class SagaRelationshipsEnricherTests
     {
         [Test]
-        public void It_can_process_a_message_that_invoked_the_same_saga_instance_twice()
+        public void New_overrides_Updated_state()
         {
             var enricher = new SagaAuditing.SagaRelationshipsEnricher();
 
             var headers = new Dictionary<string, string>
             {
-                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8;ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8",
+                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8;ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8",
+                ["ServiceControl.SagaStateChange"] = "51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:Updated;51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:New"
+            };
+
+            var metadata = new Dictionary<string, object>();
+
+            enricher.Enrich(headers, metadata);
+
+            var sagaData = (List<SagaInfo>) metadata["InvokedSagas"];
+
+            Assert.AreEqual(1, sagaData.Count);
+            Assert.AreEqual("New", sagaData[0].ChangeStatus);
+        }
+
+        [Test]
+        public void Updated_does_not_verride_new()
+        {
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8;ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8",
                 ["ServiceControl.SagaStateChange"] = "51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:New;51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:Updated"
             };
 
             var metadata = new Dictionary<string, object>();
 
             enricher.Enrich(headers, metadata);
+
+            var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
+
+            Assert.AreEqual(1, sagaData.Count);
+            Assert.AreEqual("New", sagaData[0].ChangeStatus);
+        }
+
+        [Test]
+        public void Updated_does_not_verride_completed()
+        {
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8;ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8",
+                ["ServiceControl.SagaStateChange"] = "51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:Completed;51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:Updated"
+            };
+
+            var metadata = new Dictionary<string, object>();
+
+            enricher.Enrich(headers, metadata);
+
+            var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
+
+            Assert.AreEqual(1, sagaData.Count);
+            Assert.AreEqual("Completed", sagaData[0].ChangeStatus);
+        }
+
+        [Test]
+        public void Completed_overrides_new()
+        {
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
+
+            var headers = new Dictionary<string, string>
+            {
+                ["NServiceBus.InvokedSagas"] = "ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8;ConsoleApp1.MySaga:51b5ad68-8ac4-46ee-a39c-a79900ca4ea8",
+                ["ServiceControl.SagaStateChange"] = "51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:New;51b5ad68-8ac4-46ee-a39c-a79900ca4ea8:Completed"
+            };
+
+            var metadata = new Dictionary<string, object>();
+
+            enricher.Enrich(headers, metadata);
+
+            var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
+
+            Assert.AreEqual(1, sagaData.Count);
+            Assert.AreEqual("Completed", sagaData[0].ChangeStatus);
         }
     }
 }

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Recoverability\ReturnToSenderDequeuerTests.cs" />
     <Compile Include="SagaAudit\SagaDetailsIndexTests.cs" />
     <Compile Include="SagaAudit\SagaListIndexTests.cs" />
+    <Compile Include="SagaAudit\SagaRelationshipsEnricherTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl\ServiceControl.csproj">

--- a/src/ServiceControl/SagaAudit/SagaAuditing.cs
+++ b/src/ServiceControl/SagaAudit/SagaAuditing.cs
@@ -19,7 +19,7 @@
             context.Container.ConfigureComponent<SagaRelationshipsEnricher>(DependencyLifecycle.SingleInstance);
         }
 
-        class SagaRelationshipsEnricher : ImportEnricher
+        public class SagaRelationshipsEnricher : ImportEnricher
         {
             public override void Enrich(IReadOnlyDictionary<string, string> headers, IDictionary<string, object> metadata)
             {

--- a/src/ServiceControl/SagaAudit/SagaAuditing.cs
+++ b/src/ServiceControl/SagaAudit/SagaAuditing.cs
@@ -42,10 +42,10 @@
                             {
                                 sagasChanges[id] = thisChange;
                             }
-                            else //Completed overrides New overrides Updated
+                            else
                             {
-                                if (string.Equals(thisChange, "Completed", StringComparison.OrdinalIgnoreCase)
-                                    || string.Equals(thisChange, "New", StringComparison.OrdinalIgnoreCase) && string.Equals(previousChange, "Updated", StringComparison.OrdinalIgnoreCase))
+                                if (thisChange == "Completed"   //Completed overrides everything
+                                    || thisChange == "New" && previousChange == "Updated") //New overrides Updated
                                 {
                                     sagasChanges[id] = thisChange;
                                 }

--- a/src/ServiceControl/SagaAudit/SagaAuditing.cs
+++ b/src/ServiceControl/SagaAudit/SagaAuditing.cs
@@ -19,7 +19,7 @@
             context.Container.ConfigureComponent<SagaRelationshipsEnricher>(DependencyLifecycle.SingleInstance);
         }
 
-        public class SagaRelationshipsEnricher : ImportEnricher
+        internal class SagaRelationshipsEnricher : ImportEnricher
         {
             public override void Enrich(IReadOnlyDictionary<string, string> headers, IDictionary<string, object> metadata)
             {

--- a/src/ServiceControl/SagaAudit/SagaAuditing.cs
+++ b/src/ServiceControl/SagaAudit/SagaAuditing.cs
@@ -35,11 +35,26 @@
 
                         foreach (var part in multiSagaChanges.Select(s => s.Split(':')))
                         {
-                            sagasChanges.Add(part[0], part[1]);
+                            var id = part[0];
+                            var thisChange = part[1];
+                            string previousChange;
+                            if (!sagasChanges.TryGetValue(id, out previousChange))
+                            {
+                                sagasChanges[id] = thisChange;
+                            }
+                            else //Completed overrides New overrides Updated
+                            {
+                                if (string.Equals(thisChange, "Completed", StringComparison.OrdinalIgnoreCase)
+                                    || string.Equals(thisChange, "New", StringComparison.OrdinalIgnoreCase) && string.Equals(previousChange, "Updated", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    sagasChanges[id] = thisChange;
+                                }
+                            }
                         }
                     }
 
                     var sagas = sagasInvokedRaw.Split(';')
+                        .Distinct()
                         .Select(saga =>
                         {
                             var sagaInvoked = saga.Split(':');


### PR DESCRIPTION
Connects to #977

* Deduplicates entries in the `NServiceBus.InvokedSagas` header to ensure there is one state change record created for each message even if that message caused invocation of two saga methods
* Handles various state change overrides well in case there were multiple methods invoked i.e. Completed overrides New overrides Updated

### Rationale

I've decided to go with deduplication instead of retaining multiple state changes in the list because I am not sure how the downstream consumers would react if they get a message that caused two state changes of a single saga instance. Would order matter etc.?