### PR TITLE
Split transports by instance type

### DIFF
--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMonitoringEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMonitoringEditorViewModel.cs
@@ -16,7 +16,7 @@
 
         public SharedMonitoringEditorViewModel()
         {
-            Transports = ServiceControlInstaller.Engine.Instances.Transports.All;
+            Transports = MonitoringTransports.All;
         }
 
         [DoNotNotify]

--- a/src/ServiceControlInstaller.Engine/Configuration/Monitoring/AppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/Monitoring/AppConfig.cs
@@ -16,9 +16,9 @@
 
         public void Validate()
         {
-            if (Transports.FindByName(details.TransportPackage) == null)
+            if (MonitoringTransports.FindByName(details.TransportPackage) == null)
             {
-                throw new Exception($"Invalid Transport - Must be one of: {string.Join(",", Transports.All.Select(p => p.Name))}");
+                throw new Exception($"Invalid Transport - Must be one of: {string.Join(",", MonitoringTransports.All.Select(p => p.Name))}");
             }
         }
 
@@ -30,7 +30,7 @@
             settings.Set(SettingsList.Port, details.Port.ToString());
             settings.Set(SettingsList.HostName, details.HostName);
             settings.Set(SettingsList.LogPath, details.LogPath);
-            settings.Set(SettingsList.TransportType, Transports.FindByName(details.TransportPackage).TypeName, version);
+            settings.Set(SettingsList.TransportType, MonitoringTransports.FindByName(details.TransportPackage).TypeName, version);
             settings.Set(SettingsList.ErrorQueue, details.ErrorQueue);
             Config.Save();
         }

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -101,12 +101,12 @@
         string DetermineTransportPackage()
         {
             var transportAppSetting = AppConfig.Read(SettingsList.TransportType, "NServiceBus.MsmqTransport").Split(",".ToCharArray())[0].Trim();
-            var transport = Transports.All.FirstOrDefault(p => transportAppSetting.StartsWith(p.MatchOn, StringComparison.OrdinalIgnoreCase));
+            var transport = MonitoringTransports.All.FirstOrDefault(p => transportAppSetting.StartsWith(p.MatchOn, StringComparison.OrdinalIgnoreCase));
             if (transport != null)
             {
                 return transport.Name;
             }
-            return Transports.All.First(p => p.Default).Name;
+            return MonitoringTransports.All.First(p => p.Default).Name;
         }
         
         public void ValidateChanges()

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringTransports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringTransports.cs
@@ -1,0 +1,57 @@
+﻿namespace ServiceControlInstaller.Engine.Instances
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class MonitoringTransports
+    {
+        public static TransportInfo FindByName(string name)
+        {
+            return All.FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public static List<TransportInfo> All => new List<TransportInfo>
+        {
+            new TransportInfo
+            {
+                Name = "AzureServiceBus",
+                TypeName = "NServiceBus.AzureServiceBusTransport, NServiceBus.Azure.Transports.WindowsAzureServiceBus",
+                MatchOn = "NServiceBus.AzureServiceBus",
+                SampleConnectionString = "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>"
+
+            },
+            new TransportInfo
+            {
+                Name = "AzureStorageQueue",
+                TypeName = "NServiceBus.AzureStorageQueueTransport, NServiceBus.Azure.Transports.WindowsAzureStorageQueues",
+                MatchOn  = "NServiceBus.AzureStorageQueue",
+                SampleConnectionString = "DefaultEndpointsProtocol=[http|https];AccountName=<MyAccountName>;AccountKey=<MyAccountKey>"
+            },
+            new TransportInfo
+            {
+                Name = "MSMQ",
+                TypeName = "NServiceBus.MsmqTransport, NServiceBus.Core",
+                MatchOn = "NServiceBus.Msmq",
+                SampleConnectionString = string.Empty,
+                Default = true
+            },
+            new TransportInfo
+            {
+                Name = "SQLServer",
+                TypeName = "NServiceBus.SqlServerTransport, NServiceBus.Transports.SQLServer",
+                MatchOn = "NServiceBus.SqlServer",
+                SampleConnectionString = "Data Source=<SQLInstance>;Initial Catalog=nservicebus;Integrated Security=True",
+                Help = "When integrated authentication is specified in the SQL connection string the the current installing user is used to create the required SQL tables structure not the service account."
+            },
+            new TransportInfo
+            {
+                Name = "RabbitMQ",
+                TypeName = "NServiceBus.RabbitMQTransport, NServiceBus.Transports.RabbitMQ",
+                MatchOn = "NServiceBus.RabbitMQ",
+                SampleConnectionString = "host=<HOSTNAME>;username=<USERNAME>;password=<PASSWORD>"
+            }
+        };
+
+    }
+}

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Instances\Constants.cs" />
     <Compile Include="Instances\Instances.cs" />
     <Compile Include="Instances\InstanceType.cs" />
+    <Compile Include="Instances\MonitoringTransports.cs" />
     <Compile Include="Instances\ServiceControlUpgradeOptions.cs" />
     <Compile Include="Instances\MonitoringInstance.cs" />
     <Compile Include="Instances\MonitoringNewInstance.cs" />


### PR DESCRIPTION
Enable monitoring instances and servicecontrol instances to have their own transport types.

Required to pull in https://github.com/Particular/ServiceControl.Monitoring/pull/74