### PR TITLE
ASB duplicate events

### DIFF
--- a/src/ServiceControl.Config/Extensions/VisualTreeExtensions.cs
+++ b/src/ServiceControl.Config/Extensions/VisualTreeExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace ServiceControl.Config.Extensions
+﻿// ReSharper disable HeuristicUnreachableCode
+namespace ServiceControl.Config.Extensions
 {
     using System.Windows;
     using System.Windows.Controls;
@@ -22,6 +23,7 @@
                 var child = VisualTreeHelper.GetChild(parent, i);
                 // If the child is not of the request child type child
                 var childType = child;
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                 if (childType == null)
                 {
                     // recursively drill down the tree

--- a/src/ServiceControl.UnitTests/EventHierarchy.cs
+++ b/src/ServiceControl.UnitTests/EventHierarchy.cs
@@ -1,0 +1,24 @@
+﻿namespace ServiceControl.UnitTests
+{
+    using System.Linq;
+    using NServiceBus;
+    using NUnit.Framework;
+    using Particular.ServiceControl;
+
+    [TestFixture]
+    class EventHierarchy
+    {
+        [TestCase]
+        public void EnsureEventHierarchyIsFlat()
+        {
+            var serviceControlAssembly = typeof(Bootstrapper).Assembly;
+            var eventTypes = serviceControlAssembly.GetTypes().Where(typeof(IEvent).IsAssignableFrom).ToArray();
+
+            var flatEvents = eventTypes.Where(t => t.BaseType == typeof(object)).ToArray();
+
+            var nonFlatEvents = eventTypes.Except(flatEvents).ToArray();
+
+            Assert.IsEmpty(nonFlatEvents, "Complex Event Hierarchy causes duplicate event handling with Azure ServiceBus and SubscribeToOwnEvents");
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -122,6 +122,7 @@
   <ItemGroup>
     <Compile Include="ApprovalTestConfig.cs" />
     <Compile Include="CompositeViews\FailedMessagesTests.cs" />
+    <Compile Include="EventHierarchy.cs" />
     <Compile Include="Expiration\ChunkerTests.cs" />
     <Compile Include="Expiration\ProcessedMessageExpirationTests.cs" />
     <Compile Include="Expiration\RavenLastModifiedScope.cs" />

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/EndpointFailedToHeartbeat.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/EndpointFailedToHeartbeat.cs
@@ -1,9 +1,10 @@
 namespace ServiceControl.Contracts.HeartbeatMonitoring
 {
     using System;
+    using NServiceBus;
     using Operations;
 
-    public class EndpointFailedToHeartbeat : HeartbeatStatusChanged
+    public class EndpointFailedToHeartbeat : IEvent
     {
         public EndpointDetails Endpoint { get; set; }
         public DateTime LastReceivedAt { get; set; }

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/EndpointHeartbeatRestored.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/EndpointHeartbeatRestored.cs
@@ -1,9 +1,10 @@
 namespace ServiceControl.Contracts.HeartbeatMonitoring
 {
     using System;
+    using NServiceBus;
     using Operations;
 
-    public class EndpointHeartbeatRestored : HeartbeatStatusChanged
+    public class EndpointHeartbeatRestored : IEvent
     {
         public EndpointDetails Endpoint { get; set; }
         public DateTime RestoredAt { get; set; }

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatMonitoringDisabled.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatMonitoringDisabled.cs
@@ -1,8 +1,9 @@
 namespace ServiceControl.Contracts.HeartbeatMonitoring
 {
     using System;
+    using NServiceBus;
 
-    public class HeartbeatMonitoringDisabled : HeartbeatStatusChanged
+    public class HeartbeatMonitoringDisabled : IEvent
     {
         public Guid EndpointInstanceId { get; set; }
     }

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatMonitoringEnabled.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatMonitoringEnabled.cs
@@ -1,8 +1,9 @@
 namespace ServiceControl.Contracts.HeartbeatMonitoring
 {
     using System;
+    using NServiceBus;
 
-    public class HeartbeatMonitoringEnabled : HeartbeatStatusChanged
+    public class HeartbeatMonitoringEnabled : IEvent
     {
         public Guid EndpointInstanceId { get; set; }
     }

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatStatusChanged.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatStatusChanged.cs
@@ -1,9 +1,0 @@
-﻿namespace ServiceControl.Contracts.HeartbeatMonitoring
-{
-    using NServiceBus;
-
-    public class HeartbeatStatusChanged : IEvent
-    {
-
-    }
-}

--- a/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatingEndpointDetected.cs
+++ b/src/ServiceControl/Contracts/HeartbeatMonitoring/HeartbeatingEndpointDetected.cs
@@ -1,9 +1,10 @@
 ﻿namespace ServiceControl.Contracts.HeartbeatMonitoring
 {
     using System;
+    using NServiceBus;
     using Operations;
 
-    public class HeartbeatingEndpointDetected : HeartbeatStatusChanged
+    public class HeartbeatingEndpointDetected : IEvent
     {
         public EndpointDetails Endpoint { get; set; }
         public DateTime DetectedAt { get; set; }

--- a/src/ServiceControl/Contracts/MessageFailures/FailedMessageArchived.cs
+++ b/src/ServiceControl/Contracts/MessageFailures/FailedMessageArchived.cs
@@ -1,6 +1,9 @@
 ﻿namespace ServiceControl.Contracts.MessageFailures
 {
-    public class FailedMessageArchived : MessageFailureResolved
+    using NServiceBus;
+
+    public class FailedMessageArchived : IEvent
     {
+        public string FailedMessageId { get; set; }
     }
 }

--- a/src/ServiceControl/Contracts/MessageFailures/MessageFailed.cs
+++ b/src/ServiceControl/Contracts/MessageFailures/MessageFailed.cs
@@ -8,5 +8,6 @@
         public string EndpointId{ get; set; }
         public FailureDetails FailureDetails { get; set; }
         public string FailedMessageId { get; set; }
+        public bool RepeatedFailure { get; set; }
     }
 }

--- a/src/ServiceControl/Contracts/MessageFailures/MessageFailedRepeatedly.cs
+++ b/src/ServiceControl/Contracts/MessageFailures/MessageFailedRepeatedly.cs
@@ -1,6 +1,20 @@
 ﻿namespace ServiceControl.Contracts.MessageFailures
 {
-    public class MessageFailedRepeatedly : MessageFailed
+    using NServiceBus;
+    using ServiceControl.Contracts.Operations;
+
+    // NOTE: This is a legacy event. It (and all it's handlers) have been left to capture in-flight messages. These can removed in a future version.
+    public class MessageFailedRepeatedly : IEvent
     {
+        public MessageFailedRepeatedly()
+        {
+            RepeatedFailure = true;
+        }
+
+        public string EndpointId { get; set; }
+        public FailureDetails FailureDetails { get; set; }
+        public string FailedMessageId { get; set; }
+        public bool RepeatedFailure { get; set; }
+
     }
 }

--- a/src/ServiceControl/Contracts/MessageFailures/MessageFailureResolved.cs
+++ b/src/ServiceControl/Contracts/MessageFailures/MessageFailureResolved.cs
@@ -1,9 +1,0 @@
-﻿namespace ServiceControl.Contracts.MessageFailures
-{
-    using NServiceBus;
-
-    public class MessageFailureResolved : IEvent
-    {
-        public string FailedMessageId { get; set; }
-    }
-}

--- a/src/ServiceControl/Contracts/MessageFailures/MessageFailureResolvedByRetry.cs
+++ b/src/ServiceControl/Contracts/MessageFailures/MessageFailureResolvedByRetry.cs
@@ -1,7 +1,10 @@
 ﻿namespace ServiceControl.Contracts.MessageFailures
 {
-    public class MessageFailureResolvedByRetry : MessageFailureResolved
+    using NServiceBus;
+
+    public class MessageFailureResolvedByRetry : IEvent
     {
+        public string FailedMessageId { get; set; }
         public string[] AlternativeFailedMessageIds { get; set; }
     }
 }

--- a/src/ServiceControl/Contracts/MessageFailures/MessageFailureResolvedManually.cs
+++ b/src/ServiceControl/Contracts/MessageFailures/MessageFailureResolvedManually.cs
@@ -1,6 +1,8 @@
 ﻿namespace ServiceControl.Contracts.MessageFailures
 {
-    public class MessageFailureResolvedManually : MessageFailureResolved
+    using NServiceBus;
+
+    public class MessageFailureResolvedManually : IEvent
     {
 
     }

--- a/src/ServiceControl/Contracts/MessageFailures/MessageFailureResolvedManually.cs
+++ b/src/ServiceControl/Contracts/MessageFailures/MessageFailureResolvedManually.cs
@@ -4,6 +4,6 @@
 
     public class MessageFailureResolvedManually : IEvent
     {
-
+        public string FailedMessageId { get; set; }
     }
 }

--- a/src/ServiceControl/ExternalIntegrations/MessageFailedRepeatedlyPublisher.cs
+++ b/src/ServiceControl/ExternalIntegrations/MessageFailedRepeatedlyPublisher.cs
@@ -1,0 +1,35 @@
+﻿namespace ServiceControl.ExternalIntegrations
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Raven.Client;
+    using ServiceControl.Contracts.MessageFailures;
+    using ServiceControl.MessageFailures;
+
+    public class MessageFailedRepeatedlyPublisher : EventPublisher<MessageFailedRepeatedly, MessageFailedRepeatedlyPublisher.DispatchContext>
+    {
+        protected override DispatchContext CreateDispatchRequest(MessageFailedRepeatedly @event)
+        {
+            return new DispatchContext
+            {
+                FailedMessageId = new Guid(@event.FailedMessageId)
+            };
+        }
+
+        protected override IEnumerable<object> PublishEvents(IEnumerable<DispatchContext> contexts, IDocumentSession session)
+        {
+            var documentIds = contexts.Select(x => x.FailedMessageId).Cast<ValueType>().ToArray();
+            var failedMessageData = session.Load<FailedMessage>(documentIds);
+            return failedMessageData.Where(p => p != null).Select(x => x.ToEvent());
+        }
+
+        public class DispatchContext
+        {
+            public Guid FailedMessageId { get; set; }
+        }
+
+
+    }
+
+}

--- a/src/ServiceControl/Operations/ErrorQueueImport.cs
+++ b/src/ServiceControl/Operations/ErrorQueueImport.cs
@@ -224,11 +224,12 @@
             string failedMessageId;
             if (headers.TryGetValue("ServiceControl.Retry.UniqueMessageId", out failedMessageId))
             {
-                bus.Publish<MessageFailedRepeatedly>(m =>
+                bus.Publish<MessageFailed>(m =>
                 {
                     m.FailureDetails = failureDetails;
                     m.EndpointId = failingEndpointId;
                     m.FailedMessageId = failedMessageId;
+                    m.RepeatedFailure = true;
                 });
             }
             else

--- a/src/ServiceControl/Recoverability/Retrying/Handlers/RetriesHandler.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Handlers/RetriesHandler.cs
@@ -11,6 +11,7 @@ namespace ServiceControl.Recoverability
         IHandleMessages<RetryMessagesById>,
         IHandleMessages<RetryMessage>,
         IHandleMessages<MessageFailedRepeatedly>,
+        IHandleMessages<MessageFailed>,
         IHandleMessages<RetryMessagesByQueueAddress>
     {
         public RetriesGateway Retries { get; set; }
@@ -41,6 +42,14 @@ namespace ServiceControl.Recoverability
         public void Handle(MessageFailedRepeatedly message)
         {
             RetryDocumentManager.RemoveFailedMessageRetryDocument(message.FailedMessageId);
+        }
+
+        public void Handle(MessageFailed message)
+        {
+            if (message.RepeatedFailure)
+            {
+                RetryDocumentManager.RemoveFailedMessageRetryDocument(message.FailedMessageId);
+            }
         }
 
         public void Handle(RetryMessagesByQueueAddress message)

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -276,7 +276,6 @@
     <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatingEndpointDetected.cs" />
     <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatMonitoringDisabled.cs" />
     <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatMonitoringEnabled.cs" />
-    <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatStatusChanged.cs" />
     <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatsUpdated.cs" />
     <Compile Include="Contracts\MessageFailures\FailedMessageArchived.cs" />
     <Compile Include="Contracts\MessageFailures\FailedMessagesUnArchived.cs" />

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -312,7 +312,6 @@
     <Compile Include="MessageFailures\InternalMessages\MarkPendingRetryAsResolved.cs" />
     <Compile Include="Contracts\MessageFailures\MessageFailed.cs" />
     <Compile Include="Contracts\MessageFailures\MessageFailedRepeatedly.cs" />
-    <Compile Include="Contracts\MessageFailures\MessageFailureResolved.cs" />
     <Compile Include="Contracts\MessageFailures\MessageFailureResolvedByRetry.cs" />
     <Compile Include="Contracts\MessageFailures\MessageFailureResolvedManually.cs" />
     <Compile Include="Contracts\MessageFailures\MessageFailuresUpdated.cs" />

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -287,6 +287,7 @@
     <Compile Include="DbMigrations\MigrationsModule.cs" />
     <Compile Include="DbMigrations\1.27\SplitFailedMessageDocumentsMigration.cs" />
     <Compile Include="HeartbeatMonitoring\LegacyHandler.cs" />
+    <Compile Include="ExternalIntegrations\MessageFailedRepeatedlyPublisher.cs" />
     <Compile Include="Hosting\MaintenanceHost.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
Due to the way we subscribe to our own events, we are setting up duplicate subscriptions for our events in Azure Service Bus (using the default topology). This means when we publish a message with a parent class, it matches the filters of two subscriptions, each of which sends a copy to our input queue. ServiceControl gets two copies of these messages.

To solve this we have flattened out the event hierarchy. 

## Subclasses of `MessageFailureResolved`
  - `FailedMessageArchived`
  - `MessageFailureResolvedByRetry`
  - `MessageFailureResolvedManually`

There was no handlers for `MessageFailureResolved`. This class has been removed and the corresponding subclasses now all inherit directly from `IEvent`

## Subclasses of `HeartbeatStatusChanged`
  - `HeartbeatingEndpointDetected`
  - `HeartbeatMonitoringEnabled`
  - `HeartbeatMonitoringDisabled`
  - `EndpointHeartbeatRestored`
  - `EndpoingFailedToHeartbeat`

There was one handler for `HearbeatStatusChanged` that simply publishes a heartbeats updated message. This handler has been modified to handle each of the subclasses explicitly and the base class has been removed. All of the corresponding subclasses now inherit directly from `IEvent`.

## `MessageFailedRepeatedly : MessageFailed`

This hierarchy has been split and all properties of `MessageFailed` lifted up to `MessageFailedRepeatedly`. A new property has been added to both message types to indicate repeated message failure. The system no longer publishes `MessageFailedRepeatedly`, preferring to publish `MessageFailed` with the flag set to true. All handlers for both classes have been duplicated (to allow for in-flight messages to be handled properly). In the future, `MessageFailedRepeatedly` and all associated handlers can be removed (and this has been noted as a comment on the message type).

## Test

There is a unit test added to detect deep hierarchies of events and fail the build if these are introduced in the future. The test will be updated to point back to this issue.

