### PR TITLE
Fix Retry Operations

### DIFF
--- a/src/ServiceControl/Recoverability/Retrying/Handlers/RetriesHandler.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Handlers/RetriesHandler.cs
@@ -30,12 +30,12 @@ namespace ServiceControl.Recoverability
 
         public void Handle(RetryMessagesById message)
         {
-            Retries.StageRetryByUniqueMessageIds(Guid.NewGuid().ToString(), RetryType.MultipleMessages, message.MessageUniqueIds, DateTime.UtcNow);
+            Retries.StartRetryForMessageSelection(message.MessageUniqueIds);
         }
 
         public void Handle(RetryMessage message)
         {
-            Retries.StageRetryByUniqueMessageIds(message.FailedMessageId, RetryType.SingleMessage, new[] { message.FailedMessageId }, DateTime.UtcNow);
+            Retries.StartRetryForSingleMessage(message.FailedMessageId);
         }
 
         public void Handle(MessageFailedRepeatedly message)

--- a/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
@@ -63,10 +63,17 @@ namespace ServiceControl.Recoverability
                     CountMessageAndStopIfReachedTarget();
                 }
             }
+            else
+            {
+                Log.WarnFormat("Rejecting message from staging queue as it's not part of a fully staged batch: {0}", message.Id);
+            }
+
             if (!IsCounting)
             {
+                Log.Debug("Resetting timer");
                 timer.Change(TimeSpan.FromSeconds(45), Timeout.InfiniteTimeSpan);
             }
+
             return true;
         }
 
@@ -88,6 +95,8 @@ namespace ServiceControl.Recoverability
         {
             message.Headers.Remove("ServiceControl.Retry.StagingId");
 
+            Log.DebugFormat("{0}: Retrieving message body", message.Id);
+
             string attemptMessageId;
             if (message.Headers.TryGetValue("ServiceControl.Retry.Attempt.MessageId", out attemptMessageId))
             {
@@ -99,9 +108,22 @@ namespace ServiceControl.Recoverability
                         message.Body = ReadFully(stream);
                     }
                 }
+                else
+                { 
+                    Log.WarnFormat("{0}: Message Body not found for attempt Id {1}", message.Id, attemptMessageId);
+                }
                 message.Headers.Remove("ServiceControl.Retry.Attempt.MessageId");
             }
+            else
+            {
+                Log.WarnFormat("{0}: Can't find message body. Missing header ServiceControl.Retry.Attempt.MessageId", message.Id);
+            }
+
+            Log.DebugFormat("{0}: Body size: {1} bytes", message.Id, message.Body.LongLength);
+
+
             var destination = message.Headers["ServiceControl.TargetEndpointAddress"];
+            Log.DebugFormat("{0}: Forwarding message to {1}", message.Id, destination);
             try
             {
                 string retryTo;
@@ -110,11 +132,17 @@ namespace ServiceControl.Recoverability
                     retryTo = destination;
                     message.Headers.Remove("ServiceControl.TargetEndpointAddress");
                 }
+                else
+                {
+                    Log.DebugFormat("{0}: Found ServiceControl.RetryTo header. Rerouting to {1}", message.Id, retryTo);
+                }
 
                 sender.Send(message, new SendOptions(retryTo));
