### PR TITLE
Move logging configuration earlier

### DIFF
--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -2,7 +2,6 @@ namespace Particular.ServiceControl
 {
     using System;
     using System.IO;
-    using System.Linq;
     using System.Net;
     using System.ServiceProcess;
     using Autofac;
@@ -10,17 +9,12 @@ namespace Particular.ServiceControl
     using global::ServiceControl.Infrastructure.DomainEvents;
     using global::ServiceControl.Infrastructure.SignalR;
     using Microsoft.Owin.Hosting;
-    using NLog;
-    using NLog.Config;
-    using NLog.Layouts;
-    using NLog.Targets;
     using NServiceBus;
     using Raven.Client;
     using Raven.Client.Embedded;
     using ServiceBus.Management.Infrastructure;
     using ServiceBus.Management.Infrastructure.OWIN;
     using ServiceBus.Management.Infrastructure.Settings;
-    using LogLevel = NLog.LogLevel;
     using LogManager = NServiceBus.Logging.LogManager;
 
     public class Bootstrapper
@@ -56,7 +50,7 @@ namespace Particular.ServiceControl
         private void Initialize()
         {
             var loggingSettings = new LoggingSettings(settings.ServiceName);
-            ConfigureLogging(loggingSettings);
+            RecordStartup(loggingSettings);
 
             // .NET default limit is 10. RavenDB in conjunction with transports that use HTTP exceeds that limit.
             ServicePointManager.DefaultConnectionLimit = settings.HttpDefaultConnectionLimit;
@@ -127,106 +121,24 @@ namespace Particular.ServiceControl
             }
         }
 
-        private void ConfigureLogging(LoggingSettings loggingSettings)
+        private void RecordStartup(LoggingSettings loggingSettings)
         {
-            LogManager.Use<NLogFactory>();
-
-            const long megaByte = 1073741824;
-            if (NLog.LogManager.Configuration != null)
-            {
-                return;
-            }
-
             var version = typeof(Bootstrapper).Assembly.GetName().Version;
-            var nlogConfig = new LoggingConfiguration();
-            var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}");
-            var header = $@"-------------------------------------------------------------
-ServiceControl Version:				{version}
-Selected Transport:					{settings.TransportType}
-Audit Retention Period:				{settings.AuditRetentionPeriod}
-Error Retention Period:				{settings.ErrorRetentionPeriod}
-Forwarding Error Messages:		{settings.ForwardErrorMessages}
-Forwarding Audit Messages:		{settings.ForwardAuditMessages}
-Database Size:							{DataSize()}bytes
+            var startupMessage = $@"
+-------------------------------------------------------------
+ServiceControl Version:       {version}
+Selected Transport:           {settings.TransportType}
+Audit Retention Period:       {settings.AuditRetentionPeriod}
+Error Retention Period:       {settings.ErrorRetentionPeriod}
+Forwarding Error Messages:    {settings.ForwardErrorMessages}
+Forwarding Audit Messages:    {settings.ForwardAuditMessages}
+Database Size:                {DataSize()}bytes
+ServiceControl Logging Level: {loggingSettings.LoggingLevel}
+RavenDB Logging Level:        {loggingSettings.RavenDBLogLevel}
 -------------------------------------------------------------";
 
-            var fileTarget = new FileTarget
-            {
-                ArchiveEvery = FileArchivePeriod.Day,
-                FileName = Path.Combine(loggingSettings.LogPath, "logfile.${shortdate}.txt"),
-                ArchiveFileName = Path.Combine(loggingSettings.LogPath, "logfile.{#}.txt"),
-                ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
-                Layout = simpleLayout,
-                MaxArchiveFiles = 14,
-                ArchiveAboveSize = 30*megaByte,
-                Header = new SimpleLayout(header)
-            };
-
-
-            var ravenFileTarget = new FileTarget
-            {
-                ArchiveEvery = FileArchivePeriod.Day,
-                FileName = Path.Combine(loggingSettings.LogPath, "ravenlog.${shortdate}.txt"),
-                ArchiveFileName = Path.Combine(loggingSettings.LogPath, "ravenlog.{#}.txt"),
-                ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
-                Layout = simpleLayout,
-                MaxArchiveFiles = 14,
-                ArchiveAboveSize = 30*megaByte,
-                Header = new SimpleLayout(header)
-            };
-
-            var consoleTarget = new ColoredConsoleTarget
-            {
-                Layout = simpleLayout,
-                UseDefaultRowHighlightingRules = true
-            };
-
-            var nullTarget = new NullTarget();
-
-            // There lines don't appear to be necessary.  The rules seem to work without implicitly adding the targets?!?
-            nlogConfig.AddTarget("console", consoleTarget);
-            nlogConfig.AddTarget("debugger", fileTarget);
-            nlogConfig.AddTarget("raven", ravenFileTarget);
-            nlogConfig.AddTarget("bitbucket", nullTarget);
-
-            // Only want to see raven errors
-            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", loggingSettings.RavenDBLogLevel, ravenFileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", LogLevel.Error, consoleTarget)); //Noise reduction - Only RavenDB errors on the console
-            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", LogLevel.Debug, nullTarget)
-            {
-                Final = true
-            }); //Will swallow debug and above messages
-
-
-            // Always want to see license logging regardless of default logging level
-            nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, fileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget)
-            {
-                Final = true
-            });
-
-            // Defaults
-            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel, fileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel < LogLevel.Info ? loggingSettings.LoggingLevel : LogLevel.Info, consoleTarget));
-
-            // Remove Console Logging when running as a service
-            if (!Environment.UserInteractive)
-            {
-                foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
-                {
-                    nlogConfig.LoggingRules.Remove(rule);
-                }
-            }
-
-            NLog.LogManager.Configuration = nlogConfig;
-
             var logger = LogManager.GetLogger(typeof(Bootstrapper));
