### PR TITLE
Add Feature Toggle for Monitoring Instances

### DIFF
--- a/src/ServiceControl.Config/App.config
+++ b/src/ServiceControl.Config/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="Enable-Feature:MonitoringInstances" value="false" />
+  </appSettings>
+</configuration>

--- a/src/ServiceControl.Config/App.config
+++ b/src/ServiceControl.Config/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <appSettings>
-    <add key="Enable-Feature:MonitoringInstances" value="false" />
-  </appSettings>
-</configuration>

--- a/src/ServiceControl.Config/Features.cs
+++ b/src/ServiceControl.Config/Features.cs
@@ -2,7 +2,7 @@
 
 namespace ServiceControl.Config
 {
-    using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.Configuration;
     using Autofac;
@@ -25,16 +25,16 @@ namespace ServiceControl.Config
 
     public class FeatureToggles
     {
-        private ConcurrentDictionary<string, bool> features = new ConcurrentDictionary<string, bool>(StringComparer.InvariantCultureIgnoreCase);
+        private HashSet<string> features = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
 
         public bool IsEnabled(string feature)
         {
-            return features.ContainsKey(feature);
+            return features.Contains(feature);
         }
 
         public void Enable(string feature)
         {
-            features.GetOrAdd(feature, key => true);
+            features.Add(feature);
         }
     }
 

--- a/src/ServiceControl.Config/Features.cs
+++ b/src/ServiceControl.Config/Features.cs
@@ -1,0 +1,84 @@
+﻿using System;
+
+namespace ServiceControl.Config
+{
+    using System.Collections.Concurrent;
+    using System.Collections.Specialized;
+    using System.Configuration;
+    using Autofac;
+
+    [AttributeUsage(AttributeTargets.Property)]
+    public class FeatureToggleAttribute : Attribute
+    {
+        public string Feature { get; }
+
+        public FeatureToggleAttribute(string feature)
+        {
+            Feature = feature;
+        }
+    }
+
+    public static class Feature
+    {
+        public const string MonitoringInstances = "MonitoringInstances";
+    }
+
+    public class FeatureToggles
+    {
+        private ConcurrentDictionary<string, bool> features = new ConcurrentDictionary<string, bool>(StringComparer.InvariantCultureIgnoreCase);
+
+        public bool IsEnabled(string feature)
+        {
+            return features.ContainsKey(feature);
+        }
+
+        public void Enable(string feature)
+        {
+            features.GetOrAdd(feature, key => true);
+        }
+    }
+
+    public class ToggleFeaturesFromConfig : IStartable
+    {
+        private FeatureToggles featureToggles;
+        private const string EnableFeaturePrefix = "Enable-Feature:";
+
+        public ToggleFeaturesFromConfig(FeatureToggles featureToggles)
+        {
+            this.featureToggles = featureToggles;
+        }
+
+        public void Start()
+        {
+            ConfigureFeatures(ConfigurationManager.AppSettings);
+        }
+
+        private void ConfigureFeatures(NameValueCollection appSettings)
+        {
+            foreach (var key in appSettings.AllKeys)
+            {
+                if (key.StartsWith(EnableFeaturePrefix, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    ConfigureFeature(key.Substring(EnableFeaturePrefix.Length), appSettings[key]);
+                }
+            }
+        }
+
+        private void ConfigureFeature(string feature, string value)
+        {
+            bool result;
+            if (bool.TryParse(value, out result))
+            {
+                if (result)
+                {
+                    featureToggles.Enable(feature);
+                }
+            }
+            else
+            {
+                throw new Exception($"Config setting {EnableFeaturePrefix}{feature} should be a boolean. Cannot parse {value}");
+            }
+
+        }
+    }
+}

--- a/src/ServiceControl.Config/Framework/Modules/FeatureTogglesModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/FeatureTogglesModule.cs
@@ -1,0 +1,59 @@
+﻿namespace ServiceControl.Config.Framework.Modules
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using Autofac;
+    using Autofac.Core;
+    using Module = Autofac.Module;
+
+    public class FeatureTogglesModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.RegisterType<FeatureToggles>().SingleInstance();
+            builder.RegisterType<ToggleFeaturesFromConfig>().AsImplementedInterfaces();
+        }
+
+        protected override void AttachToComponentRegistration(IComponentRegistry componentRegistry, IComponentRegistration registration)
+        {
+            registration.Activated += OnComponentActivated;
+        }
+
+        private void OnComponentActivated(object sender, ActivatedEventArgs<object> e)
+        {
+            var instanceType = e.Instance.GetType();
+
+            if (instanceType == typeof(FeatureToggles))
+            {
+                return;
+            }
+
+            var featureToggles = e.Context.Resolve<FeatureToggles>();
+
+            var featureProperties = from prop in instanceType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                let attribute = prop.GetCustomAttributes<FeatureToggleAttribute>().SingleOrDefault()
+                where attribute != null
+                select new
+                {
+                    attribute.Feature,
+                    Property = prop
+                };
+
+            foreach (var featureProp in featureProperties)
+            {
+                if (featureProp.Property.PropertyType != typeof(bool))
+                {
+                    throw new InvalidOperationException($"Prerelease Property must be a bool {instanceType.FullName}.{featureProp.Property.Name}");
+                }
+
+                if (!featureProp.Property.CanWrite)
+                {
+                    throw new InvalidOperationException($"Prerelease Property must be writeable {instanceType.FullName}.{featureProp.Property.Name}");
+                }
+
+                featureProp.Property.SetValue(e.Instance, featureToggles.IsEnabled(featureProp.Feature));
+            }
+        }
+    }
+}

