### PR TITLE
Always show monitoring instances

### DIFF
--- a/src/ServiceControl.Config/Features.cs
+++ b/src/ServiceControl.Config/Features.cs
@@ -50,6 +50,7 @@ namespace ServiceControl.Config
 
         public void Start()
         {
+            featureToggles.Enable(Feature.MonitoringInstances);
             if (DateTime.Today > new DateTime(2018, 2, 15, 0, 0, 0, DateTimeKind.Utc))
             {
                 featureToggles.Enable(Feature.LicenseChecks);


### PR DESCRIPTION
Relies on #1026 

Always show monitoring instances.

Wait for release to beta.
