### PR TITLE
Split v5 and v6 transports

### DIFF
--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMonitoringEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMonitoringEditorViewModel.cs
@@ -16,7 +16,7 @@
 
         public SharedMonitoringEditorViewModel()
         {
-            Transports = ServiceControlInstaller.Engine.Instances.Transports.All;
+            Transports = V6Transports.All;
         }
 
         [DoNotNotify]

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModel.cs
@@ -18,7 +18,7 @@
       
         public SharedServiceControlEditorViewModel()
         {
-            Transports = ServiceControlInstaller.Engine.Instances.Transports.All;
+            Transports = V5Transports.All;
             AuditForwardingOptions = new[]
             {
                 new ForwardingOption

--- a/src/ServiceControlInstaller.Engine/Configuration/Monitoring/AppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/Monitoring/AppConfig.cs
@@ -16,9 +16,9 @@
 
         public void Validate()
         {
-            if (Transports.FindByName(details.TransportPackage) == null)
+            if (V6Transports.FindByName(details.TransportPackage) == null)
             {
-                throw new Exception($"Invalid Transport - Must be one of: {string.Join(",", Transports.All.Select(p => p.Name))}");
+                throw new Exception($"Invalid Transport - Must be one of: {string.Join(",", V6Transports.All.Select(p => p.Name))}");
             }
         }
 
@@ -30,7 +30,7 @@
             settings.Set(SettingsList.Port, details.Port.ToString());
             settings.Set(SettingsList.HostName, details.HostName);
             settings.Set(SettingsList.LogPath, details.LogPath);
-            settings.Set(SettingsList.TransportType, Transports.FindByName(details.TransportPackage).TypeName, version);
+            settings.Set(SettingsList.TransportType, V6Transports.FindByName(details.TransportPackage).TypeName, version);
             settings.Set(SettingsList.ErrorQueue, details.ErrorQueue);
             Config.Save();
         }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/AppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/AppConfig.cs
@@ -18,9 +18,9 @@
 
         public void Validate()
         {
-            if (Transports.FindByName(details.TransportPackage) == null)
+            if (V5Transports.FindByName(details.TransportPackage) == null)
             {
-                throw new Exception($"Invalid Transport - Must be one of: {string.Join(",", Transports.All.Select(p => p.Name))}");
+                throw new Exception($"Invalid Transport - Must be one of: {string.Join(",", V5Transports.All.Select(p => p.Name))}");
             }
         }
 
@@ -50,7 +50,7 @@
             settings.Set(SettingsList.DBPath, details.DBPath);
             settings.Set(SettingsList.ForwardAuditMessages, details.ForwardAuditMessages.ToString());
             settings.Set(SettingsList.ForwardErrorMessages, details.ForwardErrorMessages.ToString(), version);
-            settings.Set(SettingsList.TransportType, Transports.FindByName(details.TransportPackage).TypeName, version);
+            settings.Set(SettingsList.TransportType, V5Transports.FindByName(details.TransportPackage).TypeName, version);
             settings.Set(SettingsList.AuditQueue, details.AuditQueue);
             settings.Set(SettingsList.ErrorQueue, details.ErrorQueue);
             settings.Set(SettingsList.ErrorLogQueue, details.ErrorLogQueue);

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -101,12 +101,12 @@
         string DetermineTransportPackage()
         {
             var transportAppSetting = AppConfig.Read(SettingsList.TransportType, "NServiceBus.MsmqTransport").Split(",".ToCharArray())[0].Trim();
-            var transport = Transports.All.FirstOrDefault(p => transportAppSetting.StartsWith(p.MatchOn, StringComparison.OrdinalIgnoreCase));
+            var transport = V6Transports.All.FirstOrDefault(p => transportAppSetting.StartsWith(p.MatchOn, StringComparison.OrdinalIgnoreCase));
             if (transport != null)
             {
                 return transport.Name;
             }
-            return Transports.All.First(p => p.Default).Name;
+            return V6Transports.All.First(p => p.Default).Name;
         }
         
         public void ValidateChanges()

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -175,12 +175,12 @@ namespace ServiceControlInstaller.Engine.Instances
         string DetermineTransportPackage()
         {
             var transportAppSetting = AppConfig.Read(SettingsList.TransportType, "NServiceBus.MsmqTransport").Split(",".ToCharArray())[0].Trim();
-            var transport = Transports.All.FirstOrDefault(p => transportAppSetting.StartsWith(p.MatchOn , StringComparison.OrdinalIgnoreCase));
+            var transport = V5Transports.All.FirstOrDefault(p => transportAppSetting.StartsWith(p.MatchOn , StringComparison.OrdinalIgnoreCase));
             if (transport != null)
             {
                 return transport.Name;
             }
-            return Transports.All.First(p => p.Default).Name;
+            return V5Transports.All.First(p => p.Default).Name;
         }
 
         public void ApplyConfigChange()

--- a/src/ServiceControlInstaller.Engine/Instances/V5Transports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/V5Transports.cs
@@ -1,0 +1,56 @@
+﻿namespace ServiceControlInstaller.Engine.Instances
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public  class V5Transports
+    {
+        public static TransportInfo FindByName(string name)
+        {
+            return All.FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public static List<TransportInfo> All => new List<TransportInfo>
+        {
+            new TransportInfo
+            {
+                Name = "AzureServiceBus",
+                TypeName = "NServiceBus.AzureServiceBusTransport, NServiceBus.Azure.Transports.WindowsAzureServiceBus",
+                MatchOn = "NServiceBus.AzureServiceBus",
+                SampleConnectionString = "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>"
+
+            },
+            new TransportInfo
+            {
+                Name = "AzureStorageQueue",
+                TypeName = "NServiceBus.AzureStorageQueueTransport, NServiceBus.Azure.Transports.WindowsAzureStorageQueues",
+                MatchOn  = "NServiceBus.AzureStorageQueue",
+                SampleConnectionString = "DefaultEndpointsProtocol=[http|https];AccountName=<MyAccountName>;AccountKey=<MyAccountKey>"
+            },
+            new TransportInfo
+            {
+                Name = "MSMQ",
+                TypeName = "NServiceBus.MsmqTransport, NServiceBus.Core",
+                MatchOn = "NServiceBus.Msmq",
+                SampleConnectionString = string.Empty,
+                Default = true
+            },
+            new TransportInfo
+            {
+                Name = "SQLServer",
+                TypeName = "NServiceBus.SqlServerTransport, NServiceBus.Transports.SQLServer",
+                MatchOn = "NServiceBus.SqlServer",
+                SampleConnectionString = "Data Source=<SQLInstance>;Initial Catalog=nservicebus;Integrated Security=True",
+                Help = "When integrated authentication is specified in the SQL connection string the the current installing user is used to create the required SQL tables structure not the service account."
+            },
+            new TransportInfo
+            {
+                Name = "RabbitMQ",
+                TypeName = "NServiceBus.RabbitMQTransport, NServiceBus.Transports.RabbitMQ",
+                MatchOn = "NServiceBus.RabbitMQ",
+                SampleConnectionString = "host=<HOSTNAME>;username=<USERNAME>;password=<PASSWORD>"
+            }
+        };
+    }
+}

--- a/src/ServiceControlInstaller.Engine/Instances/V6Transports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/V6Transports.cs
@@ -4,7 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
 
-    public  class Transports
+    public class V6Transports
     {
         public static TransportInfo FindByName(string name)
         {
@@ -39,7 +39,7 @@
             new TransportInfo
             {
                 Name = "SQLServer",
-                TypeName = "NServiceBus.SqlServerTransport, NServiceBus.Transports.SQLServer",
+                TypeName = "NServiceBus.SqlServerTransport, NServiceBus.Transport.SQLServer",
                 MatchOn = "NServiceBus.SqlServer",
                 SampleConnectionString = "Data Source=<SQLInstance>;Initial Catalog=nservicebus;Integrated Security=True",
                 Help = "When integrated authentication is specified in the SQL connection string the the current installing user is used to create the required SQL tables structure not the service account."

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Instances\ServiceControlUpgradeOptions.cs" />
     <Compile Include="Instances\MonitoringInstance.cs" />
     <Compile Include="Instances\MonitoringNewInstance.cs" />
+    <Compile Include="Instances\V6Transports.cs" />
     <Compile Include="Unattended\UnattendMonitoringInstaller.cs" />
     <Compile Include="Unattended\XmlTimeSpan.cs" />
     <Compile Include="Queues\QueueCreationException.cs" />
@@ -144,7 +145,7 @@
     <Compile Include="Instances\ServiceControlInstance.cs" />
     <Compile Include="Instances\ServiceControlNewInstance.cs" />
     <Compile Include="Instances\TransportInfo.cs" />
-    <Compile Include="Instances\Transports.cs" />
+    <Compile Include="Instances\V5Transports.cs" />
     <Compile Include="LicenseMgmt\DetectedLicense.cs" />
     <Compile Include="LicenseMgmt\LicenseDetails.cs" />
     <Compile Include="LicenseMgmt\LicenseManager.cs" />

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/Transports/GetServiceControlTransportTypes.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/Transports/GetServiceControlTransportTypes.cs
@@ -11,7 +11,7 @@ namespace ServiceControlInstaller.PowerShell
     {
         protected override void ProcessRecord()
         {
-            WriteObject(Transports.All.Select(PsTransportInfo.FromTransport), true);
+            WriteObject(V5Transports.All.Select(PsTransportInfo.FromTransport), true);
         }
     }
 }


### PR DESCRIPTION
Fixes #1033 

The dll portion of the TransportType string on https://github.com/Particular/ServiceControl/blob/master/src/ServiceControlInstaller.Engine/Instances/Transports.cs#L42 references the v5 assembly name of the transport. For v6 version of the transport the assembly name was changed, breaking Monitoring installs.