### PR TITLE
Provide endpoint instance details

### DIFF
--- a/src/ServiceControl.UnitTests/Recoverability/EndpointInstanceIdClassifierTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/EndpointInstanceIdClassifierTests.cs
@@ -1,0 +1,42 @@
+﻿namespace ServiceControl.UnitTests.Operations
+{
+    using NServiceBus;
+    using NUnit.Framework;
+    using ServiceControl.Recoverability;
+    using System;
+    using static ServiceControl.MessageFailures.FailedMessage;
+
+    [TestFixture]
+    public class EndpointInstanceIdClassifierTests
+    {
+        [Test]
+        public void Failure_Without_ProcessingAttempt_should_not_group()
+        {
+            var classifier = new EndpointInstanceClassifier();
+            var classification = classifier.ClassifyFailure(new ClassifiableMessageDetails());
+
+            Assert.IsNull(classification);
+        }
+
+        [Test]
+        public void Failure_With_Core_Headers_In_ProcessingAttempt_should_group()
+        {
+            var classifier = new EndpointInstanceClassifier();
+
+            var id = Guid.NewGuid().ToString();
+            var failure = new ProcessingAttempt
+            {
+                Headers = new System.Collections.Generic.Dictionary<string, string>
+                {
+                    { Headers.HostDisplayName, "Test Host Id" },
+                    { "NServiceBus.FailedQ", "Test@machine" },
+                    { Headers.HostId, id }
+                }
+            };
+
+            var classification = classifier.ClassifyFailure(new ClassifiableMessageDetails(null, null, failure));
+
+            Assert.AreEqual(id, classification);
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/Recoverability/EndpointInstanceIdClassifierTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/EndpointInstanceIdClassifierTests.cs
@@ -23,7 +23,7 @@
         {
             var classifier = new EndpointInstanceClassifier();
 
-            var id = Guid.NewGuid().ToString();
+            var id = Guid.NewGuid().ToString("N");
             var failure = new ProcessingAttempt
             {
                 Headers = new System.Collections.Generic.Dictionary<string, string>

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Operations\UpdateLicenseEnricherTest.cs" />
     <Compile Include="Recoverability\CorruptedReplyToHeaderStrategyTests.cs" />
     <Compile Include="HeaderAssertions.cs" />
+    <Compile Include="Recoverability\EndpointInstanceIdClassifierTests.cs" />
     <Compile Include="Recoverability\RetryGroupEtagHelperTests.cs" />
     <Compile Include="Recoverability\Retry_State_Tests.cs" />
     <Compile Include="Recoverability\ExceptionTypeAndStackTraceFailureClassifierTest.cs" />

--- a/src/ServiceControl/DbMigrations/1.41.3/RerunClassifiersMigration.cs
+++ b/src/ServiceControl/DbMigrations/1.41.3/RerunClassifiersMigration.cs
@@ -1,0 +1,27 @@
+﻿namespace Particular.ServiceControl.DbMigrations
+{
+    using global::ServiceControl.Recoverability;
+    using Raven.Client;
+
+    public class RerunClassifiersMigration_1_41_3 : IMigration
+    {
+        public string Apply(IDocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            {
+                var reclassifySettings = session.Load<ReclassifyErrorSettings>(ReclassifyErrorSettings.IdentifierCase);
+
+                if (reclassifySettings != null)
+                {
+                    reclassifySettings.ReclassificationDone = false;
+                }
+
+                session.SaveChanges();
+            }
+
+            return "Reclassification settings updated.";
+        }
+
+        public string MigrationId { get; } = "Rerun error classifiers 1.41.3";
+    }
+}

--- a/src/ServiceControl/Infrastructure/EndpointInstanceId.cs
+++ b/src/ServiceControl/Infrastructure/EndpointInstanceId.cs
@@ -1,0 +1,63 @@
+﻿namespace ServiceControl
+{
+    using System.Collections.Generic;
+    using NServiceBus;
+    using ServiceControl.Contracts.Operations;
+
+    public class EndpointInstanceId
+    {
+        public string EndpointName { get; }
+        public string InstanceId { get; }
+        public string InstanceName { get; }
+
+
+        public EndpointInstanceId(string endpointName, string instanceId)
+            : this(endpointName, instanceId, instanceId)
+        {
+        }
+
+        public EndpointInstanceId(string endpointName, string instanceId, string instanceName)
+        {
+            EndpointName = endpointName;
+            InstanceId = instanceId;
+            InstanceName = instanceName;
+        }
+
+        public static EndpointInstanceId From(IReadOnlyDictionary<string, string> headers)
+        {
+            var details = EndpointDetailsParser.ReceivingEndpoint(headers);
+
+            string instanceId = null;
+            headers.TryGetValue("NServiceBus.Metric.InstanceId", out instanceId);
+
+            return new EndpointInstanceId(details.Name, instanceId ?? details.HostId.ToString(), details.Host);
+        }
+
+        protected bool Equals(EndpointInstanceId other)
+        {
+            return string.Equals(EndpointName, other.EndpointName) &&
+                   string.Equals(InstanceId, other.InstanceId) &&
+                   string.Equals(InstanceName, other.InstanceName);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+
+            return Equals((EndpointInstanceId)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (EndpointName != null ? EndpointName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (InstanceId != null ? InstanceId.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (InstanceName != null ? InstanceName.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/ServiceControl/Infrastructure/EndpointInstanceId.cs
+++ b/src/ServiceControl/Infrastructure/EndpointInstanceId.cs
@@ -29,7 +29,7 @@
             string instanceId;
             headers.TryGetValue("NServiceBus.Metric.InstanceId", out instanceId);
 
-            return new EndpointInstanceId(details.Name, instanceId ?? details.HostId.ToString(), details.Host);
+            return new EndpointInstanceId(details.Name, instanceId ?? details.HostId.ToString("N"), details.Host);
         }
 
         protected bool Equals(EndpointInstanceId other)

--- a/src/ServiceControl/Infrastructure/EndpointInstanceId.cs
+++ b/src/ServiceControl/Infrastructure/EndpointInstanceId.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl
 {
     using System.Collections.Generic;
-    using NServiceBus;
     using ServiceControl.Contracts.Operations;
 
     public class EndpointInstanceId
@@ -27,7 +26,7 @@
         {
             var details = EndpointDetailsParser.ReceivingEndpoint(headers);
 
-            string instanceId = null;
+            string instanceId;
             headers.TryGetValue("NServiceBus.Metric.InstanceId", out instanceId);
 
             return new EndpointInstanceId(details.Name, instanceId ?? details.HostId.ToString(), details.Host);

--- a/src/ServiceControl/Operations/ErrorQueueImport.cs
+++ b/src/ServiceControl/Operations/ErrorQueueImport.cs
@@ -148,7 +148,7 @@
                 message.CorrelationId,
                 replyToAddress);
 
-            var groups = failedMessageFactory.GetGroups((string) metadata["MessageType"], failureDetails);
+            var groups = failedMessageFactory.GetGroups((string) metadata["MessageType"], failureDetails, processingAttempt);
 
             Store(message.Headers.UniqueId(), processingAttempt, groups);
 

--- a/src/ServiceControl/Operations/FailedMessageFactory.cs
+++ b/src/ServiceControl/Operations/FailedMessageFactory.cs
@@ -17,13 +17,13 @@
             this.failedEnrichers = failedEnrichers;
         }
 
-        public List<FailedMessage.FailureGroup> GetGroups(string messageType, FailureDetails failureDetails)
+        public List<FailedMessage.FailureGroup> GetGroups(string messageType, FailureDetails failureDetails, FailedMessage.ProcessingAttempt processingAttempt)
         {
             var groups = new List<FailedMessage.FailureGroup>();
 
             foreach (var enricher in failedEnrichers)
             {
-                groups.AddRange(enricher.Enrich(messageType, failureDetails));
+                groups.AddRange(enricher.Enrich(messageType, failureDetails, processingAttempt));
             }
             return groups;
         }

--- a/src/ServiceControl/Recoverability/API/FailureGroupsApi.cs
+++ b/src/ServiceControl/Recoverability/API/FailureGroupsApi.cs
@@ -29,7 +29,10 @@ namespace ServiceControl.Recoverability
 
             Get["/recoverability/groups/{classifier?Exception Type and Stack Trace}"] =
                 parameters => GetAllGroups(parameters.Classifier);
-            
+
+            Get["/recoverability/groups/{classifier}/{endpointName}"] =
+                parameters => GetAllGroups(parameters.Classifier, parameters.EndpointName);
+
             Get["/recoverability/groups/{groupId}/errors"] =
                 parameters => GetGroupErrors(parameters.GroupId);
 
@@ -73,16 +76,16 @@ namespace ServiceControl.Recoverability
             }
         }
 
-        dynamic GetAllGroups(string classifier)
+        dynamic GetAllGroups(string classifier, string classifierFilter = null)
         {
             using (var session = Store.OpenSession())
             {
-                var results = GroupFetcher.GetGroups(session, classifier);
+                var results = GroupFetcher.GetGroups(session, classifier, classifierFilter);
                 return Negotiate.WithModel(results)
                     .WithDeterministicEtag(EtagHelper.CalculateEtag(results));
             }
         }
-       
+
         dynamic GetGroupErrors(string groupId)
         {
             using (var session = Store.OpenSession())

--- a/src/ServiceControl/Recoverability/API/FailureGroupsApi.cs
+++ b/src/ServiceControl/Recoverability/API/FailureGroupsApi.cs
@@ -27,11 +27,8 @@ namespace ServiceControl.Recoverability
             Post["/recoverability/groups/reclassify"] =
                 _ => ReclassifyErrors();
 
-            Get["/recoverability/groups/{classifier?Exception Type and Stack Trace}"] =
-                parameters => GetAllGroups(parameters.Classifier);
-
-            Get["/recoverability/groups/{classifier}/{endpointName}"] =
-                parameters => GetAllGroups(parameters.Classifier, parameters.EndpointName);
+            Get["/recoverability/groups/{classifier?Exception Type and Stack Trace}/{classifierFilter?}"] =
+                parameters => GetAllGroups(parameters.Classifier, parameters.classifierFilter == "undefined" ? null : parameters.classifierFilter);
 
             Get["/recoverability/groups/{groupId}/errors"] =
                 parameters => GetGroupErrors(parameters.GroupId);

--- a/src/ServiceControl/Recoverability/Grouping/ClassifyFailedMessageEnricher.cs
+++ b/src/ServiceControl/Recoverability/Grouping/ClassifyFailedMessageEnricher.cs
@@ -15,9 +15,9 @@ namespace ServiceControl.Recoverability
             this.classifiers = classifiers.ToArray();
         }
 
-        public IEnumerable<FailedMessage.FailureGroup> Enrich(string messageType, FailureDetails failureDetails)
+        public IEnumerable<FailedMessage.FailureGroup> Enrich(string messageType, FailureDetails failureDetails, FailedMessage.ProcessingAttempt processingAttempt)
         {
-            var details = new ClassifiableMessageDetails(messageType, failureDetails);
+            var details = new ClassifiableMessageDetails(messageType, failureDetails, processingAttempt);
 
             foreach (var classifier in classifiers)
             {

--- a/src/ServiceControl/Recoverability/Grouping/FailedMessageClassification.cs
+++ b/src/ServiceControl/Recoverability/Grouping/FailedMessageClassification.cs
@@ -18,6 +18,8 @@
             context.Container.ConfigureComponent<MessageTypeFailureClassifier>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<ClassifyFailedMessageEnricher>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<AddressOfFailingEndpointClassifier>(DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent<EndpointInstanceClassifier>(DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent<EndpointNameClassifier>(DependencyLifecycle.SingleInstance);
         }
 
         class ReclassifyErrorsAtStartup : FeatureStartupTask

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/ClassifiableMessageDetails.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/ClassifiableMessageDetails.cs
@@ -3,24 +3,33 @@ namespace ServiceControl.Recoverability
     using System.Linq;
     using ServiceControl.Contracts.Operations;
     using ServiceControl.MessageFailures;
+    using static ServiceControl.MessageFailures.FailedMessage;
 
     public struct ClassifiableMessageDetails
     {
+        public ProcessingAttempt ProcessingAttempt { get; private set; }
         public FailureDetails Details { get; private set; }
         public string MessageType { get; private set; }
 
         public ClassifiableMessageDetails(FailedMessage message)
         {
-            var last = message.ProcessingAttempts.Last();
+            ProcessingAttempt = message.ProcessingAttempts.Last();
 
-            Details = last.FailureDetails;
-            MessageType = (string)last.MessageMetadata["MessageType"];
+            Details = ProcessingAttempt.FailureDetails;
+            MessageType = (string)ProcessingAttempt.MessageMetadata["MessageType"];
         }
 
         public ClassifiableMessageDetails(string messageType, FailureDetails failureDetails)
         {
             Details = failureDetails;
+            ProcessingAttempt = null;
+            MessageType = messageType;
+        }
 
+        public ClassifiableMessageDetails(string messageType, FailureDetails failureDetails, ProcessingAttempt processingAttempt)
+        {
+            Details = failureDetails;
+            ProcessingAttempt = processingAttempt;
             MessageType = messageType;
         }
     }

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/EndpointInstanceClassifier.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/EndpointInstanceClassifier.cs
@@ -1,0 +1,19 @@
+namespace ServiceControl.Recoverability
+{
+    public class EndpointInstanceClassifier : IFailureClassifier
+    {
+        public const string Id = "Endpoint Instance";
+        public string Name => Id;
+
+        public string ClassifyFailure(ClassifiableMessageDetails failureDetails)
+        {
+            if (failureDetails.ProcessingAttempt == null)
+            {
+                return null;
+            }
+
+            var instanceId = EndpointInstanceId.From(failureDetails.ProcessingAttempt.Headers);
+            return instanceId.InstanceId;
+        }
+    }
+}

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/EndpointNameClassifier.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/EndpointNameClassifier.cs
@@ -1,0 +1,19 @@
+namespace ServiceControl.Recoverability
+{
+    public class EndpointNameClassifier : IFailureClassifier
+    {
+        public const string Id = "Endpoint Name";
+        public string Name => Id;
+
+        public string ClassifyFailure(ClassifiableMessageDetails failureDetails)
+        {
+            if (failureDetails.ProcessingAttempt == null)
+            {
+                return null;
+            }
+
+            var instanceId = EndpointInstanceId.From(failureDetails.ProcessingAttempt.Headers);
+            return instanceId.EndpointName;
+        }
+    }
+}

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/ReclassifyErrorsHandler.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/ReclassifyErrorsHandler.cs
@@ -69,6 +69,7 @@ namespace ServiceControl.Recoverability
                         .Where(f => f.Status == FailedMessageStatus.Unresolved);
 
                     var currentBatch = new List<Tuple<string, ClassifiableMessageDetails>>();
+                    var totalMessagesReclassified = 0;
 
                     using (var stream = session.Advanced.Stream(query.As<FailedMessage>()))
                     {
@@ -80,6 +81,9 @@ namespace ServiceControl.Recoverability
                             {
                                 ReclassifyBatch(currentBatch);
                                 currentBatch.Clear();
+
+                                totalMessagesReclassified += BatchSize;
+                                logger.Info($"Reclassification of batch of {BatchSize} failed messages completed. Total messages reclassified: {totalMessagesReclassified}");
                             }
                         }
                     }

--- a/src/ServiceControl/Recoverability/Grouping/IFailedMessageEnricher.cs
+++ b/src/ServiceControl/Recoverability/Grouping/IFailedMessageEnricher.cs
@@ -6,6 +6,6 @@
 
     public interface IFailedMessageEnricher
     {
-        IEnumerable<FailedMessage.FailureGroup> Enrich(string messageType, FailureDetails failureDetails);
+        IEnumerable<FailedMessage.FailureGroup> Enrich(string messageType, FailureDetails failureDetails, FailedMessage.ProcessingAttempt processingAttempt);
     }
 }

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -282,6 +282,7 @@
     <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatsUpdated.cs" />
     <Compile Include="Contracts\MessageFailures\FailedMessageArchived.cs" />
     <Compile Include="Contracts\MessageFailures\FailedMessagesUnArchived.cs" />
+    <Compile Include="DbMigrations\1.41.3\RerunClassifiersMigration.cs" />
     <Compile Include="DbMigrations\1.39\RerunClassifiersMigration.cs" />
     <Compile Include="DbMigrations\Migrations.cs" />
     <Compile Include="DbMigrations\IMigration.cs" />
@@ -292,6 +293,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Infrastructure\DomainEvents\DomainEvents.cs" />
+    <Compile Include="Infrastructure\EndpointInstanceId.cs" />
     <Compile Include="Infrastructure\Extensions\WaitHandleExtensions.cs" />
     <Compile Include="Infrastructure\Nancy\NotFoundOverride.cs" />
     <Compile Include="Infrastructure\RavenDB\Expiration\EventLogItemsCleaner.cs" />
@@ -404,6 +406,8 @@
     <Compile Include="Recoverability\Archiving\InMemoryArchive.cs" />
     <Compile Include="Recoverability\Archiving\ArchiveState.cs" />
     <Compile Include="Recoverability\API\GroupFetcher.cs" />
+    <Compile Include="Recoverability\Grouping\Groupers\EndpointNameClassifier.cs" />
+    <Compile Include="Recoverability\Grouping\Groupers\EndpointInstanceClassifier.cs" />
     <Compile Include="Recoverability\GroupOperation.cs" />
     <Compile Include="Recoverability\API\EtagHelper.cs" />
     <Compile Include="Recoverability\PublishAllHandler.cs" />


### PR DESCRIPTION
This adds 2 additional classifiers which will be used by the monitoring page to link the failed messages in ServiceControl with the endpoint instances and logical endpoint from ServiceControl.Monitoring.

The next step will be to expose these new classifications via a HTTP method so that Pulse can query them to match them against the monitoring values, but for now this can be relatively stand alone - and will add new grouping options to ServicePulse as is.