### PR TITLE
[SPIKE]] Learning transport

### DIFF
--- a/src/ServiceControl.AcceptanceTesting/ServiceControl.AcceptanceTesting.csproj
+++ b/src/ServiceControl.AcceptanceTesting/ServiceControl.AcceptanceTesting.csproj
@@ -40,8 +40,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.5.2.21\lib\net45\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\NServiceBus.5.2.24\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/ServiceControl.AcceptanceTesting/packages.config
+++ b/src/ServiceControl.AcceptanceTesting/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="5.2.21" targetFramework="net452" />
+  <package id="NServiceBus" version="5.2.24" targetFramework="net452" />
 </packages>

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -103,8 +103,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.5.2.21\lib\net45\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\NServiceBus.5.2.24\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.NLog, Version=1.1.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.NLog.1.1.0\lib\net45\NServiceBus.NLog.dll</HintPath>

--- a/src/ServiceControl.AcceptanceTests/packages.config
+++ b/src/ServiceControl.AcceptanceTests/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
   <package id="NLog" version="4.3.7" targetFramework="net452" />
-  <package id="NServiceBus" version="5.2.21" targetFramework="net452" />
+  <package id="NServiceBus" version="5.2.24" targetFramework="net452" />
   <package id="NServiceBus.Autofac" version="5.0.0" targetFramework="net452" />
   <package id="NServiceBus.Azure.Transports.WindowsAzureServiceBus" version="6.4.0" targetFramework="net452" />
   <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="6.2.2" targetFramework="net452" />

--- a/src/ServiceControl.IntegrationDemo/ServiceControl.IntegrationDemo.csproj
+++ b/src/ServiceControl.IntegrationDemo/ServiceControl.IntegrationDemo.csproj
@@ -36,8 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.5.2.21\lib\net45\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\NServiceBus.5.2.24\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Host, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.Host.6.0.0\lib\net45\NServiceBus.Host.exe</HintPath>

--- a/src/ServiceControl.IntegrationDemo/packages.config
+++ b/src/ServiceControl.IntegrationDemo/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="5.2.21" targetFramework="net452" />
+  <package id="NServiceBus" version="5.2.24" targetFramework="net452" />
   <package id="NServiceBus.Host" version="6.0.0" targetFramework="net452" />
   <package id="ServiceControl.Contracts" version="1.1.1" targetFramework="net452" />
 </packages>

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Audit/When_ForwardReceivedMessagesTo_is_set.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Audit/When_ForwardReceivedMessagesTo_is_set.cs
@@ -1,0 +1,72 @@
+﻿namespace NServiceBus.AcceptanceTests.Audit
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+
+    public class When_ForwardReceivedMessagesTo_is_set : NServiceBusAcceptanceTest
+    {
+            [Test]
+            public void Should_forward_message()
+            {
+                var context = new Context();
+
+                Scenario.Define(context)
+                    .WithEndpoint<EndpointThatForwards>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MessageToForward());
+                    }))
+                    .WithEndpoint<ForwardReceiver>()
+                    .Done(c => c.GotForwardedMessage)
+                    .Run();
+
+                Assert.IsTrue(context.GotForwardedMessage);
+            }
+
+            public class Context : ScenarioContext
+            {
+                public bool GotForwardedMessage { get; set; }
+            }
+
+            public class ForwardReceiver : EndpointConfigurationBuilder
+            {
+                public ForwardReceiver()
+                {
+                    EndpointSetup<DefaultServer>(c => c.EndpointName("forward_receiver"));
+                }
+
+                public class MessageToForwardHandler : IHandleMessages<MessageToForward>
+                {
+                    public Context Context { get; set; }
+
+                    public void Handle(MessageToForward message)
+                    {
+                        Context.GotForwardedMessage = true;
+                    }
+                }
+            }
+
+            public class EndpointThatForwards : EndpointConfigurationBuilder
+            {
+                public EndpointThatForwards()
+                {
+                    EndpointSetup<DefaultServer>()
+                        .WithConfig<UnicastBusConfig>(c => c.ForwardReceivedMessagesTo = "forward_receiver");
+                }
+
+                public class MessageToForwardHandler : IHandleMessages<MessageToForward>
+                {
+                    public void Handle(MessageToForward message)
+                    {
+                    }
+                }
+            }
+
+            [Serializable]
+            public class MessageToForward : IMessage
+            {
+            }
+        }
+    }

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Audit/When_a_message_is_audited.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Audit/When_a_message_is_audited.cs
@@ -1,0 +1,133 @@
+﻿namespace NServiceBus.AcceptanceTests.Audit
+{
+    using System;
+    using System.Linq;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_a_message_is_audited : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_preserve_the_original_body()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                    .WithEndpoint<AuditSpyEndpoint>()
+                    .Done(c => c.AuditChecksum != default(byte))
+                    .Run();
+
+            Assert.AreEqual(context.OriginalBodyChecksum, context.AuditChecksum, "The body of the message sent to audit should be the same as the original message coming off the queue");
+        }
+
+        [Test]
+        public void Should_add_the_license_diagnostic_headers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                    .WithEndpoint<AuditSpyEndpoint>()
+                    .Done(c => c.HasDiagnosticLicensingHeaders)
+                    .Run();
+            Assert.IsTrue(context.HasDiagnosticLicensingHeaders);
+        }
+
+
+        public class Context : ScenarioContext
+        {
+            public byte OriginalBodyChecksum { get; set; }
+            public byte AuditChecksum { get; set; }
+            public bool HasDiagnosticLicensingHeaders { get; set; }
+        }
+
+        public class EndpointWithAuditOn : EndpointConfigurationBuilder
+        {
+            public EndpointWithAuditOn()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<AuditSpyEndpoint>();
+            }
+
+            class BodyMutator : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+
+                    var originalBody = transportMessage.Body;
+
+                    Context.OriginalBodyChecksum = Checksum(originalBody);
+
+                    // modifying the body by adding a line break
+                    var modifiedBody = new byte[originalBody.Length + 1];
+
+                    Buffer.BlockCopy(originalBody, 0, modifiedBody, 0, originalBody.Length);
+
+                    modifiedBody[modifiedBody.Length - 1] = 13;
+
+                    transportMessage.Body = modifiedBody;
+                }
+
+                public void Customize(BusConfiguration configuration)
+                {
+                    configuration.RegisterComponents(c => c.ConfigureComponent<BodyMutator>(DependencyLifecycle.InstancePerCall));
+                }
+            }
+
+            public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public void Handle(MessageToBeAudited message)
+                {
+                }
+            }
+        }
+
+        class AuditSpyEndpoint : EndpointConfigurationBuilder
+        {
+            public AuditSpyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class BodySpy : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    Context.AuditChecksum = Checksum(transportMessage.Body);
+                    string licenseExpired;
+                    Context.HasDiagnosticLicensingHeaders = transportMessage.Headers.TryGetValue(Headers.HasLicenseExpired, out licenseExpired);
+                }
+
+                public void Customize(BusConfiguration configuration)
+                {
+                    configuration.RegisterComponents(c => c.ConfigureComponent<BodySpy>(DependencyLifecycle.InstancePerCall));
+                }
+            }
+
+            public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public void Handle(MessageToBeAudited message)
+                {
+                }
+            }
+        }
+
+        public static byte Checksum(byte[] data)
+        {
+            var longSum = data.Sum(x => (long)x);
+            return unchecked((byte)longSum);
+        }
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Audit/When_a_replymessage_is_audited.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Audit/When_a_replymessage_is_audited.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.AcceptanceTests.Audit
+{
+    using System;
+    using System.Linq;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_a_replymessage_is_audited : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_audit_the_message()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Server>()
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.Send(new Request())))
+                    .WithEndpoint<AuditSpyEndpoint>()
+                    .Done(c => c.MessageAudited)
+                    .Run();
+
+            Assert.True(context.MessageAudited);
+        }
+
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageAudited { get; set; }
+        }
+
+        public class Server : EndpointConfigurationBuilder
+        {
+            public Server()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class RequestHandler : IHandleMessages<Request>
+            {
+                public IBus Bus { get; set; }
+                public void Handle(Request message)
+                {
+                    Bus.Reply(new ResponseToBeAudited());
+                }
+            }
+        }
+
+        public class EndpointWithAuditOn : EndpointConfigurationBuilder
+        {
+            public EndpointWithAuditOn()
+            {
+                EndpointSetup<DefaultServer>(c=>c.DisableFeature<Outbox>())
+                    .AddMapping<Request>(typeof(Server))
+                    .AuditTo<AuditSpyEndpoint>();
+            }
+
+          
+            public class MessageToBeAuditedHandler : IHandleMessages<ResponseToBeAudited>
+            {
+                public void Handle(ResponseToBeAudited message)
+                {
+
+                }
+            }
+        }
+
+        class AuditSpyEndpoint : EndpointConfigurationBuilder
+        {
+            public AuditSpyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class BodySpy : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    Context.MessageAudited = true;
+                }
+
+                public void Customize(BusConfiguration configuration)
+                {
+                    configuration.RegisterComponents(c => c.ConfigureComponent<BodySpy>(DependencyLifecycle.InstancePerCall));
+                }
+            }
+
+            public class MessageToBeAuditedHandler : IHandleMessages<ResponseToBeAudited>
+            {
+                public void Handle(ResponseToBeAudited message)
+                {
+                }
+            }
+        }
+
+        public static byte Checksum(byte[] data)
+        {
+            var longSum = data.Sum(x => (long)x);
+            return unchecked((byte)longSum);
+        }
+
+        [Serializable]
+        public class ResponseToBeAudited : IMessage
+        {
+        }
+
+
+        class Request : IMessage
+        {
+        }
+    }
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Audit/When_auditing.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Audit/When_auditing.cs
@@ -1,0 +1,111 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Audit
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_auditing : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_be_forwarded_to_auditQueue_when_auditing_is_disabled()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+            .WithEndpoint<EndpointWithAuditOff>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+            .WithEndpoint<EndpointThatHandlesAuditMessages>()
+            .Done(c => c.IsMessageHandlingComplete)
+            .Run();
+
+            Assert.IsFalse(context.IsMessageHandledByTheAuditEndpoint);
+        }
+
+        [Test]
+        public void Should_be_forwarded_to_auditQueue_when_auditing_is_enabled()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+            .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+            .WithEndpoint<EndpointThatHandlesAuditMessages>()
+            .Done(c => c.IsMessageHandlingComplete && context.IsMessageHandledByTheAuditEndpoint)
+            .Run();
+
+            Assert.IsTrue(context.IsMessageHandledByTheAuditEndpoint);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool IsMessageHandledByTheAuditEndpoint { get; set; }
+        }
+
+        public class EndpointWithAuditOff : EndpointConfigurationBuilder
+        {
+           
+            public EndpointWithAuditOff()
+            {
+                // Although the AuditTo seems strange here, this test tries to fake the scenario where
+                // even though the user has specified audit config, because auditing is explicitly turned
+                // off, no messages should be audited.
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<Features.Audit>())
+                    .AuditTo<EndpointThatHandlesAuditMessages>();
+
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+                }
+            }
+        }
+
+        public class EndpointWithAuditOn : EndpointConfigurationBuilder
+        {
+
+            public EndpointWithAuditOn()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<EndpointThatHandlesAuditMessages>();
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+                }
+            }
+        }
+
+        public class EndpointThatHandlesAuditMessages : EndpointConfigurationBuilder
+        {
+
+            public EndpointThatHandlesAuditMessages()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandledByTheAuditEndpoint = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Audit/When_using_audit_message_is_received.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Audit/When_using_audit_message_is_received.cs
@@ -1,0 +1,90 @@
+﻿namespace NServiceBus.AcceptanceTests.Audit
+{
+    using System;
+    using System.Collections.Generic;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_audit_message_is_received : NServiceBusAcceptanceTest
+    {
+
+        [Test]
+        public void Should_contain_correct_headers()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+            .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+            .WithEndpoint<EndpointThatHandlesAuditMessages>()
+            .Done(c => c.IsMessageHandlingComplete && context.IsMessageHandledByTheAuditEndpoint)
+            .Run();
+            Assert.IsTrue(context.Headers.ContainsKey(Headers.ProcessingStarted));
+            Assert.IsTrue(context.Headers.ContainsKey(Headers.ProcessingEnded));
+            Assert.IsTrue(context.IsMessageHandledByTheAuditEndpoint);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool IsMessageHandledByTheAuditEndpoint { get; set; }
+            public IDictionary<string,string> Headers{ get; set; }
+        }
+
+        public class EndpointWithAuditOn : EndpointConfigurationBuilder
+        {
+
+            public EndpointWithAuditOn()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<EndpointThatHandlesAuditMessages>();
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                Context context;
+
+                public MessageToBeAuditedHandler(Context context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    context.IsMessageHandlingComplete = true;
+                }
+            }
+        }
+
+        public class EndpointThatHandlesAuditMessages : EndpointConfigurationBuilder
+        {
+
+            public EndpointThatHandlesAuditMessages()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
+            {
+                Context context;
+                IBus bus;
+
+                public AuditMessageHandler(Context context, IBus bus)
+                {
+                    this.context = context;
+                    this.bus = bus;
+                }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    context.IsMessageHandledByTheAuditEndpoint = true;
+                    context.Headers = bus.CurrentMessageContext.Headers;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_Deferring_a_message.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_Deferring_a_message.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_Deferring_a_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_be_received()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.Defer(TimeSpan.FromSeconds(3), new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.IsTrue(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_TimeToBeReceived_has_expired.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_TimeToBeReceived_has_expired.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_TimeToBeReceived_has_expired : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_not_be_received()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .Run(TimeSpan.FromSeconds(10));
+            Assert.IsFalse(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Transactions().Disable()); //transactional msmq with ttbr not supported
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        [TimeToBeReceived("00:00:00")]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_TimeToBeReceived_has_not_expired.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_TimeToBeReceived_has_not_expired.cs
@@ -1,0 +1,53 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_TimeToBeReceived_has_not_expired : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_be_received()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.IsTrue(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Transactions().Disable()); //transactional msmq with ttbr not supported
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        [TimeToBeReceived("00:00:10")]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_a_callback_for_local_message.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_a_callback_for_local_message.cs
@@ -1,0 +1,64 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_a_callback_for_local_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_trigger_the_callback_when_the_response_comes_back()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointWithLocalCallback>(b=>b.Given(
+                        (bus,context)=>bus.SendLocal(new MyRequest()).Register(r =>
+                        {
+                            Assert.True(context.HandlerGotTheRequest);
+                            context.CallbackFired = true;
+                        })))
+                    .Done(c => c.CallbackFired)
+                    .Repeat(r =>r.For(Transports.Default))
+                    .Should(c =>
+                    {
+                        Assert.True(c.CallbackFired);
+                        Assert.True(c.HandlerGotTheRequest);
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerGotTheRequest { get; set; }
+
+            public bool CallbackFired { get; set; }
+        }
+
+        public class EndpointWithLocalCallback : EndpointConfigurationBuilder
+        {
+            public EndpointWithLocalCallback()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Assert.False(Context.CallbackFired);
+                    Context.HandlerGotTheRequest = true;
+
+                    Bus.Return(1);
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage{}
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_aborting_the_behavior_chain.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_aborting_the_behavior_chain.cs
@@ -1,0 +1,73 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_aborting_the_behavior_chain : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Subsequent_handlers_will_not_be_invoked()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.SendLocal(new SomeMessage())))
+                .Done(c => c.FirstHandlerInvoked)
+                .Run();
+
+            Assert.That(context.FirstHandlerInvoked, Is.True);
+            Assert.That(context.SecondHandlerInvoked, Is.False);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool FirstHandlerInvoked { get; set; }
+            public bool SecondHandlerInvoked { get; set; }
+        }
+
+        [Serializable]
+        public class SomeMessage : IMessage { }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<FirstHandler>.Then<SecondHandler>());
+                }
+            }
+
+            class FirstHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                
+                public IBus Bus { get; set; }
+                
+                public void Handle(SomeMessage message)
+                {
+                    Context.FirstHandlerInvoked = true;
+
+                    Bus.DoNotContinueDispatchingCurrentMessageToHandlers();
+                }
+            }
+
+            class SecondHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                
+                public void Handle(SomeMessage message)
+                {
+                    Context.SecondHandlerInvoked = true;
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_callback_from_a_send_only.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_callback_from_a_send_only.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_callback_from_a_send_only : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<SendOnlyEndpoint>(b => b.Given((bus, c) =>
+                {
+                    var exception = Assert.Throws<Exception>(() => bus.Send(new MyMessage()).Register(result => { }));
+                    Assert.AreEqual("Callbacks are invalid in a sendonly endpoint.", exception.Message);
+
+                }))
+                .WithEndpoint<Receiver>()
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class SendOnlyEndpoint : EndpointConfigurationBuilder
+        {
+            public SendOnlyEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .SendOnly()
+                    .AddMapping<MyMessage>(typeof(Receiver));
+            }
+
+        }
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_handling_current_message_later.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_handling_current_message_later.cs
@@ -1,0 +1,105 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.Features;
+    using NServiceBus.UnitOfWork;
+    using NUnit.Framework;
+
+    public class When_handling_current_message_later : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_commit_unit_of_work_and_execute_subsequent_handlers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.SendLocal(new SomeMessage())))
+                .Done(c => c.Done)
+                .Run();
+
+            Assert.True(context.UoWCommited);
+            Assert.That(context.FirstHandlerInvocationCount, Is.EqualTo(2));
+            Assert.That(context.SecondHandlerInvocationCount, Is.EqualTo(1));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+            public int FirstHandlerInvocationCount { get; set; }
+            public int SecondHandlerInvocationCount { get; set; }
+            public bool UoWCommited { get; set; }
+        }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>(b =>
+                {
+                    b.RegisterComponents(r => r.ConfigureComponent<CheckUnitOfWorkOutcome>(DependencyLifecycle.InstancePerCall));
+                    b.DisableFeature<TimeoutManager>();
+                    b.DisableFeature<SecondLevelRetries>();
+                })
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 0;
+                    });
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<FirstHandler>.Then<SecondHandler>());
+                }
+            }
+
+            class CheckUnitOfWorkOutcome : IManageUnitsOfWork
+            {
+                public Context Context { get; set; }
+
+                public void Begin()
+                {
+                }
+
+                public void End(Exception ex = null)
+                {
+                    Context.UoWCommited = (ex == null);
+                }
+            }
+
+            class FirstHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public void Handle(SomeMessage message)
+                {
+                    Context.FirstHandlerInvocationCount++;
+
+                    if (Context.FirstHandlerInvocationCount == 1)
+                    {
+                        Bus.HandleCurrentMessageLater();
+                    }
+                }
+            }
+
+            class SecondHandler : IHandleMessages<SomeMessage>
+            {
+                public Context Context { get; set; }
+                public void Handle(SomeMessage message)
+                {
+                    Context.SecondHandlerInvocationCount++;
+                    Context.Done = true;
+                }
+            }
+        }
+        [Serializable]
+        public class SomeMessage : IMessage { }
+
+    }
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_incoming_headers_should_be_shared.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_incoming_headers_should_be_shared.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_incoming_headers_should_be_shared : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_expose_header_in_downstream_handlers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new Message())))
+                .Done(c => c.GotMessage)
+                .Run();
+
+            Assert.IsTrue(context.SecondHandlerCanReadHeaderSetByFirstHandler);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondHandlerCanReadHeaderSetByFirstHandler { get; set; }
+            public bool GotMessage   { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<FirstHandler>.Then<SecondHandler>());
+                }
+            }
+       
+            class FirstHandler : IHandleMessages<Message>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(Message message)
+                {
+                    Bus.SetMessageHeader(message, "Key", "Value");
+                }
+            }
+
+            class SecondHandler : IHandleMessages<Message>
+            {
+                public IBus Bus { get; set; }
+
+                public Context Context { get; set; }
+
+                public void Handle(Message message)
+                {
+                    var header = Bus.GetMessageHeader(message, "Key");
+                    Context.SecondHandlerCanReadHeaderSetByFirstHandler = header == "Value";
+                    Context.GotMessage = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class Message : ICommand
+        {
+        }
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_injecting_handler_props.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_injecting_handler_props.cs
@@ -1,0 +1,67 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_injecting_handler_props : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Receiver>(c=>c.When(b=>b.SendLocal(new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.AreEqual(10, context.Number);
+            Assert.AreEqual("Foo", context.Name);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+            public string Name { get; set; }
+            public int Number { get; set; }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.InitializeHandlerProperty<MyMessageHandler>("Number", 10);
+                    c.InitializeHandlerProperty<MyMessageHandler>("Name", "Foo");
+                });
+
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public string Name { get; set; }
+
+                public int Number { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.Number = Number;
+                    Context.Name = Name;
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_multiple_mappings_exists.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_multiple_mappings_exists.cs
@@ -1,0 +1,100 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using System.Threading;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_multiple_mappings_exists : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void First_registration_should_be_the_final_destination()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MyCommand1())))
+                    .WithEndpoint<Receiver1>()
+                    .WithEndpoint<Receiver2>()
+                    .Done(c => c.WasCalled1 || c.WasCalled2)
+                    .Run();
+
+            Assert.IsTrue(context.WasCalled1);
+            Assert.IsFalse(context.WasCalled2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled1 { get; set; }
+            public bool WasCalled2 { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyCommand1>(typeof(Receiver1))
+                    .AddMapping<MyCommand2>(typeof(Receiver2));
+            }
+        }
+
+        public class Receiver1 : EndpointConfigurationBuilder
+        {
+            public Receiver1()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyBaseCommand>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyBaseCommand message)
+                {
+                    Context.WasCalled1 = true;
+                    Thread.Sleep(2000); // Just to be sure the other receiver is finished
+                }
+            }
+        }
+
+        public class Receiver2 : EndpointConfigurationBuilder
+        {
+            public Receiver2()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyBaseCommand>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyBaseCommand message)
+                {
+                    Context.WasCalled2 = true;
+                    Thread.Sleep(2000); // Just to be sure the other receiver is finished
+                }
+            }
+        }
+
+        [Serializable]
+        public abstract class MyBaseCommand : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MyCommand1 : MyBaseCommand
+        {
+        }
+
+        [Serializable]
+        public class MyCommand2 : MyBaseCommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_registering_custom_serializer.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_registering_custom_serializer.cs
@@ -1,0 +1,148 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+    using NServiceBus.Serialization;
+    using NUnit.Framework;
+
+    public class When_registering_custom_serializer : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_register_via_type()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<EndpointViaType>(b => b.Given(
+                    (bus, c) => bus.SendLocal(new MyRequest())))
+                .Done(c => c.HandlerGotTheRequest)
+                .Run();
+
+            Assert.IsTrue(context.SerializeCalled);
+            Assert.IsTrue(context.DeserializeCalled);
+        }
+
+        [Test]
+        public void Should_register_via_definition()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<EndpointViaDefinition>(b => b.Given(
+                    (bus, c) => bus.SendLocal(new MyRequest())))
+                .Done(c => c.HandlerGotTheRequest)
+                .Run();
+
+            Assert.IsTrue(context.SerializeCalled);
+            Assert.IsTrue(context.DeserializeCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerGotTheRequest { get; set; }
+            public bool SerializeCalled { get; set; }
+            public bool DeserializeCalled { get; set; }
+        }
+
+        public class EndpointViaType : EndpointConfigurationBuilder
+        {
+            public EndpointViaType()
+            {
+                EndpointSetup<DefaultServer>(c => c.UseSerialization(typeof(MyCustomSerializer)));
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Context.HandlerGotTheRequest = true;
+                }
+            }
+        }
+
+        public class EndpointViaDefinition : EndpointConfigurationBuilder
+        {
+            public EndpointViaDefinition()
+            {
+                EndpointSetup<DefaultServer>(c => c.UseSerialization(typeof(MySuperSerializer)));
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Context.HandlerGotTheRequest = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+        }
+
+        class MySuperSerializer : SerializationDefinition
+        {
+            protected override Type ProvidedByFeature()
+            {
+                return typeof(MySuperSerializerFeature);
+            }
+        }
+
+        class MySuperSerializerFeature : Feature
+        {
+            public MySuperSerializerFeature()
+            {
+                EnableByDefault();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<MessageMapper>(DependencyLifecycle.SingleInstance);
+                context.Container.ConfigureComponent<MyCustomSerializer>(DependencyLifecycle.SingleInstance);
+            }
+        }
+
+        class MyCustomSerializer : IMessageSerializer
+        {
+            public Context Context { get; set; }
+
+            public void Serialize(object message, Stream stream)
+            {
+                var serializer = new BinaryFormatter();
+                serializer.Serialize(stream, message);
+
+                Context.SerializeCalled = true;
+            }
+
+            public object[] Deserialize(Stream stream, IList<Type> messageTypes = null)
+            {
+                var serializer = new BinaryFormatter();
+
+                Context.DeserializeCalled = true;
+                stream.Position = 0;
+                var msg = serializer.Deserialize(stream);
+
+                return new[]
+                {
+                    msg
+                };
+            }
+
+            public string ContentType
+            {
+                get { return "MyCustomSerializer"; }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_sending_ensure_proper_headers.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_sending_ensure_proper_headers.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using System.Collections.Generic;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    class When_sending_ensure_proper_headers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_have_proper_headers_for_the_originating_endpoint()
+        {
+            var context = new Context
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Scenario.Define(context)
+                                .WithEndpoint<Sender>(b => b.Given((bus, ctx) => bus.Send<MyMessage>(m =>
+                                {
+                                    m.Id = ctx.Id;
+                                })))
+                                .WithEndpoint<Receiver>()
+                                .Done(c => c.WasCalled)
+                                .Run();
+            Assert.True(context.WasCalled, "The message handler should be called");
+            Assert.AreEqual("SenderForEnsureProperHeadersTest", context.ReceivedHeaders[Headers.OriginatingEndpoint], "Message should contain the Originating endpoint");
+            Assert.IsNotNullOrEmpty(context.ReceivedHeaders[Headers.OriginatingHostId], "OriginatingHostId cannot be null or empty");
+            Assert.IsNotNullOrEmpty(context.ReceivedHeaders[Headers.OriginatingMachine], "Endpoint machine name cannot be null or empty");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+            public IDictionary<string, string> ReceivedHeaders { get; set; }
+            public Guid Id { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                CustomEndpointName("SenderForEnsureProperHeadersTest");
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyMessage>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+            public IBus Bus { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                if (Context.Id != message.Id)
+                    return;
+
+                Context.ReceivedHeaders = Bus.CurrentMessageContext.Headers;
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_sending_from_a_send_only.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_sending_from_a_send_only.cs
@@ -1,0 +1,112 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+
+    public class When_sending_from_a_send_only : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_the_message()
+        {
+            var context = new Context
+            {
+                Id = Guid.NewGuid()
+            };
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MyMessage
+                    {
+                        Id = c.Id
+                    })))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.True(context.WasCalled, "The message handler should be called");
+        }
+
+        [Test]
+        public void Should_not_need_audit_or_fault_forwarding_config_to_start()
+        {
+            var context = new Context
+            {
+                Id = Guid.NewGuid()
+            };
+            Scenario.Define(context)
+                    .WithEndpoint<SendOnlyEndpoint>()
+                    .Done(c => c.SendOnlyEndpointWasStarted)
+                    .Run();
+
+            Assert.True(context.SendOnlyEndpointWasStarted, "The endpoint should have started without any errors");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+            public Guid Id { get; set; }
+
+            public bool SendOnlyEndpointWasStarted { get; set; }
+        }
+
+        public class SendOnlyEndpoint : EndpointConfigurationBuilder
+        {
+            public SendOnlyEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .SendOnly();
+            }
+
+            public class Bootstrapper : IWantToRunWhenConfigurationIsComplete
+            {
+                public Context Context { get; set; }
+
+                public void Run(Configure config)
+                {
+                    Context.SendOnlyEndpointWasStarted = true;
+                }
+            }
+        }
+
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .SendOnly()
+                    .AddMapping<MyMessage>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+            public IBus Bus { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                if (Context.Id != message.Id)
+                    return;
+
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_sending_to_another_endpoint.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_sending_to_another_endpoint.cs
@@ -1,0 +1,96 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using System.Collections.Generic;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_to_another_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_the_message()
+        {
+            var context = new Context
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) =>
+                    {
+                        bus.OutgoingHeaders["MyStaticHeader"] = "StaticHeaderValue";
+                        bus.Send<MyMessage>(m=>
+                        {
+                            m.Id = c.Id;
+                            bus.SetMessageHeader(m, "MyHeader", "MyHeaderValue");
+                        });
+                    }))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.True(context.WasCalled, "The message handler should be called");
+            Assert.AreEqual(1, context.TimesCalled, "The message handler should only be invoked once");
+            Assert.AreEqual("StaticHeaderValue", context.ReceivedHeaders["MyStaticHeader"], "Static headers should be attached to outgoing messages");
+            Assert.AreEqual("MyHeaderValue", context.MyHeader, "Static headers should be attached to outgoing messages");
+                       
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+
+            public int TimesCalled { get; set; }
+
+            public IDictionary<string, string> ReceivedHeaders { get; set; }
+
+            public Guid Id { get; set; }
+
+            public string MyHeader { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyMessage>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    if (Context.Id != message.Id)
+                        return;
+
+                    Context.TimesCalled++;
+
+                    Context.MyHeader = Bus.GetMessageHeader(message, "MyHeader");
+
+                    Context.ReceivedHeaders = Bus.CurrentMessageContext.Headers;
+
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_sending_with_conventions.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_sending_with_conventions.cs
@@ -1,0 +1,56 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_with_conventions : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_the_message()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, context) => bus.SendLocal(new MyMessage
+                    {
+                        Id = context.Id
+                    })))
+                    .Done(c => c.WasCalled)
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+            public Guid Id { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(b => b.Conventions().DefiningMessagesAs(type => type == typeof(MyMessage)));
+            }
+        }
+
+        [Serializable]
+        public class MyMessage
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+
+            public void Handle(MyMessage message)
+            {
+                if (Context.Id != message.Id)
+                    return;
+
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_sending_with_no_correlation_id.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_sending_with_no_correlation_id.cs
@@ -1,0 +1,73 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.MessageMutator;
+    using NUnit.Framework;
+
+    public class When_sending_with_no_correlation_id : NServiceBusAcceptanceTest
+    {  
+        [Test]
+        public void Should_use_the_message_id_as_the_correlation_id()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<CorrelationEndpoint>(b => b.Given(bus => bus.SendLocal(new MyRequest())))
+                    .Done(c => c.GotRequest)
+                    .Run();
+
+            Assert.AreEqual(context.MessageIdReceived, context.CorrelationIdReceived, "Correlation id should match MessageId");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string MessageIdReceived { get; set; }
+            public bool GotRequest { get; set; }
+            public string CorrelationIdReceived { get; set; }
+        }
+
+        public class CorrelationEndpoint : EndpointConfigurationBuilder
+        {
+            public CorrelationEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class GetValueOfIncomingCorrelationId : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    Context.CorrelationIdReceived = transportMessage.CorrelationId;
+                    Context.MessageIdReceived = transportMessage.Id;
+                }
+
+                public void Customize(BusConfiguration configuration)
+                {
+                    configuration.RegisterComponents(c => c.ConfigureComponent<GetValueOfIncomingCorrelationId>(DependencyLifecycle.InstancePerCall));
+                }
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest response)
+                {
+                    Context.GotRequest = true;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_a_custom_correlation_id.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_a_custom_correlation_id.cs
@@ -1,0 +1,89 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.MessageMutator;
+    using NUnit.Framework;
+
+    public class When_using_a_custom_correlation_id : NServiceBusAcceptanceTest
+    {
+        static string CorrelationId = "my_custom_correlation_id";
+       
+        [Test]
+        public void Should_use_the_given_id_as_the_transport_level_correlation_id()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<CorrelationEndpoint>(b => b.Given(bus => bus.SendLocal(new SendMessageWithCorrelation())))
+                    .Done(c => c.GotRequest)
+                    .Run();
+
+            Assert.AreEqual(CorrelationId, context.CorrelationIdReceived, "Correlation ids should match");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotRequest { get; set; }
+
+            public string CorrelationIdReceived { get; set; }
+        }
+
+        public class CorrelationEndpoint : EndpointConfigurationBuilder
+        {
+            public CorrelationEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class GetValueOfIncomingCorrelationId : IMutateIncomingTransportMessages, INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    Context.CorrelationIdReceived = transportMessage.CorrelationId;
+                }
+
+                public void Customize(BusConfiguration configuration)
+                {
+                    configuration.RegisterComponents(c => c.ConfigureComponent<GetValueOfIncomingCorrelationId>(DependencyLifecycle.InstancePerCall));
+                }
+            }
+
+            public class SendMessageWithCorrelationHandler : IHandleMessages<SendMessageWithCorrelation>
+            {
+                public IBus Bus { get; set; }
+                public Configure Configure { get; set; }
+
+                public void Handle(SendMessageWithCorrelation message)
+                {
+                    Bus.Send(Configure.LocalAddress, CorrelationId, new MyRequest());
+                }
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest response)
+                {
+                    Context.GotRequest = true;
+                }
+            }
+        }
+
+         [Serializable]
+        public class SendMessageWithCorrelation : IMessage
+        {
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_a_greedy_convention.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_a_greedy_convention.cs
@@ -1,0 +1,63 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_using_a_greedy_convention : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_the_message()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<EndPoint>(b => b.Given((bus, context) => bus.SendLocal(new MyMessage { Id = context.Id })))
+                    .Done(c => c.WasCalled)
+                    .Repeat(r => r
+                        .For(Transports.Default)
+                    )
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+
+            public Guid Id { get; set; }
+        }
+
+        public class EndPoint : EndpointConfigurationBuilder
+        {
+            public EndPoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Conventions().DefiningMessagesAs(MessageConvention));
+            }
+
+            static bool MessageConvention(Type t)
+            {
+                return t.Namespace != null &&
+                       (t.Assembly == typeof(Conventions).Assembly) || (t == typeof(MyMessage));
+            }
+        }
+
+        [Serializable]
+        public class MyMessage 
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+            public void Handle(MyMessage message)
+            {
+                if (Context.Id != message.Id)
+                    return;
+
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_callback_to_get_message.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_callback_to_get_message.cs
@@ -1,0 +1,59 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_callback_to_get_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_message()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<EndpointWithLocalCallback>(b => b.Given(
+                    (bus, c) => bus.SendLocal(new MyRequest()).Register(r =>
+                    {
+                        c.Reply = (MyReply)r.Messages.Single();
+                        c.CallbackFired = true;
+                    })))
+                .Done(c => c.CallbackFired)
+                .Run();
+
+            Assert.IsNotNull(context.Reply);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool CallbackFired { get; set; }
+            public MyReply Reply { get; set; }
+        }
+
+        public class EndpointWithLocalCallback : EndpointConfigurationBuilder
+        {
+            public EndpointWithLocalCallback()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Bus.Reply(new MyReply());
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage { }
+
+        [Serializable]
+        public class MyReply : IMessage { }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_callbacks_from_older_versions.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_callbacks_from_older_versions.cs
@@ -1,0 +1,79 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.MessageMutator;
+    using NUnit.Framework;
+
+    public class When_using_callbacks_from_older_versions : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_trigger_the_callback()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointWithLocalCallback>(b=>b.Given(
+                        (bus,context)=>bus.SendLocal(new MyRequest()).Register(r =>
+                        {
+                            Assert.True(context.HandlerGotTheRequest);
+                            context.CallbackFired = true;
+                        })))
+                    .Done(c => c.CallbackFired)
+                    .Repeat(r =>r.For(Transports.Default))
+                    .Should(c =>
+                    {
+                        Assert.True(c.CallbackFired);
+                        Assert.True(c.HandlerGotTheRequest);
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerGotTheRequest { get; set; }
+            public bool CallbackFired { get; set; }
+        }
+
+        public class EndpointWithLocalCallback : EndpointConfigurationBuilder
+        {
+            public EndpointWithLocalCallback()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Assert.False(Context.CallbackFired);
+                    Context.HandlerGotTheRequest = true;
+
+                    Bus.Return(1);
+                }
+            }
+        }
+
+        class BodyMutator : IMutateIncomingTransportMessages, INeedInitialization
+        {
+            public void MutateIncoming(TransportMessage transportMessage)
+            {
+                //early versions of did not have a Reply MessageIntent when Bus.Return is called 
+                transportMessage.MessageIntent = MessageIntentEnum.Send;
+                transportMessage.Headers[Headers.NServiceBusVersion] = "3.3.0";
+            }
+
+            public void Customize(BusConfiguration configuration)
+            {
+                configuration.RegisterComponents(c => c.ConfigureComponent<BodyMutator>(DependencyLifecycle.InstancePerCall));
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage{}
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_callbacks_in_a_scaleout.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_callbacks_in_a_scaleout.cs
@@ -1,0 +1,127 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Support;
+    using NUnit.Framework;
+
+    public class When_using_callbacks_in_a_scaleout : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Each_client_should_have_a_unique_input_queue()
+        {
+            //to avoid processing each others callbacks
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<Client>(b => b.CustomConfig(c => RuntimeEnvironment.MachineNameAction = () => "ClientA")
+                        .Given((bus, context) => bus.Send(new MyRequest { Id = context.Id, Client = RuntimeEnvironment.MachineName })
+                                                        .Register(r => context.CallbackAFired = true)))
+                    .WithEndpoint<Client>(b => b.CustomConfig(c => RuntimeEnvironment.MachineNameAction = () => "ClientB")
+                        .Given((bus, context) => bus.Send(new MyRequest { Id = context.Id, Client = RuntimeEnvironment.MachineName })
+                         .Register(r => context.CallbackBFired = true)))
+                    .WithEndpoint<Server>()
+                    .Done(c => c.ClientAGotResponse && c.ClientBGotResponse)
+                    .Repeat(r => r.For<AllBrokerTransports>()
+                    )
+                    .Should(c =>
+                        {
+                            Assert.True(c.CallbackAFired, "Callback on ClientA should fire");
+                            Assert.True(c.CallbackBFired, "Callback on ClientB should fire");
+                            Assert.False(c.ResponseEndedUpAtTheWrongClient, "One of the responses ended up at the wrong client");
+                        })
+                      .Run(new RunSettings { UseSeparateAppDomains = true });
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public bool ClientAGotResponse { get; set; }
+
+            public bool ClientBGotResponse { get; set; }
+
+            public bool ResponseEndedUpAtTheWrongClient { get; set; }
+
+            public bool CallbackAFired { get; set; }
+
+            public bool CallbackBFired { get; set; }
+        }
+
+        public class Client : EndpointConfigurationBuilder
+        {
+            public Client()
+            {
+                EndpointSetup<DefaultServer>(c => c.ScaleOut().UseUniqueBrokerQueuePerMachine())
+                    .AddMapping<MyRequest>(typeof(Server));
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyResponse response)
+                {
+                    if (Context.Id != response.Id)
+                        return;
+
+                    if (RuntimeEnvironment.MachineName == "ClientA")
+                        Context.ClientAGotResponse = true;
+                    else
+                    {
+                        Context.ClientBGotResponse = true;
+                    }
+
+                    if (RuntimeEnvironment.MachineName != response.Client)
+                        Context.ResponseEndedUpAtTheWrongClient = true;
+                }
+            }
+        }
+
+        public class Server : EndpointConfigurationBuilder
+        {
+            public Server()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    if (Context.Id != request.Id)
+                        return;
+
+
+                    Bus.Reply(new MyResponse { Id = request.Id, Client = request.Client });
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public string Client { get; set; }
+        }
+
+        [Serializable]
+        public class MyResponse : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public string Client { get; set; }
+        }
+
+
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_callbacks_with_messageid_eq_cid_.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_callbacks_with_messageid_eq_cid_.cs
@@ -1,0 +1,73 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.MessageMutator;
+    using NServiceBus.Unicast.Messages;
+    using NUnit.Framework;
+
+    public class When_using_callbacks_with_messageid_eq_cid_ : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_trigger_the_callback()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<EndpointWithLocalCallback>(b=>b.Given(
+                        (bus,c)=>bus.SendLocal(new MyRequest()).Register(r =>
+                        {
+                            c.CallbackFired = true;
+                        })))
+                    .Done(c => c.CallbackFired)
+                    .Run();
+
+            Assert.True(context.CallbackFired);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool CallbackFired { get; set; }
+        }
+
+        public class EndpointWithLocalCallback : EndpointConfigurationBuilder
+        {
+            public EndpointWithLocalCallback()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                    Assert.False(Context.CallbackFired);
+
+                    Bus.Return(1);
+                }
+            }
+        }
+
+        class BodyMutator : IMutateOutgoingTransportMessages, INeedInitialization
+        {
+            public void MutateOutgoing(LogicalMessage logicalMessage, TransportMessage transportMessage)
+            {
+                //to simulate native interop cases where MessageId == CorrelationId
+                transportMessage.Headers[Headers.MessageId] = transportMessage.Headers[Headers.CorrelationId];
+            }
+
+            public void Customize(BusConfiguration configuration)
+            {
+                configuration.RegisterComponents(c => c.ConfigureComponent<BodyMutator>(DependencyLifecycle.InstancePerCall));
+            }
+
+         
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage{}
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_ineedinitialization.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Basic/When_using_ineedinitialization.cs
@@ -1,0 +1,101 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_ineedinitialization : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_able_to_set_endpoint_name()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>()
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.True(context.WasCalled, "The message handler should be called");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<SendMessage>(typeof(Sender));
+            }
+
+            public class SetEndpointName : INeedInitialization
+            {
+                public void Customize(BusConfiguration config)
+                {
+                    config.EndpointName("ineedinitialization_receiver");
+                }
+            }
+
+            public class SendMessageToSender: IWantToRunWhenBusStartsAndStops
+            {
+                public IBus Bus { get; set; }
+
+                public void Start()
+                {
+                    Bus.Send(new SendMessage());
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class SendMessage : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class SendMessageHandler : IHandleMessages<SendMessage>
+        {
+            public IBus Bus { get; set; }
+
+            public void Handle(SendMessage message)
+            {
+                Bus.Send("ineedinitialization_receiver", new MyMessage());
+            }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+            public IBus Bus { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Config/When_IWantToRunWhenBusStartsAndStops_Start_throws.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Config/When_IWantToRunWhenBusStartsAndStops_Start_throws.cs
@@ -1,0 +1,50 @@
+﻿namespace NServiceBus.AcceptanceTests.Config
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_Start_throws : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_shutdown_bus_cleanly()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<StartedEndpoint>()
+                    .Done(c => c.IsDone)
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsDone { get; set; }
+        }
+
+        public class StartedEndpoint : EndpointConfigurationBuilder
+        {
+            public StartedEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AfterConfigIsComplete:IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
+
+                public void Start()
+                {
+                    Context.IsDone = true;
+
+                    throw new Exception("Boom!");
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Config/When__startup_is_complete.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Config/When__startup_is_complete.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests.Config
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Settings;
+    using NUnit.Framework;
+
+    public class When__startup_is_complete : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Configure_and_setting_should_be_available_via_DI()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<StartedEndpoint>()
+                    .Done(c => c.IsDone)
+                    .Run();
+
+            Assert.True(context.ConfigureIsAvailable,"Configure should be available in DI");
+            Assert.True(context.SettingIsAvailable, "Setting should be available in DI");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsDone { get; set; }
+            public bool ConfigureIsAvailable { get; set; }
+            public bool SettingIsAvailable { get; set; }
+        }
+
+        public class StartedEndpoint : EndpointConfigurationBuilder
+        {
+            public StartedEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AfterConfigIsComplete:IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
+
+                public Configure Configure { get; set; }
+
+                public ReadOnlySettings Settings { get; set; }
+
+
+                public void Start()
+                {
+                    Context.ConfigureIsAvailable = Configure != null;
+
+                    Context.SettingIsAvailable = Settings != null;
+
+                    Context.IsDone = true;
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Config/When_a_config_override_is_found.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Config/When_a_config_override_is_found.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.AcceptanceTests.Config
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.Config.ConfigurationSource;
+    using NUnit.Framework;
+
+    public class When_a_config_override_is_found : NServiceBusAcceptanceTest
+    {
+        static Address CustomErrorQ = Address.Parse("MyErrorQ");
+
+        [Test]
+        public void Should_be_used_instead_of_pulling_the_settings_from_appconfig()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<ConfigOverrideEndpoint>().Done(c =>c.ErrorQueueUsedByTheEndpoint != null)
+                    .Run();
+
+            Assert.AreEqual(CustomErrorQ, context.ErrorQueueUsedByTheEndpoint, "The error queue should have been changed");
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsDone { get; set; }
+
+            public Address ErrorQueueUsedByTheEndpoint { get; set; }
+        }
+
+        public class ConfigOverrideEndpoint : EndpointConfigurationBuilder
+        {
+
+            public ConfigOverrideEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class ErrorQueueExtractor:IWantToRunWhenBusStartsAndStops
+            {
+                Configure configure;
+                Context context;
+
+                public ErrorQueueExtractor(Configure configure, Context context)
+                {
+                    this.configure = configure;
+                    this.context = context;
+                }
+
+                public void Start()
+                {
+                    context.ErrorQueueUsedByTheEndpoint = Address.Parse(configure.Settings.GetConfigSection<MessageForwardingInCaseOfFaultConfig>().ErrorQueue);
+                }
+
+                public void Stop()
+                {
+                }
+            }
+
+            public class ConfigErrorQueue : IProvideConfiguration<MessageForwardingInCaseOfFaultConfig>
+            {
+                public MessageForwardingInCaseOfFaultConfig GetConfiguration()
+                {
+
+                    return new MessageForwardingInCaseOfFaultConfig
+                    {
+                        ErrorQueue = CustomErrorQ.ToString()
+                    };
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
@@ -1,0 +1,82 @@
+﻿namespace NServiceBus.AcceptanceTests.CriticalError
+{
+    using System;
+    using System.Linq;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+    using IMessage = NServiceBus.IMessage;
+
+    public class When_registering_a_custom_criticalErrorHandler : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Critical_error_should_be_raised_inside_delegate()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithLocalCallback>(b => b.Given(
+                    (bus, context) => bus.SendLocal(new MyRequest())))
+                .AllowExceptions(exception => true)
+                .Done(c => c.ExceptionReceived)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c =>
+                {
+                    Assert.AreEqual("Startup task failed to complete.", c.Message);
+                    Assert.AreEqual("ExceptionInBusStarts", c.Exception.Message);
+                })
+                .Run(new TimeSpan(1, 1, 1));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Exception Exception { get; set; }
+            public string Message { get; set; }
+            public bool ExceptionReceived { get; set; }
+        }
+
+        public class EndpointWithLocalCallback : EndpointConfigurationBuilder
+        {
+            public static Context Context { get; set; }
+            public EndpointWithLocalCallback()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.DefineCriticalErrorAction((s, exception) =>
+                {
+                    var aggregateException = (AggregateException) exception;
+                    aggregateException = (AggregateException)aggregateException.InnerExceptions.First();
+                    Context.Exception = aggregateException.InnerExceptions.First();
+                    Context.Message = s;
+                    Context.ExceptionReceived = true;
+                }));
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyRequest request)
+                {
+                }
+            }
+
+
+            class AfterConfigIsComplete : IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
+                public void Start()
+                {
+                    EndpointWithLocalCallback.Context = Context;
+                    throw new Exception("ExceptionInBusStarts");
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyRequest : IMessage{}
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/DataBus/When_sending_databus_properties.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/DataBus/When_sending_databus_properties.cs
@@ -1,0 +1,66 @@
+﻿namespace NServiceBus.AcceptanceTests.DataBus
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_sending_databus_properties:NServiceBusAcceptanceTest
+    {
+        static byte[] PayloadToSend = new byte[1024 * 1024 * 10];
+
+        [Test]
+        public void Should_receive_the_message_the_largeproperty_correctly()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus=> bus.Send(new MyMessageWithLargePayload
+                        {
+                            Payload = new DataBusProperty<byte[]>(PayloadToSend) 
+                        })))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.ReceivedPayload != null)
+                    .Run();
+
+            Assert.AreEqual(PayloadToSend, context.ReceivedPayload, "The large payload should be marshalled correctly using the databus");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public byte[] ReceivedPayload { get; set; }
+        }
+
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.UseDataBus<FileShareDataBus>().BasePath(@".\databus\sender"))
+                    .AddMapping<MyMessageWithLargePayload>(typeof (Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.UseDataBus<FileShareDataBus>().BasePath(@".\databus\sender"));
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessageWithLargePayload>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessageWithLargePayload messageWithLargePayload)
+                {
+                    Context.ReceivedPayload = messageWithLargePayload.Payload.Value;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessageWithLargePayload : ICommand
+        {
+            public DataBusProperty<byte[]> Payload { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/DataBus/When_using_custom_IDataBus.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/DataBus/When_using_custom_IDataBus.cs
@@ -1,0 +1,145 @@
+﻿namespace NServiceBus.AcceptanceTests.DataBus
+{
+    using System;
+    using System.IO;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.DataBus;
+    using NUnit.Framework;
+
+    public class When_using_custom_IDataBus : NServiceBusAcceptanceTest
+    {
+        static byte[] PayloadToSend = new byte[1024 * 10];
+
+        [Test]
+        public void Should_be_able_to_register_via_fluent()
+        {
+            var context = new Context
+            {
+                TempPath = Path.GetTempFileName()
+            };
+
+            Scenario.Define(context)
+                    .WithEndpoint<SenderViaFluent>(b => b.Given(bus => bus.Send(new MyMessageWithLargePayload
+                    {
+                        Payload = new DataBusProperty<byte[]>(PayloadToSend)
+                    })))
+                    .WithEndpoint<ReceiverViaFluent>()
+                    .Done(c => c.ReceivedPayload != null)
+                    .Run();
+
+            Assert.AreEqual(PayloadToSend, context.ReceivedPayload, "The large payload should be marshalled correctly using the databus");
+        }
+
+        [Test]
+        public void Should_be_able_to_register_via_container()
+        {
+            var context = new Context
+            {
+                TempPath = Path.GetTempFileName()
+            };
+
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>(b => b.Given(bus=> bus.Send(new MyMessageWithLargePayload
+                        {
+                            Payload = new DataBusProperty<byte[]>(PayloadToSend) 
+                        })))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.ReceivedPayload != null)
+                    .Run();
+
+            Assert.AreEqual(PayloadToSend, context.ReceivedPayload, "The large payload should be marshalled correctly using the databus");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string TempPath { get; set; }
+            public byte[] ReceivedPayload { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(b => b.RegisterComponents(r => r.RegisterSingleton<IDataBus>(new MyDataBus())))
+                    .AddMapping<MyMessageWithLargePayload>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(b => b.RegisterComponents(r => r.RegisterSingleton<IDataBus>(new MyDataBus())));
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessageWithLargePayload>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessageWithLargePayload messageWithLargePayload)
+                {
+                    Context.ReceivedPayload = messageWithLargePayload.Payload.Value;
+                }
+            }
+        }
+
+        public class SenderViaFluent : EndpointConfigurationBuilder
+        {
+            public SenderViaFluent()
+            {
+                EndpointSetup<DefaultServer>(b => b.UseDataBus(typeof(MyDataBus)))
+                    .AddMapping<MyMessageWithLargePayload>(typeof(ReceiverViaFluent));
+            }
+        }
+
+        public class ReceiverViaFluent : EndpointConfigurationBuilder
+        {
+            public ReceiverViaFluent()
+            {
+                EndpointSetup<DefaultServer>(b => b.UseDataBus(typeof(MyDataBus)));
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessageWithLargePayload>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessageWithLargePayload messageWithLargePayload)
+                {
+                    Context.ReceivedPayload = messageWithLargePayload.Payload.Value;
+                }
+            }
+        }
+
+        public class MyDataBus : IDataBus
+        {
+            public Context Context { get; set; }
+
+            public Stream Get(string key)
+            {
+                return File.OpenRead(Context.TempPath);
+            }
+
+            public string Put(Stream stream, TimeSpan timeToBeReceived)
+            {
+                using (var destination = File.OpenWrite(Context.TempPath))
+                {
+                    stream.CopyTo(destination);
+                }
+                return "key";
+            }
+
+            public void Start()
+            {
+            }
+        }
+
+        [Serializable]
+        public class MyMessageWithLargePayload : ICommand
+        {
+            public DataBusProperty<byte[]> Payload { get; set; }
+        }
+    }
+
+   
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/DeterministicGuid.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/DeterministicGuid.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus.Utils
+{
+    using System;
+    using System.Security.Cryptography;
+    using System.Text;
+
+    static class DeterministicGuid
+    {
+        public static Guid Create(params object[] data)
+        {
+            // use MD5 hash to get a 16-byte hash of the string
+            using (var provider = new MD5CryptoServiceProvider())
+            {
+                var inputBytes = Encoding.Default.GetBytes(String.Concat(data));
+                var hashBytes = provider.ComputeHash(inputBytes);
+                // generate a guid from the hash:
+                return new Guid(hashBytes);
+            }
+        } 
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Encryption/When_using_Rijndael_with_config.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Encryption/When_using_Rijndael_with_config.cs
@@ -1,0 +1,115 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System;
+    using System.Collections.Generic;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Config;
+    using NServiceBus.Config.ConfigurationSource;
+    using NUnit.Framework;
+
+    public class When_using_Rijndael_with_config : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_decrypted_message()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MessageWithSecretData
+                        {
+                            Secret = "betcha can't guess my secret",
+                            SubProperty = new MySecretSubProperty {Secret = "My sub secret"},
+                            CreditCards = new List<CreditCardDetails>
+                                {
+                                    new CreditCardDetails
+                                        {
+                                            ValidTo = DateTime.UtcNow.AddYears(1),
+                                            Number = "312312312312312"
+                                        },
+                                    new CreditCardDetails
+                                        {
+                                            ValidTo = DateTime.UtcNow.AddYears(2),
+                                            Number = "543645546546456"
+                                        }
+                                }
+                        })))
+                    .Done(c => c.GotTheMessage)
+                    .Run();
+
+            Assert.AreEqual("betcha can't guess my secret", context.Secret);
+            Assert.AreEqual("My sub secret", context.SubPropertySecret);
+            CollectionAssert.AreEquivalent(new List<string> { "312312312312312", "543645546546456" }, context.CreditCards);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheMessage { get; set; }
+
+            public string Secret { get; set; }
+
+            public string SubPropertySecret { get; set; }
+
+            public List<string> CreditCards { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.RijndaelEncryptionService());
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+
+                    Context.SubPropertySecret = message.SubProperty.Secret.Value;
+
+                    Context.CreditCards = new List<string>
+                    {
+                        message.CreditCards[0].Number.Value, 
+                        message.CreditCards[1].Number.Value
+                    };
+
+                    Context.GotTheMessage = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+            public MySecretSubProperty SubProperty { get; set; }
+            public List<CreditCardDetails> CreditCards { get; set; }
+        }
+
+        [Serializable]
+        public class CreditCardDetails
+        {
+            public DateTime ValidTo { get; set; }
+            public WireEncryptedString Number { get; set; }
+        }
+
+        [Serializable]
+        public class MySecretSubProperty
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+        public class ConfigureEncryption: IProvideConfiguration<RijndaelEncryptionServiceConfig>
+        {
+            public RijndaelEncryptionServiceConfig GetConfiguration()
+            {
+                return new RijndaelEncryptionServiceConfig
+                {
+                    KeyIdentifier = "1st",
+                    Key = "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"
+                };
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Encryption/When_using_Rijndael_with_custom.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Encryption/When_using_Rijndael_with_custom.cs
@@ -1,0 +1,108 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_Rijndael_with_custom : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_decrypted_message()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MessageWithSecretData
+                        {
+                            Secret = "betcha can't guess my secret",
+                            SubProperty = new MySecretSubProperty { Secret = "My sub secret" },
+                            CreditCards = new List<CreditCardDetails>
+                                {
+                                    new CreditCardDetails
+                                        {
+                                            ValidTo = DateTime.UtcNow.AddYears(1),
+                                            Number = "312312312312312"
+                                        },
+                                    new CreditCardDetails
+                                        {
+                                            ValidTo = DateTime.UtcNow.AddYears(2),
+                                            Number = "543645546546456"
+                                        }
+                                }
+                        })))
+                    .Done(c => c.GetTheMessage)
+                    .Run();
+
+            Assert.AreEqual("betcha can't guess my secret", context.Secret);
+            Assert.AreEqual("My sub secret", context.SubPropertySecret);
+            CollectionAssert.AreEquivalent(new List<string> { "312312312312312", "543645546546456" }, context.CreditCards);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GetTheMessage { get; set; }
+
+            public string Secret { get; set; }
+
+            public string SubPropertySecret { get; set; }
+
+            public List<string> CreditCards { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                var keys = new Dictionary<string, byte[]>
+                {
+                   {"1st", Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6")}
+                };
+
+                EndpointSetup<DefaultServer>(builder => builder.RijndaelEncryptionService("1st", keys));
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+
+                    Context.SubPropertySecret = message.SubProperty.Secret.Value;
+
+                    Context.CreditCards = new List<string>
+                    {
+                        message.CreditCards[0].Number.Value, 
+                        message.CreditCards[1].Number.Value
+                    };
+
+                    Context.GetTheMessage = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+            public MySecretSubProperty SubProperty { get; set; }
+            public List<CreditCardDetails> CreditCards { get; set; }
+        }
+
+        [Serializable]
+        public class CreditCardDetails
+        {
+            public DateTime ValidTo { get; set; }
+            public WireEncryptedString Number { get; set; }
+        }
+
+        [Serializable]
+        public class MySecretSubProperty
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Encryption/When_using_Rijndael_with_multikey.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Encryption/When_using_Rijndael_with_multikey.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_Rijndael_with_multikey : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_decrypted_message()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given((bus, context) =>
+                     {
+                         bus.Send(new MessageWithSecretData
+                         {
+                             Secret = "betcha can't guess my secret",
+                         });
+                         bus.Send(new RegularMessage());
+                     }))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.Done)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c =>
+                    {
+                        Assert.AreEqual("betcha can't guess my secret", c.Secret);
+                        Assert.IsFalse(c.HasKeyOnRegularMessage.Value, "Key identifier header present in message without encrypted properties.");
+                    })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+            public string Secret { get; set; }
+            public bool? HasKeyOnRegularMessage { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.RijndaelEncryptionService("1st", Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6")))
+                    .AddMapping<MessageWithSecretData>(typeof(Receiver))
+                    .AddMapping<RegularMessage>(typeof(Receiver))
+                    ;
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                var key = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
+                var keys = new Dictionary<string, byte[]>
+                {
+                    {"2nd", Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6") },
+                    {"1st", key  }
+                };
+
+                var expiredKeys = new[] { key };
+                EndpointSetup<DefaultServer>(builder => builder.RijndaelEncryptionService("2nd", keys, expiredKeys));
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>, IHandleMessages<RegularMessage>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+                    Context.Done = true;
+                }
+
+                public void Handle(RegularMessage message)
+                {
+                    var hasKey = null != Bus.GetMessageHeader(message, Headers.RijndaelKeyIdentifier);
+                    Context.HasKeyOnRegularMessage = hasKey;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+        [Serializable]
+        public class RegularMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Encryption/When_using_Rijndael_without_incoming_key_identifier.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Encryption/When_using_Rijndael_without_incoming_key_identifier.cs
@@ -1,0 +1,90 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.MessageMutator;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_Rijndael_without_incoming_key_identifier : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_process_decrypted_message_without_key_identifier()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given((bus, context) => bus.Send(new MessageWithSecretData
+                        {
+                            Secret = "betcha can't guess my secret",
+                        })))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.Done)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.AreEqual("betcha can't guess my secret", c.Secret))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+            public string Secret { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.RijndaelEncryptionService("will-be-removed-by-transport-mutator", Encoding.ASCII.GetBytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")))
+                    .AddMapping<MessageWithSecretData>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                var keys = new Dictionary<string, byte[]>
+                {
+                    {"new", Encoding.ASCII.GetBytes("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb") },
+                };
+
+                var expiredKeys = new[] { Encoding.ASCII.GetBytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") };
+                EndpointSetup<DefaultServer>(builder => builder.RijndaelEncryptionService("new", keys, expiredKeys));
+
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+                    Context.Done = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+
+        class RemoveKeyIdentifierHeaderMutator : IMutateIncomingTransportMessages, INeedInitialization
+        {
+            public void MutateIncoming(TransportMessage transportMessage)
+            {
+                transportMessage.Headers.Remove(Headers.RijndaelKeyIdentifier);
+            }
+
+            public void Customize(BusConfiguration configuration)
+            {
+                configuration.RegisterComponents(c => c.ConfigureComponent<RemoveKeyIdentifierHeaderMutator>(DependencyLifecycle.InstancePerCall));
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Encryption/When_using_encryption_with_custom_service.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Encryption/When_using_encryption_with_custom_service.cs
@@ -1,0 +1,119 @@
+﻿namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Encryption;
+    using NUnit.Framework;
+
+    public class When_using_encryption_with_custom_service : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_decrypted_message()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MessageWithSecretData
+                        {
+                            Secret = "betcha can't guess my secret",
+                            SubProperty = new MySecretSubProperty {Secret = "My sub secret"},
+                            CreditCards = new List<CreditCardDetails>
+                                {
+                                    new CreditCardDetails
+                                        {
+                                            ValidTo = DateTime.UtcNow.AddYears(1),
+                                            Number = "312312312312312"
+                                        },
+                                    new CreditCardDetails
+                                        {
+                                            ValidTo = DateTime.UtcNow.AddYears(2),
+                                            Number = "543645546546456"
+                                        }
+                                }
+                        })))
+                    .Done(c => c.GotTheMessage)
+                    .Run();
+
+            Assert.AreEqual("betcha can't guess my secret", context.Secret);
+            Assert.AreEqual("My sub secret", context.SubPropertySecret);
+            CollectionAssert.AreEquivalent(new List<string> { "312312312312312", "543645546546456" }, context.CreditCards);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheMessage { get; set; }
+
+            public string Secret { get; set; }
+
+            public string SubPropertySecret { get; set; }
+
+            public List<string> CreditCards { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.RegisterEncryptionService(_ => new MyEncryptionService()));
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageWithSecretData message)
+                {
+                    Context.Secret = message.Secret.Value;
+
+                    Context.SubPropertySecret = message.SubProperty.Secret.Value;
+
+                    Context.CreditCards = new List<string>
+                    {
+                        message.CreditCards[0].Number.Value, 
+                        message.CreditCards[1].Number.Value
+                    };
+
+                    Context.GotTheMessage = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageWithSecretData : IMessage
+        {
+            public WireEncryptedString Secret { get; set; }
+            public MySecretSubProperty SubProperty { get; set; }
+            public List<CreditCardDetails> CreditCards { get; set; }
+        }
+
+        [Serializable]
+        public class CreditCardDetails
+        {
+            public DateTime ValidTo { get; set; }
+            public WireEncryptedString Number { get; set; }
+        }
+
+        [Serializable]
+        public class MySecretSubProperty
+        {
+            public WireEncryptedString Secret { get; set; }
+        }
+
+        public class MyEncryptionService: IEncryptionService
+        {
+            public EncryptedValue Encrypt(string value)
+            {
+                return new EncryptedValue
+                {
+                    EncryptedBase64Value = new string(value.Reverse().ToArray())
+                };
+            }
+
+            public string Decrypt(EncryptedValue encryptedValue)
+            {
+                return new string(encryptedValue.EncryptedBase64Value.Reverse().ToArray());
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/EndpointTemplates/ConfigureExtensions.cs
@@ -1,0 +1,119 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Collections.Generic;
+    using ScenarioDescriptors;
+
+    public static class ConfigureExtensions
+    {
+        public static string GetOrNull(this IDictionary<string, string> dictionary, string key)
+        {
+            if (!dictionary.ContainsKey(key))
+            {
+                return null;
+            }
+
+            return dictionary[key];
+        }
+
+        public static void DefineTransport(this BusConfiguration builder, IDictionary<string, string> settings, Type endpointBuilderType)
+        {
+            if (!settings.ContainsKey("Transport"))
+            {
+                settings = Transports.Default.Settings;
+            }
+
+            const string typeName = "ConfigureTransport";
+
+            var transportType = Type.GetType(settings["Transport"]);
+            var transportTypeName = "Configure" + transportType.Name;
+
+            var configurerType = endpointBuilderType.GetNestedType(typeName) ??
+                                 Type.GetType(transportTypeName, false);
+
+            if (configurerType != null)
+            {
+                var configurer = Activator.CreateInstance(configurerType);
+
+                dynamic dc = configurer;
+
+                dc.Configure(builder);
+                return;
+            }
+
+            builder.UseTransport(transportType).ConnectionString(settings["Transport.ConnectionString"]);
+        }
+
+        public static void DefineTransactions(this BusConfiguration config, IDictionary<string, string> settings)
+        {
+            if (settings.ContainsKey("Transactions.Disable"))
+            {
+                config.Transactions().Disable();
+            }
+            if (settings.ContainsKey("Transactions.SuppressDistributedTransactions"))
+            {
+                config.Transactions().DisableDistributedTransactions();
+            }
+        }
+
+        public static void DefinePersistence(this BusConfiguration config, IDictionary<string, string> settings)
+        {
+            if (!settings.ContainsKey("Persistence"))
+            {
+                settings = Persistence.Default.Settings;
+            }
+
+            var persistenceType = Type.GetType(settings["Persistence"]);
+
+
+            var typeName = "Configure" + persistenceType.Name;
+
+            var configurerType = Type.GetType(typeName, false);
+
+            if (configurerType != null)
+            {
+                var configurer = Activator.CreateInstance(configurerType);
+
+                dynamic dc = configurer;
+
+                dc.Configure(config);
+                return;
+            }
+
+            config.UsePersistence(persistenceType);
+        }
+
+        public static void DefineBuilder(this BusConfiguration config, IDictionary<string, string> settings)
+        {
+            if (!settings.ContainsKey("Builder"))
+            {
+                var builderDescriptor = Builders.Default;
+
+                if (builderDescriptor == null)
+                {
+                    return; //go with the default builder
+                }
+
+                settings = builderDescriptor.Settings;
+            }
+
+            var builderType = Type.GetType(settings["Builder"]);
+
+
+            var typeName = "Configure" + builderType.Name;
+
+            var configurerType = Type.GetType(typeName, false);
+
+            if (configurerType != null)
+            {
+                var configurer = Activator.CreateInstance(configurerType);
+
+                dynamic dc = configurer;
+
+                dc.Configure(config);
+            }
+
+            config.UseContainer(builderType);
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/EndpointTemplates/ContextAppender.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/EndpointTemplates/ContextAppender.cs
@@ -1,0 +1,129 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Diagnostics;
+    using AcceptanceTesting;
+    using Logging;
+
+    public class ContextAppender : ILoggerFactory, ILog
+    {
+        public ContextAppender(ScenarioContext context, string endpointName)
+        {
+            this.context = context;
+            this.endpointName = endpointName;
+        }
+
+        void Append(Exception exception)
+        {
+            lock (context)
+            {
+                context.Exceptions += exception + "/n/r";
+            }
+        }
+
+        ScenarioContext context;
+        readonly string endpointName;
+
+        public ILog GetLogger(Type type)
+        {
+            return this;
+        }
+
+        public ILog GetLogger(string name)
+        {
+            return this;
+        }
+
+        public bool IsDebugEnabled { get{return true;}}
+        public bool IsInfoEnabled { get { return true; } }
+        public bool IsWarnEnabled { get { return true; } }
+        public bool IsErrorEnabled { get { return true; } }
+        public bool IsFatalEnabled { get { return true; } }
+
+        public void Debug(string message)
+        {
+            Trace.WriteLine(message);
+        }
+
+        public void Debug(string message, Exception exception)
+        {
+            Trace.WriteLine(string.Format("{0} {1}", message, exception));
+            Append(exception);
+        }
+
+        public void DebugFormat(string format, params object[] args)
+        {
+            Trace.WriteLine(string.Format(format,args));
+        }
+
+        public void Info(string message)
+        {
+            Trace.WriteLine(message);
+        }
+
+        public void Info(string message, Exception exception)
+        {
+            Trace.WriteLine(string.Format("{0} {1}", message, exception));
+            Append(exception);
+        }
+
+        public void InfoFormat(string format, params object[] args)
+        {
+            Trace.WriteLine(string.Format(format, args));
+        }
+
+        public void Warn(string message)
+        {
+            Trace.WriteLine(message);
+        }
+
+        public void Warn(string message, Exception exception)
+        {
+            Trace.WriteLine(string.Format("{0} {1}", message, exception));
+            Append(exception);
+        }
+
+        public void WarnFormat(string format, params object[] args)
+        {
+            Trace.WriteLine(string.Format(format, args));
+        }
+
+        public void Error(string message)
+        {
+            Trace.WriteLine(message);
+
+            context.RecordEndpointLog(endpointName,"error", message);
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            var fullMessage = string.Format("{0} {1}", message, exception);
+            Trace.WriteLine(fullMessage);
+            Append(exception);
+            context.RecordEndpointLog(endpointName, "error", fullMessage);
+        }
+
+        public void ErrorFormat(string format, params object[] args)
+        {
+            var fullMessage = string.Format(format, args);
+            Trace.WriteLine(fullMessage);
+            context.RecordEndpointLog(endpointName, "error", fullMessage);
+        }
+
+        public void Fatal(string message)
+        {
+            Trace.WriteLine(message);
+        }
+
+        public void Fatal(string message, Exception exception)
+        {
+            Trace.WriteLine(string.Format("{0} {1}", message, exception));
+            Append(exception);
+        }
+
+        public void FatalFormat(string format, params object[] args)
+        {
+            Trace.WriteLine(string.Format(format, args));
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/EndpointTemplates/DefaultPublisher.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/EndpointTemplates/DefaultPublisher.cs
@@ -1,0 +1,55 @@
+namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Collections.Generic;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.Config.ConfigurationSource;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+
+    public class DefaultPublisher : IEndpointSetupTemplate
+    {
+        public BusConfiguration GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource, Action<BusConfiguration> configurationBuilderCustomization)
+        {
+            return new DefaultServer(new List<Type> { typeof(SubscriptionTracer), typeof(SubscriptionTracer.Registration) }).GetConfiguration(runDescriptor, endpointConfiguration, configSource, b =>
+            {
+                b.Pipeline.Register<SubscriptionTracer.Registration>();
+                configurationBuilderCustomization(b);
+            });
+        }
+
+        class SubscriptionTracer : IBehavior<OutgoingContext>
+        {
+            public ScenarioContext Context { get; set; }
+
+            public void Invoke(OutgoingContext context, Action next)
+            {
+                next();
+
+                List<Address> subscribers;
+
+                if (context.TryGet("SubscribersForEvent", out  subscribers))
+                {
+                    Context.AddTrace(string.Format("Subscribers for {0} : {1}", context.OutgoingLogicalMessage.MessageType.Name, string.Join(";", subscribers)));
+                }
+
+                bool nosubscribers;
+
+                if (context.TryGet("NoSubscribersFoundForMessage", out nosubscribers) && nosubscribers)
+                {
+                    Context.AddTrace(string.Format("No Subscribers found for message {0}", context.OutgoingLogicalMessage.MessageType.Name));
+                }
+            }
+
+            public class Registration : RegisterStep
+            {
+                public Registration()
+                    : base("SubscriptionTracer", typeof(SubscriptionTracer), "Traces the list of found subscribers")
+                {
+                    InsertBefore(WellKnownStep.DispatchMessageToTransport);
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/EndpointTemplates/DefaultServer.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/EndpointTemplates/DefaultServer.cs
@@ -1,0 +1,101 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using AcceptanceTesting.Support;
+    using Hosting.Helpers;
+    using Logging;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Config.ConfigurationSource;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+
+    public class DefaultServer : IEndpointSetupTemplate
+    {
+        readonly List<Type> typesToInclude;
+
+        public DefaultServer()
+        {
+            typesToInclude = new List<Type>();
+        }
+
+        public DefaultServer(List<Type> typesToInclude)
+        {
+            this.typesToInclude = typesToInclude;
+        }
+
+        public BusConfiguration GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource, Action<BusConfiguration> configurationBuilderCustomization)
+        {
+            var settings = runDescriptor.Settings;
+
+            LogManager.UseFactory(new ContextAppender(runDescriptor.ScenarioContext, endpointConfiguration.EndpointName));
+
+            var types = GetTypesScopedByTestClass(endpointConfiguration);
+
+            typesToInclude.AddRange(types);
+
+            var builder = new BusConfiguration();
+
+            builder.EndpointName(endpointConfiguration.EndpointName);
+            builder.TypesToScan(typesToInclude);
+            builder.CustomConfigurationSource(configSource);
+            builder.EnableInstallers();
+            builder.DefineTransport(settings, endpointConfiguration.BuilderType);
+            builder.DefineTransactions(settings);
+            builder.DefineBuilder(settings);
+            builder.RegisterComponents(r =>
+            {
+                r.RegisterSingleton(runDescriptor.ScenarioContext.GetType(), runDescriptor.ScenarioContext);
+                r.RegisterSingleton(typeof(ScenarioContext), runDescriptor.ScenarioContext);
+            });
+
+       
+            var serializer = settings.GetOrNull("Serializer");
+
+            if (serializer != null)
+            {
+                builder.UseSerialization(Type.GetType(serializer));
+            }
+            builder.DefinePersistence(settings);
+
+            builder.GetSettings().SetDefault("ScaleOut.UseSingleBrokerQueue", true);
+            configurationBuilderCustomization(builder);
+
+
+            return builder;
+        }
+
+        static IEnumerable<Type> GetTypesScopedByTestClass(EndpointConfiguration endpointConfiguration)
+        {
+            var assemblies = new AssemblyScanner().GetScannableAssemblies();
+
+            var types = assemblies.Assemblies
+                //exclude all test types by default
+                                  .Where(a => a != Assembly.GetExecutingAssembly())
+                                  .SelectMany(a => a.GetTypes());
+
+
+            types = types.Union(GetNestedTypeRecursive(endpointConfiguration.BuilderType.DeclaringType, endpointConfiguration.BuilderType));
+
+            types = types.Union(endpointConfiguration.TypesToInclude);
+
+            return types.Where(t => !endpointConfiguration.TypesToExclude.Contains(t)).ToList();
+        }
+
+        static IEnumerable<Type> GetNestedTypeRecursive(Type rootType, Type builderType)
+        {
+            yield return rootType;
+
+            if (typeof(IEndpointConfigurationFactory).IsAssignableFrom(rootType) && rootType != builderType)
+                yield break;
+
+            foreach (var nestedType in rootType.GetNestedTypes(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).SelectMany(t => GetNestedTypeRecursive(t, builderType)))
+            {
+                yield return nestedType;
+            }
+        }
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/Cant_convert_to_TransportMessage/SerializerCorrupter.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/Cant_convert_to_TransportMessage/SerializerCorrupter.cs
@@ -1,0 +1,17 @@
+namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Reflection;
+
+    static class SerializerCorrupter
+    {
+
+        public static void Corrupt()
+        {
+            var msmqUtilitiesType = Type.GetType("NServiceBus.MsmqUtilities, NServiceBus.Core");
+            var headerSerializerField = msmqUtilitiesType.GetField("headerSerializer", BindingFlags.Static | BindingFlags.NonPublic);
+            headerSerializerField.SetValue(null, null);
+        }
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage.cs
@@ -1,0 +1,61 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_cant_convert_to_TransportMessage : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_send_message_to_error_queue()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus => bus.Send(new Message())))
+                    .WithEndpoint<Receiver>()
+                    .AllowExceptions()
+                    .Done(c => c.GetAllLogs().Any(l=>l.Level == "error"))
+                    .Repeat(r => r.For<MsmqOnly>())
+                    .Should(c =>
+                    {
+                        var logs = c.GetAllLogs();
+                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                    })
+                    .Run(new RunSettings
+                         {
+                             UseSeparateAppDomains = true
+                         });
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+        
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<Message>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                SerializerCorrupter.Corrupt();
+                EndpointSetup<DefaultServer>();
+            }
+        
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_NoTransactions.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_NoTransactions.cs
@@ -1,0 +1,61 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+    using IMessage = NServiceBus.IMessage;
+
+    public class When_cant_convert_to_TransportMessage_NoTransactions : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_send_message_to_error_queue()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus => bus.Send(new Message())))
+                    .WithEndpoint<Receiver>()
+                    .AllowExceptions()
+                    .Done(c => c.GetAllLogs().Any(l=>l.Level == "error"))
+                    .Repeat(r => r.For<MsmqOnly>())
+                    .Should(c =>
+                    {
+                        var logs = c.GetAllLogs();
+                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                    })
+                    .Run(new RunSettings
+                         {
+                             UseSeparateAppDomains = true
+                         });
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(b => b.Transactions().Disable())
+                    .AddMapping<Message>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                SerializerCorrupter.Corrupt();
+                EndpointSetup<DefaultServer>(b => b.Transactions().Disable());
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_SuppressedDTC.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/Cant_convert_to_TransportMessage/When_cant_convert_to_TransportMessage_SuppressedDTC.cs
@@ -1,0 +1,60 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_cant_convert_to_TransportMessage_SuppressedDTC : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_send_message_to_error_queue()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus => bus.Send(new Message())))
+                    .WithEndpoint<Receiver>()
+                    .AllowExceptions()
+                    .Done(c => c.GetAllLogs().Any(l=>l.Level == "error"))
+                    .Repeat(r => r.For<MsmqOnly>())
+                    .Should(c =>
+                    {
+                        var logs = c.GetAllLogs();
+                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                    })
+                    .Run(new RunSettings
+                         {
+                             UseSeparateAppDomains = true
+                         });
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(b => b.Transactions().DisableDistributedTransactions())
+                    .AddMapping<Message>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                SerializerCorrupter.Corrupt();
+                EndpointSetup<DefaultServer>(b => b.Transactions().DisableDistributedTransactions());
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/Message_without_an_id.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/Message_without_an_id.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.MessageMutator;
+    using NServiceBus.Unicast;
+    using NServiceBus.Unicast.Messages;
+    using NServiceBus.Unicast.Transport;
+    using NUnit.Framework;
+
+    public class Message_without_an_id : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_invoke_start_message_processing_listeners()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>()
+                    .Done(c => c.StartMessageProcessingCalled)
+                    .Run();
+
+            Assert.IsTrue(context.StartMessageProcessingCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool StartMessageProcessingCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 0;
+                    });
+            }
+
+            class StartProcessingListener : IWantToRunWhenBusStartsAndStops
+            {
+                readonly UnicastBus bus;
+                Context context;
+
+                public StartProcessingListener(UnicastBus bus, Context context)
+                {
+                    this.bus = bus;
+                    this.context = context;
+                    bus.Transport.StartedMessageProcessing += transport_StartedMessageProcessing;
+                }
+
+                void transport_StartedMessageProcessing(object sender, StartedMessageProcessingEventArgs e)
+                {
+                    context.StartMessageProcessingCalled = true;
+                }
+
+                public void Start()
+                {
+                    bus.SendLocal(new Message());
+                }
+
+                public void Stop()
+                {
+                    bus.Transport.StartedMessageProcessing -= transport_StartedMessageProcessing;
+                }
+            }
+
+            class CorruptionMutator : IMutateOutgoingTransportMessages
+            {
+                public void MutateOutgoing(LogicalMessage logicalMessage, TransportMessage transportMessage)
+                {
+                    transportMessage.Headers[Headers.MessageId] = "";
+                }
+            }
+
+            class Handler : IHandleMessages<Message>
+            {
+                public void Handle(Message message)
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+    
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/StackTraceAssert.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/StackTraceAssert.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    static class StackTraceAssert
+    {
+        public static void StartsWith(string expected, string actual)
+        {
+            if (actual == null)
+            {
+                Assert.Fail();
+            }
+            else
+            {
+                var cleanStackTrace = CleanStackTrace(actual);
+
+                var reader = new StringReader(cleanStackTrace);
+
+                var stringBuilder = new StringBuilder();
+                while (true)
+                {
+                    var actualLine = reader.ReadLine();
+                    if (actualLine == null)
+                    {
+                        break;
+                    }
+                    if (expected.Contains(actualLine))
+                    {
+                        stringBuilder.AppendLine(actualLine);
+                    }
+                }
+
+                try
+                {
+                    actual = stringBuilder.ToString().TrimEnd();
+                    Assert.AreEqual(actual, expected);
+                }
+                catch (Exception)
+                {
+                    Trace.WriteLine(cleanStackTrace);
+                    throw;
+                }
+            }
+        }
+        static string CleanStackTrace(string stackTrace)
+        {
+            if (stackTrace== null)
+            {
+                return string.Empty;
+            }
+            using (var stringReader = new StringReader(stackTrace))
+            {
+                var stringBuilder = new StringBuilder();
+                while (true)
+                {
+                    var line = stringReader.ReadLine();
+                    if (line == null)
+                    {
+                        break;
+                    }
+
+                    stringBuilder.AppendLine(line.Split(new[]
+                    {
+                        " in "
+                    }, StringSplitOptions.RemoveEmptyEntries).First().Trim());
+                }
+                return stringBuilder.ToString().Trim();
+            }
+        }
+    }
+}
+

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/When_handler_throws_serialization_exception.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/When_handler_throws_serialization_exception.cs
@@ -1,0 +1,90 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_handler_throws_serialization_exception : NServiceBusAcceptanceTest
+    {
+        public static Func<int> MaxNumberOfRetries = () => 5;
+
+        [Test]
+        public void Should_retry_the_message_using_flr()
+        {
+            var context = new Context { Id = Guid.NewGuid() };
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, ctx) => bus.SendLocal(new MessageToBeRetried { ContextId = ctx.Id })))
+                    .AllowExceptions()
+                    .Done(c => c.HandedOverToSlr)
+                    .Run(TimeSpan.FromMinutes(5));
+
+            Assert.AreEqual(MaxNumberOfRetries(), context.NumberOfTimesInvoked);
+            Assert.IsFalse(context.SerializationFailedCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public int NumberOfTimesInvoked { get; set; }
+            public bool HandedOverToSlr { get; set; }
+            public Dictionary<string, string> HeadersOfTheFailedMessage { get; set; }
+            public bool SerializationFailedCalled { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b => b.RegisterComponents(r => r.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance)));
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+                    Context.SerializationFailedCalled = true;
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.HandedOverToSlr = true;
+                    Context.HeadersOfTheFailedMessage = message.Headers;
+                }
+
+                public void Init(Address address)
+                {
+
+                }
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageToBeRetried message)
+                {
+                    if (message.ContextId != Context.Id)
+                    {
+                        return;
+                    }
+                    Context.NumberOfTimesInvoked++;
+                    throw new SerializationException();
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid ContextId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/When_serialization_throws.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Exceptions/When_serialization_throws.cs
@@ -1,0 +1,108 @@
+﻿namespace NServiceBus.AcceptanceTests.Exceptions
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.Faults;
+    using NServiceBus.Features;
+    using NServiceBus.MessageMutator;
+    using NServiceBus.Unicast.Messages;
+    using NUnit.Framework;
+
+    public class When_serialization_throws : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_MessageDeserializationException()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new Message())))
+                    .AllowExceptions()
+                    .Done(c => c.ExceptionReceived)
+                    .Run();
+
+            Assert.AreEqual(typeof(MessageDeserializationException), context.ExceptionType);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ExceptionReceived { get; set; }
+            public string StackTrace { get; set; }
+            public Type ExceptionType { get; set; }
+            public string InnerExceptionStackTrace { get; set; }
+            public Type InnerExceptionType { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(b =>
+                {
+                    b.RegisterComponents(c =>
+                    {
+                        c.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance);
+                        c.ConfigureComponent<CorruptionMutator>(DependencyLifecycle.InstancePerCall);
+                    });
+                    b.DisableFeature<TimeoutManager>();
+                })
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 0;
+                    });
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+                    Context.ExceptionType = e.GetType();
+                    Context.StackTrace = e.StackTrace;
+                    if (e.InnerException != null)
+                    {
+                        Context.InnerExceptionType = e.InnerException.GetType();
+                        Context.InnerExceptionStackTrace = e.InnerException.StackTrace;
+                    }
+                    Context.ExceptionReceived = true;
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                }
+
+                public void Init(Address address)
+                {
+                }
+            }
+
+            class CorruptionMutator : IMutateTransportMessages
+            {
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+                    transportMessage.Body[1]++;
+                }
+                
+                public void MutateOutgoing(LogicalMessage logicalMessage, TransportMessage transportMessage)
+                {
+                }
+            }
+
+            class Handler : IHandleMessages<Message>
+            {
+                public void Handle(Message message)
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class Message : IMessage
+        {
+        }
+    }
+    
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/HostInformation/When_a_message_is_received.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/HostInformation/When_a_message_is_received.cs
@@ -1,0 +1,74 @@
+﻿namespace NServiceBus.AcceptanceTests.HostInformation
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+    using Unicast;
+
+    public class When_a_message_is_received : NServiceBusAcceptanceTest
+    {
+        static Guid hostId = new Guid("39365055-daf2-439e-b84d-acbef8fd803d");
+        const string displayName = "FooBar";
+
+        [Test]
+        public void Host_information_should_be_available_in_headers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(e => e.Given(b => b.SendLocal(new MyMessage())))
+                .Done(c => c.HostId != Guid.Empty)
+                .Run();
+
+            Assert.AreEqual(hostId, context.HostId);
+            Assert.AreEqual(displayName, context.HostDisplayName);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid HostId { get; set; }
+            public string HostDisplayName { get; set; }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public IBus Bus { get; set; }
+
+            public Context Context { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                Context.HostId = new Guid(Bus.GetMessageHeader(message, Headers.HostId));
+                Context.HostDisplayName = Bus.GetMessageHeader(message, Headers.HostDisplayName);
+            }
+        }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        class OverrideHostInformation : IWantToRunWhenConfigurationIsComplete
+        {
+            public UnicastBus UnicastBus { get; set; }
+
+            public void Run(Configure config)
+            {
+                var hostInformation = new Hosting.HostInformation(hostId, displayName);
+#pragma warning disable 618
+                UnicastBus.HostInformation = hostInformation;
+#pragma warning restore 618
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/HostInformation/When_customising_hostinfo.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/HostInformation/When_customising_hostinfo.cs
@@ -1,0 +1,81 @@
+namespace NServiceBus.AcceptanceTests.HostInformation
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Utils;
+    using NUnit.Framework;
+
+    public class When_customising_hostinfo : NServiceBusAcceptanceTest
+    {
+        static Guid hostId = new Guid("6c0f50de-dac9-4693-b138-6d1033c15ed6");
+        static string instanceName = "Foo";
+        static string hostName = "Bar";
+
+        [Test]
+        public void UsingCustomIdentifier()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<UsingCustomIdentifier_Endpoint>(e => e.Given(b => b.SendLocal(new MyMessage())))
+                .Done(c => c.HostId != Guid.Empty)
+                .Run();
+
+            Assert.AreEqual(hostId, context.HostId);
+        }
+
+        [Test]
+        public void UsingNames()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<UsingNames_Endpoint>(e => e.Given(b => b.SendLocal(new MyMessage())))
+                .Done(c => c.HostId != Guid.Empty)
+                .Run();
+
+            Assert.AreEqual(DeterministicGuid.Create(instanceName, hostName), context.HostId);
+        }
+
+        public class UsingNames_Endpoint : EndpointConfigurationBuilder
+        {
+            public UsingNames_Endpoint()
+            {
+                EndpointSetup<DefaultServer>(b => b.UniquelyIdentifyRunningInstance().UsingNames(instanceName, hostName));
+            }
+        }
+
+        public class UsingCustomIdentifier_Endpoint : EndpointConfigurationBuilder
+        {
+            public UsingCustomIdentifier_Endpoint()
+            {
+                EndpointSetup<DefaultServer>(b => b.UniquelyIdentifyRunningInstance().UsingCustomIdentifier(hostId));
+            }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public IBus Bus { get; set; }
+
+            public Context Context { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                Context.HostDisplayName = Bus.GetMessageHeader(message, Headers.HostDisplayName);
+                Context.HostId = new Guid(Bus.GetMessageHeader(message, Headers.HostId));
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid HostId { get; set; }
+            public string HostDisplayName { get; set; }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/HostInformation/When_feature_overrides_hostid.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/HostInformation/When_feature_overrides_hostid.cs
@@ -1,0 +1,87 @@
+﻿namespace NServiceBus.AcceptanceTests.HostInformation
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Reflection;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_feature_overrides_hostid : NServiceBusAcceptanceTest
+    {
+
+        [Test]
+        public void MD5_should_not_be_used()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(e => e.Given(b => b.SendLocal(new MyMessage())))
+                .Done(c => c.Done)
+                .Run();
+
+            Assert.IsTrue(context.NotSet);
+        }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.UniquelyIdentifyRunningInstance().UsingCustomIdentifier(Guid.NewGuid()));
+            }
+        }
+
+        public class MyFeatureThatOverridesHostInformationDefaults : Feature
+        {
+            bool notSet;
+
+            public MyFeatureThatOverridesHostInformationDefaults()
+            {
+                EnableByDefault();
+                DependsOn("UnicastBus");
+                Defaults(s =>
+                {
+                    // remove the override, we need to hack it via reflection!
+                    var fieldInfo = s.GetType().GetField("Overrides", BindingFlags.Instance | BindingFlags.NonPublic);
+                    var dictionary = (ConcurrentDictionary<string, object>)fieldInfo.GetValue(s);
+                    object s2;
+                    dictionary.TryRemove("NServiceBus.HostInformation.HostId", out s2);
+
+                    // Try to get value, setting should not exist
+                    notSet = !s.HasSetting("NServiceBus.HostInformation.HostId");
+
+                    // Set override again so we have something
+                    s.Set("NServiceBus.HostInformation.HostId", Guid.NewGuid());
+
+                });
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureProperty<Context>(c => c.NotSet, notSet);
+            }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                Context.Done = true;
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool NotSet { get; set; }
+            public bool Done { get; set; }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/HostInformation/When_feature_overrides_hostinfo.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/HostInformation/When_feature_overrides_hostinfo.cs
@@ -1,0 +1,84 @@
+namespace NServiceBus.AcceptanceTests.HostInformation
+{
+    using System;
+    using System.Collections.Generic;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_feature_overrides_hostinfo : NServiceBusAcceptanceTest
+    {
+        static Guid hostId = new Guid("6c0f50de-dac9-4693-b138-6d1033c15ed6");
+        static string instanceName = "Foo";
+
+        [Test]
+        public void HostInfo_is_changed()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<MyEndpoint>(e => e.Given(b => b.SendLocal(new MyMessage())))
+                .Done(c => c.HostId != Guid.Empty)
+                .Run();
+
+            Assert.AreEqual(hostId, context.HostId);
+            Assert.AreEqual(instanceName, context.HostDisplayName);
+        }
+
+        public class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class MyFeatureThatOverridesHostInformationDefaults : Feature
+        {
+            public MyFeatureThatOverridesHostInformationDefaults()
+            {
+                EnableByDefault();
+                DependsOn("UnicastBus");
+                Defaults(s =>
+                {
+                    s.SetDefault("NServiceBus.HostInformation.HostId", hostId);
+                    s.SetDefault("NServiceBus.HostInformation.DisplayName", instanceName);
+                    s.SetDefault("NServiceBus.HostInformation.Properties", new Dictionary<string, string>
+                    {
+                        {"RoleName", "My role name"},
+                        {"RoleInstanceId", "the role instance id"},
+                    });
+                });
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+            }
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public IBus Bus { get; set; }
+
+            public Context Context { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                Context.HostDisplayName = Bus.GetMessageHeader(message, Headers.HostDisplayName);
+                Context.HostId = new Guid(Bus.GetMessageHeader(message, Headers.HostId));
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid HostId { get; set; }
+            public string HostDisplayName { get; set; }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_Audit_OverrideTimeToBeReceived_set_and_transactional_Msmq.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_Audit_OverrideTimeToBeReceived_set_and_transactional_Msmq.cs
@@ -1,0 +1,43 @@
+﻿namespace NServiceBus.AcceptanceTests.Msmq
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+
+    public class When_Audit_OverrideTimeToBeReceived_set_and_transactional_Msmq : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_error()
+        {
+            var context = new Context();
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Repeat(r => r.For<MsmqOnly>())
+                .Run())
+                .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            Assert.IsNotNull(scenarioException);
+            StringAssert.Contains("Setting a custom OverrideTimeToBeReceived for audits is not supported on transactional MSMQ.", scenarioException.InnerException.Message);
+        }
+        
+        public class Context : ScenarioContext { }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Transactions().Enable();
+                })
+                .WithConfig<AuditConfig>(c => c.OverrideTimeToBeReceived = TimeSpan.FromHours(1));
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_TimeToBeReceivedOnForwardedMessages_set_and_transactional_Msmq.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_TimeToBeReceivedOnForwardedMessages_set_and_transactional_Msmq.cs
@@ -1,0 +1,43 @@
+﻿namespace NServiceBus.AcceptanceTests.Msmq
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+
+    public class When_TimeToBeReceivedOnForwardedMessages_set_and_transactional_Msmq : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_error()
+        {
+            var context = new Context();
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Repeat(r => r.For<MsmqOnly>())
+                .Run())
+                .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            Assert.IsNotNull(scenarioException);
+            StringAssert.Contains("Setting a custom TimeToBeReceivedOnForwardedMessages is not supported on transactional MSMQ.", scenarioException.InnerException.Message);
+        }
+
+        public class Context : ScenarioContext { }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.Transactions().Enable();
+                })
+                .WithConfig<UnicastBusConfig>(c => c.TimeToBeReceivedOnForwardedMessages = TimeSpan.FromHours(1));
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_TimeToBeReceived_set_and_DTC_Msmq.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_TimeToBeReceived_set_and_DTC_Msmq.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.AcceptanceTests.Msmq
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_TimeToBeReceived_set_and_DTC_Msmq : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw_on_send()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given((bus, c) =>
+                    {
+                        var exception = Assert.Throws<Exception>(() =>
+                        {
+                            using (new TransactionScope(TransactionScopeOption.Required))
+                            { 
+                                bus.SendLocal(new MyMessage());
+                            }
+                        });
+                        Assert.IsTrue(exception.Message.EndsWith("Sending messages with a custom TimeToBeReceived is not supported on transactional MSMQ."));
+                        }))
+                    .Repeat(r => r.For<MsmqOnly>())
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+        public class TransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public TransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Transactions().Enable().EnableDistributedTransactions());
+            }
+        }
+
+        [Serializable]
+        [TimeToBeReceived("00:00:10")]
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_TimeToBeReceived_set_and_receivetransaction_Msmq.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_TimeToBeReceived_set_and_receivetransaction_Msmq.cs
@@ -1,0 +1,64 @@
+﻿namespace NServiceBus.AcceptanceTests.Msmq
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_TimeToBeReceived_set_and_receivetransaction_Msmq : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw_on_send()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .Repeat(r => r.For<MsmqOnly>())
+                    .Run();
+            Assert.IsTrue(context.CorrectExceptionThrown);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool CorrectExceptionThrown { get; set; }
+        }
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Transactions().Enable().DisableDistributedTransactions());
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    try
+                    {
+                        Bus.SendLocal(new MyTimeToBeReceivedMessage());
+                    }
+                    catch (Exception ex)
+                    {
+                        Context.CorrectExceptionThrown = ex.Message.EndsWith("Sending messages with a custom TimeToBeReceived is not supported on transactional MSMQ.");
+                    }
+                    
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage
+        {
+        }
+
+        [Serializable]
+        [TimeToBeReceived("00:01:00")]
+        public class MyTimeToBeReceivedMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_publishing_with_authorizer.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_publishing_with_authorizer.cs
@@ -1,0 +1,152 @@
+﻿namespace NServiceBus.AcceptanceTests.Msmq
+{
+    using System.Collections.Generic;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.PubSub;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_publishing_with_authorizer : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_only_deliver_to_authorized()
+        {
+            Scenario.Define<TestContext>()
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.Subscriber1Subscribed && c.Subscriber2Subscribed, (bus, c) => bus.Publish(new MyEvent()))
+                )
+                .WithEndpoint<Subscriber1>(b => b.When(bus =>
+                {
+                    bus.Subscribe<MyEvent>();
+                }))
+                .WithEndpoint<Subscriber2>(b => b.When(bus =>
+                {
+                    bus.Subscribe<MyEvent>();
+                }))
+                .Done(c =>
+                    c.Subscriber1GotTheEvent &&
+                    c.DeclinedSubscriber2)
+                .Repeat(r => r.For(Transports.Msmq))
+                .Should(c =>
+                {
+                    Assert.True(c.Subscriber1GotTheEvent);
+                    Assert.False(c.Subscriber2GotTheEvent);
+                })
+                .Run();
+        }
+
+        public class TestContext : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber2GotTheEvent { get; set; }
+            public bool Subscriber1Subscribed { get; set; }
+            public bool Subscriber2Subscribed { get; set; }
+            public bool DeclinedSubscriber2 { get; set; }
+        }
+
+        class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b =>
+                {
+                    b.OnEndpointSubscribed<TestContext>((s, context) =>
+                    {
+                        if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                        {
+                            context.Subscriber1Subscribed = true;
+                        }
+
+                        if (s.SubscriberReturnAddress.Queue.Contains("Subscriber2"))
+                        {
+                            context.Subscriber2Subscribed = true;
+                        }
+                    });
+                    b.DisableFeature<AutoSubscribe>();
+                });
+            }
+
+            public class SubscriptionAuthorizer : IAuthorizeSubscriptions
+            {
+                TestContext context;
+
+                public SubscriptionAuthorizer(TestContext context)
+                {
+                    this.context = context;
+                }
+
+                public bool AuthorizeSubscribe(string messageType, string clientEndpoint, IDictionary<string, string> headers)
+                {
+                    var isFromSubscriber1 = headers["NServiceBus.ReplyToAddress"]
+                        .Contains("Subscriber1");
+                    if (!isFromSubscriber1)
+                    {
+                        context.DeclinedSubscriber2 = true;
+                    }
+                    return isFromSubscriber1;
+                }
+
+                public bool AuthorizeUnsubscribe(string messageType, string clientEndpoint, IDictionary<string, string> headers)
+                {
+                    return true;
+                }
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                TestContext context;
+
+                public MyEventHandler(TestContext context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(MyEvent message)
+                {
+                    context.Subscriber1GotTheEvent = true;
+                }
+            }
+
+
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                TestContext context;
+
+                public MyEventHandler(TestContext context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    context.Subscriber2GotTheEvent = true;
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_unsubscribing_with_authorizer.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Msmq/When_unsubscribing_with_authorizer.cs
@@ -1,0 +1,134 @@
+﻿namespace NServiceBus.AcceptanceTests.Msmq
+{
+    using System.Collections.Generic;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.PubSub;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_unsubscribing_with_authorizer : NServiceBusAcceptanceTest
+    {
+
+        [Test]
+        public void Should_ignore_unsubscribe()
+        {
+            Scenario.Define<TestContext>()
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.Subscribed, (bus, c) =>
+                    {
+                        bus.Publish(new MyEvent());
+                    }).When(c => c.SubscriberEventCount ==1 , (bus, c) =>
+                    {
+                        bus.Publish(new MyEvent());
+                    })
+                )
+                .WithEndpoint<Subscriber>(b => b.When(c => c.PublisherStarted, bus =>
+                {
+                    bus.Subscribe<MyEvent>();
+                }))
+                .Done(c =>
+                    c.SubscriberEventCount == 2 &&
+                    c.DeclinedUnSubscribe)
+                .Repeat(r => r.For(Transports.Msmq))
+                .Run();
+        }
+
+        public class TestContext : ScenarioContext
+        {
+            public int SubscriberEventCount { get; set; }
+            public bool UnsubscribeAttempted { get; set; }
+            public bool DeclinedUnSubscribe { get; set; }
+            public bool Subscribed { get; set; }
+            public bool PublisherStarted { get; set; }
+        }
+
+        class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b =>
+                {
+                    b.OnEndpointSubscribed<TestContext>((s, context) =>
+                    {
+                        context.Subscribed = true;
+                        context.UnsubscribeAttempted = true;
+                    });
+                    b.DisableFeature<AutoSubscribe>();
+                });
+            }
+
+            public class CaptureStarted : IWantToRunWhenBusStartsAndStops
+            {
+                TestContext context;
+
+                public CaptureStarted(TestContext context)
+                {
+                    this.context = context;
+                }
+
+                public void Start()
+                {
+                    context.PublisherStarted = true;
+                }
+
+                public void Stop()
+                {
+                }
+            }
+
+            public class SubscriptionAuthorizer : IAuthorizeSubscriptions
+            {
+                TestContext context;
+
+                public SubscriptionAuthorizer(TestContext context)
+                {
+                    this.context = context;
+                }
+
+                public bool AuthorizeSubscribe(string messageType, string clientEndpoint, IDictionary<string, string> headers)
+                {
+                    return true;
+                }
+
+                public bool AuthorizeUnsubscribe(string messageType, string clientEndpoint, IDictionary<string, string> headers)
+                {
+                    context.DeclinedUnSubscribe = true;
+                    return false;
+                }
+            }
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                IBus bus;
+                TestContext context;
+
+                public MyEventHandler(IBus bus, TestContext context)
+                {
+                    this.bus = bus;
+                    this.context = context;
+                }
+
+                public void Handle(MyEvent message)
+                {
+                    context.SubscriberEventCount ++;
+                    bus.Unsubscribe<MyEvent>();
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Mutators/Issue_1980.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Mutators/Issue_1980.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Mutators
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.MessageMutator;
+    using NUnit.Framework;
+
+    public class Issue_1980 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new V1Message())))
+                    .Done(c => c.V2MessageReceived)
+                    .Run();
+
+            Assert.IsTrue(context.V2MessageReceived);
+            Assert.IsFalse(context.V1MessageReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool V1MessageReceived { get; set; }
+            public bool V2MessageReceived { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b => b.RegisterComponents(r => r.ConfigureComponent<MutateIncomingMessages>(DependencyLifecycle.InstancePerCall)));
+            }
+
+            class MutateIncomingMessages : IMutateIncomingMessages
+            {
+                public object MutateIncoming(object message)
+                {
+                    if (message is V1Message)
+                    {
+                        return new V2Message();
+                    }
+
+                    return message;
+                }
+            }
+
+            class V2MessageHandler : IHandleMessages<V2Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V2Message message)
+                {
+                    Context.V2MessageReceived = true;
+                }
+            }
+
+            class V1MessageHandler : IHandleMessages<V1Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V1Message message)
+                {
+                    Context.V1MessageReceived = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class V1Message : ICommand
+        {
+        }
+
+        [Serializable]
+        public class V2Message : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Mutators/When_defining_outgoing_message_mutators.cs
@@ -1,0 +1,102 @@
+﻿namespace NServiceBus.AcceptanceTests.Mutators
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.MessageMutator;
+    using NServiceBus.Unicast.Messages;
+    using NUnit.Framework;
+
+    public class When_defining_outgoing_message_mutators : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_applied_to_outgoing_messages()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<OutgoingMutatorEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeMutated())))
+                    .Done(c => c.MessageProcessed)
+                    .Run();
+
+            Assert.True(context.TransportMutatorCalled);
+            Assert.IsTrue(context.OutgoingMessageLogicalMessageReceived);
+            Assert.True(context.MessageMutatorCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageProcessed { get; set; }
+            public bool TransportMutatorCalled { get; set; }
+            public bool MessageMutatorCalled { get; set; }
+            public bool OutgoingMessageLogicalMessageReceived { get; set; }
+        }
+
+        public class OutgoingMutatorEndpoint : EndpointConfigurationBuilder
+        {
+            public OutgoingMutatorEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+
+            class MyTransportMessageMutator : IMutateOutgoingTransportMessages, INeedInitialization
+            {
+
+                public Context Context { get; set; }
+
+                public void MutateOutgoing(LogicalMessage logicalMessage, TransportMessage transportMessage)
+                {
+                    Context.OutgoingMessageLogicalMessageReceived = logicalMessage != null;
+                    transportMessage.Headers["TransportMutatorCalled"] = true.ToString();
+                }
+
+                public void Customize(BusConfiguration configuration)
+                {
+                    configuration.RegisterComponents(c => c.ConfigureComponent<MyTransportMessageMutator>(DependencyLifecycle.InstancePerCall));
+                }
+            }
+
+            class MyMessageMutator : IMutateOutgoingMessages, INeedInitialization
+            {
+                public IBus Bus { get; set; }
+             
+                public object MutateOutgoing(object message)
+                {
+                    Bus.SetMessageHeader(message, "MessageMutatorCalled", "true");
+
+                    return message;
+                }
+
+                public void Customize(BusConfiguration configuration)
+                {
+                    configuration.RegisterComponents(c => c.ConfigureComponent<MyMessageMutator>(DependencyLifecycle.InstancePerCall));
+                }
+
+            }
+
+            class MessageToBeMutatedHandler : IHandleMessages<MessageToBeMutated>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+
+                public void Handle(MessageToBeMutated message)
+                {
+                    Context.TransportMutatorCalled = Bus.CurrentMessageContext.Headers.ContainsKey("TransportMutatorCalled");
+                    Context.MessageMutatorCalled = Bus.CurrentMessageContext.Headers.ContainsKey("MessageMutatorCalled");
+
+                    Context.MessageProcessed = true;
+
+                }
+            }
+
+        }
+
+        [Serializable]
+        public class MessageToBeMutated : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Mutators/When_outgoing_mutator_replaces_instance.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Mutators/When_outgoing_mutator_replaces_instance.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Mutators
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.MessageMutator;
+    using NUnit.Framework;
+
+    public class When_outgoing_mutator_replaces_instance : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_sent_should_be_new_instance()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new V1Message())))
+                .Done(c => c.V2MessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.V2MessageReceived);
+            Assert.IsFalse(context.V1MessageReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool V1MessageReceived { get; set; }
+            public bool V2MessageReceived { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b => b.RegisterComponents(r => r.ConfigureComponent<MutateOutgoingMessages>(DependencyLifecycle.InstancePerCall)));
+            }
+
+            class MutateOutgoingMessages : IMutateOutgoingMessages
+            {
+                public object MutateOutgoing(object message)
+                {
+                    if (message is V1Message)
+                    {
+                        return new V2Message();
+                    }
+
+                    return message;
+                }
+            }
+
+            class V2MessageHandler : IHandleMessages<V2Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V2Message message)
+                {
+                    Context.V2MessageReceived = true;
+                }
+            }
+
+            class V1MessageHandler : IHandleMessages<V1Message>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V1Message message)
+                {
+                    Context.V1MessageReceived = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class V1Message : ICommand
+        {
+        }
+
+        [Serializable]
+        public class V2Message : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NServiceBusAcceptanceTest.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NServiceBusAcceptanceTest.cs
@@ -1,0 +1,40 @@
+namespace NServiceBus.AcceptanceTests
+{
+    using System.Linq;
+    using AcceptanceTesting.Customization;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Base class for all the NSB test that sets up our conventions
+    /// </summary>
+    [TestFixture]
+    // ReSharper disable once PartialTypeWithSinglePart
+    public abstract partial class NServiceBusAcceptanceTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            Conventions.EndpointNamingConvention = t =>
+            {
+                var classAndEndpoint = t.FullName.Split('.').Last();
+
+                var testName = classAndEndpoint.Split('+').First();
+
+                testName = testName.Replace("When_", "");
+
+                var endpointBuilder = classAndEndpoint.Split('+').Last();
+
+                
+                testName = System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(testName);
+              
+                testName = testName.Replace("_", "");
+
+
+
+                return testName +"."+ endpointBuilder;
+            };
+
+            Conventions.DefaultRunDescriptor = () => ScenarioDescriptors.Transports.Default;
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_blowing_up_just_after_dispatch.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_blowing_up_just_after_dispatch.cs
@@ -1,0 +1,115 @@
+﻿namespace NServiceBus.AcceptanceTests.NonDTC
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NUnit.Framework;
+
+    public class When_blowing_up_just_after_dispatch : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_still_release_the_outgoing_messages_to_the_transport()
+        {
+          
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus => bus.SendLocal(new PlaceOrder())))
+                    .AllowExceptions()
+                    .Done(c => c.OrderAckReceived == 1)
+                    .Repeat(r=>r.For<AllOutboxCapableStorages>())
+                    .Should(context => Assert.AreEqual(1, context.OrderAckReceived, "Order ack should have been received since outbox dispatch isn't part of the receive tx"))
+                    .Run(TimeSpan.FromSeconds(20));
+        }
+
+
+
+        public class Context : ScenarioContext
+        {
+            public int OrderAckReceived { get; set; }
+        }
+
+        public class NonDtcReceivingEndpoint : EndpointConfigurationBuilder
+        {
+            public NonDtcReceivingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b =>
+                    {
+                        b.GetSettings().Set("DisableOutboxTransportCheck", true);
+                        b.EnableOutbox();
+                        b.Pipeline.Register<BlowUpAfterDispatchBehavior.Registration>();
+                        b.RegisterComponents(r => r.ConfigureComponent<BlowUpAfterDispatchBehavior>(DependencyLifecycle.InstancePerCall));
+                    });
+            }
+
+            class PlaceOrderHandler : IHandleMessages<PlaceOrder>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(PlaceOrder message)
+                {
+                    Bus.SendLocal(new SendOrderAcknowledgement());
+                }
+            }
+
+            class SendOrderAcknowledgementHandler : IHandleMessages<SendOrderAcknowledgement>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(SendOrderAcknowledgement message)
+                {
+                    Context.OrderAckReceived++;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class PlaceOrder : ICommand { }
+
+        [Serializable]
+        class SendOrderAcknowledgement : IMessage { }
+    }
+
+    public class BlowUpAfterDispatchBehavior : IBehavior<IncomingContext>
+    {
+        public class Registration : RegisterStep
+        {
+            public Registration() : base("BlowUpAfterDispatchBehavior", typeof(BlowUpAfterDispatchBehavior), "For testing")
+            {
+                InsertBefore("OutboxDeduplication");
+            }
+        }
+
+        public void Invoke(IncomingContext context, Action next)
+        {
+            if (!context.PhysicalMessage.Headers[Headers.EnclosedMessageTypes].Contains(typeof(When_blowing_up_just_after_dispatch.PlaceOrder).Name))
+            {
+                next();
+                return;
+            }
+
+
+            if (called)
+            {
+                Console.Out.WriteLine("Called once, skipping next");
+                return;
+
+            }
+            else
+            {
+                next();
+            }
+
+
+            called = true;
+
+            throw new Exception("Fake ex after dispatch");
+        }
+
+        static bool called;
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_dispatching_deferred_message_fails_without_dtc.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_dispatching_deferred_message_fails_without_dtc.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.AcceptanceTests.NonDTC
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+    using NUnit.Framework;
+
+    public class When_dispatching_deferred_message_fails_without_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_be_received()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<TimeoutHandlingEndpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.Defer(TimeSpan.FromSeconds(3), new MyMessage());
+                }))
+                .AllowExceptions()
+                .Done(c => c.MessageReceivedByHandler)
+                .Run();
+
+            Assert.IsTrue(context.SendingMessageFailedOnce, "Sending message attempt should fail once.");
+            Assert.IsTrue(context.MessageReceivedByHandler, "Message should be sent and received by handler on second attempt.");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageReceivedByHandler { get; set; }
+            public bool SendingMessageFailedOnce { get; set; }
+        }
+
+        public class TimeoutHandlingEndpoint : EndpointConfigurationBuilder
+        {
+            public TimeoutHandlingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.Transactions().DisableDistributedTransactions();
+                });
+            }
+
+            public class DelayedMessageHandler : IHandleMessages<MyMessage>
+            {
+                Context context;
+
+                public DelayedMessageHandler(Context context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(MyMessage message)
+                {
+                    context.MessageReceivedByHandler = true;
+                }
+            }
+
+            public class EndpointConfiguration : IWantToRunBeforeConfigurationIsFinalized
+            {
+                public static IBuilder builder;
+
+                public void Run(Configure config)
+                {
+                    builder = config.Builder;
+                }
+            }
+
+            public class DispatcherInterceptor : Feature
+            {
+                public DispatcherInterceptor()
+                {
+                    EnableByDefault();
+                    DependsOn<MsmqTransportConfigurator>();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    var originalDispatcher = EndpointConfiguration.builder.Build<ISendMessages>();
+                    var ctx = EndpointConfiguration.builder.Build<Context>();
+                    context.Container.ConfigureComponent(() => new SenderWrapper(originalDispatcher, ctx), DependencyLifecycle.SingleInstance);
+                }
+            }
+
+            class SenderWrapper : ISendMessages
+            {
+                ISendMessages wrappedSender;
+                Context context;
+
+                public SenderWrapper(ISendMessages wrappedSender, Context context)
+                {
+                    this.wrappedSender = wrappedSender;
+                    this.context = context;
+                }
+
+                public void Send(TransportMessage message, SendOptions sendOptions)
+                {
+                    string relatedTimeoutId;
+                    if (message.Headers.TryGetValue("NServiceBus.RelatedToTimeoutId", out relatedTimeoutId) && !context.SendingMessageFailedOnce)
+                    {
+                        context.SendingMessageFailedOnce = true;
+                        throw new Exception("simulated exception");
+                    }
+
+                    wrappedSender.Send(message, sendOptions);
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage { }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_outbox_with_auditing.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_outbox_with_auditing.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.AcceptanceTests.NonDTC
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NUnit.Framework;
+
+    public class When_outbox_with_auditing : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_forwarded_to_auditQueue()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<EndpointWithOutboxAndAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                .WithEndpoint<EndpointThatHandlesAuditMessages>()
+                .Done(c => c.IsMessageHandlingComplete && context.IsMessageHandledByTheAuditEndpoint)
+                .Repeat(r => r.For<AllOutboxCapableStorages>())
+                .Run();
+
+            Assert.IsTrue(context.IsMessageHandledByTheAuditEndpoint);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool IsMessageHandledByTheAuditEndpoint { get; set; }
+        }
+
+        public class EndpointWithOutboxAndAuditOn : EndpointConfigurationBuilder
+        {
+
+            public EndpointWithOutboxAndAuditOn()
+            {
+                EndpointSetup<DefaultServer>(
+                    b =>
+                    {
+                        b.GetSettings().Set("DisableOutboxTransportCheck", true);
+                        b.EnableOutbox();
+                    })
+                    .AuditTo<EndpointThatHandlesAuditMessages>();
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+                }
+            }
+        }
+
+        public class EndpointThatHandlesAuditMessages : EndpointConfigurationBuilder
+        {
+
+            public EndpointThatHandlesAuditMessages()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandledByTheAuditEndpoint = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_receiving_a_message.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_receiving_a_message.cs
@@ -1,0 +1,89 @@
+﻿namespace NServiceBus.AcceptanceTests.NonDTC
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NUnit.Framework;
+
+    public class When_receiving_a_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_handle_it()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus => bus.SendLocal(new PlaceOrder())))
+                    .AllowExceptions()
+                    .Done(c => c.OrderAckReceived == 1)
+                    .Repeat(r => r.For<AllOutboxCapableStorages>())
+                    .Run(new RunSettings { UseSeparateAppDomains = true, TestExecutionTimeout = TimeSpan.FromSeconds(20) });
+        }
+
+        [Test]
+        public void Should_discard_duplicates_using_the_outbox()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
+                    {
+                        var duplicateMessageId = Guid.NewGuid().ToString();
+                        bus.SendLocal<PlaceOrder>(m => bus.SetMessageHeader(m, Headers.MessageId, duplicateMessageId));
+                        bus.SendLocal<PlaceOrder>(m => bus.SetMessageHeader(m, Headers.MessageId, duplicateMessageId));
+                        bus.SendLocal(new PlaceOrder());
+                    }))
+                    .AllowExceptions()
+                    .Done(c => c.OrderAckReceived >= 2)
+                    .Repeat(r => r.For<AllOutboxCapableStorages>())
+                    .Should(context => Assert.AreEqual(2, context.OrderAckReceived))
+                    .Run(new RunSettings { UseSeparateAppDomains = true, TestExecutionTimeout = TimeSpan.FromSeconds(20) });
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int OrderAckReceived { get; set; }
+        }
+
+        public class NonDtcReceivingEndpoint : EndpointConfigurationBuilder
+        {
+            public NonDtcReceivingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    
+                    b =>
+                    {
+                        b.GetSettings().Set("DisableOutboxTransportCheck", true);
+                        b.EnableOutbox();
+                    })
+                .AuditTo(Address.Parse("audit"));
+            }
+
+            class PlaceOrderHandler : IHandleMessages<PlaceOrder>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(PlaceOrder message)
+                {
+                    Bus.SendLocal(new SendOrderAcknowledgement());
+                }
+            }
+
+            class SendOrderAcknowledgementHandler : IHandleMessages<SendOrderAcknowledgement>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(SendOrderAcknowledgement message)
+                {
+                    Context.OrderAckReceived++;
+                }
+            }
+        }
+
+
+        [Serializable]
+        class PlaceOrder : ICommand { }
+
+        [Serializable]
+        class SendOrderAcknowledgement : IMessage { }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_sending_a_message_with_a_ttbr.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_sending_a_message_with_a_ttbr.cs
@@ -1,0 +1,130 @@
+﻿namespace NServiceBus.AcceptanceTests.NonDTC
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NServiceBus.Features;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+    using NUnit.Framework;
+
+    public class When_sending_a_message_with_a_ttbr : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_honor_it()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new StartMessage())))
+                .Done(c => c.WasCalled)
+                .Run();
+
+            Assert.AreEqual(TimeSpan.Parse("00:00:10"), context.TTBRUsed);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+            public TimeSpan TTBRUsed { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b =>
+                    {
+                        b.GetSettings().Set("DisableOutboxTransportCheck", true);
+                        b.EnableOutbox();
+                    });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+
+            public class StartMessageHandler : IHandleMessages<StartMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(StartMessage message)
+                {
+                    Bus.SendLocal(new MyMessage())
+;
+                }
+            }
+
+            public class DispatcherInterceptor : Feature
+            {
+                public DispatcherInterceptor()
+                {
+                    EnableByDefault();
+                    DependsOn<MsmqTransportConfigurator>();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    var originalDispatcher = EndpointConfiguration.builder.Build<ISendMessages>();
+                    var ctx = EndpointConfiguration.builder.Build<Context>();
+                    context.Container.ConfigureComponent(() => new SenderWrapper(originalDispatcher, ctx), DependencyLifecycle.SingleInstance);
+                }
+            }
+
+            public class EndpointConfiguration : IWantToRunBeforeConfigurationIsFinalized
+            {
+                public static IBuilder builder;
+
+                public void Run(Configure config)
+                {
+                    builder = config.Builder;
+                }
+            }
+
+
+            class SenderWrapper : ISendMessages
+            {
+                public SenderWrapper(ISendMessages wrappedSender, Context context)
+                {
+                    this.wrappedSender = wrappedSender;
+                    this.context = context;
+                }
+
+                public void Send(TransportMessage message, SendOptions sendOptions)
+                {
+                    if (message.Headers[Headers.EnclosedMessageTypes].Contains("MyMessage"))
+                    {
+                        context.TTBRUsed = message.TimeToBeReceived;
+                    }
+
+                    wrappedSender.Send(message, sendOptions);
+                }
+
+                Context context;
+                ISendMessages wrappedSender;
+            }
+        }
+
+        [TimeToBeReceived("00:00:10")]
+        public class MyMessage : IMessage
+        {
+        }
+
+        public class StartMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_sending_a_message_with_a_ttbr.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_sending_a_message_with_a_ttbr.cs
@@ -73,7 +73,7 @@
                 public DispatcherInterceptor()
                 {
                     EnableByDefault();
-                    DependsOn<MsmqTransportConfigurator>();
+                    //DependsOn<MsmqTransportConfigurator>();
                 }
 
                 protected override void Setup(FeatureConfigurationContext context)

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_sending_from_a_non_dtc_endpoint.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonDTC/When_sending_from_a_non_dtc_endpoint.cs
@@ -1,0 +1,67 @@
+﻿namespace NServiceBus.AcceptanceTests.NonDTC
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NUnit.Framework;
+
+    public class When_sending_from_a_non_dtc_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_store_them_and_dispatch_them_from_the_outbox()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonDtcSalesEndpoint>(b => b.Given(bus => bus.SendLocal(new PlaceOrder())))
+                    .Done(c => c.OrderAckReceived)
+                    .Repeat(r => r.For<AllOutboxCapableStorages>())
+                    .Should(context => Assert.IsTrue(context.OrderAckReceived))
+                    .Run(TimeSpan.FromSeconds(20));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool OrderAckReceived { get; set; }
+        }
+
+        public class NonDtcSalesEndpoint : EndpointConfigurationBuilder
+        {
+            public NonDtcSalesEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b =>
+                    {
+                        b.GetSettings().Set("DisableOutboxTransportCheck", true);
+                        b.EnableOutbox();
+                    });
+            }
+
+            class PlaceOrderHandler : IHandleMessages<PlaceOrder>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(PlaceOrder message)
+                {
+                    Bus.SendLocal(new SendOrderAcknowledgement());
+                }
+            }
+
+            class SendOrderAcknowledgementHandler : IHandleMessages<SendOrderAcknowledgement>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(SendOrderAcknowledgement message)
+                {
+                    Context.OrderAckReceived = true;
+                }
+            }
+        }
+
+        [Serializable]
+        class PlaceOrder : ICommand { }
+
+        [Serializable]
+        class SendOrderAcknowledgement : IMessage { }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonTx/When_sending_inside_ambient_tx.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/NonTx/When_sending_inside_ambient_tx.cs
@@ -1,0 +1,87 @@
+﻿namespace NServiceBus.AcceptanceTests.NonTx
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_sending_inside_ambient_tx : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
+        {
+
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .AllowExceptions()
+                    .Done(c => c.TestComplete)
+                    .Repeat(r => r.For<AllDtcTransports>()) 
+                    .Should(c => Assert.False(c.MessageEnlistedInTheAmbientTxReceived, "The enlisted bus.Send should not commit"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool TestComplete { get; set; }
+
+            public bool MessageEnlistedInTheAmbientTxReceived { get; set; }
+        }
+
+        public class NonTransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public NonTransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Transactions().Disable().WrapHandlersExecutionInATransactionScope());
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+                public void Handle(MyMessage message)
+                {
+                    Bus.SendLocal(new CompleteTest
+                        {
+                            EnlistedInTheAmbientTx = true
+                        });
+
+                    using (new TransactionScope(TransactionScopeOption.Suppress))
+                    {
+                        Bus.SendLocal(new CompleteTest());
+                    }
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+
+            public class CompleteTestHandler : IHandleMessages<CompleteTest>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(CompleteTest message)
+                {
+                    if (!Context.MessageEnlistedInTheAmbientTxReceived)
+                        Context.MessageEnlistedInTheAmbientTxReceived = message.EnlistedInTheAmbientTx;
+
+                    Context.TestComplete = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+        [Serializable]
+        public class CompleteTest : ICommand
+        {
+            public bool EnlistedInTheAmbientTx { get; set; }
+        }
+
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PerfMon/CriticalTime/When_CriticalTime_enabled.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PerfMon/CriticalTime/When_CriticalTime_enabled.cs
@@ -1,0 +1,68 @@
+﻿namespace NServiceBus.AcceptanceTests.PerfMon.CriticalTime
+{
+    using System.Diagnostics;
+    using System.Threading;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_CriticalTime_enabled : NServiceBusAcceptanceTest
+    {
+        float counterValue;
+
+        [Test]
+        [Explicit("Since perf counters need to be enabled with powershell")]
+        public void Should_have_perf_counter_set()
+        {
+            using (var counter = new PerformanceCounter("NServiceBus", "Critical Time", "CriticaltimeEnabled.Endpoint", false))
+            using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
+            {
+                var context = new Context();
+                Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
+                    .Run();
+            }
+            Assert.Greater(counterValue, 0);
+        }
+
+        void CheckPerfCounter(PerformanceCounter counter)
+        {
+            float rawValue = counter.RawValue;
+            if (rawValue > 0)
+            {
+                counterValue = rawValue;
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.EnableCriticalTimePerformanceCounter());
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+            
+            public void Handle(MyMessage message)
+            {
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PerfMon/CriticalTime/When_deferring_a_message.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PerfMon/CriticalTime/When_deferring_a_message.cs
@@ -1,0 +1,71 @@
+﻿namespace NServiceBus.AcceptanceTests.PerfMon.CriticalTime
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_deferring_a_message : NServiceBusAcceptanceTest
+    {
+        float counterValue;
+
+        [Test]
+        [Explicit("Since perf counters need to be enabled with powershell")]
+        public void Critical_time_should_not_include_the_time_message_was_waiting_in_the_timeout_store()
+        {
+            using (var counter = new PerformanceCounter("NServiceBus", "Critical Time", "DeferringAMessage.Endpoint", false))
+            using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
+            {
+                var context = new Context();
+                Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.Defer(TimeSpan.FromSeconds(5), new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
+                    .Run();
+            }
+            Assert.Greater(counterValue, 0, "Critical time has not been recorded");
+            Assert.Less(counterValue, 2);
+        }
+
+        void CheckPerfCounter(PerformanceCounter counter)
+        {
+            float rawValue = counter.RawValue;
+            if (rawValue > 0)
+            {
+                counterValue = rawValue;
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.EnableCriticalTimePerformanceCounter())
+                    .AddMapping<MyMessage>(typeof(Endpoint));
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+            
+            public void Handle(MyMessage message)
+            {
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PerfMon/CriticalTime/When_slow_with_CriticalTime_enabled.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PerfMon/CriticalTime/When_slow_with_CriticalTime_enabled.cs
@@ -1,0 +1,68 @@
+﻿namespace NServiceBus.AcceptanceTests.PerfMon.CriticalTime
+{
+    using System.Diagnostics;
+    using System.Threading;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_slow_with_CriticalTime_enabled : NServiceBusAcceptanceTest
+    {
+        float counterValue;
+
+        [Test]
+        [Explicit("Since perf counters need to be enabled with powershell")]
+        public void Should_have_perf_counter_set()
+        {
+            using (var counter = new PerformanceCounter("NServiceBus", "Critical Time", "SlowWithCriticaltimeEnabled.Endpoint", true))
+            using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
+            {
+                var context = new Context();
+                Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
+                    .Run();
+            }
+            Assert.Greater(counterValue, 2);
+        }
+
+        void CheckPerfCounter(PerformanceCounter counter)
+        {
+            float rawValue = counter.RawValue;
+            if (rawValue > 0)
+            {
+                counterValue = rawValue;
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.EnableCriticalTimePerformanceCounter());
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+            public void Handle(MyMessage message)
+            {
+                Thread.Sleep(2000);
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PerfMon/SLA/When_sending_slow_with_SLA_enabled.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PerfMon/SLA/When_sending_slow_with_SLA_enabled.cs
@@ -1,0 +1,70 @@
+﻿namespace NServiceBus.AcceptanceTests.PerfMon.SLA
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_sending_slow_with_SLA_enabled : NServiceBusAcceptanceTest
+    {
+        float counterValue;
+
+        [Test]
+        [Explicit("Since perf counters need to be enabled with powershell")]
+        public void Should_have_perf_counter_set()
+        {
+            using (var counter = new PerformanceCounter("NServiceBus", "SLA violation countdown", "PerformanceMonitoring.Endpoint.WhenSendingSlowWithSLAEnabled." + Transports.Default.Key, true))
+            using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
+            {
+                var context = new Context();
+                Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
+                    .Run();
+            }
+            Assert.Greater(counterValue, 2);
+        }
+
+        void CheckPerfCounter(PerformanceCounter counter)
+        {
+            float rawValue = counter.RawValue;
+            if (rawValue > 0)
+            {
+                counterValue = rawValue;
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.EnableSLAPerformanceCounter(new TimeSpan(0, 0, 0, 0, 1)));
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+            
+            public void Handle(MyMessage message)
+            {
+                Thread.Sleep(1000);
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PerfMon/SLA/When_sending_with_SLA_enabled.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PerfMon/SLA/When_sending_with_SLA_enabled.cs
@@ -1,0 +1,70 @@
+﻿namespace NServiceBus.AcceptanceTests.PerfMon.SLA
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_sending_with_SLA_enabled : NServiceBusAcceptanceTest
+    {
+        float counterValue;
+
+        [Test]
+        [Explicit("Since perf counters need to be enabled with powershell")]
+        public void Should_have_perf_counter_set()
+        {
+            using (var counter = new PerformanceCounter("NServiceBus", "SLA violation countdown", "PerformanceMonitoring.Endpoint.WhenSendingWithSLAEnabled." + Transports.Default.Key, true))
+            using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
+            {
+                var context = new Context();
+                Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
+                    .Run();
+            }
+            Assert.Greater(counterValue, 0);
+        }
+
+        void CheckPerfCounter(PerformanceCounter counter)
+        {
+            float rawValue = counter.RawValue;
+            if (rawValue > 0)
+            {
+                counterValue = rawValue;
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(builder => builder.EnableSLAPerformanceCounter(TimeSpan.FromMinutes(10)));
+            }
+        }
+
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PipelineExt/FilteringWhatGetsAudited.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PipelineExt/FilteringWhatGetsAudited.cs
@@ -1,0 +1,135 @@
+﻿
+namespace NServiceBus.AcceptanceTests.PipelineExt
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// This is a demo on how pipeline overrides can be used to control which messages that gets audited by NServiceBus
+    /// </summary>
+    public class FilteringWhatGetsAudited : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void RunDemo()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<UserEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                .WithEndpoint<AuditSpy>()
+                .Done(c => c.IsMessageHandlingComplete)
+                .Run();
+
+            Assert.IsFalse(context.MessageAudited);
+        }
+
+
+        public class UserEndpoint : EndpointConfigurationBuilder
+        {
+            public UserEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<AuditSpy>();
+            }
+
+            class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+                }
+            }
+
+            class SetFiltering : IBehavior<IncomingContext>
+            {
+                public void Invoke(IncomingContext context, Action next)
+                {
+                    if (context.IncomingLogicalMessage.MessageType == typeof(MessageToBeAudited))
+                    {
+                        context.Get<AuditFilterResult>().DoNotAuditMessage = true;
+                    }
+                }
+
+                class AuditFilteringOverride : INeedInitialization
+                {
+                    public void Customize(BusConfiguration configuration)
+                    {
+                        configuration.Pipeline.Register("SetFiltering", typeof(SetFiltering), "Filters audit entries");
+                    }
+                }
+            }
+
+            class AuditFilterResult
+            {
+                public bool DoNotAuditMessage { get; set; }
+            }
+
+            class FilteringAuditBehavior : IBehavior<IncomingContext>
+            {
+                public IAuditMessages MessageAuditer { get; set; }
+
+                public void Invoke(IncomingContext context, Action next)
+                {
+                    var auditResult = new AuditFilterResult();
+                    context.Set(auditResult);
+                    next();
+
+                    //note: and rule operating on the raw TransportMessage can be applied here if needed.
+                    // Access to the message is through: context.PhysicalMessage. Eg:  context.PhysicalMessage.Headers.ContainsKey("NServiceBus.ControlMessage")
+                    if (auditResult.DoNotAuditMessage)
+                    {
+                        return;
+                    }
+                    MessageAuditer.Audit(new SendOptions("audit"),context.PhysicalMessage);
+                }
+
+                //here we inject our behavior
+                class AuditFilteringOverride : INeedInitialization
+                {
+                    public void Customize(BusConfiguration configuration)
+                    {
+                        //we replace the default audit behavior with out own
+                        configuration.Pipeline.Replace(WellKnownStep.AuditProcessedMessage, typeof(FilteringAuditBehavior), "A new audit forwarder that has filtering");
+                    }
+                }
+            }
+        }
+
+        public class AuditSpy : EndpointConfigurationBuilder
+        {
+            public AuditSpy()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageToBeAudited message)
+                {
+                    MyContext.MessageAudited = true;
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool MessageAudited { get; set; }
+        }
+
+
+        [Serializable]
+        public class MessageToBeAudited : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PipelineExt/MutingHandlerExceptions.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PipelineExt/MutingHandlerExceptions.cs
@@ -1,0 +1,120 @@
+﻿
+namespace NServiceBus.AcceptanceTests.PipelineExt
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// This is a demo on how pipeline overrides can be used to control which messages that gets audited by NServiceBus
+    /// </summary>
+    public class MutingHandlerExceptions : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void RunDemo()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<EndpointWithCustomExceptionMuting>(b => b.Given(bus => bus.SendLocal(new MessageThatWillBlowUpButExWillBeMuted())))
+                .WithEndpoint<AuditSpy>()
+                .Done(c => c.IsMessageHandlingComplete)
+                .Run();
+
+            Assert.IsTrue(context.MessageAudited);
+        }
+
+        public class EndpointWithCustomExceptionMuting : EndpointConfigurationBuilder
+        {
+            public EndpointWithCustomExceptionMuting()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AuditTo<AuditSpy>();
+            }
+
+            class Handler : IHandleMessages<MessageThatWillBlowUpButExWillBeMuted>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageThatWillBlowUpButExWillBeMuted message)
+                {
+                    MyContext.IsMessageHandlingComplete = true;
+
+                    throw new Exception("Lets filter on this text");
+                }
+            }
+
+            class MyExceptionFilteringBehavior : IBehavior<IncomingContext>
+            {
+                public void Invoke(IncomingContext context, Action next)
+                {
+                    try
+                    {
+                        //invoke the handler/rest of the pipeline
+                        next();
+                    }
+                    //catch specifix exceptions or
+                    catch (Exception ex)
+                    {
+                        //modify this to your liking
+                        if (ex.Message == "Lets filter on this text")
+                        {
+                            return;
+                        }
+
+                        throw;
+                    }
+                }
+
+                //here we inject our behavior
+                class MyExceptionFilteringOverride : INeedInitialization
+                {
+                    public void Customize(BusConfiguration configuration)
+                    {
+                        configuration.Pipeline.Register<MyExceptionFilteringRegistration>();
+                    }
+                }
+
+                class MyExceptionFilteringRegistration : RegisterStep
+                {
+                    public MyExceptionFilteringRegistration() : base("ExceptionFiltering", typeof(MyExceptionFilteringBehavior), "Custom exception filtering")
+                    {
+                        InsertAfter(WellKnownStep.AuditProcessedMessage);
+                        InsertBefore(WellKnownStep.InvokeHandlers);
+                    }
+                }
+            }
+        }
+
+        public class AuditSpy : EndpointConfigurationBuilder
+        {
+            public AuditSpy()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class AuditMessageHandler : IHandleMessages<MessageThatWillBlowUpButExWillBeMuted>
+            {
+                public Context MyContext { get; set; }
+
+                public void Handle(MessageThatWillBlowUpButExWillBeMuted message)
+                {
+                    MyContext.MessageAudited = true;
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool IsMessageHandlingComplete { get; set; }
+            public bool MessageAudited { get; set; }
+        }
+
+        [Serializable]
+        public class MessageThatWillBlowUpButExWillBeMuted : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PipelineExt/SkipDeserialization.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PipelineExt/SkipDeserialization.cs
@@ -1,0 +1,77 @@
+﻿namespace NServiceBus.AcceptanceTests.PipelineExt
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NUnit.Framework;
+
+    //This is a demo on how the pipeline overrides can be used to create endpoints that doesn't deserialize incoming messages and there by
+    // allows the user to handle the raw transport message. This replaces the old feature on the UnicastBus where SkipDeserialization could be set to tru
+    public class SkipDeserialization : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void RunDemo()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonSerializingEndpoint>(
+                        b => b.Given(bus => bus.SendLocal(new SomeMessage())))
+                    .Done(c => c.GotTheRawMessage)
+                    .Run();
+        }
+
+        public class NonSerializingEndpoint : EndpointConfigurationBuilder
+        {
+            public NonSerializingEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            //first we override the default "extraction" behavior
+            class MyOverride : INeedInitialization
+            {
+                public void Customize(BusConfiguration configuration)
+                {
+                    configuration.Pipeline.Replace(WellKnownStep.DeserializeMessages, typeof(MyRawMessageHandler));
+                }
+            }
+
+            //and then we handle the physical message our self
+            class MyRawMessageHandler:IBehavior<IncomingContext>
+            {
+                public Context Context { get; set; }
+
+                public void Invoke(IncomingContext context, Action next)
+                {
+                    var transportMessage = context.PhysicalMessage;
+
+                    Assert.True(transportMessage.Headers[Headers.EnclosedMessageTypes].Contains(typeof(SomeMessage).Name));
+
+                    Context.GotTheRawMessage = true;
+                }
+            }
+
+            class ThisHandlerWontGetInvoked:IHandleMessages<SomeMessage>
+            {
+                public void Handle(SomeMessage message)
+                {
+                    Assert.Fail();
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheRawMessage { get; set; }
+        }
+
+        [Serializable]
+        public class SomeMessage : ICommand
+        {
+
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/SubscriptionBehavior.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/SubscriptionBehavior.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using Pipeline;
+    using Pipeline.Contexts;
+
+    static class SubscriptionBehaviorExtensions
+    {
+        public static void OnEndpointSubscribed<TContext>(this BusConfiguration b, Action<SubscriptionEventArgs, TContext> action) where TContext : ScenarioContext
+        {
+            b.Pipeline.Register<SubscriptionBehavior<TContext>.Registration>();
+
+            b.RegisterComponents(c => c.ConfigureComponent(builder =>
+            {
+                var context = builder.Build<TContext>();
+                return new SubscriptionBehavior<TContext>(action, context);
+            }, DependencyLifecycle.InstancePerCall));
+        }
+    }
+
+    class SubscriptionBehavior<TContext> : IBehavior<IncomingContext> where TContext : ScenarioContext
+    {
+        readonly Action<SubscriptionEventArgs, TContext> action;
+        readonly TContext scenarioContext;
+
+        public SubscriptionBehavior(Action<SubscriptionEventArgs, TContext> action, TContext scenarioContext)
+        {
+            this.action = action;
+            this.scenarioContext = scenarioContext;
+        }
+
+        public void Invoke(IncomingContext context, Action next)
+        {
+            next();
+            var subscriptionMessageType = GetSubscriptionMessageTypeFrom(context.PhysicalMessage);
+            if (subscriptionMessageType != null)
+            {
+                action(new SubscriptionEventArgs
+                {
+                    MessageType = subscriptionMessageType,
+                    SubscriberReturnAddress = context.PhysicalMessage.ReplyToAddress
+                }, scenarioContext);
+            }
+        }
+
+        static string GetSubscriptionMessageTypeFrom(TransportMessage msg)
+        {
+            return (from header in msg.Headers where header.Key == Headers.SubscriptionMessageType select header.Value).FirstOrDefault();
+        }
+
+        internal class Registration : RegisterStep
+        {
+            public Registration()
+                : base("SubscriptionBehavior", typeof(SubscriptionBehavior<TContext>), "So we can get subscription events")
+            {
+                InsertBefore(WellKnownStep.CreateChildContainer);
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/SubscriptionEventArgs.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/SubscriptionEventArgs.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    public class SubscriptionEventArgs
+    {
+        /// <summary>
+        /// The address of the subscriber.
+        /// </summary>
+        public Address SubscriberReturnAddress { get; set; }
+
+        /// <summary>
+        /// The type of message the client subscribed to.
+        /// </summary>
+        public string MessageType { get; set; }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_base_event_from_2_publishers.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_base_event_from_2_publishers.cs
@@ -1,0 +1,120 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_base_event_from_2_publishers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_events_from_all_publishers()
+        {
+            var cc = new Context();
+
+            Scenario.Define(cc)
+               .WithEndpoint<Publisher1>(b =>
+                        b.When(c => c.SubscribedToPublisher1, bus => bus.Publish(new DerivedEvent1()))
+                     )
+                .WithEndpoint<Publisher2>(b =>
+                        b.When(c => c.SubscribedToPublisher2, bus => bus.Publish(new DerivedEvent2()))
+                     )
+               .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+               {
+                   bus.Subscribe<DerivedEvent1>();
+                   bus.Subscribe<DerivedEvent2>();
+
+                   if (context.HasNativePubSubSupport)
+                   {
+                       context.SubscribedToPublisher1 = true;
+                       context.SubscribedToPublisher2 = true;
+                   }
+               }))
+               .AllowExceptions(e => e.Message.Contains("Oracle.DataAccess.Client.OracleException: ORA-00001") || e.Message.Contains("System.Data.SqlClient.SqlException: Violation of PRIMARY KEY constraint"))
+               .Done(c => c.GotTheEventFromPublisher1 && c.GotTheEventFromPublisher2)
+               .Run();
+
+            Assert.True(cc.GotTheEventFromPublisher1);
+            Assert.True(cc.GotTheEventFromPublisher2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheEventFromPublisher1 { get; set; }
+            public bool GotTheEventFromPublisher2 { get; set; }
+            public bool SubscribedToPublisher1 { get; set; }
+            public bool SubscribedToPublisher2 { get; set; }
+        }
+
+        public class Publisher1 : EndpointConfigurationBuilder
+        {
+            public Publisher1()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    context.AddTrace("Publisher1 SubscriberReturnAddress=" + s.SubscriberReturnAddress.Queue);
+                    if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                    {
+                        context.SubscribedToPublisher1 = true;
+                    }
+                }));
+            }
+        }
+
+        public class Publisher2 : EndpointConfigurationBuilder
+        {
+            public Publisher2()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    context.AddTrace("Publisher2 SubscriberReturnAddress=" + s.SubscriberReturnAddress.Queue);
+
+                    if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                    {
+                        context.SubscribedToPublisher2 = true;
+                    }
+                }));
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<DerivedEvent1>(typeof(Publisher1))
+                    .AddMapping<DerivedEvent2>(typeof(Publisher2));
+            }
+
+            public class BaseEventHandler : IHandleMessages<BaseEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(BaseEvent message)
+                {
+                    if (message.GetType().FullName.Contains("DerivedEvent1"))
+                        Context.GotTheEventFromPublisher1 = true;
+                    if (message.GetType().FullName.Contains("DerivedEvent2"))
+                        Context.GotTheEventFromPublisher2 = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class BaseEvent : IEvent
+        {
+        }
+
+        [Serializable]
+        public class DerivedEvent1 : BaseEvent
+        {
+
+        }
+
+        [Serializable]
+        public class DerivedEvent2 : BaseEvent
+        {
+
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_multi_subscribing_to_a_polymorphic_event.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_multi_subscribing_to_a_polymorphic_event.cs
@@ -1,0 +1,128 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_multi_subscribing_to_a_polymorphic_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Both_events_should_be_delivered()
+        {
+            var rootContext = new Context();
+
+            Scenario.Define(rootContext)
+                .WithEndpoint<Publisher1>(b => b.When(c => c.Publisher1HasASubscriberForIMyEvent, (bus, c) =>
+                {
+                    c.AddTrace("Publishing MyEvent1");
+                    bus.Publish(new MyEvent1());
+                }))
+                .WithEndpoint<Publisher2>(b => b.When(c => c.Publisher2HasDetectedASubscriberForEvent2, (bus, c) =>
+                {
+                    c.AddTrace("Publishing MyEvent2");
+                    bus.Publish(new MyEvent2());
+                }))
+                .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                {
+                    context.AddTrace("Subscriber1 subscribing to both events");
+                    bus.Subscribe<IMyEvent>();
+                    bus.Subscribe<MyEvent2>();
+
+                    if (context.HasNativePubSubSupport)
+                    {
+                        context.Publisher1HasASubscriberForIMyEvent = true;
+                        context.Publisher2HasDetectedASubscriberForEvent2 = true;
+                    }
+                }))
+                .AllowExceptions(e => e.Message.Contains("Oracle.DataAccess.Client.OracleException: ORA-00001") || e.Message.Contains("System.Data.SqlClient.SqlException: Violation of PRIMARY KEY constraint"))
+                .Done(c => c.SubscriberGotIMyEvent && c.SubscriberGotMyEvent2)
+                .Run();
+
+            Assert.True(rootContext.SubscriberGotIMyEvent);
+            Assert.True(rootContext.SubscriberGotMyEvent2);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SubscriberGotIMyEvent { get; set; }
+            public bool SubscriberGotMyEvent2 { get; set; }
+            public bool Publisher1HasASubscriberForIMyEvent { get; set; }
+            public bool Publisher2HasDetectedASubscriberForEvent2 { get; set; }
+        }
+
+        public class Publisher1 : EndpointConfigurationBuilder
+        {
+            public Publisher1()
+            {
+                EndpointSetup<DefaultPublisher>( b => b.OnEndpointSubscribed<Context>((args, context) =>
+                {
+                    context.AddTrace("Publisher1 OnEndpointSubscribed " + args.MessageType);
+                    if (args.MessageType.Contains(typeof(IMyEvent).Name))
+                    {
+                        context.Publisher1HasASubscriberForIMyEvent = true;
+                    }
+                }));
+            }
+        }
+
+        public class Publisher2 : EndpointConfigurationBuilder
+        {
+            public Publisher2()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((args, context) =>
+                {
+                    context.AddTrace("Publisher2 OnEndpointSubscribed " + args.MessageType);
+
+                    if (args.MessageType.Contains(typeof(MyEvent2).Name))
+                    {
+                        context.Publisher2HasDetectedASubscriberForEvent2 = true;
+                    }
+                }));
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<IMyEvent>(typeof(Publisher1))
+                    .AddMapping<MyEvent2>(typeof(Publisher2));
+            }
+
+            public class MyEventHandler : IHandleMessages<IMyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IMyEvent messageThatIsEnlisted)
+                {
+                    Context.AddTrace(String.Format("Got event '{0}'", messageThatIsEnlisted));
+                    if (messageThatIsEnlisted is MyEvent2)
+                    {
+                        Context.SubscriberGotMyEvent2 = true;
+                    }
+                    else
+                    {
+                        Context.SubscriberGotIMyEvent = true;
+                    }
+                }
+            }
+        }
+        
+        [Serializable]
+        public class MyEvent1 : IMyEvent
+        {
+        }
+
+        [Serializable]
+        public class MyEvent2 : IMyEvent
+        {
+        }
+
+        public interface IMyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishin.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishin.cs
@@ -1,0 +1,201 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishin : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Issue_1851()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher3>(b =>
+                        b.When(c => c.Subscriber3Subscribed, bus => bus.Publish<IFoo>())
+                     )
+                    .WithEndpoint<Subscriber3>(b => b.Given((bus, context) =>
+                    {
+                        bus.Subscribe<IFoo>();
+
+                        if (context.HasNativePubSubSupport)
+                        {
+                            context.Subscriber3Subscribed = true;
+                        }
+                    }))
+
+                    .Done(c => c.Subscriber3GotTheEvent)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.Subscriber3GotTheEvent))
+                    .Run();
+        }
+
+        [Test]
+        public void Should_be_delivered_to_all_subscribers()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.When(c => c.Subscriber1Subscribed && c.Subscriber2Subscribed, (bus, c) =>
+                        {
+                            c.AddTrace("Both subscribers is subscribed, going to publish MyEvent");
+                            bus.Publish(new MyEvent());
+                        })
+                     )
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+                            if (context.HasNativePubSubSupport)
+                            {
+                                context.Subscriber1Subscribed = true;
+                                context.AddTrace("Subscriber1 is now subscribed (at least we have asked the broker to be subscribed)");
+                            }
+                            else
+                            {
+                                context.AddTrace("Subscriber1 has now asked to be subscribed to MyEvent");
+                            }
+                        }))
+                      .WithEndpoint<Subscriber2>(b => b.Given((bus, context) =>
+                      {
+                          bus.Subscribe<MyEvent>();
+
+                          if (context.HasNativePubSubSupport)
+                          {
+                              context.Subscriber2Subscribed = true;
+                              context.AddTrace("Subscriber2 is now subscribed (at least we have asked the broker to be subscribed)");
+                          }
+                          else
+                          {
+                              context.AddTrace("Subscriber2 has now asked to be subscribed to MyEvent");
+                          }
+                      }))
+                    .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c =>
+                    {
+                        Assert.True(c.Subscriber1GotTheEvent);
+                        Assert.True(c.Subscriber2GotTheEvent);
+                    })
+
+                    .Run(TimeSpan.FromSeconds(10));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber2GotTheEvent { get; set; }
+            public bool Subscriber3GotTheEvent { get; set; }
+            public bool Subscriber1Subscribed { get; set; }
+            public bool Subscriber2Subscribed { get; set; }
+            public bool Subscriber3Subscribed { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b =>
+                {
+                    b.OnEndpointSubscribed<Context>((s, context) =>
+                    {
+                        if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                        {
+                            context.Subscriber1Subscribed = true;
+                            context.AddTrace("Subscriber1 is now subscribed");
+                        }
+
+
+                        if (s.SubscriberReturnAddress.Queue.Contains("Subscriber2"))
+                        {
+                            context.AddTrace("Subscriber2 is now subscribed");
+                            context.Subscriber2Subscribed = true;
+                        }
+                    });
+                    b.DisableFeature<AutoSubscribe>();
+                });
+            }
+        }
+
+        public class Publisher3 : EndpointConfigurationBuilder
+        {
+            public Publisher3()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    if (s.SubscriberReturnAddress.Queue.Contains("Subscriber3"))
+                    {
+                        context.Subscriber3Subscribed = true;
+                    }
+                }));
+            }
+        }
+
+        public class Subscriber3 : EndpointConfigurationBuilder
+        {
+            public Subscriber3()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<IFoo>(typeof(Publisher3));
+            }
+
+            public class MyEventHandler : IHandleMessages<IFoo>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IFoo messageThatIsEnlisted)
+                {
+                    Context.Subscriber3GotTheEvent = true;
+                }
+            }
+
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                        .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber2GotTheEvent = true;
+                }
+            }
+        }
+
+        public interface IFoo : IEvent
+        {
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
@@ -1,0 +1,142 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_an_event_implementing_two_unrelated_interfaces : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Event_should_be_published_using_instance_type()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<Publisher>(b =>
+                        b.When(c => c.EventASubscribed && c.EventBSubscribed, (bus, ctx) =>
+                        {
+                            var message = new CompositeEvent
+                            {
+                                ContextId = ctx.Id
+                            };
+                            bus.Publish(message);
+                        }))
+                    .WithEndpoint<Subscriber>(b => b.Given((bus, context) =>
+                    {
+                        bus.Subscribe<IEventA>();
+                        bus.Subscribe<IEventB>();
+
+                        if (context.HasNativePubSubSupport)
+                        {
+                            context.EventASubscribed = true;
+                            context.EventBSubscribed = true;
+                        }
+                    }))
+                    .Done(c => c.GotEventA && c.GotEventB)
+                    .Repeat(r => r.For(Serializers.Xml))
+                    .Should(c =>
+                    {
+                        Assert.True(c.GotEventA);
+                        Assert.True(c.GotEventB);
+                    })
+                    .Run(TimeSpan.FromSeconds(20));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool EventASubscribed { get; set; }
+            public bool EventBSubscribed { get; set; }
+            public bool GotEventA { get; set; }
+            public bool GotEventB { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    if (s.SubscriberReturnAddress.Queue.Contains("Subscriber"))
+                    {
+                        if (s.MessageType == typeof(IEventA).AssemblyQualifiedName)
+                        {
+                            context.EventASubscribed = true;
+                        }
+                        if (s.MessageType == typeof(IEventB).AssemblyQualifiedName)
+                        {
+                            context.EventBSubscribed = true;
+                        }
+                    }
+                }));
+            }
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions().DefiningMessagesAs(t => t != typeof(CompositeEvent) && typeof(IMessage).IsAssignableFrom(t) &&
+                                                            typeof(IMessage) != t &&
+                                                            typeof(IEvent) != t &&
+                                                            typeof(ICommand) != t);
+
+                    c.Conventions().DefiningEventsAs(t => t != typeof(CompositeEvent) && typeof(IEvent).IsAssignableFrom(t) && typeof(IEvent) != t);
+                    c.DisableFeature<AutoSubscribe>();
+                })
+                    .AddMapping<IEventA>(typeof(Publisher))
+                    .AddMapping<IEventB>(typeof(Publisher));
+            }
+
+            public class EventAHandler : IHandleMessages<IEventA>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IEventA evnt)
+                {
+                    if (evnt.ContextId != Context.Id)
+                    {
+                        return;
+                    }
+                    Context.GotEventA = true;
+                }
+            }
+
+            public class EventBHandler : IHandleMessages<IEventB>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IEventB evnt)
+                {
+                    if (evnt.ContextId != Context.Id)
+                    {
+                        return;
+                    }
+                    Context.GotEventB = true;
+                }
+            }
+        }
+
+        class CompositeEvent : IEventA, IEventB
+        {
+            public Guid ContextId { get; set; }
+            public int IntProperty { get; set; }
+            public string StringProperty { get; set; }
+        }
+
+        public interface IEventA : IEvent
+        {
+            Guid ContextId { get; set; }
+            string StringProperty { get; set; }
+        }
+
+        public interface IEventB : IEvent
+        {
+            Guid ContextId { get; set; }
+            int IntProperty { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_from_sendonly.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_from_sendonly.cs
@@ -1,0 +1,110 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using System.Collections.Generic;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Persistence;
+    using NServiceBus.Unicast.Subscriptions;
+    using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+
+    public class When_publishing_from_sendonly : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_delivered_to_all_subscribers()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<SendOnlyPublisher>(b => b.Given((bus, c) => bus.Publish(new MyEvent())))
+                .WithEndpoint<Subscriber>()
+                .Done(c => c.SubscriberGotTheEvent)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(ctx => Assert.True(ctx.SubscriberGotTheEvent))
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SubscriberGotTheEvent { get; set; }
+        }
+
+        public class SendOnlyPublisher : EndpointConfigurationBuilder
+        {
+            public SendOnlyPublisher()
+            {
+                EndpointSetup<DefaultPublisher>(b =>
+                {
+                    b.UsePersistence(typeof(HardCodedPersistence));
+                    b.DisableFeature<AutoSubscribe>();
+                }).SendOnly();
+            }
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<MyEvent>(typeof(SendOnlyPublisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.SubscriberGotTheEvent = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+
+        public class HardCodedPersistence : PersistenceDefinition
+        {
+            internal HardCodedPersistence()
+            {
+                Supports<StorageType.Subscriptions>(s => s.EnableFeatureByDefault<HardCodedPersistenceFeature>());
+            }
+        }
+
+        public class HardCodedPersistenceFeature:Feature
+        {
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<HardCodedPersistenceImpl>(DependencyLifecycle.SingleInstance);
+            }
+        }
+
+        public class HardCodedPersistenceImpl : ISubscriptionStorage
+        {
+            public void Subscribe(Address client, IEnumerable<MessageType> messageTypes)
+            {
+            }
+
+            public void Unsubscribe(Address client, IEnumerable<MessageType> messageTypes)
+            {
+            }
+
+            public IEnumerable<Address> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes)
+            {
+                return new[]
+                {
+                    Address.Parse("publishingfromsendonly.subscriber")
+                };
+            }
+
+            public void Init()
+            {
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_on_brokers.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_on_brokers.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_on_brokers : NServiceBusAcceptanceTest
+    {
+        [Test, Ignore] // Ignore because, test this test is unreliable. Passed on the build server without the core fix!
+        public void Should_be_delivered_to_allsubscribers_without_the_need_for_config()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<CentralizedPublisher>
+                    (b => b.When(c => c.IsSubscriptionProcessedForSub1 && c.IsSubscriptionProcessedForSub2, bus => bus.Publish(new MyEvent())))
+                    .WithEndpoint<CentralizedSubscriber1>(b => b.Given((bus, context) =>
+                    {
+                      context.IsSubscriptionProcessedForSub1 = true;
+                    }))
+                    .WithEndpoint<CentralizedSubscriber2>(b => b.Given((bus, context) =>
+                    {
+                        context.IsSubscriptionProcessedForSub2 = true;
+                    }))
+                    .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
+                    .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
+                    .Should(c =>
+                    {
+                        Assert.True(c.Subscriber1GotTheEvent);
+                        Assert.True(c.Subscriber2GotTheEvent);
+                    })
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber2GotTheEvent { get; set; }
+
+            public bool IsSubscriptionProcessedForSub1 { get; set; }
+            public bool IsSubscriptionProcessedForSub2 { get; set; }
+        }
+
+        public class CentralizedPublisher : EndpointConfigurationBuilder
+        {
+            public CentralizedPublisher()
+            {
+                EndpointSetup<DefaultPublisher>();
+            }
+        }
+
+        public class CentralizedSubscriber1 : EndpointConfigurationBuilder
+        {
+            public CentralizedSubscriber1()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        public class CentralizedSubscriber2 : EndpointConfigurationBuilder
+        {
+            public CentralizedSubscriber2()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber2GotTheEvent = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_using_root_type.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_using_root_type.cs
@@ -1,0 +1,92 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_using_root_type : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Event_should_be_published_using_instance_type()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.When(c => c.Subscriber1Subscribed, bus =>
+                        {
+                            IMyEvent message = new EventMessage();
+
+                            bus.Publish(message);
+                        }))
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                    {
+                        bus.Subscribe<EventMessage>();
+
+                        if (context.HasNativePubSubSupport)
+                        {
+                            context.Subscriber1Subscribed = true;
+                        }
+                    }))
+                    .Done(c => c.Subscriber1GotTheEvent)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.Subscriber1GotTheEvent))
+                    .Run(TimeSpan.FromSeconds(20));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber1Subscribed { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    if (s.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                    {
+                        context.Subscriber1Subscribed = true;
+                    }
+                }));
+            }
+        }
+        
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<EventMessage>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<EventMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(EventMessage messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class EventMessage : IMyEvent
+        {
+            public Guid EventId { get; set; }
+            public DateTime? Time { get; set; }
+            public TimeSpan Duration { get; set; }
+        }
+
+        public interface IMyEvent : IEvent
+        {
+            Guid EventId { get; set; }
+            DateTime? Time { get; set; }
+            TimeSpan Duration { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_with_only_local_messagehandlers.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_with_only_local_messagehandlers.cs
@@ -1,0 +1,101 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_with_only_local_messagehandlers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_trigger_the_catch_all_handler_for_message_driven_subscriptions()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<MessageDrivenPublisher>(b =>
+                    b.When(c => c.LocalEndpointSubscribed, bus => bus.Publish(new EventHandledByLocalEndpoint())))
+                .Done(c => c.CatchAllHandlerGotTheMessage)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c => Assert.True(c.CatchAllHandlerGotTheMessage))
+                .Run();
+        }
+
+        [Test]
+        public void Should_trigger_the_catch_all_handler_for_publishers_with_centralized_pubsub()
+        {
+            Scenario.Define<Context>()
+                       .WithEndpoint<CentralizedStoragePublisher>(b =>
+                       {
+                           b.Given(bus => bus.Subscribe<EventHandledByLocalEndpoint>());
+                           b.When(c => c.EndpointsStarted, (bus, context) => bus.Publish(new EventHandledByLocalEndpoint()));
+                       })
+                       .Done(c => c.CatchAllHandlerGotTheMessage)
+                       .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
+                       .Should(c => Assert.True(c.CatchAllHandlerGotTheMessage))
+                       .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool CatchAllHandlerGotTheMessage { get; set; }
+
+            public bool LocalEndpointSubscribed { get; set; }
+        }
+
+        public class MessageDrivenPublisher : EndpointConfigurationBuilder
+        {
+            public MessageDrivenPublisher()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    context.LocalEndpointSubscribed = true;
+                }))
+                .AddMapping<EventHandledByLocalEndpoint>(typeof(MessageDrivenPublisher)); //an explicit mapping is needed
+            }
+
+            class CatchAllHandler:IHandleMessages<IEvent> //not enough for auto subscribe to work
+            {
+                public Context Context { get; set; }
+                public void Handle(IEvent message)
+                {
+                    Context.CatchAllHandlerGotTheMessage = true;
+                }
+            }
+
+            class DummyHandler : IHandleMessages<EventHandledByLocalEndpoint> //explicit handler for the event is needed
+            {
+                public void Handle(EventHandledByLocalEndpoint message)
+                {
+                }
+            }
+        }
+
+        public class CentralizedStoragePublisher : EndpointConfigurationBuilder
+        {
+            public CentralizedStoragePublisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class CatchAllHandler : IHandleMessages<IEvent> 
+            {
+                public Context Context { get; set; }
+                public void Handle(IEvent message)
+                {
+                    Context.CatchAllHandlerGotTheMessage = true;
+                }
+            }
+
+            class DummyHandler : IHandleMessages<EventHandledByLocalEndpoint> //explicit handler for the event is needed
+            {
+                public void Handle(EventHandledByLocalEndpoint message)
+                {
+                }
+            }
+        }
+        [Serializable]
+        public class EventHandledByLocalEndpoint : IEvent
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_with_overridden_local_address.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_publishing_with_overridden_local_address.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_with_overridden_local_address : NServiceBusAcceptanceTest
+    {
+        [Test, Explicit("This test fails against RabbitMQ")]
+        public void Should_be_delivered_to_all_subscribers()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Publisher>(b =>
+                        b.When(c => c.Subscriber1Subscribed, bus => bus.Publish(new MyEvent()))
+                     )
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+
+                            if (context.HasNativePubSubSupport)
+                                context.Subscriber1Subscribed = true;
+                        }))
+                    .Done(c => c.Subscriber1GotTheEvent)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.Subscriber1GotTheEvent))
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+            public bool Subscriber1Subscribed { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    if (s.SubscriberReturnAddress.Queue.Contains("myinputqueue"))
+                    {
+                        context.Subscriber1Subscribed = true;
+                    }
+                }));
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    builder.DisableFeature<AutoSubscribe>();
+                    builder.OverrideLocalAddress("myinputqueue");
+                })
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_subscribing_to_a_polymorphic_event.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/PubSub/When_subscribing_to_a_polymorphic_event.cs
@@ -1,0 +1,118 @@
+﻿namespace NServiceBus.AcceptanceTests.PubSub
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_subscribing_to_a_polymorphic_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Event_should_be_delivered()
+        {
+            var cc = new Context();
+
+            Scenario.Define(cc)
+                    .WithEndpoint<Publisher>(b => b.When(c => c.Subscriber1Subscribed && c.Subscriber2Subscribed, bus => bus.Publish(new MyEvent())))
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<IMyEvent>();
+
+                            if (context.HasNativePubSubSupport)
+                                context.Subscriber1Subscribed = true;
+                        }))
+                    .WithEndpoint<Subscriber2>(b => b.Given((bus, context) =>
+                        {
+                            bus.Subscribe<MyEvent>();
+
+                            if (context.HasNativePubSubSupport)
+                                context.Subscriber2Subscribed = true;
+                        }))
+                    .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
+                    .Run();
+
+            Assert.True(cc.Subscriber1GotTheEvent);
+            Assert.True(cc.Subscriber2GotTheEvent);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1GotTheEvent { get; set; }
+
+            public bool Subscriber2GotTheEvent { get; set; }
+
+            public int NumberOfSubscribers { get; set; }
+
+            public bool Subscriber1Subscribed { get; set; }
+
+            public bool Subscriber2Subscribed { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((args, context) =>
+                {
+                    if (args.SubscriberReturnAddress.Queue.Contains("Subscriber1"))
+                    {
+                        context.Subscriber1Subscribed = true;
+                    }
+
+                    if (args.SubscriberReturnAddress.Queue.Contains("Subscriber2"))
+                    {
+                        context.Subscriber2Subscribed = true;
+                    }
+                }));
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<IMyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<IMyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(IMyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber1GotTheEvent = true;
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                        .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyEvent messageThatIsEnlisted)
+                {
+                    Context.Subscriber2GotTheEvent = true;
+                }
+            }
+        }
+        
+        [Serializable]
+        public class MyEvent : IMyEvent
+        {
+        }
+
+        public interface IMyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_Subscribing_to_errors.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_Subscribing_to_errors.cs
@@ -1,0 +1,140 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using System.Collections.Generic;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+
+    public class When_Subscribing_to_errors : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_contain_exception_details()
+        {
+            var context = new Context
+            {
+                Id = Guid.NewGuid()
+            };
+            Scenario.Define(context)
+                .WithEndpoint<SLREndpoint>(b => b.Given((bus, c) => bus.SendLocal(new MessageToBeRetried
+                {
+                    Id = c.Id
+                })))
+                .AllowExceptions(e => e.Message.Contains("Simulated exception"))
+                .Done(c => c.MessageSentToError)
+                .Run(TimeSpan.FromMinutes(5));
+
+            Assert.IsInstanceOf<MySpecialException>(context.MessageSentToErrorException);
+        }
+
+        [Test]
+        public void Should_receive_notifications()
+        {
+            var context = new Context
+            {
+                Id = Guid.NewGuid()
+            };
+            Scenario.Define(context)
+                .WithEndpoint<SLREndpoint>()
+                .AllowExceptions(e => e.Message.Contains("Simulated exception"))
+                .Done(c => c.MessageSentToError)
+                .Run(TimeSpan.FromMinutes(5));
+
+            Assert.AreEqual(3*3, context.TotalNumberOfFLRTimesInvokedInHandler);
+            Assert.AreEqual(3*3, context.TotalNumberOfFLRTimesInvoked);
+            Assert.AreEqual(2, context.NumberOfSLRRetriesPerformed);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public int TotalNumberOfFLRTimesInvoked { get; set; }
+            public int TotalNumberOfFLRTimesInvokedInHandler { get; set; }
+            public int NumberOfSLRRetriesPerformed { get; set; }
+            public bool MessageSentToError { get; set; }
+            public Exception MessageSentToErrorException { get; set; }
+        }
+
+        public class SLREndpoint : EndpointConfigurationBuilder
+        {
+            public SLREndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .WithConfig<TransportConfig>(c => { c.MaxRetries = 3; })
+                    .WithConfig<SecondLevelRetriesConfig>(c =>
+                    {
+                        c.NumberOfRetries = 2;
+                        c.TimeIncrease = TimeSpan.FromSeconds(1);
+                    });
+            }
+
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageToBeRetried message)
+                {
+                    if (message.Id != Context.Id)
+                    {
+                        return; // ignore messages from previous test runs
+                    }
+
+                    Context.TotalNumberOfFLRTimesInvokedInHandler++;
+
+                    throw new MySpecialException();
+                }
+            }
+        }
+
+        public class MySpecialException : Exception
+        {
+            public MySpecialException()
+                : base("Simulated exception")
+            {
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class MyErrorSubscriber : IWantToRunWhenBusStartsAndStops
+        {
+            public Context Context { get; set; }
+
+            public BusNotifications Notifications { get; set; }
+
+            public IBus Bus { get; set; }
+
+            public void Start()
+            {
+                unsubscribeStreams.Add(Notifications.Errors.MessageSentToErrorQueue.Subscribe(message =>
+                {
+                    Context.MessageSentToErrorException = message.Exception;
+                    Context.MessageSentToError = true;
+                }));
+                unsubscribeStreams.Add(Notifications.Errors.MessageHasFailedAFirstLevelRetryAttempt.Subscribe(message => Context.TotalNumberOfFLRTimesInvoked++));
+                unsubscribeStreams.Add(Notifications.Errors.MessageHasBeenSentToSecondLevelRetries.Subscribe(message => Context.NumberOfSLRRetriesPerformed++));
+
+                Bus.SendLocal(new MessageToBeRetried
+                {
+                    Id = Context.Id
+                });
+            }
+
+            public void Stop()
+            {
+                foreach (var unsubscribeStream in unsubscribeStreams)
+                {
+                    unsubscribeStream.Dispose();
+                }
+            }
+
+            List<IDisposable> unsubscribeStreams = new List<IDisposable>();
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_Subscribing_to_errors.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_Subscribing_to_errors.cs
@@ -17,10 +17,7 @@
                 Id = Guid.NewGuid()
             };
             Scenario.Define(context)
-                .WithEndpoint<SLREndpoint>(b => b.Given((bus, c) => bus.SendLocal(new MessageToBeRetried
-                {
-                    Id = c.Id
-                })))
+                .WithEndpoint<SLREndpoint>()
                 .AllowExceptions(e => e.Message.Contains("Simulated exception"))
                 .Done(c => c.MessageSentToError)
                 .Run(TimeSpan.FromMinutes(5));

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_doing_flr_with_default_settings.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_doing_flr_with_default_settings.cs
@@ -1,0 +1,105 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_doing_flr_with_default_settings : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_do_any_retries_if_transactions_are_off()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) =>
+                    {
+                        bus.SendLocal(new MessageToBeRetried { Id = context.Id });
+                        bus.SendLocal(new MessageToBeRetried { Id = context.Id, SecondMessage = true });
+                    }))
+                    .AllowExceptions()
+                    .Done(c => c.SecondMessageReceived || c.NumberOfTimesInvoked > 1)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.AreEqual(1, c.NumberOfTimesInvoked, "No retries should be in use if transactions are off"))
+                    .Run();
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public int NumberOfTimesInvoked { get; set; }
+
+            public bool HandedOverToSlr { get; set; }
+
+            public bool SecondMessageReceived { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b =>
+                    {
+                        b.Transactions().Disable();
+                        b.RegisterComponents(r => r.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance));
+                    })
+                    .WithConfig<TransportConfig>(c => c.MaximumConcurrencyLevel = 1);
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.HandedOverToSlr = true;
+                }
+
+                public void Init(Address address)
+                {
+
+                }
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageToBeRetried message)
+                {
+                    if (message.Id != Context.Id) return; // messages from previous test runs must be ignored
+
+                    if (message.SecondMessage)
+                    {
+                        Context.SecondMessageReceived = true;
+                        return;
+                    }
+
+                    Context.NumberOfTimesInvoked++;
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public bool SecondMessage { get; set; }
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_doing_flr_with_dtc_on.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_doing_flr_with_dtc_on.cs
@@ -1,0 +1,100 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_doing_flr_with_dtc_on : NServiceBusAcceptanceTest
+    {
+        public static Func<int> X = () => 5;
+            
+        [Test]
+        public void Should_do_X_retries_by_default_with_dtc_on()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried{ Id = context.Id })))
+                    .AllowExceptions()
+                    .Done(c => c.HandedOverToSlr || c.NumberOfTimesInvoked > X())
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c => Assert.AreEqual(X(), c.NumberOfTimesInvoked, string.Format("The FLR should by default retry {0} times", X())))
+                    .Run();
+
+        }
+
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public int NumberOfTimesInvoked { get; set; }
+
+            public bool HandedOverToSlr { get; set; }
+
+            public bool SecondMessageReceived { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b => b.RegisterComponents(r => r.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance)))
+                    .WithConfig<TransportConfig>(c => c.MaximumConcurrencyLevel = 1);
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.HandedOverToSlr = true;
+                }
+
+                public void Init(Address address)
+                {
+
+                }
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageToBeRetried message)
+                {
+                    if (message.Id != Context.Id) return; // messages from previous test runs must be ignored
+
+                    if (message.SecondMessage)
+                    {
+                        Context.SecondMessageReceived = true;
+                        return;
+                    }
+
+                    Context.NumberOfTimesInvoked++;
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public bool SecondMessage { get; set; }
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_doing_flr_with_native_transactions.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_doing_flr_with_native_transactions.cs
@@ -1,0 +1,104 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_doing_flr_with_native_transactions : NServiceBusAcceptanceTest
+    {
+        public static Func<int> X = () => 5;
+            
+
+        [Test]
+        public void Should_do_X_retries_by_default_with_native_transactions()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried { Id = context.Id })))
+                    .AllowExceptions()
+                    .Done(c => c.HandedOverToSlr || c.NumberOfTimesInvoked > X())
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.AreEqual(X(), c.NumberOfTimesInvoked, string.Format("The FLR should by default retry {0} times", X())))
+                    .Run(TimeSpan.FromMinutes(X()));
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public int NumberOfTimesInvoked { get; set; }
+
+            public bool HandedOverToSlr { get; set; }
+
+            public bool SecondMessageReceived { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b =>
+                    {
+                        b.Transactions().DisableDistributedTransactions();
+                        b.RegisterComponents(r => r.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance));
+                    })
+                    .WithConfig<TransportConfig>(c => c.MaximumConcurrencyLevel = 1);
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.HandedOverToSlr = true;
+                }
+
+                public void Init(Address address)
+                {
+
+                }
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageToBeRetried message)
+                {
+                    if (message.Id != Context.Id) return; // messages from previous test runs must be ignored
+
+                    if (message.SecondMessage)
+                    {
+                        Context.SecondMessageReceived = true;
+                        return;
+                    }
+
+                    Context.NumberOfTimesInvoked++;
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+
+            public bool SecondMessage { get; set; }
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_fails_flr.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_fails_flr.cs
@@ -1,0 +1,100 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_fails_flr : NServiceBusAcceptanceTest
+    {
+        static TimeSpan SlrDelay = TimeSpan.FromSeconds(5);
+
+        [Test]
+        public void Should_be_moved_to_slr()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<SLREndpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried { Id = context.Id })))
+                    .AllowExceptions(e => e.Message.Contains("Simulated exception"))
+                    .Done(c => c.NumberOfTimesInvoked >= 2)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(context =>
+                        {
+                            Assert.GreaterOrEqual(1,context.NumberOfSlrRetriesPerformed, "The SLR should only do one retry");
+                            Assert.GreaterOrEqual(context.TimeOfSecondAttempt - context.TimeOfFirstAttempt,SlrDelay , "The SLR should delay the retry");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public int NumberOfTimesInvoked { get; set; }
+
+            public DateTime TimeOfFirstAttempt { get; set; }
+            public DateTime TimeOfSecondAttempt { get; set; }
+
+            public int NumberOfSlrRetriesPerformed { get; set; }
+        }
+
+        public class SLREndpoint : EndpointConfigurationBuilder
+        {
+            public SLREndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .WithConfig<TransportConfig>(c =>
+                        {
+                            c.MaxRetries = 0; //to skip the FLR
+                        })
+                        .WithConfig<SecondLevelRetriesConfig>(c =>
+                        {
+                            c.NumberOfRetries = 1;
+                            c.TimeIncrease = SlrDelay;
+                        });
+            }
+
+
+            class MessageToBeRetriedHandler:IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MessageToBeRetried message)
+                {
+                    if (message.Id != Context.Id) return; // ignore messages from previous test runs
+
+                    Context.NumberOfTimesInvoked++;
+
+                    if (Context.NumberOfTimesInvoked == 1)
+                        Context.TimeOfFirstAttempt = DateTime.UtcNow;
+
+                    if (Context.NumberOfTimesInvoked == 2)
+                    {
+                        Context.TimeOfSecondAttempt = DateTime.UtcNow;
+                    }
+
+                    string retries;
+
+                    if (Bus.CurrentMessageContext.Headers.TryGetValue(Headers.Retries,out retries))
+                    {
+                        Context.NumberOfSlrRetriesPerformed = int.Parse(retries);     
+                    }
+                    
+                        
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_fails_with_retries_set_to_0.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_fails_with_retries_set_to_0.cs
@@ -1,0 +1,87 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using System.Collections.Generic;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+
+    public class When_fails_with_retries_set_to_0 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_retry_the_message_using_flr()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                    .AllowExceptions()
+                    .Done(c => c.HandedOverToSlr)
+                    .Run();
+
+            Assert.AreEqual(1, context.NumberOfTimesInvoked,"No FLR should be in use if MaxRetries is set to 0");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int NumberOfTimesInvoked { get; set; }
+
+            public bool HandedOverToSlr { get; set; }
+
+            public Dictionary<string, string> HeadersOfTheFailedMessage { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b => b.RegisterComponents(r => r.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance)))
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 0;
+                    });
+            }
+
+            class CustomFaultManager: IManageMessageFailures
+            {
+                public Context  Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+                    
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.HandedOverToSlr = true;
+                    Context.HeadersOfTheFailedMessage = message.Headers;
+                }
+
+                public void Init(Address address)
+                {
+                    
+                }
+            }
+
+            class MessageToBeRetriedHandler:IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+                public void Handle(MessageToBeRetried message)
+                {
+                    Context.NumberOfTimesInvoked++;
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_sending_to_slr.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Retries/When_sending_to_slr.cs
@@ -1,0 +1,193 @@
+﻿namespace NServiceBus.AcceptanceTests.Retries
+{
+    using System;
+    using System.Linq;
+    using Faults;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using MessageMutator;
+    using NServiceBus.Config;
+    using NServiceBus.Unicast;
+    using NServiceBus.Unicast.Transport;
+    using NUnit.Framework;
+    using Unicast.Messages;
+
+    public class When_sending_to_slr : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_preserve_the_original_body_for_regular_exceptions()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                    .AllowExceptions()
+                    .Done(c => c.SlrChecksum != default(byte))
+                    .Run();
+
+            Assert.AreEqual(context.OriginalBodyChecksum, context.SlrChecksum, "The body of the message sent to slr should be the same as the original message coming off the queue");
+
+        }
+        
+        [Test]
+        public void Should_raise_FinishedMessageProcessing_event()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                    .Done(c => c.FinishedMessageProcessingCalledAfterFaultManagerInvoked)
+                    .Run();
+
+            Assert.IsTrue(context.FinishedMessageProcessingCalledAfterFaultManagerInvoked);
+
+        }
+
+        [Test]
+        public void Should_preserve_the_original_body_for_serialization_exceptions()
+        {
+            var context = new Context
+                {
+                    SimulateSerializationException = true
+                };
+
+            Scenario.Define(context)
+                    .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                    .AllowExceptions()
+                    .Done(c => c.SlrChecksum != default(byte))
+                    .Run();
+
+            Assert.AreEqual(context.OriginalBodyChecksum, context.SlrChecksum, "The body of the message sent to slr should be the same as the original message coming off the queue");
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool FinishedMessageProcessingCalledAfterFaultManagerInvoked { get; set; }
+            public bool FaultManagerInvoked { get; set; }
+
+            public byte OriginalBodyChecksum { get; set; }
+
+            public byte SlrChecksum { get; set; }
+
+            public bool SimulateSerializationException { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b => b.RegisterComponents(r => r.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance)))
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 0;
+                    });
+            }
+
+            class FinishedProcessingListener : IWantToRunWhenBusStartsAndStops
+            {
+                readonly Context context;
+
+                public FinishedProcessingListener(UnicastBus bus, Context context)
+                {
+                    this.context = context;
+                    bus.Transport.FinishedMessageProcessing += Transport_FinishedMessageProcessing;
+                }
+
+                void Transport_FinishedMessageProcessing(object sender, FinishedMessageProcessingEventArgs e)
+                {
+                    if (context.FaultManagerInvoked)
+                    {
+                        context.FinishedMessageProcessingCalledAfterFaultManagerInvoked = true;
+                    }
+                }
+
+                public void Start()
+                {
+                }
+
+                public void Stop()
+                {
+                }
+            }
+
+            class BodyMutator : IMutateTransportMessages, INeedInitialization
+            {
+                public Context Context { get; set; }
+
+                public void MutateIncoming(TransportMessage transportMessage)
+                {
+
+                    var originalBody = transportMessage.Body;
+
+                    Context.OriginalBodyChecksum = Checksum(originalBody);
+
+                    var decryptedBody = new byte[originalBody.Length];
+
+                    Buffer.BlockCopy(originalBody,0,decryptedBody,0,originalBody.Length);
+                   
+                    //decrypt
+                    decryptedBody[0]++;
+
+                    if (Context.SimulateSerializationException)
+                        decryptedBody[1]++;
+
+                    transportMessage.Body = decryptedBody;
+                }
+
+
+                public void MutateOutgoing(LogicalMessage logicalMessage, TransportMessage transportMessage)
+                {
+                    transportMessage.Body[0]--;
+                }
+
+                public void Customize(BusConfiguration configuration)
+                {
+                    configuration.RegisterComponents(c => c.ConfigureComponent<BodyMutator>(DependencyLifecycle.InstancePerCall));
+                }
+            }
+
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+                    Context.FaultManagerInvoked = true;
+                    Context.SlrChecksum = Checksum(message.Body);
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.FaultManagerInvoked = true;
+                    Context.SlrChecksum = Checksum(message.Body);
+                }
+
+                public void Init(Address address)
+                {
+
+                }
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public void Handle(MessageToBeRetried message)
+                {
+                    throw new Exception("Simulated exception");
+                }
+            }
+
+            public static byte Checksum(byte[] data)
+            {
+                var longSum = data.Sum(x => (long)x);
+                return unchecked((byte)longSum);
+            }
+        }
+
+        [Serializable]
+        public class MessageToBeRetried : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/Issue_1819.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/Issue_1819.cs
@@ -1,0 +1,122 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class Issue_1819 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context { Id = Guid.NewGuid() };
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new StartSaga1 { ContextId = c.Id })))
+                    .Done(c => (c.Saga1TimeoutFired && c.Saga2TimeoutFired) || c.SagaNotFound)
+                    .Run(TimeSpan.FromSeconds(20));
+
+            Assert.IsFalse(context.SagaNotFound);
+            Assert.IsTrue(context.Saga1TimeoutFired);
+            Assert.IsTrue(context.Saga2TimeoutFired);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool Saga1TimeoutFired { get; set; }
+            public bool Saga2TimeoutFired { get; set; }
+            public bool SagaNotFound { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>, IHandleTimeouts<Saga2Timeout>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga1 message)
+                {
+                    if (message.ContextId != Context.Id) return;
+
+                    RequestTimeout(TimeSpan.FromSeconds(5), new Saga1Timeout { ContextId = Context.Id });
+                    RequestTimeout(new DateTime(2011, 10, 14, 23, 08, 0, DateTimeKind.Local), new Saga2Timeout { ContextId = Context.Id });
+                }
+
+                public void Timeout(Saga1Timeout state)
+                {
+                    MarkAsComplete();
+
+                    if (state.ContextId != Context.Id) return;
+                    Context.Saga1TimeoutFired = true;
+                }
+
+                public void Timeout(Saga2Timeout state)
+                {
+                    if (state.ContextId != Context.Id) return;
+                    Context.Saga2TimeoutFired = true;
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                {
+                }
+            }
+
+            public class SagaNotFound : IHandleSagaNotFound
+            {
+                public Context Context { get; set; }
+
+                public void Handle(object message)
+                {
+                    if (((dynamic)message).ContextId != Context.Id) return;
+
+                    Context.SagaNotFound = true;
+                }
+            }
+
+            public class CatchAllMessageHandler : IHandleMessages<object>
+            {
+                public void Handle(object message)
+                {
+
+                }
+            }
+
+            public class Foo : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.SpecifyFirst<CatchAllMessageHandler>();
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+            public Guid ContextId { get; set; }
+        }
+
+
+        public class Saga1Timeout
+        {
+            public Guid ContextId { get; set; }
+        }
+
+        public class Saga2Timeout
+        {
+            public Guid ContextId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/Issue_2044.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/Issue_2044.cs
@@ -1,0 +1,103 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class Issue_2044 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MessageToSaga())))
+                    .WithEndpoint<ReceiverWithSaga>()
+                    .Done(c => c.ReplyReceived)
+                    .Run();
+
+            Assert.IsTrue(context.ReplyReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ReplyReceived { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MessageToSaga>(typeof(ReceiverWithSaga));
+            }
+
+            public class ReplyHandler : IHandleMessages<Reply>
+            {
+                public Context Context { get; set; }
+
+
+                public void Handle(Reply message)
+                {
+                    Context.ReplyReceived = true;
+                }
+            }
+        }
+
+        public class ReceiverWithSaga : EndpointConfigurationBuilder
+        {
+            public ReceiverWithSaga()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga1 message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                {
+                }
+            }
+
+            public class SagaNotFound : IHandleSagaNotFound
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(object message)
+                {
+                    Bus.Reply(new Reply());
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MessageToSaga : ICommand
+        {
+        }
+
+        [Serializable]
+        public class Reply : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_a_base_class_message_hits_a_saga.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_a_base_class_message_hits_a_saga.cs
@@ -1,0 +1,90 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Saga;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_a_base_class_message_hits_a_saga
+    {
+        [Test]
+        public void Should_find_existing_instance()
+        {
+            var correlationId = Guid.NewGuid();
+            var context = Scenario.Define<Context>()
+                   .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                   {
+                       bus.SendLocal(new StartSagaMessage
+                       {
+                           SomeId = correlationId
+                       });
+                       bus.SendLocal(new StartSagaMessage
+                       {
+                           SomeId = correlationId
+                       });
+                   }))
+                   .Done(c => c.SecondMessageFoundExistingSaga)
+                   .Run(TimeSpan.FromSeconds(20));
+
+            Assert.True(context.SecondMessageFoundExistingSaga);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondMessageFoundExistingSaga { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+
+
+            public class TestSaga : Saga<TestSaga.SagaData>, IAmStartedByMessages<StartSagaMessageBase>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSagaMessageBase message)
+                {
+                    if (Data.SomeId != Guid.Empty)
+                    {
+                        Context.SecondMessageFoundExistingSaga = true;
+                    }
+                    else
+                    {
+                        Data.SomeId = message.SomeId;
+                    }
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessageBase>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                }
+
+                public class SagaData : ContainSagaData
+                {
+                    [Unique]
+                    public Guid SomeId { get; set; }
+                }
+            }
+
+        }
+
+
+        public class StartSagaMessage : StartSagaMessageBase
+        {
+        }
+        public class StartSagaMessageBase : IMessage
+        {
+            public Guid SomeId { get; set; }
+        }
+
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_a_existing_saga_instance_exists.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_a_existing_saga_instance_exists.cs
@@ -1,0 +1,92 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_a_existing_saga_instance_exists : NServiceBusAcceptanceTest
+    {
+        static Guid IdThatSagaIsCorrelatedOn = Guid.NewGuid();
+
+        [Test]
+        public void Should_hydrate_and_invoke_the_existing_instance()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                        {
+                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn });
+                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn, SecondMessage = true });                                    
+                        }))
+                    .Done(c => c.SecondMessageReceived)
+                    .Repeat(r => r.For(Persistence.Default))
+                    .Should(c => Assert.AreEqual(c.FirstSagaInstance, c.SecondSagaInstance, "The same saga instance should be invoked invoked for both messages"))
+
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondMessageReceived { get; set; }
+
+            public Guid FirstSagaInstance { get; set; }
+            public Guid SecondSagaInstance { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    
+                    builder => builder.Transactions().DoNotWrapHandlersExecutionInATransactionScope());
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>
+            {
+                public Context Context { get; set; }
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+
+                    if (message.SecondMessage)
+                    {
+                        Context.SecondSagaInstance = Data.Id;
+                        Context.SecondMessageReceived = true;
+                    }
+                    else
+                    {
+                        Context.FirstSagaInstance = Data.Id;
+                    }
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s=>s.SomeId);
+                }
+
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+
+            public bool SecondMessage { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_a_finder_exists.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_a_finder_exists.cs
@@ -1,0 +1,67 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Saga;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_a_finder_exists
+    {
+        [Test]
+        public void Should_use_it_to_find_saga()
+        {
+            var context = Scenario.Define<Context>()
+                   .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+                   .Done(c => c.FinderUsed)
+                   .Run();
+
+            Assert.True(context.FinderUsed);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool FinderUsed { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class CustomFinder : IFindSagas<TestSaga.SagaData>.Using<StartSagaMessage>
+            {
+                public Context Context { get; set; }
+                public TestSaga.SagaData FindBy(StartSagaMessage message)
+                {
+                    Context.FinderUsed = true;
+                    return null;
+                }
+            }
+
+            public class TestSaga : Saga<TestSaga.SagaData>, IAmStartedByMessages<StartSagaMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                {
+                }
+
+                public class SagaData : ContainSagaData
+                {
+                }
+            }
+
+        }
+
+        public class StartSagaMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -1,0 +1,100 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    //repro for issue: https://github.com/NServiceBus/NServiceBus/issues/1020
+    public class When_a_saga_message_goes_through_the_slr : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_invoke_the_correct_handle_methods_on_the_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid() })))
+                    .AllowExceptions()
+                    .Done(c => c.SecondMessageProcessed)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondMessageProcessed { get; set; }
+
+
+            public int NumberOfTimesInvoked { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>,IHandleMessages<SecondSagaMessage>
+            {
+                public Context Context { get; set; }
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+
+                    Bus.SendLocal(new SecondSagaMessage
+                        {
+                            SomeId = Data.SomeId
+                        });
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s=>s.SomeId);
+                    mapper.ConfigureMapping<SecondSagaMessage>(m => m.SomeId)
+                      .ToSaga(s => s.SomeId);
+                }
+
+                public void Handle(SecondSagaMessage message)
+                {
+                    Context.NumberOfTimesInvoked++;
+                    var shouldFail = Context.NumberOfTimesInvoked < 2; //1 FLR and 1 SLR
+
+                    if(shouldFail)
+                        throw new Exception("Simulated exception");
+
+                    Context.SecondMessageProcessed = true;
+                }
+
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+                
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+        public class SecondSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+        
+        public class SomeTimeout
+        {
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_an_endpoint_replies_to_a_saga.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_an_endpoint_replies_to_a_saga.cs
@@ -1,0 +1,106 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    // Repro for issue  https://github.com/NServiceBus/NServiceBus/issues/1277 to test the fix
+    // making sure that the saga correlation still works.
+    public class When_an_endpoint_replies_to_a_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_correlate_all_saga_messages_properly()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointThatHostsASaga>(b => b.Given(bus => bus.SendLocal(new StartSaga { DataId = Guid.NewGuid() })))
+                    .WithEndpoint<EndpointThatHandlesAMessageFromSagaAndReplies>()
+                    .Done(c => c.DidSagaReplyMessageGetCorrelated)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSagaReplyMessageGetCorrelated))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSagaReplyMessageGetCorrelated { get; set; }
+        }
+
+        public class EndpointThatHandlesAMessageFromSagaAndReplies : EndpointConfigurationBuilder
+        {
+            public EndpointThatHandlesAMessageFromSagaAndReplies()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class DoSomethingHandler : IHandleMessages<DoSomething>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(DoSomething message)
+                {
+                    Console.WriteLine("Received DoSomething command for DataId:{0} ... and responding with a reply", message.DataId);
+                    Bus.Reply(new DoSomethingResponse { DataId = message.DataId });
+                }
+            }
+        }
+
+        public class EndpointThatHostsASaga : EndpointConfigurationBuilder
+        {
+            public EndpointThatHostsASaga()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<DoSomething>(typeof (EndpointThatHandlesAMessageFromSagaAndReplies));
+
+            }
+
+            public class Saga2 : Saga<Saga2.MySaga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<DoSomethingResponse>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    Console.Out.WriteLine("Saga2 sending DoSomething for DataId: {0}", message.DataId);
+                    Data.DataId = message.DataId;
+                    Bus.Send(new DoSomething { DataId = message.DataId });
+                }
+
+                public void Handle(DoSomethingResponse message)
+                {
+                    Context.DidSagaReplyMessageGetCorrelated = message.DataId == Data.DataId;
+                    Console.Out.WriteLine("Saga received DoSomethingResponse for DataId: {0} and MarkAsComplete", message.DataId);
+                    MarkAsComplete();
+                }
+                
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga2Data> mapper)
+                {
+                }
+
+                public class MySaga2Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+            }
+        }
+        
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class DoSomething : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class DoSomethingResponse : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_doing_request_response_between_sagas.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_doing_request_response_between_sagas.cs
@@ -1,0 +1,192 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NUnit.Framework;
+    using Saga;
+
+    public class When_doing_request_response_between_sagas : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_autocorrelate_the_response_back_to_the_requesting_saga_from_the_first_handler()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga())))
+                    .Done(c => c.DidRequestingSagaGetTheResponse)
+                    .Run(new RunSettings { UseSeparateAppDomains = true });
+
+            Assert.True(context.DidRequestingSagaGetTheResponse);
+        }
+
+        [Test]
+        public void Should_autocorrelate_the_response_back_to_the_requesting_saga_from_timeouts()
+        {
+            var context = new Context
+            {
+                ReplyFromTimeout = true
+            };
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga())))
+                    .Done(c => c.DidRequestingSagaGetTheResponse)
+                    .Run(new RunSettings { UseSeparateAppDomains = true, TestExecutionTimeout = TimeSpan.FromSeconds(15) });
+
+            Assert.True(context.DidRequestingSagaGetTheResponse);
+        }
+
+
+        [Test]
+        public void Should_autocorrelate_the_response_back_to_the_requesting_saga_from_handler_other_than_the_initiating_one()
+        {
+            var context = new Context
+            {
+                ReplyFromNonInitiatingHandler = true
+            };
+
+            Scenario.Define(context)
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga())))
+                    .Done(c => c.DidRequestingSagaGetTheResponse)
+                    .Run(new RunSettings { UseSeparateAppDomains = true, TestExecutionTimeout = TimeSpan.FromSeconds(15) });
+
+            Assert.True(context.DidRequestingSagaGetTheResponse);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidRequestingSagaGetTheResponse { get; set; }
+            public bool ReplyFromTimeout { get; set; }
+            public bool ReplyFromNonInitiatingHandler { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class RequestingSaga : Saga<RequestingSaga.RequestingSagaData>,
+                IAmStartedByMessages<InitiateRequestingSaga>,
+                IHandleMessages<ResponseFromOtherSaga>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(InitiateRequestingSaga message)
+                {
+                    Data.CorrIdForResponse = Guid.NewGuid(); //wont be needed in the future
+
+                    Bus.SendLocal(new RequestToRespondingSaga
+                    {
+                        SomeIdThatTheResponseSagaCanCorrelateBackToUs = Data.CorrIdForResponse //wont be needed in the future
+                    });
+                }
+
+                public void Handle(ResponseFromOtherSaga message)
+                {
+                    Context.DidRequestingSagaGetTheResponse = true;
+                    MarkAsComplete();
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestingSagaData> mapper)
+                {
+                    //if this line is un-commented the timeout and secondary handler tests will start to fail
+                    // for more info and discussion see TBD
+                    mapper.ConfigureMapping<ResponseFromOtherSaga>(m => m.SomeCorrelationId).ToSaga(s => s.CorrIdForResponse);
+                }
+                public class RequestingSagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid CorrIdForResponse { get; set; } //wont be needed in the future
+                }
+
+            }
+
+            public class RespondingSaga : Saga<RespondingSaga.RespondingSagaData>,
+                IAmStartedByMessages<RequestToRespondingSaga>,
+                IHandleTimeouts<RespondingSaga.DelayReply>,
+                IHandleMessages<SendReplyFromNonInitiatingHandler>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(RequestToRespondingSaga message)
+                {
+                    if (Context.ReplyFromNonInitiatingHandler)
+                    {
+                        Data.CorrIdForRequest = message.SomeIdThatTheResponseSagaCanCorrelateBackToUs; //wont be needed in the future
+                        Bus.SendLocal(new SendReplyFromNonInitiatingHandler { SagaIdSoWeCanCorrelate = Data.Id });
+                        return;
+                    }
+
+                    if (Context.ReplyFromTimeout)
+                    {
+                        Data.CorrIdForRequest = message.SomeIdThatTheResponseSagaCanCorrelateBackToUs; //wont be needed in the future
+                        RequestTimeout<DelayReply>(TimeSpan.FromSeconds(1));
+                        return;
+                    }
+
+                    // Both reply and reply to originator work here since the sender of the incoming message is the requesting saga
+                    // also note we don't set the correlation ID since auto correlation happens to work for this special case 
+                    // where we reply from the first handler
+                    Bus.Reply(new ResponseFromOtherSaga());
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RespondingSagaData> mapper)
+                {
+                    //this line is just needed so we can test the non initiating handler case
+                    mapper.ConfigureMapping<SendReplyFromNonInitiatingHandler>(m => m.SagaIdSoWeCanCorrelate).ToSaga(s => s.Id);
+                }
+
+                public class RespondingSagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid CorrIdForRequest { get; set; }
+                }
+
+
+                public class DelayReply { }
+
+                public void Timeout(DelayReply state)
+                {
+                    SendReply();
+                }
+
+                public void Handle(SendReplyFromNonInitiatingHandler message)
+                {
+                    SendReply();
+                }
+
+                void SendReply()
+                {
+                    //reply to originator must be used here since the sender of the incoming message the timeoutmanager and not the requesting saga
+                    ReplyToOriginator(new ResponseFromOtherSaga //change this line to Bus.Reply(new ResponseFromOtherSaga  and see it fail
+                    {
+                        SomeCorrelationId = Data.CorrIdForRequest //wont be needed in the future
+                    });
+                }
+            }
+        }
+
+        public class InitiateRequestingSaga : ICommand { }
+
+        public class RequestToRespondingSaga : ICommand
+        {
+            public Guid SomeIdThatTheResponseSagaCanCorrelateBackToUs { get; set; }
+        }
+
+        public class ResponseFromOtherSaga : IMessage
+        {
+            public Guid SomeCorrelationId { get; set; }
+        }
+
+        public class SendReplyFromNonInitiatingHandler : ICommand
+        {
+            public Guid SagaIdSoWeCanCorrelate { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_message_has_a_saga_id.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_message_has_a_saga_id.cs
@@ -1,0 +1,104 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Saga;
+    using NUnit.Framework;
+
+    public class When_message_has_a_saga_id : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_start_a_new_saga_if_not_found()
+        {
+            var context = Scenario.Define<Context>()
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                {
+                    var message = new MessageWithSagaId();
+
+                    bus.SetMessageHeader(message, Headers.SagaId, Guid.NewGuid().ToString());
+                    bus.SetMessageHeader(message, Headers.SagaType, typeof(MySaga).AssemblyQualifiedName);
+
+                    bus.SendLocal(message);
+                }))
+                .Done(c => c.OtherSagaStarted)
+                .Run();
+
+            Assert.False(context.NotFoundHandlerCalled);
+            Assert.True(context.OtherSagaStarted);
+            Assert.False(context.MessageHandlerCalled);
+            Assert.False(context.TimeoutHandlerCalled);
+        }
+
+        class MySaga : Saga<MySaga.SagaData>, IAmStartedByMessages<MessageWithSagaId>,
+            IHandleTimeouts<MessageWithSagaId>,
+            IHandleSagaNotFound
+        {
+            public Context Context { get; set; }
+
+            public class SagaData : ContainSagaData
+            {
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+            {
+
+            }
+
+            public void Handle(MessageWithSagaId message)
+            {
+                Context.MessageHandlerCalled = true;
+            }
+
+            public void Handle(object message)
+            {
+                Context.NotFoundHandlerCalled = true;
+            }
+
+            public void Timeout(MessageWithSagaId state)
+            {
+                Context.TimeoutHandlerCalled = true;
+            }
+        }
+
+        class MyOtherSaga : Saga<MyOtherSaga.SagaData>, IAmStartedByMessages<MessageWithSagaId>
+        {
+            public Context Context { get; set; }
+
+            public void Handle(MessageWithSagaId message)
+            {
+                Context.OtherSagaStarted = true;
+            }
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+            {
+
+            }
+
+            public class SagaData : ContainSagaData
+            {
+            }
+
+        }
+
+
+        class Context : ScenarioContext
+        {
+            public bool NotFoundHandlerCalled { get; set; }
+            public bool MessageHandlerCalled { get; set; }
+            public bool TimeoutHandlerCalled { get; set; }
+            public bool OtherSagaStarted { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class MessageWithSagaId : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_receiving_that_completes_the_saga.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_receiving_that_completes_the_saga.cs
@@ -1,0 +1,176 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_receiving_that_completes_the_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_hydrate_and_complete_the_existing_instance()
+        {
+            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+                    .WithEndpoint<SagaEndpoint>(b =>
+                        {
+                            b.Given((bus, context) => bus.SendLocal(new StartSagaMessage { SomeId = context.Id }));
+                            b.When(context => context.StartSagaMessageReceived, (bus, context) =>
+                            {
+                                context.AddTrace("CompleteSagaMessage sent");
+
+                                bus.SendLocal(new CompleteSagaMessage
+                                {
+                                    SomeId = context.Id
+                                });
+                            });
+                        })
+                    .Done(c => c.SagaCompleted)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.SagaCompleted))
+
+                    .Run();
+        }
+
+        [Test]
+        public void Should_ignore_messages_afterwards()
+        {
+            var context = new Context
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Scenario.Define(context)
+                .WithEndpoint<SagaEndpoint>(b =>
+                {
+                    b.Given((bus, c) => bus.SendLocal(new StartSagaMessage
+                    {
+                        SomeId = c.Id
+                    }));
+                    b.When(c => c.StartSagaMessageReceived, (bus, c) =>
+                    {
+                        c.AddTrace("CompleteSagaMessage sent");
+                        bus.SendLocal(new CompleteSagaMessage
+                        {
+                            SomeId = c.Id
+                        });
+                    });
+                    b.When(c => c.SagaCompleted, (bus, c) => bus.SendLocal(new AnotherMessage
+                    {
+                        SomeId = c.Id
+                    }));
+                })
+                .Done(c => c.AnotherMessageReceived)
+                .Repeat(r => r.For(Transports.Default))
+                .Run();
+
+            Assert.True(context.AnotherMessageReceived, "AnotherMessage should have been delivered to the handler outside the saga");
+            Assert.False(context.SagaReceivedAnotherMessage, "AnotherMessage should not be delivered to the saga after completion");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool StartSagaMessageReceived { get; set; }
+            public bool SagaCompleted { get; set; }
+            public bool AnotherMessageReceived { get; set; }
+            public bool SagaReceivedAnotherMessage { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(b => b.LoadMessageHandlers<First<TestSaga>>());
+            }
+
+            public class TestSaga : Saga<TestSagaData>, 
+                IAmStartedByMessages<StartSagaMessage>, 
+                IHandleMessages<CompleteSagaMessage>, 
+                IHandleMessages<AnotherMessage>,
+                IHandleSagaNotFound
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                    Context.AddTrace("Saga started");
+
+                    Data.SomeId = message.SomeId;
+
+                    Context.StartSagaMessageReceived = true;
+                }
+
+                public void Handle(CompleteSagaMessage message)
+                {
+                    Context.AddTrace("CompleteSagaMessage received");
+                    MarkAsComplete();
+                    Context.SagaCompleted = true;
+                }
+
+                public void Handle(AnotherMessage message)
+                {
+                    Context.AddTrace("AnotherMessage received");
+                    Context.SagaReceivedAnotherMessage = true;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                    mapper.ConfigureMapping<CompleteSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                    mapper.ConfigureMapping<AnotherMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                }
+
+                public void Handle(object message)
+                {
+                    if (message is AnotherMessage)
+                    {
+                        return;
+                    }
+
+                    throw new Exception("Unexpected 'saga not found' for message: " + message.GetType().Name);
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        public class CompletionHandler : IHandleMessages<AnotherMessage>
+        {
+            public Context Context { get; set; }
+            public void Handle(AnotherMessage message)
+            {
+                Context.AnotherMessageReceived = true;
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        [Serializable]
+        public class CompleteSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        [Serializable]
+        public class AnotherMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_receiving_that_should_start_a_saga.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_receiving_that_should_start_a_saga.cs
@@ -1,0 +1,107 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_receiving_that_should_start_a_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_start_the_saga_and_call_messagehandlers()
+        {
+            Scenario.Define<SagaEndpointContext>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+                    .Done(context => context.InterceptingHandlerCalled && context.SagaStarted)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c =>
+                    {
+                        Assert.True(c.InterceptingHandlerCalled, "The message handler should be called");
+                        Assert.True(c.SagaStarted, "The saga should have been started");
+                    })
+                    .Run();
+        }
+
+
+        [Test]
+        public void Should_not_start_saga_if_a_interception_handler_has_been_invoked()
+        {
+            Scenario.Define(() => new SagaEndpointContext { InterceptSaga = true })
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+                   .Done(context => context.InterceptingHandlerCalled)
+                   .Repeat(r => r.For(Transports.Default))
+                   .Should(c =>
+                        {
+                            Assert.True(c.InterceptingHandlerCalled, "The intercepting handler should be called");
+                            Assert.False(c.SagaStarted, "The saga should not have been started since the intercepting handler stops the pipeline");
+                        })
+                    .Run();
+        }
+
+
+        public class SagaEndpointContext : ScenarioContext
+        {
+            public bool InterceptingHandlerCalled { get; set; }
+
+            public bool SagaStarted { get; set; }
+
+            public bool InterceptSaga { get; set; }
+        }
+
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(b => b.LoadMessageHandlers<First<InterceptingHandler>>());
+            }
+
+            public class TestSaga : Saga<TestSaga.TestSagaData>, IAmStartedByMessages<StartSagaMessage>
+            {
+                public SagaEndpointContext Context { get; set; }
+                public void Handle(StartSagaMessage message)
+                {
+                    Context.SagaStarted = true;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m=>m.SomeId)
+                        .ToSaga(s=>s.SomeId);
+                }
+
+                public class TestSagaData : ContainSagaData
+                {
+                    public string SomeId { get; set; }
+                }
+            }
+
+            
+            public class InterceptingHandler : IHandleMessages<StartSagaMessage>
+            {
+                public SagaEndpointContext Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                    Context.InterceptingHandlerCalled = true;
+
+                    if (Context.InterceptSaga)
+                        Bus.DoNotContinueDispatchingCurrentMessageToHandlers();
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public string SomeId { get; set; }
+        }
+
+
+    }
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_replies_to_message_published_by_a_saga.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_replies_to_message_published_by_a_saga.cs
@@ -1,0 +1,128 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+    using PubSub;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_replies_to_message_published_by_a_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_reply_to_a_message_published_by_a_saga()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<SagaEndpoint>
+                (b => b.When(c => c.Subscribed, bus => bus.SendLocal(new StartSaga
+                {
+                    DataId = Guid.NewGuid()
+                }))
+                )
+                .WithEndpoint<ReplyEndpoint>(b => b.Given((bus, context) =>
+                {
+                    bus.Subscribe<DidSomething>();
+                    if (context.HasNativePubSubSupport)
+                    {
+                        context.Subscribed = true;
+                    }
+                }))
+                .Done(c => c.DidSagaReplyMessageGetCorrelated)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c => Assert.True(c.DidSagaReplyMessageGetCorrelated))
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSagaReplyMessageGetCorrelated { get; set; }
+            public bool Subscribed { get; set; }
+        }
+
+        public class ReplyEndpoint : EndpointConfigurationBuilder
+        {
+            public ReplyEndpoint()
+            {
+                EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>())
+                    .AddMapping<DidSomething>(typeof(SagaEndpoint))
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 0;
+                    })
+                    .WithConfig<SecondLevelRetriesConfig>(c =>
+                    {
+                        c.Enabled = false;
+                    });
+            }
+
+            class DidSomethingHandler : IHandleMessages<DidSomething>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(DidSomething message)
+                {
+                    Bus.Reply(new DidSomethingResponse { DataId = message.DataId });
+                }
+            }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    context.Subscribed = true;
+                }));
+            }
+
+            public class Saga2 : Saga<Saga2.MySaga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<DidSomethingResponse>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    Data.DataId = message.DataId;
+                    Bus.Publish(new DidSomething { DataId = message.DataId });
+                }
+
+                public void Handle(DidSomethingResponse message)
+                {
+                    Context.DidSagaReplyMessageGetCorrelated = message.DataId == Data.DataId;
+                    MarkAsComplete();
+                }
+                
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga2Data> mapper)
+                {
+                }
+
+                public class MySaga2Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+            }
+        }
+        
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        [Serializable]
+        public class DidSomething : IEvent
+        {
+            public Guid DataId { get; set; }
+        }
+
+        [Serializable]
+        public class DidSomethingResponse : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_reply_from_a_finder.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_reply_from_a_finder.cs
@@ -1,0 +1,102 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Saga;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_reply_from_a_finder
+    {
+        [Test]
+        public void Should_be_received_by_handler()
+        {
+            var context = new Context
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Scenario.Define(context)
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage
+                                                                              {
+                                                                                  Id = context.Id
+                                                                              })))
+                .Done(c => c.HandlerFired)
+                .Run();
+
+            Assert.True(context.HandlerFired);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerFired { get; set; }
+            public Guid Id { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class CustomFinder : IFindSagas<TestSaga.SagaData>.Using<StartSagaMessage>
+            {
+                public IBus Bus { get; set; }
+                public Context Context { get; set; }
+
+                public TestSaga.SagaData FindBy(StartSagaMessage message)
+                {
+                    Bus.Reply(new SagaNotFoundMessage
+                              {
+                                  Id = Context.Id
+                              });
+                    return null;
+                }
+            }
+
+            public class TestSaga : Saga<TestSaga.SagaData>,
+                IAmStartedByMessages<StartSagaMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                {
+                }
+
+                public class SagaData : ContainSagaData
+                {
+                }
+            }
+
+            public class Handler : IHandleMessages<SagaNotFoundMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(SagaNotFoundMessage message)
+                {
+                    if (Context.Id != message.Id)
+                    {
+                        return;
+                    }
+                    Context.HandlerFired = true;
+                }
+            }
+        }
+
+        public class SagaNotFoundMessage : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class StartSagaMessage : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_saga_has_a_non_empty_constructor.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_saga_has_a_non_empty_constructor.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_saga_has_a_non_empty_constructor : NServiceBusAcceptanceTest
+    {
+        static Guid IdThatSagaIsCorrelatedOn = Guid.NewGuid();
+
+        [Test]
+        public void Should_hydrate_and_invoke_the_existing_instance()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                        {
+                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn });
+                            bus.SendLocal(new OtherMessage { SomeId = IdThatSagaIsCorrelatedOn });                                    
+                        }))
+                    .Done(c => c.SecondMessageReceived)
+                    .Repeat(r => r.For(Persistence.Default))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondMessageReceived { get; set; }
+
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    
+                    builder => builder.Transactions().DoNotWrapHandlersExecutionInATransactionScope());
+            }
+
+            public class TestSaga : Saga<TestSagaData>,
+                IAmStartedByMessages<StartSagaMessage>, IHandleMessages<OtherMessage>
+            {
+                Context context;
+
+                // ReSharper disable once UnusedParameter.Local
+                public TestSaga(IBus bus,Context context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<OtherMessage>(m => m.SomeId)
+                        .ToSaga(s=>s.SomeId);
+                }
+
+                public void Handle(OtherMessage message)
+                {
+                    context.SecondMessageReceived = true;
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+
+        }
+        [Serializable]
+        public class OtherMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_saga_id_changed.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_saga_id_changed.cs
@@ -1,0 +1,104 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Diagnostics;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Config;
+    using NServiceBus.Faults;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_saga_id_changed : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(
+                    b => b.Given(bus => bus.SendLocal(new StartSaga
+                    {
+                        DataId = Guid.NewGuid()
+                    })))
+                    .AllowExceptions()
+                .Done(c => c.ExceptionReceived)
+                .Repeat(r => r.For(Transports.Default))
+                .Run();
+
+            Debug.WriteLine(context.ExceptionMessage, "A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType: " + typeof(Endpoint.MySaga));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ExceptionReceived { get; set; }
+            public string ExceptionMessage { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(b =>
+                {
+                    b.RegisterComponents(c => c.ConfigureComponent<CustomFaultManager>(DependencyLifecycle.SingleInstance));
+                    b.DisableFeature<TimeoutManager>();
+                })
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 0;
+                    });
+            }
+
+            public class MySaga : Saga<MySaga.MySagaData>,
+                IAmStartedByMessages<StartSaga>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    Data.DataId = message.DataId;
+                    Data.Id = Guid.NewGuid();
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+            }
+            class CustomFaultManager : IManageMessageFailures
+            {
+                public Context Context { get; set; }
+
+                public void SerializationFailedForMessage(TransportMessage message, Exception e)
+                {
+                }
+
+                public void ProcessingAlwaysFailsForMessage(TransportMessage message, Exception e)
+                {
+                    Context.ExceptionMessage = e.Message;
+                    Context.ExceptionReceived = true;
+                }
+
+                public void Init(Address address)
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_saga_is_mapped_to_complex_expression.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_saga_is_mapped_to_complex_expression.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_saga_is_mapped_to_complex_expression : NServiceBusAcceptanceTest
+    {
+
+        [Test]
+        public void Should_hydrate_and_invoke_the_existing_instance()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                        {
+                            bus.SendLocal(new StartSagaMessage { Key = "Part1_Part2"});
+                            bus.SendLocal(new OtherMessage { Part1 = "Part1", Part2 = "Part2" });                                    
+                        }))
+                    .Done(c => c.SecondMessageReceived)
+                    .Repeat(r => r.For(Persistence.Default))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SecondMessageReceived { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    
+                    builder => builder.Transactions().DoNotWrapHandlersExecutionInATransactionScope());
+            }
+
+            public class TestSaga : Saga<TestSagaData>,
+                IAmStartedByMessages<StartSagaMessage>, IHandleMessages<OtherMessage>
+            {
+                public Context Context { get; set; }
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.KeyValue = message.Key;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<OtherMessage>(m => m.Part1 + "_" + m.Part2)
+                        .ToSaga(s => s.KeyValue);
+                }
+
+                public void Handle(OtherMessage message)
+                {
+                    Context.SecondMessageReceived = true;
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+                public virtual string KeyValue { get; set; }
+            }
+        }
+
+        [Serializable]
+        public class StartSagaMessage : ICommand
+        {
+            public string Key { get; set; }
+        }
+        [Serializable]
+        public class OtherMessage : ICommand
+        {
+            public string Part2 { get; set; }
+            public string Part1 { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_saga_started_concurrently.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_saga_started_concurrently.cs
@@ -1,0 +1,172 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Config;
+    using NServiceBus.Saga;
+    using NUnit.Framework;
+
+    public class When_saga_started_concurrently : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_start_single_saga()
+        {
+            var context = new Context
+            {
+                SomeId = Guid.NewGuid().ToString()
+            };
+
+            Scenario.Define(context)
+                .WithEndpoint<ConcurrentHandlerEndpoint>(b =>
+                {
+                    b.When(bus =>
+                    {
+                        Parallel.Invoke(() =>
+                        {
+                            bus.SendLocal(new StartMessageOne
+                            {
+                                SomeId = context.SomeId
+                            });
+                        }, () =>
+                        {
+                            bus.SendLocal(new StartMessageTwo
+                                {
+                                    SomeId = context.SomeId
+                                }
+                            );
+                        });
+                    });
+                })
+                .AllowExceptions()
+                .Done(c => c.PlacedSagaId != Guid.Empty && c.BilledSagaId != Guid.Empty)
+                .Run();
+
+            Assert.AreNotEqual(Guid.Empty, context.PlacedSagaId);
+            Assert.AreNotEqual(Guid.Empty, context.BilledSagaId);
+            Assert.AreEqual(context.PlacedSagaId, context.BilledSagaId, "Both messages should have been handled by the same saga, but SagaIds don't match.");
+        }
+
+        class Context : ScenarioContext
+        {
+            public string SomeId { get; set; }
+            public Guid PlacedSagaId { get; set; }
+            public Guid BilledSagaId { get; set; }
+            public bool SagaCompleted { get; set; }
+        }
+
+        class ConcurrentHandlerEndpoint : EndpointConfigurationBuilder
+        {
+            public ConcurrentHandlerEndpoint()
+            {
+                EndpointSetup<DefaultServer>(b => { })
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 3;
+                        c.MaximumConcurrencyLevel = 2;
+                    })
+                    .WithConfig<SecondLevelRetriesConfig>(c =>
+                    {
+                        c.Enabled = false;
+                    });
+            }
+
+            class ConcurrentlyStartedSaga : Saga<ConcurrentlyStartedSagaData>,
+                IAmStartedByMessages<StartMessageTwo>,
+                IAmStartedByMessages<StartMessageOne>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartMessageOne message)
+                {
+                    Data.OrderId = message.SomeId;
+                    Data.Placed = true;
+                    Bus.SendLocal(new SuccessfulProcessing
+                    {
+                        SagaId = Data.Id,
+                        Type = nameof(StartMessageOne)
+                    });
+                    CheckForCompletion();
+                }
+
+                public void Handle(StartMessageTwo message)
+                {
+                    Data.OrderId = message.SomeId;
+                    Data.Billed = true;
+                    Bus.SendLocal(new SuccessfulProcessing
+                    {
+                        SagaId = Data.Id,
+                        Type = nameof(StartMessageTwo)
+                    });
+                    CheckForCompletion();
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ConcurrentlyStartedSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartMessageOne>(msg => msg.SomeId).ToSaga(saga => saga.OrderId);
+                    mapper.ConfigureMapping<StartMessageTwo>(msg => msg.SomeId).ToSaga(saga => saga.OrderId);
+                }
+
+                void CheckForCompletion()
+                {
+                    if (!Data.Billed || !Data.Placed)
+                    {
+                        return;
+                    }
+                    MarkAsComplete();
+                    Context.SagaCompleted = true;
+                }
+            }
+
+            class ConcurrentlyStartedSagaData : ContainSagaData
+            {
+                [Unique]
+                public virtual string OrderId { get; set; }
+                public virtual bool Placed { get; set; }
+                public virtual bool Billed { get; set; }
+            }
+
+            // Intercepts the messages sent out by the saga
+            class LogSuccessfulHandler : IHandleMessages<SuccessfulProcessing>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(SuccessfulProcessing message)
+                {
+                    if (message.Type == nameof(StartMessageOne))
+                    {
+                        Context.PlacedSagaId = message.SagaId;
+                    }
+                    else if (message.Type == nameof(StartMessageTwo))
+                    {
+                        Context.BilledSagaId = message.SagaId;
+                    }
+                    else
+                    {
+                        throw new Exception("Unknown type");
+                    }
+                }
+            }
+        }
+
+        [Serializable]
+        class StartMessageOne : ICommand
+        {
+            public string SomeId { get; set; }
+        }
+
+        [Serializable]
+        class StartMessageTwo : ICommand
+        {
+            public string SomeId { get; set; }
+        }
+
+        [Serializable]
+        class SuccessfulProcessing : ICommand
+        {
+            public string Type { get; set; }
+            public Guid SagaId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_sagas_cant_be_found.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_sagas_cant_be_found.cs
@@ -1,0 +1,221 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class When_sagas_cant_be_found : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void IHandleSagaNotFound_only_called_once()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<ReceiverWithSagas>(b => b.Given((bus, c) => bus.SendLocal(new MessageToSaga())))
+                    .Done(c => c.Done)
+                    .Run();
+
+            Assert.AreEqual(1, context.TimesFired);
+        }
+
+        [Test]
+        public void IHandleSagaNotFound_not_called_if_second_saga_is_executed()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<ReceiverWithOrderedSagas>(b => b.Given((bus, c) => bus.SendLocal(new MessageToSaga())))
+                    .Done(c => c.Done)
+                    .Run();
+
+            Assert.AreEqual(0, context.TimesFired);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int TimesFired { get; set; }
+            public bool Done { get; set; }
+        }
+
+        public class ReceiverWithSagas : EndpointConfigurationBuilder
+        {
+            public ReceiverWithSagas()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MessageToSagaHandler : IHandleMessages<MessageToSaga>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(MessageToSaga message)
+                {
+                    Bus.Defer(TimeSpan.FromSeconds(10), new FinishMessage());
+                }
+            }
+
+            public class FinishHandler: IHandleMessages<FinishMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(FinishMessage message)
+                {
+                    Context.Done = true;
+                }
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                {
+                }
+            }
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                {
+                }
+            }
+
+            public class SagaNotFound : IHandleSagaNotFound
+            {
+                public Context Context { get; set; }
+
+                public void Handle(object message)
+                {
+                    Context.TimesFired++;
+                }
+            }
+        }
+
+        public class ReceiverWithOrderedSagas : EndpointConfigurationBuilder
+        {
+            public ReceiverWithOrderedSagas()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<Saga1>.Then<Saga2>());
+                }
+            }
+
+            public class MessageToSagaHandler : IHandleMessages<MessageToSaga>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(MessageToSaga message)
+                {
+                    Bus.Defer(TimeSpan.FromSeconds(10), new FinishMessage());
+                }
+            }
+
+            public class FinishHandler : IHandleMessages<FinishMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(FinishMessage message)
+                {
+                    Context.Done = true;
+                }
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                {
+                }
+            }
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IHandleMessages<StartSaga>, IAmStartedByMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                {
+                }
+            }
+
+            public class SagaNotFound : IHandleSagaNotFound
+            {
+                public Context Context { get; set; }
+
+                public void Handle(object message)
+                {
+                    Context.TimesFired++;
+                }
+            }
+        }
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+        }
+
+        [Serializable]
+        public class FinishMessage : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MessageToSaga : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_sending_from_a_saga_handle.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_sending_from_a_saga_handle.cs
@@ -1,0 +1,109 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_sending_from_a_saga_handle : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_match_different_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() })))
+                    .Done(c => c.DidSaga2ReceiveMessage)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSaga2ReceiveMessage))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSaga2ReceiveMessage { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageSaga1WillHandle>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga1 message)
+                {
+                    var dataId = Guid.NewGuid();
+                    Data.DataId = dataId;
+                    Bus.SendLocal(new MessageSaga1WillHandle
+                             {
+                                 DataId = dataId
+                             });
+                }
+
+                public void Handle(MessageSaga1WillHandle message)
+                {
+                    Bus.SendLocal(new StartSaga2());
+                    MarkAsComplete();
+                }
+                
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                {
+                    mapper.ConfigureMapping<MessageSaga1WillHandle>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+            }
+
+            public class Saga1Data : ContainSagaData
+            {
+                [Unique]
+                public virtual Guid DataId { get; set; }
+            }
+
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga2>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga2 message)
+                {
+                    Context.DidSaga2ReceiveMessage = true;
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                {
+                }
+            }
+
+        }
+
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+
+        [Serializable]
+        public class StartSaga2 : ICommand
+        {
+        }
+        public class MessageSaga1WillHandle : IMessage
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_sending_from_a_saga_timeout.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_sending_from_a_saga_timeout.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    public class When_sending_from_a_saga_timeout : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_match_different_saga()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new StartSaga1())))
+                    .Done(c => c.DidSaga2ReceiveMessage)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidSaga2ReceiveMessage))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSaga2ReceiveMessage { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga1 message)
+                {
+                    RequestTimeout(TimeSpan.FromSeconds(1), new Saga1Timeout());
+                }
+
+                public void Timeout(Saga1Timeout state)
+                {
+                    Bus.SendLocal(new StartSaga2());
+                    MarkAsComplete();
+                }
+                public class Saga1Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                {
+                }
+            }
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga2>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga2 message)
+                {
+                    Context.DidSaga2ReceiveMessage = true;
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                {
+                }
+            }
+
+        }
+
+
+        [Serializable]
+        public class StartSaga1 : ICommand
+        {
+        }
+
+        [Serializable]
+        public class StartSaga2 : ICommand
+        {
+        }
+
+        public class Saga1Timeout : IMessage
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_started_by_base_event_from_other_saga.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_started_by_base_event_from_other_saga.cs
@@ -1,0 +1,104 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using PubSub;
+    using Saga;
+    using ScenarioDescriptors;
+
+    //Repro for #1323
+    public class When_started_by_base_event_from_other_saga : NServiceBusAcceptanceTest
+    {
+
+        [Test]
+        public void Should_start_the_saga_when_set_up_to_start_for_the_base_event()
+        {
+            Scenario.Define<SagaContext>()
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.IsEventSubscriptionReceived,
+                        bus =>
+                            bus.Publish<SomethingHappenedEvent>(m => { m.DataId = Guid.NewGuid(); }))
+                )
+                .WithEndpoint<SagaThatIsStartedByABaseEvent>(
+                    b => b.Given((bus, context) =>
+                    {
+                        bus.Subscribe<BaseEvent>();
+
+                        if (context.HasNativePubSubSupport)
+                            context.IsEventSubscriptionReceived = true;
+                    }))
+                .Done(c => c.DidSagaComplete)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c => Assert.True(c.DidSagaComplete))
+                .Run();
+        }
+
+        public class SagaContext : ScenarioContext
+        {
+            public bool IsEventSubscriptionReceived { get; set; }
+            public bool DidSagaComplete { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<SagaContext>((s, context) =>
+                {
+                    context.AddTrace("Subscription received for " + s.SubscriberReturnAddress.Queue);
+                    context.IsEventSubscriptionReceived = true;
+                }));
+            }
+        }
+
+        public class SagaThatIsStartedByABaseEvent : EndpointConfigurationBuilder
+        {
+            public SagaThatIsStartedByABaseEvent()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<BaseEvent>(typeof(Publisher));
+            }
+
+            public class SagaStartedByBaseEvent : Saga<SagaStartedByBaseEvent.SagaData>, IAmStartedByMessages<BaseEvent>
+            {
+                public SagaContext Context { get; set; }
+
+                public void Handle(BaseEvent message)
+                {
+                    Data.DataId = message.DataId;
+                    MarkAsComplete();
+                    Context.DidSagaComplete = true;
+                }
+
+                public class SagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public interface SomethingHappenedEvent : BaseEvent
+        {
+
+        }
+
+        public interface BaseEvent : IEvent
+        {
+            Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_started_by_event_from_another_saga.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_started_by_event_from_another_saga.cs
@@ -1,0 +1,154 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using Features;
+    using NUnit.Framework;
+    using PubSub;
+    using Saga;
+    using ScenarioDescriptors;
+
+    //Repro for #1323
+    public class When_started_by_event_from_another_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_start_the_saga_and_request_a_timeout()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<SagaThatPublishesAnEvent>(b =>
+                    b.When(c => c.IsEventSubscriptionReceived,
+                            bus =>
+                                bus.SendLocal(new StartSaga
+                                {
+                                    DataId = Guid.NewGuid()
+                                }))
+                )
+                .WithEndpoint<SagaThatIsStartedByTheEvent>(
+                    b => b.Given((bus, context) =>
+                    {
+                        bus.Subscribe<SomethingHappenedEvent>();
+
+                        if (context.HasNativePubSubSupport)
+                            context.IsEventSubscriptionReceived = true;
+                    }))
+                .Done(c => c.DidSaga1Complete && c.DidSaga2Complete)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c => Assert.True(c.DidSaga1Complete && c.DidSaga2Complete))
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidSaga1Complete { get; set; }
+            public bool DidSaga2Complete { get; set; }
+            public bool IsEventSubscriptionReceived { get; set; }
+        }
+
+        public class SagaThatPublishesAnEvent : EndpointConfigurationBuilder
+        {
+            public SagaThatPublishesAnEvent()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    context.IsEventSubscriptionReceived = true;
+                }));
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleTimeouts<Saga1.Timeout1>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    Data.DataId = message.DataId;
+
+                    //Publish the event, which will start the second saga
+                    Bus.Publish<SomethingHappenedEvent>(m => { m.DataId = message.DataId; });
+
+                    //Request a timeout
+                    RequestTimeout<Timeout1>(TimeSpan.FromSeconds(5));
+                }
+
+                public void Timeout(Timeout1 state)
+                {
+                    MarkAsComplete();
+                    Context.DidSaga1Complete = true;
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+                public class Timeout1
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                {
+                }
+            }
+        }
+
+        public class SagaThatIsStartedByTheEvent : EndpointConfigurationBuilder
+        {
+            public SagaThatIsStartedByTheEvent()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
+                    .AddMapping<SomethingHappenedEvent>(typeof(SagaThatPublishesAnEvent));
+
+            }
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<SomethingHappenedEvent>, IHandleTimeouts<Saga2.Saga2Timeout>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(SomethingHappenedEvent message)
+                {
+                    Data.DataId = message.DataId;
+
+                    //Request a timeout
+                    RequestTimeout<Saga2Timeout>(TimeSpan.FromSeconds(5));
+                }
+
+                public void Timeout(Saga2Timeout state)
+                {
+                    MarkAsComplete();
+                    Context.DidSaga2Complete = true;
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+                public class Saga2Timeout
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public interface SomethingHappenedEvent : BaseEvent
+        {
+          
+        }
+
+        public interface BaseEvent : IEvent
+        {
+            Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_timeout_hit_not_found_saga.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_timeout_hit_not_found_saga.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class When_timeout_hit_not_found_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_fire_notfound_for_tm()
+        {
+            var context = Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new StartSaga())))
+                .Done(c => c.NotFoundHandlerCalledForRegularMessage)
+                .Run();
+
+
+            Assert.False(context.NotFoundHandlerCalledForTimeout);
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool NotFoundHandlerCalledForRegularMessage { get; set; }
+            public bool NotFoundHandlerCalledForTimeout { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MySaga : Saga<MySaga.MySagaData>,
+                IAmStartedByMessages<StartSaga>, IHandleSagaNotFound,
+                IHandleTimeouts<MySaga.MyTimeout>,
+                IHandleMessages<SomeOtherMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    //this will cause the message to be delivered right away
+                    RequestTimeout<MyTimeout>(TimeSpan.Zero);
+                    Bus.SendLocal(new SomeOtherMessage());
+
+                    MarkAsComplete();
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
+                {
+                }
+
+                public class MySagaData : ContainSagaData
+                {
+                    public virtual Guid DataId { get; set; }
+                }
+
+                public class MyTimeout { }
+
+                public void Handle(object message)
+                {
+                    if (message is SomeOtherMessage)
+                    {
+                        Context.NotFoundHandlerCalledForRegularMessage = true;
+                    }
+
+
+                    if (message is MyTimeout)
+                    {
+                        Context.NotFoundHandlerCalledForTimeout = true;
+                    }
+
+                }
+
+                public void Handle(SomeOtherMessage message)
+                {
+
+                }
+
+                public void Timeout(MyTimeout state)
+                {
+
+                }
+            }
+        }
+
+        public class StartSaga : IMessage { }
+        public class SomeOtherMessage : IMessage { }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
@@ -1,0 +1,165 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using PubSub;
+    using Saga;
+    using ScenarioDescriptors;
+
+    // Repro for issue  https://github.com/NServiceBus/NServiceBus/issues/1277
+    public class When_two_sagas_subscribe_to_the_same_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_invoke_all_handlers_on_all_sagas()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SagaEndpoint>(b =>
+                        b.When(c => c.Subscribed, bus => bus.SendLocal(new StartSaga2
+                        {
+                            DataId = Guid.NewGuid()
+                        }))
+                     )
+                    .WithEndpoint<Publisher>(b => b.Given((bus, context) =>
+                    {
+                        if (context.HasNativePubSubSupport)
+                        {
+                            context.Subscribed = true;
+                            context.AddTrace("EndpointThatHandlesAMessageAndPublishesEvent is now subscribed (at least we have asked the broker to be subscribed)");
+                        }
+                    }))
+                    .Done(c => c.DidSaga1EventHandlerGetInvoked && c.DidSaga2EventHandlerGetInvoked)
+                    .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>()) // exclude the brokers since c.Subscribed won't get set for them
+                    .Should(c => Assert.True(c.DidSaga1EventHandlerGetInvoked && c.DidSaga2EventHandlerGetInvoked))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscribed { get; set; }
+            public bool DidSaga1EventHandlerGetInvoked { get; set; }
+            public bool DidSaga2EventHandlerGetInvoked { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    context.Subscribed = true;
+                }));
+            }
+
+            class OpenGroupCommandHandler : IHandleMessages<OpenGroupCommand>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(OpenGroupCommand message)
+                {
+                    Console.WriteLine("Received OpenGroupCommand for DataId:{0} ... and publishing GroupPendingEvent", message.DataId);
+                    Bus.Publish(new GroupPendingEvent { DataId = message.DataId });
+                }
+            }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<OpenGroupCommand>(typeof(Publisher))
+                    .AddMapping<GroupPendingEvent>(typeof(Publisher));
+            }
+
+            public class Saga1 : Saga<Saga1.MySaga1Data>, IAmStartedByMessages<GroupPendingEvent>, IHandleMessages<CompleteSaga1Now>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(GroupPendingEvent message)
+                {
+                    Data.DataId = message.DataId;
+                    Console.Out.WriteLine("Saga1 received GroupPendingEvent for DataId: {0}", message.DataId);
+                    Bus.SendLocal(new CompleteSaga1Now { DataId = message.DataId });
+                }
+
+                public void Handle(CompleteSaga1Now message)
+                {
+                    Console.Out.WriteLine("Saga1 received CompleteSaga1Now for DataId:{0} and MarkAsComplete", message.DataId);
+                    Context.DidSaga1EventHandlerGetInvoked = true;
+
+                    MarkAsComplete();
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga1Data> mapper)
+                {
+                    mapper.ConfigureMapping<GroupPendingEvent>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<CompleteSaga1Now>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySaga1Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+            }
+
+            public class Saga2 : Saga<Saga2.MySaga2Data>, IAmStartedByMessages<StartSaga2>, IHandleMessages<GroupPendingEvent>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga2 message)
+                {
+                    var dataId = Guid.NewGuid();
+                    Console.Out.WriteLine("Saga2 sending OpenGroupCommand for DataId: {0}", dataId);
+                    Data.DataId = dataId;
+                    Bus.Send(new OpenGroupCommand { DataId = dataId });
+                }
+
+                public void Handle(GroupPendingEvent message)
+                {
+                    Context.DidSaga2EventHandlerGetInvoked = true;
+                    Console.Out.WriteLine("Saga2 received GroupPendingEvent for DataId: {0} and MarkAsComplete", message.DataId);
+                    MarkAsComplete();
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga2Data> mapper)
+                {
+                    mapper.ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<GroupPendingEvent>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySaga2Data : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+            }
+        }
+
+        [Serializable]
+        public class GroupPendingEvent : IEvent
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class OpenGroupCommand : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        [Serializable]
+        public class StartSaga2 : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+
+        public class CompleteSaga1Now : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_using_ReplyToOriginator.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_using_ReplyToOriginator.cs
@@ -1,0 +1,97 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class When_using_ReplyToOriginator : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_set_Reply_as_messageintent()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga())))
+                .Done(c => c.Done)
+                .Run();
+
+            Assert.AreEqual(MessageIntentEnum.Reply, context.Intent);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public MessageIntentEnum Intent { get; set; }
+            public bool Done { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class RequestingSaga : Saga<RequestingSaga.RequestingSagaData>,
+                IAmStartedByMessages<InitiateRequestingSaga>,
+                IHandleMessages<AnotherRequest>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(InitiateRequestingSaga message)
+                {
+                    Data.CorrIdForResponse = Guid.NewGuid(); //wont be needed in the future
+
+                    Bus.SendLocal(new AnotherRequest
+                    {
+                        SomeCorrelationId = Data.CorrIdForResponse //wont be needed in the future
+                    });
+                }
+
+                public void Handle(AnotherRequest message)
+                {
+                    ReplyToOriginator(new MyReplyToOriginator());
+                    MarkAsComplete();
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestingSagaData> mapper)
+                {
+                    //if this line is un-commented the timeout and secondary handler tests will start to fail
+                    // for more info and discussion see TBD
+                    mapper.ConfigureMapping<AnotherRequest>(m => m.SomeCorrelationId).ToSaga(s => s.CorrIdForResponse);
+                }
+                public class RequestingSagaData : ContainSagaData
+                {
+                    public virtual Guid CorrIdForResponse { get; set; } //wont be needed in the future
+                }
+            }
+
+            class MyReplyToOriginatorHandler : IHandleMessages<MyReplyToOriginator>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public void Handle(MyReplyToOriginator message)
+                {
+                    Context.Intent = (MessageIntentEnum)Enum.Parse(typeof(MessageIntentEnum), Bus.CurrentMessageContext.Headers[Headers.MessageIntent]);
+                    Context.Done = true;
+                }
+            }
+        }
+
+        public class InitiateRequestingSaga : ICommand { }
+
+        public class AnotherRequest : ICommand
+        {
+            public Guid SomeCorrelationId { get; set; }
+        }
+
+        public class MyReplyToOriginator : IMessage
+        {
+            public Guid SomeCorrelationId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_using_a_received_message_for_timeout.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class When_using_a_received_message_for_timeout : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Timeout_should_be_received_after_expiration()
+        {
+            Scenario.Define(() => new Context {Id = Guid.NewGuid()})
+                    .WithEndpoint<SagaEndpoint>(g => g.Given(bus=>bus.SendLocal(new StartSagaMessage())))
+                    .Done(c => c.TimeoutReceived)
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+
+            public bool StartSagaMessageReceived { get; set; }
+
+            public bool TimeoutReceived { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<StartSagaMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                    Data.SomeId = message.SomeId;
+                    RequestTimeout(TimeSpan.FromMilliseconds(100), message);
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                }
+
+                public void Timeout(StartSagaMessage message)
+                {
+                    Context.TimeoutReceived = true;
+                    MarkAsComplete();
+                }
+            }
+
+            public class TestSagaData : IContainSagaData
+            {
+                public virtual Guid Id { get; set; }
+                public virtual string Originator { get; set; }
+                public virtual string OriginalMessageId { get; set; }
+
+                [Unique]
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_using_contain_saga_data.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Sagas/When_using_contain_saga_data.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+    using ScenarioDescriptors;
+
+    // Repro for #SB-191
+    public class When_using_contain_saga_data : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_handle_timeouts_properly()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<EndpointThatHostsASaga>(
+                        b => b.Given(bus => bus.SendLocal(new StartSaga {DataId = Guid.NewGuid()})))
+                    .Done(c => c.DidAllSagaInstancesReceiveTimeouts)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.DidAllSagaInstancesReceiveTimeouts))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool DidAllSagaInstancesReceiveTimeouts { get; set; }
+        }
+
+        public class EndpointThatHostsASaga : EndpointConfigurationBuilder
+        {
+            public EndpointThatHostsASaga()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MySaga : Saga<MySaga.MySagaData>,
+                                                             IAmStartedByMessages<StartSaga>,
+                                                             IHandleTimeouts<MySaga.TimeHasPassed>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
+                {
+                    Data.DataId = message.DataId;
+
+                    RequestTimeout(TimeSpan.FromSeconds(5), new TimeHasPassed());
+                }
+
+                public void Timeout(TimeHasPassed state)
+                {
+                    MarkAsComplete();
+
+                    Context.DidAllSagaInstancesReceiveTimeouts = true;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class MySagaData : ContainSagaData
+                {
+                    [Unique]
+                    public virtual Guid DataId { get; set; }
+                }
+
+                public class TimeHasPassed
+                {
+                }
+
+            }
+        }
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScaleOut/When_individualization_is_enabled.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScaleOut/When_individualization_is_enabled.cs
@@ -1,0 +1,54 @@
+﻿namespace NServiceBus.AcceptanceTests.ScaleOut
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_individualization_is_enabled : NServiceBusAcceptanceTest
+    {
+        const string discriminator = "-something";
+
+        
+        [Test]
+        public void Should_use_the_configured_differentiator()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<IndividualizedEndpoint>().Done(c =>c.EndpointsStarted)
+                    .Run();
+
+           
+            Assert.True(context.Address.Contains("-something"),context.Address + " should contain the discriminator " + discriminator);
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string Address { get; set; }
+        }
+
+        public class IndividualizedEndpoint : EndpointConfigurationBuilder
+        {
+       
+            public IndividualizedEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c=>c.ScaleOut().UniqueQueuePerEndpointInstance(discriminator));
+            }
+
+            class AddressSpy : IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
+
+                public Configure Configure { get; set; }
+
+                public void Start()
+                {
+                    Context.Address = Configure.LocalAddress.ToString();
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScaleOut/When_individualization_is_enabled_for_msmq.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScaleOut/When_individualization_is_enabled_for_msmq.cs
@@ -1,0 +1,56 @@
+﻿namespace NServiceBus.AcceptanceTests.ScaleOut
+{
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Settings;
+    using NUnit.Framework;
+
+    public class When_individualization_is_enabled_for_msmq : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_a_no_op_discriminator()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<IndividualizedEndpoint>().Done(c =>c.EndpointsStarted)
+                    .Repeat(r => r.For<MsmqOnly>())
+                    .Should(c=>Assert.AreEqual(c.EndpointName,c.Address.Split('@').First()))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string Address { get; set; }
+            public string EndpointName { get; set; }
+        }
+
+        public class IndividualizedEndpoint : EndpointConfigurationBuilder
+        {
+       
+            public IndividualizedEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c=>c.ScaleOut().UniqueQueuePerEndpointInstance());
+            }
+
+            class AddressSpy : IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
+
+                public Configure Configure { get; set; }
+
+                public ReadOnlySettings ReadOnlySettings { get; set; }
+
+                public void Start()
+                {
+                    Context.Address = Configure.LocalAddress.ToString();
+                    Context.EndpointName = ReadOnlySettings.EndpointName();
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScaleOut/When_no_discriminator_is_available.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScaleOut/When_no_discriminator_is_available.cs
@@ -1,0 +1,68 @@
+﻿namespace NServiceBus.AcceptanceTests.ScaleOut
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_no_discriminator_is_available : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_blow_up()
+        {
+            var ex = Assert.Throws<AggregateException>(()=> Scenario.Define<Context>()
+                    .WithEndpoint<IndividualizedEndpoint>().Done(c =>c.EndpointsStarted)
+                    .AllowExceptions()
+                    .Run());
+
+            var configEx = ex.InnerExceptions.First()
+                .InnerException;
+
+            Assert.True(configEx.Message.StartsWith("No endpoint instance discriminator found"));
+
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class IndividualizedEndpoint : EndpointConfigurationBuilder
+        {
+       
+            public IndividualizedEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.ScaleOut().UniqueQueuePerEndpointInstance();
+                    c.UseTransport<TransportThatDoesntSetADefaultDiscriminator>();
+                });
+            }
+        }
+
+        public class TransportThatDoesntSetADefaultDiscriminator:TransportDefinition
+        {
+            protected override void Configure(BusConfiguration config)
+            {
+                config.EnableFeature<TransportThatDoesntSetADefaultDiscriminatorConfigurator>();
+            }
+        }
+
+            public class TransportThatDoesntSetADefaultDiscriminatorConfigurator : ConfigureTransport
+            {
+                protected override void Configure(FeatureConfigurationContext context, string connectionString)
+                {
+                    
+                }
+
+                protected override string ExampleConnectionStringForErrorMessage
+                {
+                    get { return ""; }
+                }
+            }
+    }
+
+    
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/AllOutboxCapableStorages.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/AllOutboxCapableStorages.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using AcceptanceTesting.Support;
+    using NServiceBus.Persistence;
+
+    public class AllOutboxCapableStorages:ScenarioDescriptor
+    {
+        public AllOutboxCapableStorages()
+        {
+            var defaultStorage = Persistence.Default;
+
+            var definitionType = Type.GetType(defaultStorage.Settings["Persistence"]);
+
+            var definition = (PersistenceDefinition)Activator.CreateInstance(definitionType, true);
+            if (definition.HasSupportFor<StorageType.Outbox>())
+            {
+                Add(defaultStorage);
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/AllTransactionSettings.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/AllTransactionSettings.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using NServiceBus.AcceptanceTesting.Support;
+
+    public class AllTransactionSettings : ScenarioDescriptor
+    {
+        public AllTransactionSettings()
+        {
+            Add(TransactionSettings.DistributedTransaction);
+            Add(TransactionSettings.LocalTransaction);
+            Add(TransactionSettings.NoTransaction);
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/AllTransports.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/AllTransports.cs
@@ -1,0 +1,129 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using AcceptanceTesting.Support;
+    using Hosting.Helpers;
+    using NServiceBus.Transports;
+
+    public class AllTransports : ScenarioDescriptor
+    {
+        public AllTransports()
+        {
+            AddRange(ActiveTransports);
+        }
+
+        static IEnumerable<RunDescriptor> ActiveTransports
+        {
+            get
+            {
+                if (activeTransports == null)
+                {
+                    //temporary fix until we can get rid of the "AllTransports" all together
+                    activeTransports = new List<RunDescriptor>
+                    {
+                        Transports.Default
+                    }; 
+                }
+
+                return activeTransports;
+            }
+        }
+
+        static ICollection<RunDescriptor> activeTransports;
+    }
+
+    public class AllDtcTransports : AllTransports
+    {
+        public AllDtcTransports()
+        {
+            AllTransportsFilter.Run(t => t.HasSupportForDistributedTransactions.HasValue
+                                         && !t.HasSupportForDistributedTransactions.Value, Remove);
+        }
+    }
+
+    public class AllBrokerTransports : AllTransports
+    {
+        public AllBrokerTransports()
+        {
+            AllTransportsFilter.Run(t => !t.HasNativePubSubSupport, Remove);
+        }
+    }
+
+    public class AllTransportsWithCentralizedPubSubSupport : AllTransports
+    {
+        public AllTransportsWithCentralizedPubSubSupport()
+        {
+            AllTransportsFilter.Run(t => !t.HasSupportForCentralizedPubSub, Remove);
+        }
+    }
+
+    public class AllTransportsWithMessageDrivenPubSub : AllTransports
+    {
+        public AllTransportsWithMessageDrivenPubSub()
+        {
+            AllTransportsFilter.Run(t => t.HasNativePubSubSupport, Remove);
+        }
+    }
+
+    public class MsmqOnly : ScenarioDescriptor
+    {
+        public MsmqOnly()
+        {
+            if (Transports.Default == Transports.Msmq)
+            {
+                Add(Transports.Msmq);
+            }
+        }
+    }
+
+    public class TypeScanner
+    {
+
+        public static IEnumerable<Type> GetAllTypesAssignableTo<T>()
+        {
+            return AvailableAssemblies.SelectMany(a => a.GetTypes())
+                                      .Where(t => typeof (T).IsAssignableFrom(t) && t != typeof(T))
+                                      .ToList();
+        }
+
+        static IEnumerable<Assembly> AvailableAssemblies
+        {
+            get
+            {
+                if (assemblies == null)
+                {
+                    var result = new AssemblyScanner().GetScannableAssemblies();
+
+                    assemblies = result.Assemblies;
+                }
+                    
+                return assemblies;
+            }
+        }
+
+        static List<Assembly> assemblies;
+    }
+
+    public static class AllTransportsFilter
+    {
+        public static void Run(Func<TransportDefinition, bool> condition, Func<RunDescriptor, bool> remove)
+        {
+            foreach (var rundescriptor in Transports.AllAvailable)
+            {
+                var transportAssemblyQualifiedName = rundescriptor.Settings["Transport"];
+                var type = Type.GetType(transportAssemblyQualifiedName);
+                if (type != null)
+                {
+                    var transport = Activator.CreateInstance(type, true) as TransportDefinition;
+                    if (condition(transport))
+                    {
+                        remove(rundescriptor);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/Builders.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/Builders.cs
@@ -1,0 +1,32 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using Container;
+
+    public static class Builders
+    {
+        static IEnumerable<RunDescriptor> GetAllAvailable()
+        {
+            var builders = TypeScanner.GetAllTypesAssignableTo<ContainerDefinition>()
+                .Where(t => !t.Assembly.FullName.StartsWith("NServiceBus.Core"))//exclude the default builder
+                .ToList();
+
+            return from builder in builders
+                   select (new RunDescriptor
+                       {
+                           Key = builder.Name,
+                           Settings = new Dictionary<string, string> { { "Builder", builder.AssemblyQualifiedName } }
+                       });
+        }
+
+        public static RunDescriptor Default
+        {
+            get
+            {
+                return GetAllAvailable().FirstOrDefault();
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/Persistence.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/Persistence.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using NServiceBus.Persistence;
+
+    public static class Persistence
+    {
+        public static RunDescriptor Default
+        {
+            get
+            {
+                var specificPersistence = Environment.GetEnvironmentVariable("Persistence.UseSpecific");
+
+                if (!string.IsNullOrEmpty(specificPersistence))
+                {
+                    return AllAvailable.Single(r => r.Key == specificPersistence);
+                }
+
+                var nonCorePersister = AllAvailable.FirstOrDefault();
+
+                if (nonCorePersister != null)
+                {
+                    return nonCorePersister;
+                }
+
+                return InMemoryPersistenceDescriptor;
+            }
+        }
+
+        static IEnumerable<RunDescriptor> AllAvailable
+        {
+            get
+            {
+                if (availablePersisters == null)
+                {
+                    availablePersisters = GetAllAvailable().ToList();
+                }
+
+                return availablePersisters;
+            }
+        }
+
+        static Type InMemoryPersistenceType = typeof(InMemoryPersistence);
+
+        static RunDescriptor InMemoryPersistenceDescriptor = new RunDescriptor
+        {
+            Key = InMemoryPersistenceType.Name,
+            Settings =
+                new Dictionary<string, string>
+                {
+                    {"Persistence", InMemoryPersistenceType.AssemblyQualifiedName}
+                }
+        };
+
+        static IEnumerable<RunDescriptor> GetAllAvailable()
+        {
+            var foundDefinitions = TypeScanner.GetAllTypesAssignableTo<PersistenceDefinition>()
+                .Where(t => t.Assembly != InMemoryPersistenceType.Assembly &&
+                t.Assembly != typeof(Persistence).Assembly);
+
+            foreach (var definition in foundDefinitions)
+            {
+                var key = definition.Name;
+
+                var runDescriptor = new RunDescriptor
+                {
+                    Key = key,
+                    Settings =
+                        new Dictionary<string, string>
+                                {
+                                    {"Persistence", definition.AssemblyQualifiedName}
+                                }
+                };
+
+                yield return runDescriptor;
+            }
+        }
+
+        static IList<RunDescriptor> availablePersisters;
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/Serializers.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/Serializers.cs
@@ -1,0 +1,56 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System.Collections.Generic;
+    using AcceptanceTesting.Support;
+
+    public static class Serializers
+    {
+        public static readonly RunDescriptor Binary = new RunDescriptor
+            {
+                Key = "Binary",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (BinarySerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+        public static readonly RunDescriptor Bson = new RunDescriptor
+            {
+                Key = "Bson",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (BsonSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+        public static readonly RunDescriptor Xml = new RunDescriptor
+            {
+                Key = "Xml",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (XmlSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+
+        public static readonly RunDescriptor Json = new RunDescriptor
+            {
+                Key = "Json",
+                Settings =
+                    new Dictionary<string, string>
+                        {
+                            {
+                                "Serializer", typeof (JsonSerializer).AssemblyQualifiedName
+                            }
+                        }
+            };
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/TransactionSettings.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/TransactionSettings.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using NServiceBus.AcceptanceTesting.Support;
+
+
+    public static class TransactionSettings
+    {
+        public static readonly RunDescriptor DistributedTransaction = new RunDescriptor
+        {
+            Key = "DistributedTransaction",
+            Settings =
+                new Dictionary<string, string>()
+        };
+
+        public static readonly RunDescriptor LocalTransaction = new RunDescriptor
+        {
+            Key = "LocalTransaction",
+            Settings =
+                new Dictionary<string, string>
+                {
+                    {"Transactions.SuppressDistributedTransactions", bool.TrueString}
+                }
+        };
+
+        public static readonly RunDescriptor NoTransaction = new RunDescriptor
+        {
+            Key = "NoTransaction",
+            Settings =
+                new Dictionary<string, string>
+                {
+                    {"Transactions.Disable", bool.TrueString},
+                }
+        };
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/Transports.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/ScenarioDescriptors/Transports.cs
@@ -1,0 +1,96 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AcceptanceTesting.Support;
+    using NServiceBus.Transports;
+
+    public static class Transports
+    {
+        internal static IEnumerable<RunDescriptor> AllAvailable
+        {
+            get
+            {
+                lock (lockObject)
+                {
+                    if (availableTransports == null)
+                    {
+                        availableTransports = GetAllAvailable().ToList();
+                    }
+                }
+
+                return availableTransports;
+            }
+        }
+
+
+        public static RunDescriptor Default
+        {
+            get
+            {
+                var specificTransport = Environment.GetEnvironmentVariable("Transport.UseSpecific");
+
+                if (!string.IsNullOrEmpty(specificTransport))
+                    return AllAvailable.Single(r => r.Key == specificTransport);
+
+                var transportsOtherThanMsmq = AllAvailable.Where(t => t != Msmq);
+
+                if (transportsOtherThanMsmq.Count() == 1)
+                    return transportsOtherThanMsmq.First();
+
+                return Msmq;
+            }
+        }
+
+        public static RunDescriptor Msmq
+        {
+            get { return AllAvailable.SingleOrDefault(r => r.Key == "MsmqTransport"); }
+        }
+
+        static IEnumerable<RunDescriptor> GetAllAvailable()
+        {
+            var foundTransportDefinitions = TypeScanner.GetAllTypesAssignableTo<TransportDefinition>();
+
+            
+            foreach (var transportDefinitionType in foundTransportDefinitions)
+            {
+                var key = transportDefinitionType.Name;
+
+                var runDescriptor = new RunDescriptor
+                {
+                    Key = key,
+                    Settings =
+                        new Dictionary<string, string>
+                                {
+                                    {"Transport", transportDefinitionType.AssemblyQualifiedName}
+                                }
+                };
+
+                var connectionString = Environment.GetEnvironmentVariable(key + ".ConnectionString");
+
+                if (string.IsNullOrEmpty(connectionString) && DefaultConnectionStrings.ContainsKey(key))
+                    connectionString = DefaultConnectionStrings[key];
+
+
+                if (!string.IsNullOrEmpty(connectionString))
+                {
+                    runDescriptor.Settings.Add("Transport.ConnectionString", connectionString);
+                    yield return runDescriptor;
+                }
+            }
+        }
+
+        static IList<RunDescriptor> availableTransports;
+        static readonly object lockObject = new object();
+
+        static readonly Dictionary<string, string> DefaultConnectionStrings = new Dictionary<string, string>
+            {
+                {"RabbitMQTransport", "host=localhost"},
+                {"SqlServerTransport", @"Server=localhost\sqlexpress;Database=nservicebus;Trusted_Connection=True;"},
+                {"MsmqTransport", @"cacheSendConnection=false;journal=false;"}
+            };
+
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Scheduling/When_scheduling_a_recurring_task.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Scheduling/When_scheduling_a_recurring_task.cs
@@ -1,0 +1,61 @@
+﻿namespace NServiceBus.AcceptanceTests.Scheduling
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_scheduling_a_recurring_task : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_execute_the_task()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<SchedulingEndpoint>()
+                    .Done(c => c.InvokedAt.HasValue)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c =>
+                    {
+                        Assert.True(c.InvokedAt.HasValue);
+                        Assert.Greater(c.InvokedAt.Value - c.RequestedAt, TimeSpan.FromSeconds(5));
+                    })
+                  .Run(TimeSpan.FromSeconds(20));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public DateTime? InvokedAt{ get; set; }
+            public DateTime RequestedAt{ get; set; }
+        }
+
+        public class SchedulingEndpoint : EndpointConfigurationBuilder
+        {
+            public SchedulingEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class SetupScheduledAction : IWantToRunWhenBusStartsAndStops
+            {
+                public Schedule Schedule { get; set; }
+                public Context Context { get; set; }
+                public void Start()
+                {
+                    Context.RequestedAt = DateTime.UtcNow;
+
+                    Schedule.Every(TimeSpan.FromSeconds(5), "MyTask", () =>
+                    {
+                        Context.InvokedAt = DateTime.UtcNow;
+                    });
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Serialization/When_serializing_a_message.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Serialization/When_serializing_a_message.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using System;
+
+    [TestFixture]
+    public class When_serializing_a_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void DateTime_properties_should_keep_their_original_timezone_information()
+        {
+            var expectedDateTime = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Unspecified);
+            var expectedDateTimeLocal = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Local);
+            var expectedDateTimeUtc = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Utc);
+            var expectedDateTimeOffset = new DateTimeOffset(2012, 12, 12, 12, 12, 12, TimeSpan.FromHours(6));
+            var expectedDateTimeOffsetLocal = DateTimeOffset.Now;
+            var expectedDateTimeOffsetUtc = DateTimeOffset.UtcNow;
+
+            var context = Scenario.Define<Context>()
+                .WithEndpoint<DateTimeReceiver>(b => b.When(
+                    bus => bus.SendLocal(new DateTimeMessage
+                    {
+                        DateTime = expectedDateTime,
+                        DateTimeLocal = expectedDateTimeLocal,
+                        DateTimeUtc = expectedDateTimeUtc,
+                        DateTimeOffset = expectedDateTimeOffset,
+                        DateTimeOffsetLocal = expectedDateTimeOffsetLocal,
+                        DateTimeOffsetUtc = expectedDateTimeOffsetUtc
+                    })))
+                .Done(c => c.ReceivedMessage != null)
+                .Run();
+
+            Assert.AreEqual(expectedDateTime, context.ReceivedMessage.DateTime);
+            Assert.AreEqual(expectedDateTimeLocal, context.ReceivedMessage.DateTimeLocal);
+            Assert.AreEqual(expectedDateTimeUtc, context.ReceivedMessage.DateTimeUtc);
+            Assert.AreEqual(expectedDateTimeOffset, context.ReceivedMessage.DateTimeOffset);
+            Assert.AreEqual(expectedDateTimeOffsetLocal, context.ReceivedMessage.DateTimeOffsetLocal);
+            Assert.AreEqual(expectedDateTimeOffsetUtc, context.ReceivedMessage.DateTimeOffsetUtc);
+            Assert.AreEqual(expectedDateTimeOffsetLocal, context.ReceivedMessage.DateTimeOffsetLocal);
+            Assert.AreEqual(expectedDateTimeOffsetLocal.Offset, context.ReceivedMessage.DateTimeOffsetLocal.Offset);
+            Assert.AreEqual(expectedDateTimeOffsetUtc, context.ReceivedMessage.DateTimeOffsetUtc);
+            Assert.AreEqual(expectedDateTimeOffsetUtc.Offset, context.ReceivedMessage.DateTimeOffsetUtc.Offset);
+        }
+
+        class DateTimeReceiver : EndpointConfigurationBuilder
+        {
+            public DateTimeReceiver()
+            {
+                EndpointSetup<DefaultServer>(c => { c.UseSerialization<JsonSerializer>(); });
+            }
+
+            class DateTimeMessageHandler : IHandleMessages<DateTimeMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(DateTimeMessage message)
+                {
+                    Context.ReceivedMessage = message;
+                }
+            }
+        }
+
+        public class DateTimeMessage : IMessage
+        {
+            public DateTime DateTime { get; set; }
+            public DateTime DateTimeLocal { get; set; }
+            public DateTime DateTimeUtc { get; set; }
+            public DateTimeOffset DateTimeOffset { get; set; }
+            public DateTimeOffset DateTimeOffsetLocal { get; set; }
+            public DateTimeOffset DateTimeOffsetUtc { get; set; }
+        }
+
+        class Context : ScenarioContext
+        {
+            public DateTimeMessage ReceivedMessage { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/OutdatedTimeoutPersister.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/OutdatedTimeoutPersister.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Timeout.Core;
+
+    class OutdatedTimeoutPersister : IPersistTimeouts
+    {
+        public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        {
+            nextTimeToRunQuery = DateTime.Now.AddYears(42);
+            return Enumerable.Empty<Tuple<string, DateTime>>().ToList();
+        }
+
+        public void Add(TimeoutData timeout)
+        {
+        }
+
+        public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+        {
+            timeoutData = null;
+            return false;
+        }
+
+        public void RemoveTimeoutBy(Guid sagaId)
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/TemporarilyUnavailableTimeoutPersister.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/TemporarilyUnavailableTimeoutPersister.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Timeout.Core;
+
+    class TemporarilyUnavailableTimeoutPersister : IPersistTimeouts
+    {
+        public int SecondsToWait { get; set; }
+        static bool isAvailable = false;
+        DateTime NextChangeTime;
+
+        public TemporarilyUnavailableTimeoutPersister()
+        {
+            NextChangeTime = DateTime.Now.AddSeconds(SecondsToWait);
+        }
+
+        private void ThrowExceptionUntilWait()
+        {
+            if (NextChangeTime <= DateTime.Now)
+            {
+                NextChangeTime = DateTime.Now.AddSeconds(SecondsToWait);
+                isAvailable = !isAvailable;
+            }
+
+            if (!isAvailable)
+            {
+                throw new Exception("Persister is temporarily unavailable");
+            }
+        }
+
+        public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        {
+            ThrowExceptionUntilWait();
+            nextTimeToRunQuery = DateTime.Now.AddSeconds(2);
+            return Enumerable.Empty<Tuple<string, DateTime>>().ToList();
+        }
+
+        public void Add(TimeoutData timeout)
+        {
+            ThrowExceptionUntilWait();
+        }
+
+        public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+        {
+            ThrowExceptionUntilWait();
+            timeoutData = null;
+            return true;
+        }
+
+        public void RemoveTimeoutBy(Guid sagaId)
+        {
+            ThrowExceptionUntilWait();
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/TransportWithFakeQueues.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/TransportWithFakeQueues.cs
@@ -1,0 +1,47 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+
+    public class TransportWithFakeQueues : TransportDefinition
+    {
+        protected override void Configure(BusConfiguration config)
+        {
+            config.RegisterComponents(c => c.ConfigureComponent<FakeDequeuer>(DependencyLifecycle.SingleInstance));
+            config.RegisterComponents(c => c.ConfigureComponent<FakeSender>(DependencyLifecycle.SingleInstance));
+            config.RegisterComponents(c => c.ConfigureComponent<FakeQueueCreator>(DependencyLifecycle.SingleInstance));
+        }
+    }
+
+    class FakeDequeuer : IDequeueMessages
+    {
+
+        public void Init(Address address, Unicast.Transport.TransactionSettings transactionSettings, Func<TransportMessage, bool> tryProcessMessage, Action<TransportMessage, Exception> endProcessMessage)
+        {
+        }
+
+        public void Start(int maximumConcurrencyLevel)
+        {
+        }
+
+        public void Stop()
+        {
+        }
+    }
+
+    class FakeQueueCreator : ICreateQueues
+    {
+        public void CreateQueueIfNecessary(Address address, string account)
+        {
+        }
+    }
+
+    class FakeSender : ISendMessages
+    {
+        public void Send(TransportMessage message, SendOptions sendOptions)
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/UpdatedTimeoutPersister.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/UpdatedTimeoutPersister.cs
@@ -1,0 +1,40 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Timeout.Core;
+
+    class UpdatedTimeoutPersister : IPersistTimeouts, IPersistTimeoutsV2
+    {
+        public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        {
+            nextTimeToRunQuery = DateTime.Now.AddYears(42);
+            return Enumerable.Empty<Tuple<string, DateTime>>().ToList();
+        }
+
+        public void Add(TimeoutData timeout)
+        {
+        }
+
+        public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+        {
+            timeoutData = null;
+            return false;
+        }
+
+        public void RemoveTimeoutBy(Guid sagaId)
+        {
+        }
+
+        public TimeoutData Peek(string timeoutId)
+        {
+            return null;
+        }
+
+        public bool TryRemove(string timeoutId)
+        {
+            return true;
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_dispatched_timeout_already_removed_from_timeout_storage.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_dispatched_timeout_already_removed_from_timeout_storage.cs
@@ -1,0 +1,187 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Timeout.Core;
+    using NUnit.Framework;
+
+    public class When_timeout_already_removed : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_rollback_and_not_deliver_timeout_when_using_dtc()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b
+                    .CustomConfig(configure => configure.Transactions().EnableDistributedTransactions())
+                    .Given(bus =>
+                    {
+                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+                    }))
+                .Done(c => c.AttemptedToRemoveTimeout || c.MessageReceived)
+                .Run();
+
+            Assert.IsFalse(context.MessageReceived, "Message should not be delivered using dtc.");
+            Assert.AreEqual(2, context.NumberOfProcessingAttempts, "The rollback should cause a retry.");
+            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+        }
+
+        [Test]
+        public void Should_rollback_and_deliver_timeout_anyway_when_using_native_tx()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b
+                    .CustomConfig(configure => configure.Transactions().DisableDistributedTransactions())
+                    .Given(bus =>
+                    {
+                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+                    }))
+                .Done(c => c.AttemptedToRemoveTimeout && c.MessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.MessageReceived, "Message should be delivered although transaction was aborted.");
+            Assert.AreEqual(2, context.NumberOfProcessingAttempts, "The rollback should cause a retry.");
+            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+        }
+
+        [Test]
+        public void Should_deliver_timeout_anyway_when_using_no_tx()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b
+                    .CustomConfig(configure => configure.Transactions().Disable())
+                    .Given(bus =>
+                    {
+                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+                    }))
+                .Done(c => c.AttemptedToRemoveTimeout && c.MessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.MessageReceived, "Message should be delivered although timeout processing fails.");
+            Assert.AreEqual(1, context.NumberOfProcessingAttempts, "Should not retry without transactions enabled.");
+            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+            public bool AttemptedToRemoveTimeout { get; set; }
+            public int NumberOfProcessingAttempts { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class DelayedMessageHandler : IHandleMessages<MyMessage>
+            {
+                Context context;
+
+                public DelayedMessageHandler(Context context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(MyMessage message)
+                {
+                    context.MessageReceived = true;
+                }
+            }
+
+            public class EndpointConfiguration : IWantToRunBeforeConfigurationIsFinalized
+            {
+                public static IBuilder builder;
+
+                public void Run(Configure config)
+                {
+                    builder = config.Builder;
+                }
+            }
+
+            public class DispatcherInterceptor : Feature
+            {
+                public DispatcherInterceptor()
+                {
+                    EnableByDefault();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    var originalPersister = EndpointConfiguration.builder.Build<IPersistTimeouts>();
+                    var ctx = EndpointConfiguration.builder.Build<Context>();
+                    context.Container.ConfigureComponent(() => new TimeoutPersistanceWrapper(originalPersister, originalPersister as IPersistTimeoutsV2, ctx), DependencyLifecycle.SingleInstance);
+                }
+            }
+
+            class TimeoutPersistanceWrapper : IPersistTimeouts, IPersistTimeoutsV2
+            {
+                IPersistTimeouts originalTimeoutPersister;
+                IPersistTimeoutsV2 originalTimeoutPersisterV2;
+                Context context;
+
+                public TimeoutPersistanceWrapper(IPersistTimeouts originalTimeoutPersister, IPersistTimeoutsV2 originalTimeoutPersisterV2, Context context)
+                {
+                    this.originalTimeoutPersister = originalTimeoutPersister;
+                    this.originalTimeoutPersisterV2 = originalTimeoutPersisterV2;
+                    this.context = context;
+                }
+
+                public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+                {
+                    return originalTimeoutPersister.GetNextChunk(startSlice, out nextTimeToRunQuery);
+                }
+
+                public void Add(TimeoutData timeout)
+                {
+                    originalTimeoutPersister.Add(timeout);
+                }
+
+                public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+                {
+                    return originalTimeoutPersister.TryRemove(timeoutId, out timeoutData);
+                }
+
+                public void RemoveTimeoutBy(Guid sagaId)
+                {
+                    originalTimeoutPersister.RemoveTimeoutBy(sagaId);
+                }
+
+                public TimeoutData Peek(string timeoutId)
+                {
+                    context.NumberOfProcessingAttempts++;
+                    return originalTimeoutPersisterV2.Peek(timeoutId);
+                }
+
+                public bool TryRemove(string timeoutId)
+                {
+                    context.AttemptedToRemoveTimeout = true;
+
+                    using (var tx = new TransactionScope(TransactionScopeOption.Suppress))
+                    { 
+                        // delete the timeout so it won't be available on retries
+                        originalTimeoutPersisterV2.TryRemove(timeoutId);
+                        tx.Complete();
+                    }
+
+                    return false;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage { }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs
@@ -1,0 +1,69 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NServiceBus.Timeout.Core;
+    using NUnit.Framework;
+
+    class When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_warning()
+        {
+            var context = new Context();
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run())
+                .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            Assert.IsNotNull(scenarioException);
+            StringAssert.Contains("You are using an outdated timeout persistence which can lead to message loss!", scenarioException.InnerException.Message);
+        }
+
+        [Test]
+        public void Endpoint_should_start_when_warning_suppressed()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(c => c.CustomConfig(b => b.SuppressOutdatedTimeoutPersistenceWarning()))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+
+        public class Context : ScenarioContext { }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.Transactions().DisableDistributedTransactions();
+                });
+            }
+        }
+
+        public class Initalizer : Feature
+        {
+            public Initalizer()
+            {
+                EnableByDefault();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_timeout_persistence_with_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Context : ScenarioContext { }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.Transactions().EnableDistributedTransactions();
+                });
+            }
+        }
+
+        public class Initalizer : Feature
+        {
+            public Initalizer()
+            {
+                EnableByDefault();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_timeout_persistence_without_dtc
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_warning()
+        {
+            var context = new Context();
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run())
+                .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            Assert.IsNotNull(scenarioException);
+            StringAssert.Contains("You are using an outdated timeout persistence which can lead to message loss!", scenarioException.InnerException.Message);
+        }
+
+        public class Context : ScenarioContext { }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.UseTransport<NonDtcTransportDefinition>();
+                    config.OverrideLocalAddress("FakeQueueName");
+                });
+            }
+        }
+        public class Initalizer : Feature
+        {
+            public Initalizer()
+            {
+                EnableByDefault();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent(() => new OutdatedTimeoutPersister(), DependencyLifecycle.SingleInstance);
+            }
+        }
+
+        public class NonDtcTransportDefinition : TransportWithFakeQueues
+        {
+            public NonDtcTransportDefinition()
+            {
+                HasSupportForDistributedTransactions = false;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_endpoint_uses_updated_timeout_persistence.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_endpoint_uses_updated_timeout_persistence.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    class When_endpoint_uses_updated_timeout_persistence : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Context : ScenarioContext { }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.Transactions().DisableDistributedTransactions();
+                });
+            }
+        }
+
+        public class Initalizer : Feature
+        {
+            public Initalizer()
+            {
+                EnableByDefault();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<UpdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_timeout_storage_is_unavailable_temporarily.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Timeouts/When_timeout_storage_is_unavailable_temporarily.cs
@@ -1,0 +1,88 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using Timeout.Core;
+    using NUnit.Framework;
+
+    class When_timeout_storage_is_unavailable_temporarily : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new TestContext();
+
+            Scenario.Define(context)
+                .WithEndpoint<EndpointWithFlakyTimeoutPersister>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+
+        [Test]
+        public void Endpoint_should_not_shutdown()
+        {
+            var context = new TestContext{SecondsToWait = 10};
+            var stopTime = DateTime.Now.AddSeconds(45);
+
+            Scenario.Define(context)
+                .AllowExceptions(ex => ex.Message.Contains("Persister is temporarily unavailable"))
+                .WithEndpoint<EndpointWithFlakyTimeoutPersister>(b =>
+                {
+                    b.CustomConfig(busConfig =>
+                    {
+                        busConfig.DefineCriticalErrorAction((s, ex) =>
+                        {
+                            context.FatalErrorOccurred = true;
+                        });
+                    });
+                })
+                .Done(c => context.FatalErrorOccurred || stopTime <= DateTime.Now)
+                .Run();
+
+            Assert.IsFalse(context.FatalErrorOccurred, "Circuit breaker was trigged too soon.");
+        }
+
+        public class TestContext : ScenarioContext
+        {
+            public int SecondsToWait { get; set; }
+            public bool FatalErrorOccurred { get; set; }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage { }
+
+        public class EndpointWithFlakyTimeoutPersister : EndpointConfigurationBuilder
+        {
+            public TestContext TestContext { get; set; }
+            public EndpointWithFlakyTimeoutPersister()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.Transactions().DisableDistributedTransactions();
+                    config.SuppressOutdatedTimeoutPersistenceWarning();
+                });
+            }
+
+            class Initalizer : Feature
+            {
+                public Initalizer()
+                {
+                    EnableByDefault();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    context.Container
+                        .ConfigureComponent<TemporarilyUnavailableTimeoutPersister>(DependencyLifecycle.SingleInstance)
+                        .ConfigureProperty(tp => tp.SecondsToWait, 10);
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/FakePromotableResourceManager.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/FakePromotableResourceManager.cs
@@ -1,0 +1,54 @@
+﻿namespace NServiceBus.AcceptanceTests.Tx
+{
+    using System;
+    using System.Transactions;
+
+    public class FakePromotableResourceManager : IPromotableSinglePhaseNotification, IEnlistmentNotification
+    {
+        public static Guid ResourceManagerId = Guid.Parse("6f057e24-a0d8-4c95-b091-b8dc9a916fa4");
+
+        public void Prepare(PreparingEnlistment preparingEnlistment)
+        {
+            preparingEnlistment.Prepared();
+        }
+
+        public void Commit(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+        public void Rollback(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+        public void InDoubt(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+
+        public void Initialize()
+        {
+        }
+
+        public void SinglePhaseCommit(SinglePhaseEnlistment singlePhaseEnlistment)
+        {
+            singlePhaseEnlistment.Committed();
+        }
+
+        public void Rollback(SinglePhaseEnlistment singlePhaseEnlistment)
+        {
+            singlePhaseEnlistment.Done();
+        }
+
+        public byte[] Promote()
+        {
+            return TransactionInterop.GetTransmitterPropagationToken(new CommittableTransaction());
+
+        }
+
+
+    }
+
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/Issue_2481.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/Issue_2481.cs
@@ -1,0 +1,58 @@
+﻿namespace NServiceBus.AcceptanceTests.Tx
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class Issue_2481 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_enlist_the_receive_in_the_dtc_tx()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<DTCEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.HandlerInvoked)
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c => Assert.False(c.CanEnlistPromotable, "There should exists a DTC tx"))
+                    .Run();
+        }
+
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerInvoked { get; set; }
+
+            public bool CanEnlistPromotable { get; set; }
+        }
+
+        public class DTCEndpoint : EndpointConfigurationBuilder
+        {
+            public DTCEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c=>c.Transactions().Enable());
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessage messageThatIsEnlisted)
+                {
+                    Context.CanEnlistPromotable = Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager());
+                    Context.HandlerInvoked = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/When_receiving_with_dtc_disabled.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/When_receiving_with_dtc_disabled.cs
@@ -1,0 +1,67 @@
+﻿namespace NServiceBus.AcceptanceTests.Tx
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_receiving_with_dtc_disabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_escalate_a_single_durable_rm_to_dtc_tx()
+        {
+
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonDTCEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.HandlerInvoked)
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c =>
+                        {
+                            //this check mainly applies to MSMQ who creates a DTC tx right of the bat if DTC is on
+                            Assert.AreEqual(Guid.Empty, c.DistributedIdentifierBefore, "No DTC tx should exist before enlistment");
+                            Assert.True(c.CanEnlistPromotable, "A promotable RM should be able to enlist");
+                        })
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerInvoked { get; set; }
+
+            public Guid DistributedIdentifierBefore { get; set; }
+
+            public bool CanEnlistPromotable { get; set; }
+        }
+
+        public class NonDTCEndpoint : EndpointConfigurationBuilder
+        {
+            public NonDTCEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Transactions()
+                    .DisableDistributedTransactions()
+                    .WrapHandlersExecutionInATransactionScope());
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessage messageThatIsEnlisted)
+                {
+                    Context.DistributedIdentifierBefore = Transaction.Current.TransactionInformation.DistributedIdentifier;
+
+                    Context.CanEnlistPromotable = Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager());
+
+                    Context.HandlerInvoked = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/When_receiving_with_dtc_enabled.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/When_receiving_with_dtc_enabled.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Tx
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_receiving_with_dtc_enabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_enlist_the_receive_in_the_dtc_tx()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<DTCEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.HandlerInvoked)
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c => Assert.False(c.CanEnlistPromotable, "There should exists a DTC tx"))
+                    .Run();
+        }
+
+        [Test]
+        public void Basic_assumptions_promotable_should_fail_if_durable_already_exists()
+        {
+            using (var tx = new TransactionScope())
+            {
+                Transaction.Current.EnlistDurable(FakePromotableResourceManager.ResourceManagerId, new FakePromotableResourceManager(), EnlistmentOptions.None);
+                Assert.False(Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager()));
+
+                tx.Complete();
+            }
+        }
+
+
+        [Test]
+        public void Basic_assumptions_second_promotable_should_fail()
+        {
+            using (var tx = new TransactionScope())
+            {
+                Assert.True(Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager()));
+
+                Assert.False(Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager()));
+
+                tx.Complete();
+            }
+        }
+
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerInvoked { get; set; }
+
+            public bool CanEnlistPromotable { get; set; }
+        }
+
+        public class DTCEndpoint : EndpointConfigurationBuilder
+        {
+            public DTCEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessage messageThatIsEnlisted)
+                {
+                    Context.CanEnlistPromotable = Transaction.Current.EnlistPromotableSinglePhase(new FakePromotableResourceManager());
+                    Context.HandlerInvoked = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/When_receiving_with_the_default_settings.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/When_receiving_with_the_default_settings.cs
@@ -1,0 +1,53 @@
+﻿namespace NServiceBus.AcceptanceTests.Tx
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_receiving_with_the_default_settings : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_wrap_the_handler_pipeline_with_a_transactionscope()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .Done(c => c.HandlerInvoked)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.AmbientTransactionExists, "There should exist an ambient transaction"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool AmbientTransactionExists { get; set; }
+            public bool HandlerInvoked { get; set; }
+        }
+
+        public class TransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public TransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MyMessage messageThatIsEnlisted)
+                {
+                    Context.AmbientTransactionExists = (Transaction.Current != null);
+                    Context.HandlerInvoked = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/When_receiving_with_transactions_disabled.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/When_receiving_with_transactions_disabled.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.Tx
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_receiving_with_transactions_disabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
+        {
+
+            Scenario.Define<Context>()
+                    .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .AllowExceptions()
+                    .Done(c => c.TestComplete)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.AreEqual(1, c.TimesCalled, "Should not retry the message"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool TestComplete { get; set; }
+
+            public int TimesCalled { get; set; }
+        }
+
+        public class NonTransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public NonTransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Transactions().Disable());
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+                public void Handle(MyMessage message)
+                {
+                    Context.TimesCalled++;
+
+                    using (new TransactionScope(TransactionScopeOption.Suppress))
+                    {
+                        Bus.SendLocal(new CompleteTest());
+                    }
+
+                    throw new Exception("Simulated exception");
+                }
+            }
+
+            public class CompleteTestHandler : IHandleMessages<CompleteTest>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(CompleteTest message)
+                {
+                    Context.TestComplete = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+
+        [Serializable]
+        public class CompleteTest : ICommand
+        {
+        }
+
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/When_sending_within_an_ambient_transaction.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Tx/When_sending_within_an_ambient_transaction.cs
@@ -1,0 +1,122 @@
+﻿namespace NServiceBus.AcceptanceTests.Tx
+{
+    using System;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_sending_within_an_ambient_transaction : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_deliver_them_until_the_commit_phase()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given((bus, context) =>
+                        {
+                            using (var tx = new TransactionScope())
+                            {
+                                bus.Send(new MessageThatIsEnlisted { SequenceNumber = 1 });
+                                bus.Send(new MessageThatIsEnlisted { SequenceNumber = 2 });
+
+                                //send another message as well so that we can check the order in the receiver
+                                using (new TransactionScope(TransactionScopeOption.Suppress))
+                                {
+                                    bus.Send(new MessageThatIsNotEnlisted());
+                                }
+
+                                tx.Complete();
+                            }
+                        }))
+                    .Done(c => c.MessageThatIsNotEnlistedHandlerWasCalled && c.TimesCalled >= 2)
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c => Assert.AreEqual(1, c.SequenceNumberOfFirstMessage,"The transport should preserve the order in which the transactional messages are delivered to the queuing system"))
+                    .Run();
+        }
+
+        [Test]
+        public void Should_not_deliver_them_on_rollback()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given(bus =>
+                        {
+                            using (new TransactionScope())
+                            {
+                                bus.Send(new MessageThatIsEnlisted());
+
+                                //rollback
+                            }
+
+                            bus.Send(new MessageThatIsNotEnlisted());
+
+                        }))
+                    .Done(c => c.MessageThatIsNotEnlistedHandlerWasCalled)
+                    .Repeat(r => r.For<AllDtcTransports>())
+                    .Should(c => Assert.False(c.MessageThatIsEnlistedHandlerWasCalled, "The transactional handler should not be called"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageThatIsEnlistedHandlerWasCalled { get; set; }
+
+            public bool MessageThatIsNotEnlistedHandlerWasCalled { get; set; }
+            public int TimesCalled { get; set; }
+
+            public int SequenceNumberOfFirstMessage { get; set; }
+
+            public bool NonTransactionalHandlerCalledFirst { get; set; }
+        }
+
+        public class TransactionalEndpoint : EndpointConfigurationBuilder
+        {
+            public TransactionalEndpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MessageThatIsEnlisted>(typeof(TransactionalEndpoint))
+                    .AddMapping<MessageThatIsNotEnlisted>(typeof(TransactionalEndpoint));
+            }
+
+            public class MessageThatIsEnlistedHandler : IHandleMessages<MessageThatIsEnlisted>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageThatIsEnlisted messageThatIsEnlisted)
+                {
+                    Context.MessageThatIsEnlistedHandlerWasCalled = true;
+                    Context.TimesCalled++;
+
+                    if (Context.SequenceNumberOfFirstMessage == 0)
+                    {
+                        Context.SequenceNumberOfFirstMessage = messageThatIsEnlisted.SequenceNumber;
+                    }
+                }
+            }
+
+            public class MessageThatIsNotEnlistedHandler : IHandleMessages<MessageThatIsNotEnlisted>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(MessageThatIsNotEnlisted messageThatIsNotEnlisted)
+                {
+                    Context.MessageThatIsNotEnlistedHandlerWasCalled = true;
+                    Context.NonTransactionalHandlerCalledFirst = !Context.MessageThatIsEnlistedHandlerWasCalled;
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class MessageThatIsEnlisted : ICommand
+        {
+            public int SequenceNumber { get; set; }
+        }
+        [Serializable]
+        public class MessageThatIsNotEnlisted : ICommand
+        {
+        }
+
+
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Versioning/When_multiple_versions_of_a_message_is_published.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Versioning/When_multiple_versions_of_a_message_is_published.cs
@@ -1,0 +1,118 @@
+﻿namespace NServiceBus.AcceptanceTests.Versioning
+{
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+    using PubSub;
+
+    public class When_multiple_versions_of_a_message_is_published : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_deliver_is_to_both_v1_and_vX_subscribers()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<V2Publisher>(b =>
+                        b.When(c => c.V1Subscribed && c.V2Subscribed, (bus, c) => bus.Publish<V2Event>(e =>
+                                 {
+                                     e.SomeData = 1;
+                                     e.MoreInfo = "dasd";
+                                 })))
+                    .WithEndpoint<V1Subscriber>(b => b.Given((bus,c) =>
+                        {
+                            bus.Subscribe<V1Event>();
+                            if (c.HasNativePubSubSupport)
+                                c.V1Subscribed = true;
+                        }))
+                    .WithEndpoint<V2Subscriber>(b => b.Given((bus,c) =>
+                        {
+                            bus.Subscribe<V2Event>();
+                            if (c.HasNativePubSubSupport)
+                                c.V2Subscribed = true;
+                        }))
+                    .Done(c => c.V1SubscriberGotTheMessage && c.V2SubscriberGotTheMessage)
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool V1SubscriberGotTheMessage { get; set; }
+
+            public bool V2SubscriberGotTheMessage { get; set; }
+
+            public bool V1Subscribed { get; set; }
+
+            public bool V2Subscribed { get; set; }
+        }
+
+        public class V2Publisher : EndpointConfigurationBuilder
+        {
+            public V2Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    if (s.SubscriberReturnAddress.Queue.Contains("V1Subscriber"))
+                    {
+                        context.V1Subscribed = true;
+                    }
+
+                    if (s.SubscriberReturnAddress.Queue.Contains("V2Subscriber"))
+                    {
+                        context.V2Subscribed = true;
+                    }
+                }));
+            }
+        }
+        public class V1Subscriber : EndpointConfigurationBuilder
+        {
+            public V1Subscriber()
+            {
+                EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>())
+                    .ExcludeType<V2Event>()
+                    .AddMapping<V1Event>(typeof(V2Publisher));
+
+            }
+
+
+            class V1Handler:IHandleMessages<V1Event>
+            {
+                public Context Context { get; set; }
+                public void Handle(V1Event message)
+                {
+                    Context.V1SubscriberGotTheMessage = true;
+                }
+            }
+        }
+
+
+        public class V2Subscriber : EndpointConfigurationBuilder
+        {
+            public V2Subscriber()
+            {
+                EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>())
+                     .AddMapping<V2Event>(typeof(V2Publisher));
+            }
+
+            class V2Handler : IHandleMessages<V2Event>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(V2Event message)
+                {
+                    Context.V2SubscriberGotTheMessage = true;
+                }
+            }
+        }
+
+
+        public interface V1Event : IEvent
+        {
+            int SomeData { get; set; }
+        }
+
+        public interface V2Event : V1Event
+        {
+            string MoreInfo { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Volatile/When_sending_to_non_durable_endpoint.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/App_Packages/NSB.AcceptanceTests.5.2.24/Volatile/When_sending_to_non_durable_endpoint.cs
@@ -1,0 +1,69 @@
+﻿namespace NServiceBus.AcceptanceTests.Volatile
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_sending_to_non_durable_endpoint: NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_receive_the_message()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MyMessage())))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.WasCalled)
+                    .Repeat(r => r.For(Transports.Default))
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    builder.DisableDurableMessages();
+                    builder.DiscardFailedMessagesInsteadOfSendingToErrorQueue(); // to avoid creating the error q, it might blow up for brokers (RabbitMQ)
+                })
+                    .AddMapping<MyMessage>(typeof(Receiver));
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    builder.DisableDurableMessages();
+                    builder.DiscardFailedMessagesInsteadOfSendingToErrorQueue(); // to avoid creating the error q, it might blow up for brokers (RabbitMQ)
+                });
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        public class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Context Context { get; set; }
+
+            public IBus Bus { get; set; }
+
+            public void Handle(MyMessage message)
+            {
+                Context.WasCalled = true;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/Properties/AssemblyInfo.cs
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ServiceControl.LearningTransport.AcceptanceTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ServiceControl.LearningTransport.AcceptanceTests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("145a4671-e0df-4955-829a-1355533c0e4f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/ServiceControl.LearningTransport.AcceptanceTests.csproj
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/ServiceControl.LearningTransport.AcceptanceTests.csproj
@@ -196,15 +196,6 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScenarioDescriptors\Transports.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Scheduling\When_scheduling_a_recurring_task.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Serialization\When_serializing_a_message.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\OutdatedTimeoutPersister.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\TemporarilyUnavailableTimeoutPersister.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\TransportWithFakeQueues.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\UpdatedTimeoutPersister.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_updated_timeout_persistence.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_timeout_storage_is_unavailable_temporarily.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Tx\FakePromotableResourceManager.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Tx\Issue_2481.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Tx\When_receiving_with_dtc_disabled.cs" />

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/ServiceControl.LearningTransport.AcceptanceTests.csproj
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/ServiceControl.LearningTransport.AcceptanceTests.csproj
@@ -119,12 +119,6 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\HostInformation\When_customising_hostinfo.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\HostInformation\When_feature_overrides_hostid.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\HostInformation\When_feature_overrides_hostinfo.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_Audit_OverrideTimeToBeReceived_set_and_transactional_Msmq.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_publishing_with_authorizer.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_TimeToBeReceivedOnForwardedMessages_set_and_transactional_Msmq.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_TimeToBeReceived_set_and_DTC_Msmq.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_TimeToBeReceived_set_and_receivetransaction_Msmq.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_unsubscribing_with_authorizer.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Mutators\Issue_1980.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Mutators\When_defining_outgoing_message_mutators.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Mutators\When_outgoing_mutator_replaces_instance.cs" />

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/ServiceControl.LearningTransport.AcceptanceTests.csproj
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/ServiceControl.LearningTransport.AcceptanceTests.csproj
@@ -123,7 +123,6 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Mutators\When_defining_outgoing_message_mutators.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Mutators\When_outgoing_mutator_replaces_instance.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_blowing_up_just_after_dispatch.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_dispatching_deferred_message_fails_without_dtc.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_outbox_with_auditing.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_receiving_a_message.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_sending_a_message_with_a_ttbr.cs" />
@@ -201,7 +200,6 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\TemporarilyUnavailableTimeoutPersister.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\TransportWithFakeQueues.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\UpdatedTimeoutPersister.cs" />
-    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_dispatched_timeout_already_removed_from_timeout_storage.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs" />

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/ServiceControl.LearningTransport.AcceptanceTests.csproj
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/ServiceControl.LearningTransport.AcceptanceTests.csproj
@@ -1,0 +1,238 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{145A4671-E0DF-4955-829A-1355533C0E4F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ServiceControl.LearningTransport.AcceptanceTests</RootNamespace>
+    <AssemblyName>ServiceControl.LearningTransport.AcceptanceTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NServiceBus.AcceptanceTesting, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.AcceptanceTesting.5.2.24\lib\net45\NServiceBus.AcceptanceTesting.dll</HintPath>
+    </Reference>
+    <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.5.2.24\lib\net45\NServiceBus.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-PlatformServices.2.3\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Audit\When_auditing.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Audit\When_a_message_is_audited.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Audit\When_a_replymessage_is_audited.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Audit\When_ForwardReceivedMessagesTo_is_set.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Audit\When_using_audit_message_is_received.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_aborting_the_behavior_chain.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_a_callback_for_local_message.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_callback_from_a_send_only.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_Deferring_a_message.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_handling_current_message_later.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_incoming_headers_should_be_shared.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_injecting_handler_props.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_multiple_mappings_exists.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_registering_custom_serializer.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_sending_ensure_proper_headers.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_sending_from_a_send_only.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_sending_to_another_endpoint.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_sending_with_conventions.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_sending_with_no_correlation_id.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_TimeToBeReceived_has_expired.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_TimeToBeReceived_has_not_expired.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_using_a_custom_correlation_id.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_using_a_greedy_convention.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_using_callbacks_from_older_versions.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_using_callbacks_in_a_scaleout.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_using_callbacks_with_messageid_eq_cid_.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_using_callback_to_get_message.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Basic\When_using_ineedinitialization.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Config\When_a_config_override_is_found.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Config\When_IWantToRunWhenBusStartsAndStops_Start_throws.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Config\When__startup_is_complete.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\CriticalError\When_registering_a_custom_criticalErrorHandler.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\DataBus\When_sending_databus_properties.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\DataBus\When_using_custom_IDataBus.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\DeterministicGuid.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Encryption\When_using_encryption_with_custom_service.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Encryption\When_using_Rijndael_without_incoming_key_identifier.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Encryption\When_using_Rijndael_with_config.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Encryption\When_using_Rijndael_with_custom.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Encryption\When_using_Rijndael_with_multikey.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\EndpointTemplates\ConfigureExtensions.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\EndpointTemplates\ContextAppender.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\EndpointTemplates\DefaultPublisher.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\EndpointTemplates\DefaultServer.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Exceptions\Cant_convert_to_TransportMessage\SerializerCorrupter.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Exceptions\Cant_convert_to_TransportMessage\When_cant_convert_to_TransportMessage.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Exceptions\Cant_convert_to_TransportMessage\When_cant_convert_to_TransportMessage_NoTransactions.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Exceptions\Cant_convert_to_TransportMessage\When_cant_convert_to_TransportMessage_SuppressedDTC.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Exceptions\Message_without_an_id.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Exceptions\StackTraceAssert.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Exceptions\When_handler_throws_serialization_exception.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Exceptions\When_serialization_throws.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\HostInformation\When_a_message_is_received.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\HostInformation\When_customising_hostinfo.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\HostInformation\When_feature_overrides_hostid.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\HostInformation\When_feature_overrides_hostinfo.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_Audit_OverrideTimeToBeReceived_set_and_transactional_Msmq.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_publishing_with_authorizer.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_TimeToBeReceivedOnForwardedMessages_set_and_transactional_Msmq.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_TimeToBeReceived_set_and_DTC_Msmq.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_TimeToBeReceived_set_and_receivetransaction_Msmq.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Msmq\When_unsubscribing_with_authorizer.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Mutators\Issue_1980.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Mutators\When_defining_outgoing_message_mutators.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Mutators\When_outgoing_mutator_replaces_instance.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_blowing_up_just_after_dispatch.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_dispatching_deferred_message_fails_without_dtc.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_outbox_with_auditing.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_receiving_a_message.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_sending_a_message_with_a_ttbr.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonDTC\When_sending_from_a_non_dtc_endpoint.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NonTx\When_sending_inside_ambient_tx.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\NServiceBusAcceptanceTest.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PerfMon\CriticalTime\When_CriticalTime_enabled.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PerfMon\CriticalTime\When_deferring_a_message.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PerfMon\CriticalTime\When_slow_with_CriticalTime_enabled.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PerfMon\SLA\When_sending_slow_with_SLA_enabled.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PerfMon\SLA\When_sending_with_SLA_enabled.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PipelineExt\FilteringWhatGetsAudited.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PipelineExt\MutingHandlerExceptions.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PipelineExt\SkipDeserialization.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\SubscriptionBehavior.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\SubscriptionEventArgs.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\When_base_event_from_2_publishers.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\When_multi_subscribing_to_a_polymorphic_event.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\When_publishin.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\When_publishing_an_event_implementing_two_unrelated_interfaces.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\When_publishing_from_sendonly.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\When_publishing_on_brokers.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\When_publishing_using_root_type.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\When_publishing_with_only_local_messagehandlers.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\When_publishing_with_overridden_local_address.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\PubSub\When_subscribing_to_a_polymorphic_event.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Retries\When_doing_flr_with_default_settings.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Retries\When_doing_flr_with_dtc_on.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Retries\When_doing_flr_with_native_transactions.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Retries\When_fails_flr.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Retries\When_fails_with_retries_set_to_0.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Retries\When_sending_to_slr.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Retries\When_Subscribing_to_errors.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\Issue_1819.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\Issue_2044.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_an_endpoint_replies_to_a_saga.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_a_base_class_message_hits_a_saga.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_a_existing_saga_instance_exists.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_a_finder_exists.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_a_saga_message_goes_through_the_slr.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_doing_request_response_between_sagas.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_message_has_a_saga_id.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_receiving_that_completes_the_saga.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_receiving_that_should_start_a_saga.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_replies_to_message_published_by_a_saga.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_reply_from_a_finder.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_sagas_cant_be_found.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_saga_has_a_non_empty_constructor.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_saga_id_changed.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_saga_is_mapped_to_complex_expression.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_saga_started_concurrently.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_sending_from_a_saga_handle.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_sending_from_a_saga_timeout.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_started_by_base_event_from_other_saga.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_started_by_event_from_another_saga.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_timeout_hit_not_found_saga.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_two_sagas_subscribe_to_the_same_event.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_using_a_received_message_for_timeout.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_using_contain_saga_data.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Sagas\When_using_ReplyToOriginator.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScaleOut\When_individualization_is_enabled.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScaleOut\When_individualization_is_enabled_for_msmq.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScaleOut\When_no_discriminator_is_available.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScenarioDescriptors\AllOutboxCapableStorages.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScenarioDescriptors\AllTransactionSettings.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScenarioDescriptors\AllTransports.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScenarioDescriptors\Builders.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScenarioDescriptors\Persistence.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScenarioDescriptors\Serializers.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScenarioDescriptors\TransactionSettings.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\ScenarioDescriptors\Transports.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Scheduling\When_scheduling_a_recurring_task.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Serialization\When_serializing_a_message.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\OutdatedTimeoutPersister.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\TemporarilyUnavailableTimeoutPersister.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\TransportWithFakeQueues.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\UpdatedTimeoutPersister.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_dispatched_timeout_already_removed_from_timeout_storage.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_endpoint_uses_updated_timeout_persistence.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Timeouts\When_timeout_storage_is_unavailable_temporarily.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Tx\FakePromotableResourceManager.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Tx\Issue_2481.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Tx\When_receiving_with_dtc_disabled.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Tx\When_receiving_with_dtc_enabled.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Tx\When_receiving_with_the_default_settings.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Tx\When_receiving_with_transactions_disabled.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Tx\When_sending_within_an_ambient_transaction.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
+    <Compile Include="App_Packages\NSB.AcceptanceTests.5.2.24\Volatile\When_sending_to_non_durable_endpoint.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.LearningTransport\ServiceControl.LearningTransport.csproj">
+      <Project>{12f4b317-b885-4d43-a152-fdb5b0ea2042}</Project>
+      <Name>ServiceControl.LearningTransport</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/app.config
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/src/ServiceControl.LearningTransport.AcceptanceTests/packages.config
+++ b/src/ServiceControl.LearningTransport.AcceptanceTests/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NServiceBus" version="5.2.24" targetFramework="net451" />
+  <package id="NServiceBus.AcceptanceTesting" version="5.2.24" targetFramework="net451" />
+  <package id="NServiceBus.AcceptanceTests.Sources" version="5.2.24" targetFramework="net452" />
+  <package id="NUnit" version="2.6.4" targetFramework="net451" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net451" />
+  <package id="Rx-PlatformServices" version="2.3" targetFramework="net451" />
+</packages>

--- a/src/ServiceControl.LearningTransport/DelayedMessagePoller.cs
+++ b/src/ServiceControl.LearningTransport/DelayedMessagePoller.cs
@@ -1,0 +1,62 @@
+﻿namespace ServiceControl.LearningTransport
+{
+    using System;
+    using System.Globalization;
+    using System.IO;
+    using System.Threading;
+    using NServiceBus.Logging;
+
+    class DelayedMessagePoller
+    {
+        public DelayedMessagePoller(PathCalculator.EndpointBasePaths endpointPaths)
+        {
+            this.endpointPaths = endpointPaths;
+            timer = new Timer(MoveDelayedMessagesToMainDirectory);
+        }
+
+        void MoveDelayedMessagesToMainDirectory(object state)
+        {
+            try
+            {
+                foreach (var delayDir in new DirectoryInfo(endpointPaths.Deferred).EnumerateDirectories())
+                {
+                    var timeToTrigger = DateTime.ParseExact(delayDir.Name, "yyyyMMddHHmmss", DateTimeFormatInfo.InvariantInfo);
+
+                    if (DateTime.UtcNow >= timeToTrigger)
+                    {
+                        foreach (var fileInfo in delayDir.EnumerateFiles())
+                        {
+                            FileOps.Move(fileInfo.FullName, Path.Combine(endpointPaths.Header, fileInfo.Name));
+                        }
+                    }
+
+                    //wait a bit more so we can safely delete the dir
+                    if (DateTime.UtcNow >= timeToTrigger.AddSeconds(10))
+                    {
+                        Directory.Delete(delayDir.FullName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Unable to move expired messages to main input queue.", ex);
+            }
+        }
+
+        public void Start()
+        {
+            timer.Change(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        }
+
+        public void Stop()
+        {
+            timer.Dispose();
+        }
+
+        readonly PathCalculator.EndpointBasePaths endpointPaths;
+
+        Timer timer;
+
+        static ILog Logger = LogManager.GetLogger<DelayedMessagePoller>();
+    }
+}

--- a/src/ServiceControl.LearningTransport/DirectoryBasedTransaction.cs
+++ b/src/ServiceControl.LearningTransport/DirectoryBasedTransaction.cs
@@ -1,0 +1,159 @@
+namespace ServiceControl.LearningTransport
+{
+    using System.Collections.Concurrent;
+    using System.IO;
+    using NServiceBus.Logging;
+
+    class DirectoryBasedTransaction : ILearningTransportTransaction
+    {
+        private readonly PathCalculator.EndpointBasePaths endpointPaths;
+
+        public DirectoryBasedTransaction(PathCalculator.EndpointBasePaths endpointPaths, string transactionId)
+        {
+            this.endpointPaths = endpointPaths;
+            this.transactionDir = Path.Combine(endpointPaths.Pending, transactionId);
+            this.commitDir = Path.Combine(endpointPaths.Committed, transactionId);
+        }
+
+        public string FileToProcess { get; private set; }
+
+        public bool BeginTransaction(string incomingFilePath)
+        {
+            Directory.CreateDirectory(transactionDir);
+            FileToProcess = Path.Combine(transactionDir, Path.GetFileName(incomingFilePath));
+
+            try
+            {
+                FileOps.Move(incomingFilePath, FileToProcess);
+            }
+            catch (IOException ex)
+            {
+                log.Debug($"Failed to move {incomingFilePath} to {FileToProcess}", ex);
+                return false;
+            }
+
+            //seem like File.Move is not atomic at least within the same process so we need this extra check
+            return File.Exists(FileToProcess);
+        }
+
+        public void Commit()
+        {
+            Directory.Move(transactionDir, commitDir);
+            committed = true;
+        }
+
+        public void Rollback()
+        {
+            //rollback by moving the file back to the main dir
+            FileOps.Move(FileToProcess, Path.Combine(endpointPaths.Header, Path.GetFileName(FileToProcess)));
+            Directory.Delete(transactionDir, true);
+        }
+
+        public void ClearPendingOutgoingOperations()
+        {
+            OutgoingFile _;
+            while (outgoingFiles.TryDequeue(out _)) { }
+        }
+
+        public void Enlist(string messagePath, string messageContents)
+        {
+            var inProgressFileName = Path.GetFileNameWithoutExtension(messagePath) + ".out";
+
+            var txPath = Path.Combine(transactionDir, inProgressFileName);
+            var committedPath = Path.Combine(commitDir, inProgressFileName);
+
+            outgoingFiles.Enqueue(new OutgoingFile(committedPath, messagePath));
+
+            File.WriteAllText(txPath, messageContents);
+        }
+
+        public bool Complete()
+        {
+            if (!committed)
+            {
+                return false;
+            }
+
+            OutgoingFile outgoingFile;
+            while (outgoingFiles.TryDequeue(out outgoingFile))
+            {
+                FileOps.Move(outgoingFile.TxPath, outgoingFile.TargetPath);
+            }
+
+            Directory.Delete(commitDir, true);
+
+            return true;
+        }
+
+        public static void RecoverPartiallyCompletedTransactions(PathCalculator.EndpointBasePaths endpointPaths)
+        {
+            if (Directory.Exists(endpointPaths.Pending))
+            {
+                foreach (var transactionDir in new DirectoryInfo(endpointPaths.Pending).EnumerateDirectories())
+                {
+                    new DirectoryBasedTransaction(endpointPaths, transactionDir.Name)
+                        .RecoverPending();
+                }
+            }
+
+            if (Directory.Exists(endpointPaths.Committed))
+            {
+                foreach (var transactionDir in new DirectoryInfo(endpointPaths.Committed).EnumerateDirectories())
+                {
+                    new DirectoryBasedTransaction(endpointPaths, transactionDir.Name)
+                        .RecoverCommitted();
+                }
+            }
+        }
+
+        void RecoverPending()
+        {
+            var pendingDir = new DirectoryInfo(transactionDir);
+
+            //only need to move the incoming file
+            foreach (var file in pendingDir.EnumerateFiles(TxtFileExtension))
+            {
+                FileOps.Move(file.FullName, Path.Combine(endpointPaths.Header, file.Name));
+            }
+
+            pendingDir.Delete(true);
+        }
+
+        void RecoverCommitted()
+        {
+            var committedDir = new DirectoryInfo(commitDir);
+
+            //for now just rollback the completed ones as well. We could consider making this smarter in the future
+            // but its good enough for now since duplicates is a possibility anyway
+            foreach (var file in committedDir.EnumerateFiles(TxtFileExtension))
+            {
+                FileOps.Move(file.FullName, Path.Combine(endpointPaths.Header, file.Name));
+            }
+
+            committedDir.Delete(true);
+        }
+
+        bool committed;
+
+        string transactionDir;
+        string commitDir;
+
+        ConcurrentQueue<OutgoingFile> outgoingFiles = new ConcurrentQueue<OutgoingFile>();
+
+        const string TxtFileExtension = "*.txt";
+
+        static ILog log = LogManager.GetLogger<DirectoryBasedTransaction>();
+
+        class OutgoingFile
+        {
+            public OutgoingFile(string txPath, string targetPath)
+            {
+                TxPath = txPath;
+                TargetPath = targetPath;
+            }
+
+            public string TxPath { get; }
+            public string TargetPath { get; }
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport/FileOps.cs
+++ b/src/ServiceControl.LearningTransport/FileOps.cs
@@ -1,0 +1,176 @@
+namespace ServiceControl.LearningTransport
+{
+    using System;
+    using System.IO;
+    using System.Security.Cryptography;
+    using System.Text;
+    using System.Threading;
+    using Janitor;
+
+    static class FileOps
+    {
+        public static void WriteBytes(string filePath, byte[] bytes, bool allowNullBytes = false)
+        {
+            if (bytes == null)
+            {
+                if (!allowNullBytes)
+                {
+                    throw new Exception("bytes array is null");
+                }
+
+                using (new WriteLock(filePath))
+                {
+                    File.Create(filePath).Dispose();
+                }
+                return;
+            }
+
+            using (new WriteLock(filePath))
+            {
+                using (var stream = CreateWriteStream(filePath, FileMode.Create))
+                {
+                    stream.Write(bytes, 0, bytes.Length);
+                }
+            }
+        }
+
+        //write to temp file first so we can do a atomic move
+        public static void WriteTextAtomic(string targetPath, string text)
+        {
+            var tempFile = Path.GetTempFileName();
+            var bytes = Encoding.UTF8.GetBytes(text);
+
+            try
+            {
+                using (var stream = CreateWriteStream(tempFile, FileMode.Open))
+                {
+                    stream.Write(bytes, 0, bytes.Length);
+                }
+            }
+            catch
+            {
+                File.Delete(tempFile);
+                throw;
+            }
+
+            using (new WriteLock(targetPath))
+            {
+                File.Move(tempFile, targetPath);
+            }
+        }
+
+        public static string ReadText(string filePath)
+        {
+            using (new ReadLock(filePath))
+            {
+                using (var stream = new StreamReader(CreateReadStream(filePath), Encoding.UTF8))
+                {
+                    var result = stream.ReadToEnd();
+
+                    return result;
+                }
+            }
+        }
+
+        public static byte[] ReadBytes(string filePath)
+        {
+            using (new ReadLock(filePath))
+            {
+                using (var stream = CreateReadStream(filePath))
+                {
+                    var length = (int) stream.Length;
+                    var body = new byte[length];
+                    stream.Read(body, 0, length);
+
+                    return body;
+                }
+            }
+        }
+
+        public static void Move(string sourcePath, string targetPath)
+        {
+            using (new WriteLock(sourcePath))
+            {
+                using (new WriteLock(targetPath))
+                {
+                    File.Move(sourcePath, targetPath);
+                }
+            }
+        }
+
+        public static void Delete(string filePath)
+        {
+            using (new WriteLock(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        public static void WriteText(string filePath, string text)
+        {
+            var bytes = Encoding.UTF8.GetBytes(text);
+
+            WriteBytes(filePath, bytes);
+        }
+
+        static FileStream CreateReadStream(string filePath)
+        {
+            return new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096);
+        }
+
+        static FileStream CreateWriteStream(string filePath, FileMode fileMode)
+        {
+            return new FileStream(filePath, fileMode, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true);
+        }
+
+        [SkipWeaving]
+        class ReadLock : IDisposable
+        {
+            public ReadLock(string filePath)
+            {
+                readHandle = new EventWaitHandle(true, EventResetMode.AutoReset, CalculateDeterministicId(filePath, "READ"));
+                readHandle.WaitOne();
+            }
+
+            protected static string CalculateDeterministicId(params object[] data)
+            {
+                // use MD5 hash to get a 16-byte hash of the string
+                using (var provider = new MD5CryptoServiceProvider())
+                {
+                    var inputBytes = Encoding.Default.GetBytes(String.Concat(data));
+                    var hashBytes = provider.ComputeHash(inputBytes);
+                    // generate a guid from the hash:
+                    return new Guid(hashBytes).ToString();
+                }
+            }
+
+            public virtual void Dispose()
+            {
+                readHandle?.Set();
+                readHandle?.Dispose();
+            }
+
+            EventWaitHandle readHandle;
+        }
+
+        [SkipWeaving]
+        class WriteLock : ReadLock, IDisposable
+        {
+            public WriteLock(string filePath) : base(filePath)
+            {
+                writeHandle = new EventWaitHandle(true, EventResetMode.AutoReset, CalculateDeterministicId(filePath, "WRITE"));
+                writeHandle.WaitOne();
+            }
+
+            public new void Dispose()
+            {
+                base.Dispose();
+                writeHandle?.Set();
+                writeHandle?.Dispose();
+            }
+
+            EventWaitHandle writeHandle;
+        }
+
+    }
+}

--- a/src/ServiceControl.LearningTransport/FodyWeavers.xml
+++ b/src/ServiceControl.LearningTransport/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers>
+  <Janitor />
+</Weavers>

--- a/src/ServiceControl.LearningTransport/HeaderSerializer.cs
+++ b/src/ServiceControl.LearningTransport/HeaderSerializer.cs
@@ -1,0 +1,39 @@
+namespace ServiceControl.LearningTransport
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Runtime.Serialization.Json;
+    using System.Text;
+
+    static class HeaderSerializer
+    {
+        public static string Serialize(Dictionary<string, string> dictionary)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = JsonReaderWriterFactory.CreateJsonWriter(stream, Encoding.UTF8, true, true, "  "))
+                {
+                    serializer.WriteObject(writer, dictionary);
+                    writer.Flush();
+                }
+
+                return Encoding.UTF8.GetString(stream.ToArray());
+            }
+        }
+
+        public static Dictionary<string, string> Deserialize(string value)
+        {
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(value)))
+            {
+                return (Dictionary<string, string>)serializer.ReadObject(ms);
+            }
+        }
+
+        static DataContractJsonSerializer serializer = new DataContractJsonSerializer(
+            type: typeof(Dictionary<string, string>),
+            settings: new DataContractJsonSerializerSettings
+            {
+                UseSimpleDictionaryFormat = true
+            });
+    }
+}

--- a/src/ServiceControl.LearningTransport/ILearningTransportTransaction.cs
+++ b/src/ServiceControl.LearningTransport/ILearningTransportTransaction.cs
@@ -1,0 +1,19 @@
+namespace ServiceControl.LearningTransport
+{
+    interface ILearningTransportTransaction
+    {
+        string FileToProcess { get; }
+
+        bool BeginTransaction(string incomingFilePath);
+
+        void Commit();
+
+        void Rollback();
+
+        void ClearPendingOutgoingOperations();
+
+        void Enlist(string messagePath, string messageContents);
+
+        bool Complete();
+    }
+}

--- a/src/ServiceControl.LearningTransport/LearningDequeueStrategy.cs
+++ b/src/ServiceControl.LearningTransport/LearningDequeueStrategy.cs
@@ -1,0 +1,320 @@
+﻿namespace ServiceControl.LearningTransport
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.Logging;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast.Transport;
+
+    class LearningDequeueStrategy : IDequeueMessages, IDisposable
+    {
+        public LearningDequeueStrategy(Configure configure, CriticalError criticalError, LearningTransportUnitOfWork unitOfWork, PathCalculator pathCalculator)
+        {
+            this.configure = configure;
+            this.criticalError = criticalError;
+            this.unitOfWork = unitOfWork;
+            this.pathCalculator = pathCalculator;
+        }
+
+        /// <summary>
+        ///     Initializes the <see cref="IDequeueMessages" />.
+        /// </summary>
+        public void Init(Address address, TransactionSettings transactionSettings, Func<TransportMessage, bool> tryProcessMessage, Action<TransportMessage, Exception> endProcessMessage)
+        {
+            this.transactionSettings = transactionSettings;
+            this.tryProcessMessage = tryProcessMessage;
+            this.endProcessMessage = endProcessMessage;
+
+            PathChecker.ThrowForBadPath(address.Queue, "InputQueue");
+
+            endpointPaths = pathCalculator.PathsForEndpoint(address.Queue);
+
+            delayedMessagePoller = new DelayedMessagePoller(endpointPaths);
+
+            purgeOnStartup = configure.PurgeOnStartup();
+        }
+
+        /// <summary>
+        ///     Starts the dequeuing of message using the specified <paramref name="maximumConcurrencyLevel" />.
+        /// </summary>
+        public void Start(int maximumConcurrencyLevel)
+        {
+            maxConcurrency = maximumConcurrencyLevel;
+            concurrencyLimiter = new SemaphoreSlim(maxConcurrency);
+            cancellationTokenSource = new CancellationTokenSource();
+
+            cancellationToken = cancellationTokenSource.Token;
+
+            if (purgeOnStartup)
+            {
+                if (Directory.Exists(endpointPaths.Header))
+                {
+                    Directory.Delete(endpointPaths.Header, true);
+                }
+            }
+
+            RecoverPendingTransactions();
+
+            EnsureDirectoriesExists();
+
+            messagePumpTask = Task.Run(ProcessMessages, cancellationToken);
+
+            delayedMessagePoller.Start();
+        }
+
+        /// <summary>
+        ///     Stops the dequeuing of messages.
+        /// </summary>
+        public void Stop()
+        {
+            cancellationTokenSource.Cancel();
+
+            delayedMessagePoller.Stop();
+
+            messagePumpTask.Wait(CancellationToken.None);
+
+            while (concurrencyLimiter.CurrentCount != maxConcurrency)
+            {
+                Thread.Sleep(50);
+            }
+
+            concurrencyLimiter.Dispose();
+        }
+
+        /// <summary>
+        ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            // Injected
+        }
+
+        void RecoverPendingTransactions()
+        {
+            if (transactionSettings.IsTransactional)
+            {
+                DirectoryBasedTransaction.RecoverPartiallyCompletedTransactions(endpointPaths);
+            }
+            else
+            {
+                if (Directory.Exists(endpointPaths.Pending))
+                {
+                    Directory.Delete(endpointPaths.Pending, true);
+                }
+            }
+        }
+
+        void EnsureDirectoriesExists()
+        {
+            Directory.CreateDirectory(endpointPaths.Header);
+            Directory.CreateDirectory(endpointPaths.Body);
+            Directory.CreateDirectory(endpointPaths.Deferred);
+            Directory.CreateDirectory(endpointPaths.Pending);
+
+            if (transactionSettings.IsTransactional)
+            {
+                Directory.CreateDirectory(endpointPaths.Committed);
+            }
+        }
+
+        [DebuggerNonUserCode]
+        async Task ProcessMessages()
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await InnerProcessMessages()
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // graceful shutdown
+                }
+                catch (Exception ex)
+                {
+                    criticalError.Raise("Failure to process messages", ex);
+                }
+            }
+        }
+
+        async Task InnerProcessMessages()
+        {
+            log.Debug($"Started polling for new messages in {endpointPaths.Header}");
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var filesFound = false;
+
+                foreach (var filePath in Directory.EnumerateFiles(endpointPaths.Header, "*.*"))
+                {
+                    filesFound = true;
+
+                    var nativeMessageId = Path.GetFileNameWithoutExtension(filePath).Replace(".metadata", "");
+
+                    await concurrencyLimiter.WaitAsync(cancellationToken)
+                        .ConfigureAwait(false);
+
+                    ILearningTransportTransaction transaction;
+
+                    try
+                    {
+                        transaction = GetTransaction();
+
+                        var ableToLockFile = transaction.BeginTransaction(filePath);
+
+                        if (!ableToLockFile)
+                        {
+                            log.Debug($"Unable to lock file {filePath}({transaction.FileToProcess})");
+                            concurrencyLimiter.Release();
+                            continue;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Debug($"Failed to begin transaction {filePath}", ex);
+
+                        concurrencyLimiter.Release();
+                        throw;
+                    }
+
+
+                    ProcessFile(transaction, nativeMessageId);
+                    try
+                    {
+                        if (log.IsDebugEnabled)
+                        {
+                            log.Debug($"Completing processing for {filePath}({transaction.FileToProcess})");
+                        }
+
+                        var wasCommitted = transaction.Complete();
+
+                        if (wasCommitted)
+                        {
+                            FileOps.Delete(Path.Combine(endpointPaths.Body, nativeMessageId + PathCalculator.BodyFileSuffix));
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        criticalError.Raise($"Failure while trying to complete receive transaction for  {filePath}({transaction.FileToProcess})" + filePath, ex);
+                    }
+                    finally
+                    {
+                        concurrencyLimiter.Release();
+                    }
+                }
+
+                if (!filesFound)
+                {
+                    await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        ILearningTransportTransaction GetTransaction()
+        {
+            if (!transactionSettings.IsTransactional)
+            {
+                return new NoTransaction(endpointPaths.Header, endpointPaths.Pending);
+            }
+
+            return new DirectoryBasedTransaction(endpointPaths, Guid.NewGuid().ToString());
+        }
+
+        void ProcessFile(ILearningTransportTransaction transaction, string messageId)
+        {
+            var message = FileOps.ReadText(transaction.FileToProcess);
+
+            var headers = HeaderSerializer.Deserialize(message);
+
+            string ttbrString;
+            if (headers.TryGetValue(LearningTransportHeaders.TimeToBeReceived, out ttbrString))
+            {
+                headers.Remove(LearningTransportHeaders.TimeToBeReceived);
+
+                var ttbr = TimeSpan.Parse(ttbrString);
+
+                //file.move preserves create time
+                var sentTime = File.GetCreationTimeUtc(transaction.FileToProcess);
+
+                var utcNow = DateTime.UtcNow;
+                if (sentTime + ttbr < utcNow)
+                {
+                    transaction.Commit();
+                    log.InfoFormat("Dropping message '{0}' as the specified TimeToBeReceived of '{1}' expired since sending the message at '{2:O}'. Current UTC time is '{3:O}'", messageId, ttbrString, sentTime, utcNow);
+                    return;
+                }
+            }
+
+            var tokenSource = new CancellationTokenSource();
+
+            var bodyPath = Path.Combine(endpointPaths.Body, $"{messageId}{PathCalculator.BodyFileSuffix}");
+
+            var body = FileOps.ReadBytes(bodyPath);
+
+            var transportMessage = new TransportMessage(messageId, headers)
+            {
+                Body = body
+            };
+
+            Exception exception = null;
+
+            unitOfWork.SetTransaction(transaction);
+
+            try
+            {
+                if (tryProcessMessage(transportMessage))
+                {
+                    if (tokenSource.IsCancellationRequested)
+                    {
+                        transaction.Rollback();
+
+                        return;
+                    }
+
+                    transaction.Commit();
+                }
+                else
+                {
+                    transaction.Rollback();
+                }
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+                transaction.Rollback();
+            }
+            finally
+            {
+                unitOfWork.ClearTransaction();
+                endProcessMessage(transportMessage, exception);
+            }
+        }
+
+        CancellationToken cancellationToken;
+        CancellationTokenSource cancellationTokenSource;
+        SemaphoreSlim concurrencyLimiter;
+        Task messagePumpTask;
+
+        Configure configure;
+        readonly CriticalError criticalError;
+        LearningTransportUnitOfWork unitOfWork;
+        private readonly PathCalculator pathCalculator;
+
+        TransactionSettings transactionSettings;
+        Func<TransportMessage, bool> tryProcessMessage;
+        Action<TransportMessage, Exception> endProcessMessage;
+
+        bool purgeOnStartup;
+
+        DelayedMessagePoller delayedMessagePoller;
+        int maxConcurrency;
+
+        static ILog log = LogManager.GetLogger<LearningDequeueStrategy>();
+        private PathCalculator.EndpointBasePaths endpointPaths;
+    }
+}

--- a/src/ServiceControl.LearningTransport/LearningMessageDeferrer.cs
+++ b/src/ServiceControl.LearningTransport/LearningMessageDeferrer.cs
@@ -1,0 +1,61 @@
+﻿namespace ServiceControl.LearningTransport
+{
+    using System;
+    using NServiceBus;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+
+    class LearningMessageDeferrer : IDeferMessages
+    {
+        public LearningMessageDeferrer(MessageDispatcher dispatcher, PathCalculator pathCalculator)
+        {
+            this.dispatcher = dispatcher;
+            this.pathCalculator = pathCalculator;
+        }
+
+        public void Defer(TransportMessage message, SendOptions sendOptions)
+        {
+            DateTime? timeToDeliver = null;
+
+            if (sendOptions.DeliverAt.HasValue)
+            {
+                timeToDeliver = sendOptions.DeliverAt.Value;
+            }
+            else if (sendOptions.DelayDeliveryWith.HasValue)
+            {
+                timeToDeliver = DateTime.UtcNow + sendOptions.DelayDeliveryWith;
+            }
+
+            if (!timeToDeliver.HasValue)
+            {
+                throw new Exception("Deferred message sent without a time to deliver.");
+            }
+
+            // we need to "ceil" the seconds to guarantee that we delay with at least the requested value
+            // since the folder name has only second resolution.
+            if (timeToDeliver.Value.Millisecond > 0)
+            {
+                timeToDeliver += TimeSpan.FromSeconds(1);
+            }
+
+            // ReSharper disable once PossibleInvalidOperationException
+            var paths = pathCalculator.PathsForDispatch(sendOptions.Destination.Queue, timeToDeliver.Value);
+
+            if (message.TimeToBeReceived < TimeSpan.MaxValue)
+            {
+                throw new Exception($"Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of type '{message.Headers[Headers.EnclosedMessageTypes]}'.");
+            }
+
+            var replyToAddress = sendOptions.ReplyToAddress ?? message.ReplyToAddress;
+
+            dispatcher.Dispatch(message, paths, replyToAddress.Queue, sendOptions.EnlistInReceiveTransaction);
+        }
+
+        public void ClearDeferredMessages(string headerKey, string headerValue)
+        {
+        }
+
+        private readonly MessageDispatcher dispatcher;
+        private readonly PathCalculator pathCalculator;
+    }
+}

--- a/src/ServiceControl.LearningTransport/LearningMessagePublisher.cs
+++ b/src/ServiceControl.LearningTransport/LearningMessagePublisher.cs
@@ -1,0 +1,64 @@
+﻿namespace ServiceControl.LearningTransport
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+
+    class LearningMessagePublisher : IPublishMessages
+    {
+        public LearningMessagePublisher(MessageDispatcher dispatcher, PathCalculator pathCalculator)
+        {
+            this.dispatcher = dispatcher;
+            this.pathCalculator = pathCalculator;
+        }
+
+        public void Publish(TransportMessage message, PublishOptions publishOptions)
+        {
+            var replyToAddress = publishOptions.ReplyToAddress ?? message.ReplyToAddress;
+
+            var allEventTypes = GetPotentialEventTypes(publishOptions.EventType);
+
+            var subscribers = pathCalculator.GetSubscribersFor(allEventTypes);
+
+            foreach (var subscriberPaths in subscribers)
+            {
+                dispatcher.Dispatch(message, subscriberPaths, replyToAddress.Queue, publishOptions.EnlistInReceiveTransaction);
+            }
+        }
+
+        static IEnumerable<Type> GetPotentialEventTypes(Type messageType)
+        {
+            var allEventTypes = new HashSet<Type>();
+
+            var currentType = messageType;
+
+            while (currentType != null)
+            {
+                //do not include the marker interfaces
+                if (IsCoreMarkerInterface(currentType))
+                {
+                    break;
+                }
+
+                allEventTypes.Add(currentType);
+
+                currentType = currentType.BaseType;
+            }
+
+            foreach (var type in messageType.GetInterfaces().Where(i => !IsCoreMarkerInterface(i)))
+            {
+                allEventTypes.Add(type);
+            }
+
+            return allEventTypes;
+        }
+
+        static bool IsCoreMarkerInterface(Type type) => type == typeof(IMessage) || type == typeof(IEvent) || type == typeof(ICommand);
+
+        private readonly MessageDispatcher dispatcher;
+        private readonly PathCalculator pathCalculator;
+    }
+}

--- a/src/ServiceControl.LearningTransport/LearningMessageSender.cs
+++ b/src/ServiceControl.LearningTransport/LearningMessageSender.cs
@@ -1,0 +1,30 @@
+﻿namespace ServiceControl.LearningTransport
+{
+    using NServiceBus;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+
+    class LearningMessageSender : ISendMessages
+    {
+        public LearningMessageSender(MessageDispatcher dispatcher, PathCalculator pathCalculator)
+        {
+            this.dispatcher = dispatcher;
+            this.pathCalculator = pathCalculator;
+        }
+
+        /// <summary>
+        /// Sends the given <paramref name="message"/>
+        /// </summary>
+        public void Send(TransportMessage message, SendOptions sendOptions)
+        {
+            var paths = pathCalculator.PathsForDispatch(sendOptions.Destination.Queue);
+
+            var replyToAddress = sendOptions.ReplyToAddress ?? message.ReplyToAddress;
+
+            dispatcher.Dispatch(message, paths, replyToAddress?.Queue, sendOptions.EnlistInReceiveTransaction);
+        }
+
+        private readonly MessageDispatcher dispatcher;
+        private readonly PathCalculator pathCalculator;
+    }
+}

--- a/src/ServiceControl.LearningTransport/LearningQueueCreator.cs
+++ b/src/ServiceControl.LearningTransport/LearningQueueCreator.cs
@@ -1,0 +1,12 @@
+﻿namespace ServiceControl.LearningTransport
+{
+    using NServiceBus;
+    using NServiceBus.Transports;
+
+    class LearningQueueCreator : ICreateQueues
+    {
+        public void CreateQueueIfNecessary(Address address, string account)
+        {
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport/LearningTransport.cs
+++ b/src/ServiceControl.LearningTransport/LearningTransport.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus
+{
+    using Transports;
+
+    /// <summary>
+    /// Transport definition for LearningTransport
+    /// </summary>
+    public class LearningTransport : TransportDefinition
+    {
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        public LearningTransport()
+        {
+            HasNativePubSubSupport = true;
+            HasSupportForCentralizedPubSub = true;
+            HasSupportForDistributedTransactions = false;
+        }
+
+        /// <summary>
+        /// Gives implementations access to the <see cref="BusConfiguration"/> instance at configuration time.
+        /// </summary>
+        /// <param name="config"></param>
+        protected override void Configure(BusConfiguration config)
+        {
+            config.EnableFeature<LearningTransportConfigurator>();
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport/LearningTransportConfigurator.cs
+++ b/src/ServiceControl.LearningTransport/LearningTransportConfigurator.cs
@@ -1,0 +1,45 @@
+﻿namespace NServiceBus
+{
+    using Features;
+    using ServiceControl.LearningTransport;
+    using Transports;
+
+    class LearningTransportConfigurator : ConfigureTransport
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="ConfigureTransport"/>.
+        /// </summary>
+        protected override void Configure(FeatureConfigurationContext context, string connectionString)
+        {
+            var endpointName = context.Settings.EndpointName();
+            var localAddress = context.Settings.LocalAddress().Queue;
+
+            PathChecker.ThrowForBadPath(connectionString, "ConnectionString");
+            PathChecker.ThrowForBadPath(endpointName, "EndpointName");
+            PathChecker.ThrowForBadPath(localAddress, "LocalAddress");
+
+            context.Container.ConfigureComponent(() => new PathCalculator(connectionString), DependencyLifecycle.SingleInstance);
+
+            context.Container.ConfigureComponent<MessageDispatcher>(DependencyLifecycle.InstancePerCall);
+
+            context.Container.ConfigureComponent<LearningTransportUnitOfWork>(DependencyLifecycle.SingleInstance);
+
+            if (!context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"))
+            {
+                context.Container.ConfigureComponent<LearningDequeueStrategy>(DependencyLifecycle.InstancePerCall);
+            }
+
+            context.Container.ConfigureComponent<LearningMessageSender>(DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureComponent<LearningMessageDeferrer>(DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureComponent<LearningMessagePublisher>(DependencyLifecycle.InstancePerCall);
+
+            context.Container.ConfigureComponent(() => new LearningTransportSubscriptionManager(connectionString, endpointName, localAddress),  DependencyLifecycle.InstancePerCall);
+
+            context.Container.ConfigureComponent<LearningQueueCreator>(DependencyLifecycle.SingleInstance);
+        }
+
+        protected override string ExampleConnectionStringForErrorMessage { get; } = @"C:\.learningtransport";
+
+        protected override bool RequiresConnectionString { get; } = true;
+    }
+}

--- a/src/ServiceControl.LearningTransport/LearningTransportHeaders.cs
+++ b/src/ServiceControl.LearningTransport/LearningTransportHeaders.cs
@@ -1,0 +1,7 @@
+﻿namespace ServiceControl.LearningTransport
+{
+    static class LearningTransportHeaders
+    {
+        public const string TimeToBeReceived = "NServiceBus.Transport.Learning.TimeToBeReceived";
+    }
+}

--- a/src/ServiceControl.LearningTransport/LearningTransportSubscriptionManager.cs
+++ b/src/ServiceControl.LearningTransport/LearningTransportSubscriptionManager.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using ServiceControl.LearningTransport;
+    using Transports;
+
+    class LearningTransportSubscriptionManager : IManageSubscriptions
+    {
+        public LearningTransportSubscriptionManager(string basePath, string endpointName, string localAddress)
+        {
+            this.endpointName = endpointName;
+            this.localAddress = localAddress;
+            this.basePath = Path.Combine(basePath, ".events");
+
+            Directory.CreateDirectory(this.basePath);
+        }
+
+        public void Subscribe(Type eventType, Address publisherAddress)
+        {
+            var eventDir = GetEventDirectory(eventType);
+
+            // that way we can detect that there is indeed a publisher for the event. That said it also means that we will have do "retries" here due to race condition.
+            Directory.CreateDirectory(eventDir);
+
+            var subscriptionEntryPath = GetSubscriptionEntryPath(eventDir);
+
+            var attempts = 0;
+
+            // since we have a design that can run into concurrency exceptions we perform a few retries
+            while (true)
+            {
+                try
+                {
+                    FileOps.WriteText(subscriptionEntryPath, localAddress);
+
+                    return;
+                }
+                catch (IOException)
+                {
+                    attempts++;
+
+                    if (attempts > 10)
+                    {
+                        throw;
+                    }
+
+                    //allow the other task to complete
+                    Thread.Sleep(100);
+                }
+            }
+        }
+
+        public void Unsubscribe(Type eventType, Address publisherAddress)
+        {
+            var eventDir = GetEventDirectory(eventType);
+            var subscriptionEntryPath = GetSubscriptionEntryPath(eventDir);
+
+            var attempts = 0;
+
+            // since we have a design that can run into concurrency exceptions we perform a few retries
+            while (true)
+            {
+                try
+                {
+                    if (!File.Exists(subscriptionEntryPath))
+                    {
+                        return;
+                    }
+
+                    FileOps.Delete(subscriptionEntryPath);
+
+                    return;
+                }
+                catch (IOException)
+                {
+                    attempts++;
+
+                    if (attempts > 10)
+                    {
+                        throw;
+                    }
+
+                    //allow the other task to complete
+                    Thread.Sleep(100);
+                }
+            }
+        }
+
+        string GetSubscriptionEntryPath(string eventDir) => Path.Combine(eventDir, endpointName + ".subscription");
+
+        string GetEventDirectory(Type eventType) => Path.Combine(basePath, eventType.FullName);
+
+        string basePath;
+        string endpointName;
+        string localAddress;
+    }
+}

--- a/src/ServiceControl.LearningTransport/LearningTransportUnitOfWork.cs
+++ b/src/ServiceControl.LearningTransport/LearningTransportUnitOfWork.cs
@@ -1,0 +1,40 @@
+﻿namespace ServiceControl.LearningTransport
+{
+    using System;
+    using System.Threading;
+
+    class LearningTransportUnitOfWork : IDisposable
+    {
+        public ILearningTransportTransaction Transaction => currentTransaction.Value;
+
+        public void SetTransaction(ILearningTransportTransaction transaction)
+        {
+            currentTransaction.Value = transaction;
+        }
+
+        public bool HasActiveTransaction
+        {
+            get
+            {
+                if (!currentTransaction.IsValueCreated)
+                {
+                    return false;
+                }
+
+                return currentTransaction.Value != null;
+            }
+        }
+
+        public void ClearTransaction()
+        {
+            currentTransaction.Value = null;
+        }
+
+        public void Dispose()
+        {
+            //Injected
+        }
+
+        ThreadLocal<ILearningTransportTransaction> currentTransaction = new ThreadLocal<ILearningTransportTransaction>();
+    }
+}

--- a/src/ServiceControl.LearningTransport/MessageDispatcher.cs
+++ b/src/ServiceControl.LearningTransport/MessageDispatcher.cs
@@ -1,0 +1,63 @@
+﻿namespace ServiceControl.LearningTransport
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using NServiceBus;
+
+    class MessageDispatcher
+    {
+        public MessageDispatcher(LearningTransportUnitOfWork unitOfWork)
+        {
+            maxMessageSizeKb = int.MaxValue / 1024;
+            this.unitOfWork = unitOfWork;
+        }
+
+        public void Dispatch(TransportMessage message, PathCalculator.MessageBasePaths basePaths, string replyToAddress, bool enlist)
+        {
+            PathChecker.ThrowForBadPath(basePaths.Header, "message destination");
+            PathChecker.ThrowForBadPath(basePaths.Body, "body destination");
+
+            Directory.CreateDirectory(basePaths.Header);
+            Directory.CreateDirectory(basePaths.Body);
+
+            message.Headers[Headers.ReplyToAddress] = replyToAddress;
+
+            var nativeMessageId = Guid.NewGuid().ToString();
+
+            var bodyPath = Path.Combine(basePaths.Body, nativeMessageId) + PathCalculator.BodyFileSuffix;
+
+            FileOps.WriteBytes(bodyPath, message.Body, true);
+
+            if (message.TimeToBeReceived < TimeSpan.MaxValue)
+            {
+                message.Headers[LearningTransportHeaders.TimeToBeReceived] = message.TimeToBeReceived.ToString();
+            }
+
+            var messagePath = Path.Combine(basePaths.Header, nativeMessageId) + ".metadata.txt";
+
+            var headerPayload = HeaderSerializer.Serialize(message.Headers);
+            var headerSize = Encoding.UTF8.GetByteCount(headerPayload);
+
+            var bodySize = message.Body?.Length ?? 0;
+
+            if (headerSize + bodySize > maxMessageSizeKb * 1024)
+            {
+                throw new Exception($"The total size of the '{message.Headers[Headers.EnclosedMessageTypes]}' message body ({bodySize} bytes) plus headers ({headerSize} bytes) is larger than {maxMessageSizeKb} KB and will not be supported on some production transports. Consider using the NServiceBus DataBus or the claim check pattern to avoid messages with a large payload. Use 'EndpointConfiguration.UseTransport<LearningTransport>().NoPayloadSizeRestriction()' to disable this check and proceed with the current message size.");
+            }
+
+            if (enlist && unitOfWork.HasActiveTransaction)
+            {
+                unitOfWork.Transaction.Enlist(messagePath, headerPayload);
+            }
+            else
+            {
+                // atomic avoids the file being locked when the receiver tries to process it
+                FileOps.WriteTextAtomic(messagePath, headerPayload);
+            }
+        }
+
+        readonly int maxMessageSizeKb;
+        LearningTransportUnitOfWork unitOfWork;
+    }
+}

--- a/src/ServiceControl.LearningTransport/NoTransaction.cs
+++ b/src/ServiceControl.LearningTransport/NoTransaction.cs
@@ -1,0 +1,54 @@
+namespace ServiceControl.LearningTransport
+{
+    using System;
+    using System.IO;
+    using NServiceBus.Logging;
+
+    class NoTransaction : ILearningTransportTransaction
+    {
+        public NoTransaction(string basePath, string pendingDirName)
+        {
+            processingDirectory = Path.Combine(basePath, pendingDirName, Guid.NewGuid().ToString());
+        }
+
+        public string FileToProcess { get; private set; }
+
+        public bool BeginTransaction(string incomingFilePath)
+        {
+            Directory.CreateDirectory(processingDirectory);
+            FileToProcess = Path.Combine(processingDirectory, Path.GetFileName(incomingFilePath));
+
+            try
+            {
+                FileOps.Move(incomingFilePath, FileToProcess);
+            }
+            catch (IOException ex)
+            {
+                log.Debug($"Failed to move {incomingFilePath} to {FileToProcess}", ex);
+                return false;
+            }
+
+            //seem like File.Move is not atomic at least within the same process so we need this extra check
+            return File.Exists(FileToProcess);
+        }
+
+        public void Enlist(string messagePath, string messageContents) => FileOps.WriteText(messagePath, messageContents);
+
+        public void Commit() { }
+
+        public void Rollback() { }
+
+        public void ClearPendingOutgoingOperations() { }
+
+        public bool Complete()
+        {
+            Directory.Delete(processingDirectory, true);
+
+            return true;
+        }
+
+        string processingDirectory;
+
+        static ILog log = LogManager.GetLogger<NoTransaction>();
+    }
+}

--- a/src/ServiceControl.LearningTransport/PathCalculator.cs
+++ b/src/ServiceControl.LearningTransport/PathCalculator.cs
@@ -1,0 +1,102 @@
+﻿namespace ServiceControl.LearningTransport
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    class PathCalculator
+    {
+        public PathCalculator(string basePath)
+        {
+            this.basePath = basePath;
+        }
+
+        public EndpointBasePaths PathsForEndpoint(string endpoint)
+        {
+            var queuePath = Path.Combine(basePath, endpoint);
+
+            return new EndpointBasePaths
+            {
+                Header = queuePath,
+                Body = Path.Combine(queuePath, BodyDirName),
+                Deferred = Path.Combine(queuePath, DelayedDirName),
+                Pending = Path.Combine(queuePath, PendingDirName),
+                Committed = Path.Combine(queuePath, CommittedDirName)
+            };
+        }
+
+        public MessageBasePaths PathsForDispatch(string endpoint)
+        {
+            var endpointPaths = PathsForEndpoint(endpoint);
+
+            return new MessageBasePaths
+            {
+                Header = endpointPaths.Header,
+                Body = endpointPaths.Body
+            };
+        }
+
+        public MessageBasePaths PathsForDispatch(string endpoint, DateTime timeToDeliver)
+        {
+            var endpointPaths = PathsForEndpoint(endpoint);
+            return new MessageBasePaths
+            {
+                Header = Path.Combine(endpointPaths.Deferred, timeToDeliver.ToString("yyyyMMddHHmmss")),
+                Body = endpointPaths.Body
+            };
+        }
+        public IEnumerable<MessageBasePaths> GetSubscribersFor(IEnumerable<Type> allEventTypes)
+        {
+            var subscribers = new HashSet<MessageBasePaths>();
+
+            foreach (var eventType in allEventTypes)
+            {
+                if (eventType.FullName == null)
+                {
+                    continue;
+                }
+                var subscriptionsPath = Path.Combine(basePath, EventsDirName, eventType.FullName);
+
+                if (!Directory.Exists(subscriptionsPath))
+                {
+                    continue;
+                }
+
+                foreach (var subscription in Directory.GetFiles(subscriptionsPath))
+                {
+                    var subscriber = FileOps.ReadText(subscription);
+
+                    subscribers.Add(PathsForDispatch(subscriber));
+                }
+            }
+
+            return subscribers;
+        }
+
+        public struct EndpointBasePaths
+        {
+            public string Header;
+            public string Body;
+            public string Deferred;
+            public string Committed;
+            public string Pending;
+        }
+
+        public struct MessageBasePaths
+        {
+            public string Header;
+            public string Body;
+        }
+
+        readonly string basePath;
+
+        const string EventsDirName = ".events";
+
+        public const string BodyFileSuffix = ".body.txt";
+        const string BodyDirName = ".bodies";
+        const string DelayedDirName = ".delayed";
+
+        const string CommittedDirName = ".committed";
+        const string PendingDirName = ".pending";
+    }
+}

--- a/src/ServiceControl.LearningTransport/PathChecker.cs
+++ b/src/ServiceControl.LearningTransport/PathChecker.cs
@@ -1,0 +1,25 @@
+namespace NServiceBus
+{
+    using System;
+    using System.IO;
+
+    static class PathChecker
+    {
+        public static void ThrowForBadPath(string value, string valueName)
+        {
+            var invalidPathChars = Path.GetInvalidPathChars();
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return;
+            }
+
+            if (value.IndexOfAny(invalidPathChars) < 0)
+            {
+                return;
+            }
+
+            throw new Exception($"The value for '{valueName}' has illegal path characters. Provided value: {value}. Must not contain any of {string.Join(", ", invalidPathChars)}.");
+        }
+    }
+}

--- a/src/ServiceControl.LearningTransport/Properties/AssemblyInfo.cs
+++ b/src/ServiceControl.LearningTransport/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ServiceControl.LearningTransport")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ServiceControl.LearningTransport")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("12f4b317-b885-4d43-a152-fdb5b0ea2042")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceControl.LearningTransport/ServiceControl.LearningTransport.csproj
+++ b/src/ServiceControl.LearningTransport/ServiceControl.LearningTransport.csproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{12F4B317-B885-4D43-A152-FDB5B0EA2042}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ServiceControl.LearningTransport</RootNamespace>
+    <AssemblyName>ServiceControl.LearningTransport</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Janitor, Version=1.5.2.0, Culture=neutral, PublicKeyToken=d34c7d3bba3746e6, processorArchitecture=MSIL">
+      <HintPath>..\packages\Janitor.Fody.1.5.2\lib\portable-net4+sl5+wp8+win8+wpa81+MonoAndroid16+MonoTouch40\Janitor.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.5.2.24\lib\net45\NServiceBus.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DelayedMessagePoller.cs" />
+    <Compile Include="DirectoryBasedTransaction.cs" />
+    <Compile Include="FileOps.cs" />
+    <Compile Include="HeaderSerializer.cs" />
+    <Compile Include="ILearningTransportTransaction.cs" />
+    <Compile Include="LearningDequeueStrategy.cs" />
+    <Compile Include="LearningMessageDeferrer.cs" />
+    <Compile Include="LearningMessageSender.cs" />
+    <Compile Include="LearningQueueCreator.cs" />
+    <Compile Include="LearningTransport.cs" />
+    <Compile Include="LearningTransportConfigurator.cs" />
+    <Compile Include="LearningTransportHeaders.cs" />
+    <Compile Include="LearningMessagePublisher.cs" />
+    <Compile Include="LearningTransportSubscriptionManager.cs" />
+    <Compile Include="LearningTransportUnitOfWork.cs" />
+    <Compile Include="MessageDispatcher.cs" />
+    <Compile Include="PathCalculator.cs" />
+    <Compile Include="NoTransaction.cs" />
+    <Compile Include="PathChecker.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Fody.2.1.3\build\netstandard1.2\Fody.targets" Condition="Exists('..\packages\Fody.2.1.3\build\netstandard1.2\Fody.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Fody.2.1.3\build\netstandard1.2\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.1.3\build\netstandard1.2\Fody.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/ServiceControl.LearningTransport/packages.config
+++ b/src/ServiceControl.LearningTransport/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Fody" version="2.1.3" targetFramework="net452" developmentDependency="true" />
+  <package id="Janitor.Fody" version="1.5.2" targetFramework="net452" developmentDependency="true" />
+  <package id="NServiceBus" version="5.2.24" targetFramework="net452" />
+</packages>

--- a/src/ServiceControl.SqlServerWithDTC/ServiceControl.Transports.SqlServerWithDTC.csproj
+++ b/src/ServiceControl.SqlServerWithDTC/ServiceControl.Transports.SqlServerWithDTC.csproj
@@ -34,8 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.5.2.19\lib\net45\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\NServiceBus.5.2.24\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Transports.SQLServer, Version=2.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.SqlServer.2.2.4\lib\net45\NServiceBus.Transports.SQLServer.dll</HintPath>

--- a/src/ServiceControl.SqlServerWithDTC/packages.config
+++ b/src/ServiceControl.SqlServerWithDTC/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="3.6.5" targetFramework="net452" developmentDependency="true" />
-  <package id="NServiceBus" version="5.2.19" targetFramework="net452" />
+  <package id="NServiceBus" version="5.2.24" targetFramework="net452" />
   <package id="NServiceBus.SqlServer" version="2.2.4" targetFramework="net452" />
 </packages>

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -79,8 +79,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.5.2.19\lib\net45\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\NServiceBus.5.2.24\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/src/ServiceControl.UnitTests/packages.config
+++ b/src/ServiceControl.UnitTests/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net452" />
   <package id="Nancy" version="1.4.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
-  <package id="NServiceBus" version="5.2.19" targetFramework="net452" />
+  <package id="NServiceBus" version="5.2.24" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
   <package id="RavenDB.Client" version="2.5.2996" targetFramework="net452" />
   <package id="RavenDB.Database" version="2.5.2996" targetFramework="net452" />

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -46,6 +46,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Transports.S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.LearningTransport", "ServiceControl.LearningTransport\ServiceControl.LearningTransport.csproj", "{12F4B317-B885-4D43-A152-FDB5B0EA2042}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.LearningTransport.AcceptanceTests", "ServiceControl.LearningTransport.AcceptanceTests\ServiceControl.LearningTransport.AcceptanceTests.csproj", "{145A4671-E0DF-4955-829A-1355533C0E4F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -112,6 +114,10 @@ Global
 		{12F4B317-B885-4D43-A152-FDB5B0EA2042}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{12F4B317-B885-4D43-A152-FDB5B0EA2042}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{12F4B317-B885-4D43-A152-FDB5B0EA2042}.Release|Any CPU.Build.0 = Release|Any CPU
+		{145A4671-E0DF-4955-829A-1355533C0E4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{145A4671-E0DF-4955-829A-1355533C0E4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{145A4671-E0DF-4955-829A-1355533C0E4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{145A4671-E0DF-4955-829A-1355533C0E4F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -44,6 +44,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CustomTransportConfiguratio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Transports.SqlServerWithDTC", "ServiceControl.SqlServerWithDTC\ServiceControl.Transports.SqlServerWithDTC.csproj", "{691074CB-67F0-45CE-B3DE-AC9A94AF29B4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.LearningTransport", "ServiceControl.LearningTransport\ServiceControl.LearningTransport.csproj", "{12F4B317-B885-4D43-A152-FDB5B0EA2042}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -106,6 +108,10 @@ Global
 		{691074CB-67F0-45CE-B3DE-AC9A94AF29B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{691074CB-67F0-45CE-B3DE-AC9A94AF29B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{691074CB-67F0-45CE-B3DE-AC9A94AF29B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12F4B317-B885-4D43-A152-FDB5B0EA2042}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12F4B317-B885-4D43-A152-FDB5B0EA2042}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12F4B317-B885-4D43-A152-FDB5B0EA2042}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12F4B317-B885-4D43-A152-FDB5B0EA2042}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -156,8 +156,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.5.2.21\lib\net45\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\NServiceBus.5.2.24\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.NLog, Version=1.1.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.NLog.1.1.0\lib\net45\NServiceBus.NLog.dll</HintPath>

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -655,7 +655,12 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.LearningTransport\ServiceControl.LearningTransport.csproj">
+      <Project>{12f4b317-b885-4d43-a152-fdb5b0ea2042}</Project>
+      <Name>ServiceControl.LearningTransport</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/ServiceControl/packages.config
+++ b/src/ServiceControl/packages.config
@@ -22,7 +22,7 @@
   <package id="Nancy.Owin" version="1.4.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
   <package id="NLog" version="4.3.7" targetFramework="net452" />
-  <package id="NServiceBus" version="5.2.21" targetFramework="net452" />
+  <package id="NServiceBus" version="5.2.24" targetFramework="net452" />
   <package id="NServiceBus.Autofac" version="5.0.0" targetFramework="net452" />
   <package id="NServiceBus.NLog" version="1.1.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />

--- a/src/ServiceControlInstaller.Engine/Instances/Transports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/Transports.cs
@@ -50,6 +50,13 @@
                 TypeName = "NServiceBus.RabbitMQTransport, NServiceBus.Transports.RabbitMQ",
                 MatchOn = "NServiceBus.RabbitMQ",
                 SampleConnectionString = "host=<HOSTNAME>;username=<USERNAME>;password=<PASSWORD>"
+            },
+            new TransportInfo
+            {
+                Name = "Learning",
+                TypeName = "NServiceBus.LearningTransport, ServiceControl.LearningTransport",
+                MatchOn = "NServiceBus.LearningTransport",
+                SampleConnectionString = @"C:\.learningtransport"
             }
         };
     }

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -81,8 +81,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.5.2.21\lib\net45\NServiceBus.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\NServiceBus.5.2.24\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
     <Reference Include="NServiceBus.Transports.RabbitMQ, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.RabbitMQ.3.5.1\lib\net451\NServiceBus.Transports.RabbitMQ.dll</HintPath>

--- a/src/ServiceControlInstaller.Packaging/packages.config
+++ b/src/ServiceControlInstaller.Packaging/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
-  <package id="NServiceBus" version="5.2.21" targetFramework="net452" />
+  <package id="NServiceBus" version="5.2.24" targetFramework="net452" />
   <package id="NServiceBus.Azure.Transports.WindowsAzureServiceBus" version="6.4.0" targetFramework="net452" />
   <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="6.2.2" targetFramework="net452" />
   <package id="NServiceBus.RabbitMQ" version="3.5.1" targetFramework="net452" />


### PR DESCRIPTION
I marked this as a spike since it was not a planned PR. I have been working on this in my spare time, being mostly frustrated that SC does not support learning transport when doing product demos with docs samples that do. I have no built up some obsolete knowledge on V5 transports 😄 

I based this on the V6 transport, making some changes to match V5 contracts / initialization style.  It is introduced as a separate project that the Service Control project references. One change made from the V6 Core version of the transport is the switch to supporting and relying solely on a connection string,. which is simply a path. It no longer scans for a root solution directory, and I dropped support for configuring the transport directory via code.

It also brings in an acceptance test project using the 5.2.24 acceptance tests. Some of those tests have been removed or changed as (I thought) appropriate. All of the tests pass (on my machine). The acceptance tests require a environment variable, like the others, to set the connection string.

I added the transport to the Config project so it can be selected when an instance is added. I have no problems adding a new instance.

I smoke tested by using the V6 fault tolerance sample, adding audit and error configuration and providing a mechanism to fail in the handler, but succeed when it retries later. I was able to successfully add a new SC instance configured with the learning transport using the V6 Fault Tolerance sample `.learningtransport` directory for the connection string. This limited smoke test passed.

This is submitted as embedded and only for SC, but it could be done as a separate repository with a nuget, with only a change to the Packages / Config project needed for SC to support it.