-            var logEventInfo = new LogEventInfo
-            {
-                TimeStamp = DateTime.Now
-            };
-            logger.InfoFormat("Logging to {0} with LoggingLevel '{1}'", fileTarget.FileName.Render(logEventInfo), loggingSettings.LoggingLevel.Name);
-            logger.InfoFormat("RavenDB logging to {0} with LoggingLevel '{1}'", ravenFileTarget.FileName.Render(logEventInfo), loggingSettings.RavenDBLogLevel.Name);
+            logger.Info(startupMessage);
         }
     }
 }

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -20,7 +20,7 @@ namespace Particular.ServiceControl.Hosting
         
         public HostArguments(string[] args)
         {
-            if (SettingsReader<bool>.Read("MaintenanceMode"))
+            if (ConfigFileSettingsReader<bool>.Read("MaintenanceMode"))
             {
                 args = args.Concat(new[]
                 {

--- a/src/ServiceControl/Infrastructure/Settings/ConfigFileSettingsReader.cs
+++ b/src/ServiceControl/Infrastructure/Settings/ConfigFileSettingsReader.cs
@@ -1,0 +1,37 @@
+namespace ServiceBus.Management.Infrastructure.Settings
+{
+    using System;
+    using System.Configuration;
+
+    public static class ConfigFileSettingsReader<T>
+    {
+        public static T Read(string name, T defaultValue = default(T))
+        {
+            return Read("ServiceControl", name, defaultValue);
+        }
+
+        public static T Read(string root, string name, T defaultValue = default(T))
+        {
+            T value;
+            if (TryRead(root, name, out value))
+            {
+                return value;
+            }
+            return defaultValue;
+        }
+
+        public static bool TryRead(string root, string name, out T value)
+        {
+            var fullKey = $"{root}/{name}";
+
+            if (ConfigurationManager.AppSettings[fullKey] != null)
+            {
+                value = (T)Convert.ChangeType(ConfigurationManager.AppSettings[fullKey], typeof(T));
+                return true;
+            }
+
+            value = default(T);
+            return false;
+        }
+    }
+}

--- a/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
@@ -11,7 +11,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
         {
             LoggingLevel = InitializeLevel("LogLevel");
             RavenDBLogLevel = InitializeLevel("RavenDBLogLevel");
-            LogPath = Environment.ExpandEnvironmentVariables(SettingsReader<string>.Read("LogPath", DefaultLogPathForInstance(serviceName)));
+            LogPath = Environment.ExpandEnvironmentVariables(ConfigFileSettingsReader<string>.Read("LogPath", DefaultLogPathForInstance(serviceName)));
         }
 
         LogLevel InitializeLevel(string key)
@@ -19,7 +19,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
             var level = LogLevel.Warn;
             try
             {
-                level = LogLevel.FromString(SettingsReader<string>.Read(key, LogLevel.Warn.Name));
+                level = LogLevel.FromString(ConfigFileSettingsReader<string>.Read(key, LogLevel.Warn.Name));
             }
             catch
             {

--- a/src/ServiceControl/Infrastructure/Settings/SettingsReader.cs
+++ b/src/ServiceControl/Infrastructure/Settings/SettingsReader.cs
@@ -1,8 +1,5 @@
 ﻿namespace ServiceBus.Management.Infrastructure.Settings
 {
-    using System;
-    using System.Configuration;
-
     public class SettingsReader<T>
     {
         public static T Read(string name, T defaultValue = default(T))
@@ -12,11 +9,10 @@
 
         public static T Read(string root, string name, T defaultValue = default(T))
         {
-            var fullKey = root + "/" + name;
-
-            if (ConfigurationManager.AppSettings[fullKey] != null)
+            T value;
+            if (ConfigFileSettingsReader<T>.TryRead(root, name, out value))
             {
-                return (T) Convert.ChangeType(ConfigurationManager.AppSettings[fullKey], typeof(T));
+                return value;
             }
 
             return RegistryReader<T>.Read(root, name, defaultValue);

--- a/src/ServiceControl/LoggingConfigurator.cs
+++ b/src/ServiceControl/LoggingConfigurator.cs
@@ -1,0 +1,96 @@
+namespace Particular.ServiceControl
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using NLog.Config;
+    using NLog.Layouts;
+    using NLog.Targets;
+    using NServiceBus;
+    using NServiceBus.Logging;
+    using ServiceBus.Management.Infrastructure.Settings;
+    using LogLevel = NLog.LogLevel;
+
+    public static class LoggingConfigurator
+    {
+        public static void ConfigureLogging(LoggingSettings loggingSettings)
+        {
+            LogManager.Use<NLogFactory>();
+
+            const long megaByte = 1073741824;
+            if (NLog.LogManager.Configuration != null)
+            {
+                return;
+            }
+
+            var nlogConfig = new LoggingConfiguration();
+            var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}");
+
+            var fileTarget = new FileTarget
+            {
+                ArchiveEvery = FileArchivePeriod.Day,
+                FileName = Path.Combine(loggingSettings.LogPath, "logfile.${shortdate}.txt"),
+                ArchiveFileName = Path.Combine(loggingSettings.LogPath, "logfile.{#}.txt"),
+                ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
+                Layout = simpleLayout,
+                MaxArchiveFiles = 14,
+                ArchiveAboveSize = 30 * megaByte
+            };
+
+            var ravenFileTarget = new FileTarget
+            {
+                ArchiveEvery = FileArchivePeriod.Day,
+                FileName = Path.Combine(loggingSettings.LogPath, "ravenlog.${shortdate}.txt"),
+                ArchiveFileName = Path.Combine(loggingSettings.LogPath, "ravenlog.{#}.txt"),
+                ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
+                Layout = simpleLayout,
+                MaxArchiveFiles = 14,
+                ArchiveAboveSize = 30 * megaByte
+            };
+
+            var consoleTarget = new ColoredConsoleTarget
+            {
+                Layout = simpleLayout,
+                UseDefaultRowHighlightingRules = true
+            };
+
+            var nullTarget = new NullTarget();
+
+            // There lines don't appear to be necessary.  The rules seem to work without implicitly adding the targets?!?
+            nlogConfig.AddTarget("console", consoleTarget);
+            nlogConfig.AddTarget("debugger", fileTarget);
+            nlogConfig.AddTarget("raven", ravenFileTarget);
+            nlogConfig.AddTarget("bitbucket", nullTarget);
+
+            // Only want to see raven errors
+            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", loggingSettings.RavenDBLogLevel, ravenFileTarget));
+            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", LogLevel.Error, consoleTarget)); //Noise reduction - Only RavenDB errors on the console
+            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", LogLevel.Debug, nullTarget)
+            {
+                Final = true
+            }); //Will swallow debug and above messages
+
+            // Always want to see license logging regardless of default logging level
+            nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, fileTarget));
+            nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget)
+            {
+                Final = true
+            });
+
+            // Defaults
+            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel, fileTarget));
+            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel < LogLevel.Info ? loggingSettings.LoggingLevel : LogLevel.Info, consoleTarget));
+
+            // Remove Console Logging when running as a service
+            if (!Environment.UserInteractive)
+            {
+                foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
+                {
+                    nlogConfig.LoggingRules.Remove(rule);
+                }
+            }
+
+            NLog.LogManager.Configuration = nlogConfig;
+        }
+    }
+}

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -5,6 +5,7 @@
     using System.Reflection;
     using Commands;
     using Hosting;