--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -110,6 +110,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -183,10 +184,12 @@
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\ValidatorExtensions.cs" />
     <Compile Include="Extensions\VisualTreeExtensions.cs" />
+    <Compile Include="Features.cs" />
     <Compile Include="Framework\Commands\AwaitableAbstractCommand.cs" />
     <Compile Include="Framework\IProgressViewModel.cs" />
     <Compile Include="Framework\Modules\InstallerModule.cs" />
     <Compile Include="Framework\Modules\MiscModule.cs" />
+    <Compile Include="Framework\Modules\FeatureTogglesModule.cs" />
     <Compile Include="Framework\RaygunFeedback.cs" />
     <Compile Include="Framework\RaygunReporter.cs" />
     <Compile Include="Framework\Rx\RxProgressScreen.cs" />
@@ -402,6 +405,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="App.config" />
     <None Include="app.manifest" />
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">

--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -405,7 +405,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="App.config" />
     <None Include="app.manifest" />
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">

--- a/src/ServiceControl.Config/Styles/Button.xaml
+++ b/src/ServiceControl.Config/Styles/Button.xaml
@@ -587,6 +587,49 @@
         </Setter>
     </Style>
 
+    <Style x:Key="OriginalNewButton"
+           BasedOn="{StaticResource LinkButton}"
+           TargetType="{x:Type Button}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid Background="{TemplateBinding Background}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup Name="CommonStates">
+                                <VisualState Name="Normal" />
+                                <VisualState Name="MouseOver" Storyboard="{StaticResource LinkButtonMouseOverStoryboard}" />
+                                <VisualState Name="Pressed" Storyboard="{StaticResource LinkButtonPressedStoryboard}" />
+                                <VisualState Name="Disabled" Storyboard="{StaticResource LinkButtonDisabledStoryboard}" />
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Control x:Name="Icon"
+                                 Width="12"
+                                 Height="12"
+                                 Background="{TemplateBinding Background}"
+                                 BorderBrush="{TemplateBinding BorderBrush}"
+                                 Foreground="{TemplateBinding Foreground}"
+                                 SnapsToDevicePixels="True"
+                                 Template="{StaticResource NewIcon}" />
+
+                        <TextBlock x:Name="Text"
+                                   Grid.Column="1"
+                                   Margin="5,0,0,0"
+                                   FontSize="14"
+                                   FontWeight="Bold"
+                                   Foreground="{TemplateBinding Foreground}"
+                                   Text="NEW INSTANCE" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="NewButton" TargetType="{x:Type ToggleButton}">
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />

--- a/src/ServiceControl.Config/UI/NoInstances/NoInstancesView.xaml
+++ b/src/ServiceControl.Config/UI/NoInstances/NoInstancesView.xaml
@@ -18,5 +18,15 @@
                    FontSize="20"
                    Foreground="{StaticResource Gray60Brush}"
                    Text="No service instances installed" />
+
+        <Button Grid.Row="1"
+                Margin="10"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Top"
+                Command="{Binding AddInstance}"
+                Content="Add new instance"
+                Style="{StaticResource HiliteButton}" 
+                Visibility="{Binding ShowMonitoringInstances,
+                             Converter={StaticResource boolToVisInverted}}"/>
     </Grid>
 </UserControl>

--- a/src/ServiceControl.Config/UI/NoInstances/NoInstancesViewModel.cs
+++ b/src/ServiceControl.Config/UI/NoInstances/NoInstancesViewModel.cs
@@ -2,11 +2,21 @@
 
 namespace ServiceControl.Config.UI.NoInstances
 {
+    using System.Windows.Input;
+    using ServiceControl.Config.Commands;
+
     class NoInstancesViewModel : RxScreen
     {
-        public NoInstancesViewModel()
+        public NoInstancesViewModel(AddServiceControlInstanceCommand addInstance)
         {
             DisplayName = "";
+
+            AddInstance = addInstance;
         }
+
+        public ICommand AddInstance { get; }
+
+        [FeatureToggle(Feature.MonitoringInstances)]
+        public bool ShowMonitoringInstances { get; set; }
     }
 }

--- a/src/ServiceControl.Config/UI/Shell/ShellView.xaml
+++ b/src/ServiceControl.Config/UI/Shell/ShellView.xaml
@@ -56,7 +56,14 @@
                         Visibility="{Binding IsModal,
                                              Converter={StaticResource boolToVisInverted}}">
 
-                <ToggleButton Name="AddInstanceButton" Style="{StaticResource NewButton}" />
+                <Button Command="{Binding AddInstance}" Style="{StaticResource OriginalNewButton}" 
+                        Visibility="{Binding ShowMonitoringInstances, 
+                                     Converter={StaticResource boolToVisInverted}}"/>
+                
+                <ToggleButton Name="AddInstanceButton"
+                              Style="{StaticResource NewButton}" 
+                              Visibility="{Binding ShowMonitoringInstances,
+                                                   Converter={StaticResource boolToVis}}"/>
 
                 <Popup PlacementTarget="{Binding ElementName=AddInstanceButton}" 
                        Placement="Bottom" 

--- a/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
+++ b/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
@@ -64,6 +64,9 @@
 
         public bool HasInstances { get; private set; }
 
+        [FeatureToggle(Feature.MonitoringInstances)]
+        public bool ShowMonitoringInstances { get; set; }
+
         public ICommand AddInstance { get; private set; }
 
         public ICommand AddMonitoringInstance { get; private set; }


### PR DESCRIPTION
Adds a feature toggle for monitoring instances. 

By default, Management Utility will not show Monitoring Instances. If you set the app-config setting `Enable-Feature:MonitoringInstances` to `true` then you will get UI to start monitoring instances.