### PR TITLE
Concurrency error when storing message bodies as RavenDB attachments

### DIFF
--- a/src/ServiceControl/Operations/BodyStorage/RavenAttachments/RavenAttachmentsBodyStorage.cs
+++ b/src/ServiceControl/Operations/BodyStorage/RavenAttachments/RavenAttachmentsBodyStorage.cs
@@ -1,6 +1,8 @@
 ﻿namespace ServiceControl.Operations.BodyStorage.RavenAttachments
 {
+    using System;
     using System.IO;
+    using System.Linq;
     using Raven.Client;
     using Raven.Json.Linq;
 
@@ -8,15 +10,29 @@
     {
         public IDocumentStore DocumentStore { get; set; }
 
+        public RavenAttachmentsBodyStorage()
+        {
+            locks = Enumerable.Range(0, 42).Select(i => new object()).ToArray(); //because 42 is the answer
+        }
+
         public string Store(string bodyId, string contentType, int bodySize, Stream bodyStream)
         {
-            DocumentStore.DatabaseCommands.PutAttachment("messagebodies/" + bodyId, null, bodyStream, new RavenJObject
-            {
-                {"ContentType", contentType},
-                {"ContentLength", bodySize}
-            });
+            /*
+             * The locking here is a workaround for RavenDB bug DocumentDatabase.PutStatic that allows multiple threads to enter a critical section.
+             */
+            var idHash = Math.Abs(bodyId.GetHashCode());
+            var lockIndex = idHash % locks.Length; //I think using bit manipulation is not worth the effort
 
-            return $"/messages/{bodyId}/body";
+            lock (locks[lockIndex])
+            {
+                DocumentStore.DatabaseCommands.PutAttachment("messagebodies/" + bodyId, null, bodyStream, new RavenJObject
+                {
+                    {"ContentType", contentType},
+                    {"ContentLength", bodySize}
+                });
+
+                return $"/messages/{bodyId}/body";
+            }
         }
 
         public bool TryFetch(string bodyId, out Stream stream)
@@ -32,5 +48,7 @@
             stream = attachment.Data();
             return true;
         }
+
+        object[] locks;
     }
 }


### PR DESCRIPTION
### Symptoms

An audit or error message fails processing because of a concurrency exception when storing the message body as RavenDB attachment. Under heavy load this problem is not resolved via FLR and lead to messages being marked as failed audits/errors.

### Who's affected

All ServiceControl users. The issue seems to cause more problems if SC is under heavy load (e.g. when processing a backlog of messages

### Root cause

Given the following code in RavenDB has a concurrency problem

```
public Etag PutStatic(string name, Etag etag, Stream data, RavenJObject metadata)
{
    if (name == null)
    throw new ArgumentNullException("name");
    name = name.Trim();
    if (Encoding.Unicode.GetByteCount(name) >= 2048)
    throw new ArgumentException("The key must be a maximum of 2,048 bytes in Unicode, 1,024 characters", "name");
    object orAdd = this.putAttachmentSerialLock.GetOrAdd(name, (Func<string, object>) (s => new object()));
    Monitor.Enter(orAdd);
    try
    {
    Etag newEtag = Etag.Empty;
    this.TransactionalStorage.Batch((Action<IStorageActionsAccessor>) (actions =>
    {
        this.AssertAttachmentPutOperationNotVetoed(name, metadata, data);
        this.AttachmentPutTriggers.Apply((Action<AbstractAttachmentPutTrigger>) (trigger => trigger.OnPut(name, data, metadata)));
        newEtag = actions.Attachments.AddAttachment(name, etag, data, metadata);
        this.AttachmentPutTriggers.Apply((Action<AbstractAttachmentPutTrigger>) (trigger => trigger.AfterPut(name, data, metadata, newEtag)));
        this.workContext.ShouldNotifyAboutWork((Func<string>) (() => "PUT ATTACHMENT " + name));
    }));
    this.TransactionalStorage.ExecuteImmediatelyOrRegisterForSynchronization((Action) (() => this.AttachmentPutTriggers.Apply((Action<AbstractAttachmentPutTrigger>) (trigger => trigger.AfterCommit(name, data, metadata, newEtag)))));
    return newEtag;
    }
    finally
    {
    Monitor.Exit(orAdd);
    this.putAttachmentSerialLock.TryRemove(name, out orAdd);
    }
}
```

we need to add locking on SC level. Here's the scenario which causes multiple threads to enter the critical section:

 * thread one puts an object #1 into the dictionary and continues
 * thread two with same key enters the method, get object #1 from the dictionary and blocks on `Monitor.Enter`
 * thread three with the same key enters the method but does not invoke `GetOrAdd` just yet
 * thread one calls `Monitor.Exit`
 * thread two is unblocked on the monitor and proceeds to `Batch`
 * thread one calls `TryRemove` on the dictionary removing the lock object for that key
 * thread three calls `GetOrAdd` and creates a brand new lock object for this key
 * thread three enters `Batch` while thread two is already there

### Solution

Use pre-allocated array of locks. Lock in SC before invoking RavenDB code.