+    using ServiceBus.Management.Infrastructure.Settings;
 
     public class Program
     {
@@ -19,6 +20,9 @@
                 arguments.PrintUsage();
                 return;
             }
+
+            var loggingSettings = new LoggingSettings(arguments.ServiceName);
+            LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             new CommandRunner(arguments.Commands).Execute(arguments);
         }

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -303,8 +303,10 @@
     <Compile Include="Infrastructure\RavenDB\Subscriptions\Subscription.cs" />
     <Compile Include="Infrastructure\RavenDB\Subscriptions\SubscriptionPersister.cs" />
     <Compile Include="Infrastructure\RavenDB\Subscriptions\SubscriptionStorage.cs" />
+    <Compile Include="Infrastructure\Settings\ConfigFileSettingsReader.cs" />
     <Compile Include="Licensing\LicenseCheckFeature.cs" />
     <Compile Include="Licensing\LicenseModule.cs" />
+    <Compile Include="LoggingConfigurator.cs" />
     <Compile Include="MaintenanceBootstrapper.cs" />
     <Compile Include="MessageFailures\Api\PendingRetryMessages.cs" />
     <Compile Include="MessageFailures\InternalMessages\MarkPendingRetryAsResolved.cs" />


### PR DESCRIPTION
Fixes #966 

- Log settings cannot come from registry (which settings should at this point?), only from config file
- Configure Logging as early as possible (in the Main method)
- Replace file header with a startup message