+                Log.DebugFormat("{0}: Forwarded message to {1}", message.Id, retryTo);
             }
             catch (Exception)
             {
+                Log.WarnFormat("{0}: Error forwarding message, resetting headers", message.Id);
                 message.Headers["ServiceControl.TargetEndpointAddress"] = destination;
                 if (attemptMessageId != null)
                 {
@@ -133,6 +161,7 @@ namespace ServiceControl.Recoverability
             Log.DebugFormat("Handling message {0} of {1}", currentMessageCount, targetMessageCount);
             if (currentMessageCount >= targetMessageCount.GetValueOrDefault())
             {
+                Log.DebugFormat("Target count reached. Shutting down forwarder");
                 // NOTE: This needs to run on a different thread or a deadlock will happen trying to shut down the receiver
                 Task.Factory.StartNew(StopInternal);
             }
@@ -146,6 +175,8 @@ namespace ServiceControl.Recoverability
         {
             try
             {
+                Log.DebugFormat("Started. Expectected message count {0}", expectedMessageCount);
+
                 if (expectedMessageCount.HasValue && expectedMessageCount.Value == 0)
                 {
                     return;
@@ -155,16 +186,20 @@ namespace ServiceControl.Recoverability
                 resetEvent.Reset();
                 targetMessageCount = expectedMessageCount;
                 actualMessageCount = 0;
+                Log.DebugFormat("Starting receiver");
                 receiver.StartInternal();
                 if (!expectedMessageCount.HasValue)
                 {
+                    Log.Debug("Running in timeout mode. Starting timer");
                     timer.Change(TimeSpan.FromSeconds(45), Timeout.InfiniteTimeSpan);
                 }
                 Log.InfoFormat("{0} started", GetType().Name);
             }
             finally
             {
+                Log.DebugFormat("Waiting for finish");
                 resetEvent.Wait(cancellationToken);
+                Log.DebugFormat("Finished");
             }
 
             if (endedPrematurelly || cancellationToken.IsCancellationRequested)

--- a/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
@@ -119,8 +119,14 @@ namespace ServiceControl.Recoverability
                 Log.WarnFormat("{0}: Can't find message body. Missing header ServiceControl.Retry.Attempt.MessageId", message.Id);
             }
 
-            Log.DebugFormat("{0}: Body size: {1} bytes", message.Id, message.Body.LongLength);
-
+            if (message.Body != null)
+            {
+                Log.DebugFormat("{0}: Body size: {1} bytes", message.Id, message.Body.LongLength);
+            }
+            else
+            {
+                Log.DebugFormat("{0}: Body is NULL");
+            }
 
             var destination = message.Headers["ServiceControl.TargetEndpointAddress"];
             Log.DebugFormat("{0}: Forwarding message to {1}", message.Id, destination);

--- a/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
@@ -125,7 +125,7 @@ namespace ServiceControl.Recoverability
             }
             else
             {
-                Log.DebugFormat("{0}: Body is NULL");
+                Log.DebugFormat("{0}: Body is NULL", message.Id);
             }
 
             var destination = message.Headers["ServiceControl.TargetEndpointAddress"];

--- a/src/ServiceControl/Recoverability/Retrying/RetriesGateway.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetriesGateway.cs
@@ -123,7 +123,29 @@ namespace ServiceControl.Recoverability
             bulkRequests.Enqueue(request);
         }
 
-        public void StageRetryByUniqueMessageIds(string requestId, RetryType retryType, string[] messageIds, DateTime startTime, DateTime? last = null, string originator = null, string batchName = null, string classifier = null)
+        public void StartRetryForSingleMessage(string uniqueMessageId)
+        {
+            var requestId = uniqueMessageId;
+            var retryType = RetryType.SingleMessage;
+            var numberOfMessages = 1;
+
+            OperationManager.Prepairing(requestId, retryType, numberOfMessages);
+            StageRetryByUniqueMessageIds(requestId, retryType, new[] { uniqueMessageId }, DateTime.UtcNow);
+            OperationManager.PreparedBatch(requestId, retryType, numberOfMessages);
+        }
+
+        public void StartRetryForMessageSelection(string[] uniqueMessageIds)
+        {
+            var requestId = Guid.NewGuid().ToString();
+            var retryType = RetryType.MultipleMessages;
+            var numberOfMessages = uniqueMessageIds.Length;
+
+            OperationManager.Prepairing(requestId, retryType, numberOfMessages);
+            StageRetryByUniqueMessageIds(requestId, retryType, uniqueMessageIds, DateTime.UtcNow);
+            OperationManager.PreparedBatch(requestId, retryType, numberOfMessages);
+        }
+
+        private void StageRetryByUniqueMessageIds(string requestId, RetryType retryType, string[] messageIds, DateTime startTime, DateTime? last = null, string originator = null, string batchName = null, string classifier = null)
         {
             if (messageIds == null || !messageIds.Any())
             {

--- a/src/ServiceControl/Recoverability/Retrying/RetriesGateway.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetriesGateway.cs
@@ -125,6 +125,8 @@ namespace ServiceControl.Recoverability
 
         public void StartRetryForSingleMessage(string uniqueMessageId)
         {
+            log.InfoFormat("Retrying a single message {0}", uniqueMessageId);
+
             var requestId = uniqueMessageId;
             var retryType = RetryType.SingleMessage;
             var numberOfMessages = 1;
@@ -136,6 +138,8 @@ namespace ServiceControl.Recoverability
 
         public void StartRetryForMessageSelection(string[] uniqueMessageIds)
         {
+            log.InfoFormat("Retrying a selection of {0} messages", uniqueMessageIds.Length);
+
             var requestId = Guid.NewGuid().ToString();
             var retryType = RetryType.MultipleMessages;
             var numberOfMessages = uniqueMessageIds.Length;


### PR DESCRIPTION
Fixes #990 

Creates the retry operation for single and user-selected sets of messages. Ensures operation exists later when messages are being sent.