### PR TITLE
Fix URL-ACL regex check

### DIFF
--- a/src/ServiceControlInstaller.Engine.UnitTests/UrlAcl/UrlReservationTest.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/UrlAcl/UrlReservationTest.cs
@@ -121,6 +121,10 @@
             Assert.IsTrue(testUrl.Port == 443);
             Assert.IsTrue(testUrl.VirtualDirectory == "foo/api");
 
+            testUrl = new UrlReservation("https://[::1]:10253/");
+            Assert.IsTrue(testUrl.HTTPS);
+            Assert.IsTrue(testUrl.HostName == "::1");
+            Assert.IsTrue(testUrl.Port == 10253);
 
             // ReSharper disable once ObjectCreationAsStatement
             Assert.Throws<ArgumentException>(() => new UrlReservation("https://localhost:8000/foo/api"), "UrlAcl is invalid without trailing /");

--- a/src/ServiceControlInstaller.Engine.UnitTests/UrlAcl/UrlReservationTest.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/UrlAcl/UrlReservationTest.cs
@@ -123,7 +123,7 @@
 
             testUrl = new UrlReservation("https://[::1]:10253/");
             Assert.IsTrue(testUrl.HTTPS);
-            Assert.IsTrue(testUrl.HostName == "::1");
+            Assert.IsTrue(testUrl.HostName == "[::1]");
             Assert.IsTrue(testUrl.Port == 10253);
 
             // ReSharper disable once ObjectCreationAsStatement

--- a/src/ServiceControlInstaller.Engine/UrlAcl/UrlReservation.cs
+++ b/src/ServiceControlInstaller.Engine/UrlAcl/UrlReservation.cs
@@ -13,7 +13,7 @@
 
     public class UrlReservation
     {
-        static Regex urlPattern = new Regex(@"^(?<protocol>https?)://(?<hostname>[^:/]+):?(?<port>\d{0,5})/?(?<virtual>[^:]*)/$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        static Regex urlPattern = new Regex(@"^(?<protocol>https?)://(?<hostname>([^/]*?))(:(?<port>\d{0,5}))?(/(?<virtual>[^:]*))?/$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         const int GENERIC_EXECUTE = 536870912;
 


### PR DESCRIPTION
Connects to: https://github.com/Particular/ServiceControl/issues/1050

Uses the new Regex from @mikeminutillo (❤️)