### PR TITLE
Suspend license checks

### DIFF
--- a/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
@@ -22,15 +22,21 @@ namespace ServiceControl.Config.Commands
 
         public override void Execute(object obj)
         {
-            var licenseCheckResult = installer.CheckLicenseIsValid();
-            if (!licenseCheckResult.Valid)
+            if (LicenseChecks)
             {
-                windowManager.ShowMessage("LICENSE ERROR", $"Install could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact sales@particular.net", hideCancel: true);
-                return;
+                var licenseCheckResult = installer.CheckLicenseIsValid();
+                if (!licenseCheckResult.Valid)
+                {
+                    windowManager.ShowMessage("LICENSE ERROR", $"Install could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact sales@particular.net", hideCancel: true);
+                    return;
+                }
             }
-            
+
             var instanceViewModel = addInstance();
             windowManager.ShowInnerDialog(instanceViewModel);
         }
+
+        [FeatureToggle(Feature.LicenseChecks)]
+        public bool LicenseChecks { get; set; }
     }
 }

--- a/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
@@ -22,15 +22,21 @@ namespace ServiceControl.Config.Commands
 
         public override void Execute(object obj)
         {
-            var licenseCheckResult = installer.CheckLicenseIsValid();
-            if (!licenseCheckResult.Valid)
+            if (LicenseChecks)
             {
-                windowManager.ShowMessage("LICENSE ERROR", $"Install could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact sales@particular.net", hideCancel: true);
-                return;
+                var licenseCheckResult = installer.CheckLicenseIsValid();
+                if (!licenseCheckResult.Valid)
+                {
+                    windowManager.ShowMessage("LICENSE ERROR", $"Install could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact sales@particular.net", hideCancel: true);
+                    return;
+                }
             }
 
             var instanceViewModel = addInstance();
             windowManager.ShowInnerDialog(instanceViewModel);
         }
+
+        [FeatureToggle(Feature.LicenseChecks)]
+        public bool LicenseChecks { get; set; }
     }
 }

--- a/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
@@ -31,13 +31,16 @@
 
         public override async Task ExecuteAsync(InstanceDetailsViewModel model)
         {
-            var licenseCheckResult = installer.CheckLicenseIsValid();
-            if (!licenseCheckResult.Valid)
+            if (LicenseChecks)
             {
-                windowManager.ShowMessage("LICENSE ERROR", $"Upgrade could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact sales@particular.net", hideCancel: true);
-                return;
+                var licenseCheckResult = installer.CheckLicenseIsValid();
+                if (!licenseCheckResult.Valid)
+                {
+                    windowManager.ShowMessage("LICENSE ERROR", $"Upgrade could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact sales@particular.net", hideCancel: true);
+                    return;
+                }
             }
-            
+
             var instance = InstanceFinder.FindMonitoringInstance(model.Name);
             
 
@@ -88,5 +91,8 @@
                 eventAggregator.PublishOnUIThread(new RefreshInstances());
             }
         }
+
+        [FeatureToggle(Feature.LicenseChecks)]
+        public bool LicenseChecks { get; set; }
     }
 }

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -34,13 +34,16 @@
 
         public override async Task ExecuteAsync(InstanceDetailsViewModel model)
         {
-            var licenseCheckResult = installer.CheckLicenseIsValid();
-            if (!licenseCheckResult.Valid)
+            if (LicenseChecks)
             {
-                windowManager.ShowMessage("LICENSE ERROR", $"Upgrade could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact sales@particular.net", hideCancel: true);
-                return;
+                var licenseCheckResult = installer.CheckLicenseIsValid();
+                if (!licenseCheckResult.Valid)
+                {
+                    windowManager.ShowMessage("LICENSE ERROR", $"Upgrade could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact sales@particular.net", hideCancel: true);
+                    return;
+                }
             }
-            
+
             var instance = InstanceFinder.FindServiceControlInstance(model.Name);
             
 
@@ -169,5 +172,8 @@
                 eventAggregator.PublishOnUIThread(new RefreshInstances());
             }
         }
+
+        [FeatureToggle(Feature.LicenseChecks)]
+        public bool LicenseChecks { get; set; }
     }
 }

--- a/src/ServiceControl.Config/Features.cs
+++ b/src/ServiceControl.Config/Features.cs
@@ -21,6 +21,7 @@ namespace ServiceControl.Config
     public static class Feature
     {
         public const string MonitoringInstances = "MonitoringInstances";
+        public const string LicenseChecks = "LicenseChecks";
     }
 
     public class FeatureToggles
@@ -35,6 +36,24 @@ namespace ServiceControl.Config
         public void Enable(string feature)
         {
             features.Add(feature);
+        }
+    }
+
+    public class FeatureToggleDefaults : IStartable
+    {
+        private FeatureToggles featureToggles;
+
+        public FeatureToggleDefaults(FeatureToggles featureToggles)
+        {
+            this.featureToggles = featureToggles;
+        }
+
+        public void Start()
+        {
+            if (DateTime.Today > new DateTime(2018, 2, 15, 0, 0, 0, DateTimeKind.Utc))
+            {
+                featureToggles.Enable(Feature.LicenseChecks);
+            }
         }
     }
 

--- a/src/ServiceControl.Config/Framework/Modules/FeatureTogglesModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/FeatureTogglesModule.cs
@@ -13,6 +13,7 @@
         {
             builder.RegisterType<FeatureToggles>().SingleInstance();
             builder.RegisterType<ToggleFeaturesFromConfig>().AsImplementedInterfaces();
+            builder.RegisterType<FeatureToggleDefaults>().AsImplementedInterfaces();
         }
 
         protected override void AttachToComponentRegistration(IComponentRegistry componentRegistry, IComponentRegistration registration)


### PR DESCRIPTION
Only when adding new instances or upgrading existing instances and only until Feb 2018.

