### PR TITLE
Add custom checks for error and audit messages

### DIFF
--- a/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
@@ -24,7 +24,7 @@
                 {
                     if (ie.MoveNext())
                     {
-                        var message = @"One or more audit messages have previously failed to import properly into ServiceControl and have been stored in the ServiceControl database.
+                        var message = @"One or more audit messages have failed to import properly into ServiceControl and have been stored in the ServiceControl database.
 The import of these messages could have failed for a number of reasons and ServiceControl is not able to automatically reimport them. For guidance on how to resolve this see https://docs.particular.net/search?q=import%20failed%20audit%20messages";
 
                         Logger.Warn(message);

--- a/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
@@ -3,9 +3,7 @@
     using NServiceBus.CustomChecks;
     using NServiceBus.Logging;
     using Raven.Client;
-    using Raven.Client.Indexes;
     using System;
-    using System.Linq;
 
     class FailedAuditImportCustomCheck : CustomCheck
     {

--- a/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
@@ -25,8 +25,7 @@
                     if (ie.MoveNext())
                     {
                         var message = @"One or more audit messages have previously failed to import properly into ServiceControl and have been stored in the ServiceControl database.
-Due to a defect however, ServiceControl would not be able to automatically reimport them. Please run ServiceControl in the maintenance mode and use embedded RavenStudio available by default at http://localhost:33333/storage to examine the payloads of failed messages to ensure no information has been lost.
-Delete the failed import documents afterwards so that you don't see this warning message again.";
+The import of these messages could have failed for a number of reasons and ServiceControl is not able to automatically reimport them. For guidance on how to resolve this see https://docs.particular.net/search?q=import%20failed%20audit%20messages";
 
                         Logger.Warn(message);
                         return CheckResult.Failed(message);

--- a/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
@@ -1,0 +1,41 @@
+﻿namespace ServiceControl.Operations
+{
+    using NServiceBus.CustomChecks;
+    using NServiceBus.Logging;
+    using Raven.Client;
+    using System;
+
+    class FailedAuditImportCustomCheck : CustomCheck
+    {
+        public FailedAuditImportCustomCheck(IDocumentStore store)
+            : base("Audit Message Ingestion", "ServiceControl Health", TimeSpan.FromHours(1))
+        {
+            this.store = store;
+        }
+
+        public override CheckResult PerformCheck()
+        {
+            using (var session = store.OpenSession())
+            {
+                var query = session.Query<FailedAuditImport, FailedAuditImportIndex>();
+                using (var ie = session.Advanced.Stream(query))
+                {
+                    if (ie.MoveNext())
+                    {
+                        var message = @"One or more audit messages have previously failed to import properly into ServiceControl and have been stored in the ServiceControl database.
+Due to a defect however, ServiceControl would not be able to automatically reimport them. Please run ServiceControl in the maintenance mode and use embedded RavenStudio available by default at http://localhost:33333/storage to examine the payloads of failed messages to ensure no information has been lost.
+Delete the failed import documents afterwards so that you don't see this warning message again.";
+
+                        Logger.Warn(message);
+                        return CheckResult.Failed(message);
+                    }
+                }
+            }
+
+            return CheckResult.Pass;
+        }
+
+        readonly IDocumentStore store;
+        static readonly ILog Logger = LogManager.GetLogger(typeof(FailedAuditImportCustomCheck));
+    }
+}

--- a/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
@@ -23,7 +23,7 @@
                     if (ie.MoveNext())
                     {
                         var message = @"One or more audit messages have failed to import properly into ServiceControl and have been stored in the ServiceControl database.
-The import of these messages could have failed for a number of reasons and ServiceControl is not able to automatically reimport them. For guidance on how to resolve this see https://docs.particular.net/search?q=import%20failed%20audit%20messages";
+The import of these messages could have failed for a number of reasons and ServiceControl is not able to automatically reimport them. For guidance on how to resolve this see https://docs.particular.net/servicecontrol/import-failed-audit-messages";
 
                         Logger.Warn(message);
                         return CheckResult.Failed(message);

--- a/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
@@ -39,19 +39,4 @@ The import of these messages could have failed for a number of reasons and Servi
         readonly IDocumentStore store;
         static readonly ILog Logger = LogManager.GetLogger(typeof(FailedAuditImportCustomCheck));
     }
-
-    class FailedAuditImportIndex : AbstractIndexCreationTask<FailedAuditImport>
-    {
-        public FailedAuditImportIndex()
-        {
-            Map = docs => from cc in docs
-                          select new FailedAuditImport
-                          {
-                              Id = cc.Id,
-                              Message = cc.Message
-                          };
-
-            DisableInMemoryIndexing = true;
-        }
-    }
 }

--- a/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
@@ -3,7 +3,9 @@
     using NServiceBus.CustomChecks;
     using NServiceBus.Logging;
     using Raven.Client;
+    using Raven.Client.Indexes;
     using System;
+    using System.Linq;
 
     class FailedAuditImportCustomCheck : CustomCheck
     {
@@ -37,5 +39,20 @@ Delete the failed import documents afterwards so that you don't see this warning
 
         readonly IDocumentStore store;
         static readonly ILog Logger = LogManager.GetLogger(typeof(FailedAuditImportCustomCheck));
+    }
+
+    class FailedAuditImportIndex : AbstractIndexCreationTask<FailedAuditImport>
+    {
+        public FailedAuditImportIndex()
+        {
+            Map = docs => from cc in docs
+                          select new FailedAuditImport
+                          {
+                              Id = cc.Id,
+                              Message = cc.Message
+                          };
+
+            DisableInMemoryIndexing = true;
+        }
     }
 }

--- a/src/ServiceControl/Operations/FailedErrorImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedErrorImportCustomCheck.cs
@@ -3,7 +3,9 @@
     using NServiceBus.CustomChecks;
     using NServiceBus.Logging;
     using Raven.Client;
+    using Raven.Client.Indexes;
     using System;
+    using System.Linq;
 
     class FailedErrorImportCustomCheck : CustomCheck
     {
@@ -37,5 +39,20 @@ Delete the failed import documents afterwards so that you don't see this warning
 
         readonly IDocumentStore store;
         static readonly ILog Logger = LogManager.GetLogger(typeof(FailedAuditImportCustomCheck));
+    }
+
+    class FailedErrorImportIndex : AbstractIndexCreationTask<FailedErrorImport>
+    {
+        public FailedErrorImportIndex()
+        {
+            Map = docs => from cc in docs
+                          select new FailedErrorImport
+                          {
+                              Id = cc.Id,
+                              Message = cc.Message
+                          };
+
+            DisableInMemoryIndexing = true;
+        }
     }
 }

--- a/src/ServiceControl/Operations/FailedErrorImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedErrorImportCustomCheck.cs
@@ -24,7 +24,7 @@
                 {
                     if (ie.MoveNext())
                     {
-                        var message = @"One or more error messages have previously failed to import properly into ServiceControl and have been stored in the ServiceControl database.
+                        var message = @"One or more error messages have failed to import properly into ServiceControl and have been stored in the ServiceControl database.
 The import of these messages could have failed for a number of reasons and ServiceControl is not able to automatically reimport them. For guidance on how to resolve this see https://docs.particular.net/search?q=import%20failed%20audit%20messages";
 
                         Logger.Warn(message);

--- a/src/ServiceControl/Operations/FailedErrorImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedErrorImportCustomCheck.cs
@@ -1,0 +1,41 @@
+﻿namespace ServiceControl.Operations
+{
+    using NServiceBus.CustomChecks;
+    using NServiceBus.Logging;
+    using Raven.Client;
+    using System;
+
+    class FailedErrorImportCustomCheck : CustomCheck
+    {
+        public FailedErrorImportCustomCheck(IDocumentStore store)
+            : base("Error Message Ingestion", "ServiceControl Health", TimeSpan.FromHours(1))
+        {
+            this.store = store;
+        }
+
+        public override CheckResult PerformCheck()
+        {
+            using (var session = store.OpenSession())
+            {
+                var query = session.Query<FailedErrorImport, FailedErrorImportIndex>();
+                using (var ie = session.Advanced.Stream(query))
+                {
+                    if (ie.MoveNext())
+                    {
+                        var message = @"One or more error messages have previously failed to import properly into ServiceControl and have been stored in the ServiceControl database.
+Due to a defect however, ServiceControl would not be able to automatically reimport them. Please run ServiceControl in the maintenance mode and use embedded RavenStudio available by default at http://localhost:33333/storage to examine the payloads of failed messages to ensure no information has been lost.
+Delete the failed import documents afterwards so that you don't see this warning message again.";
+
+                        Logger.Warn(message);
+                        return CheckResult.Failed(message);
+                    }
+                }
+            }
+
+            return CheckResult.Pass;
+        }
+
+        readonly IDocumentStore store;
+        static readonly ILog Logger = LogManager.GetLogger(typeof(FailedAuditImportCustomCheck));
+    }
+}

--- a/src/ServiceControl/Operations/FailedErrorImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedErrorImportCustomCheck.cs
@@ -25,7 +25,7 @@
                     if (ie.MoveNext())
                     {
                         var message = @"One or more error messages have failed to import properly into ServiceControl and have been stored in the ServiceControl database.
-The import of these messages could have failed for a number of reasons and ServiceControl is not able to automatically reimport them. For guidance on how to resolve this see https://docs.particular.net/search?q=import%20failed%20audit%20messages";
+The import of these messages could have failed for a number of reasons and ServiceControl is not able to automatically reimport them. For guidance on how to resolve this see https://docs.particular.net/servicecontrol/import-failed-audit-messages";
 
                         Logger.Warn(message);
                         return CheckResult.Failed(message);

--- a/src/ServiceControl/Operations/FailedErrorImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedErrorImportCustomCheck.cs
@@ -25,8 +25,7 @@
                     if (ie.MoveNext())
                     {
                         var message = @"One or more error messages have previously failed to import properly into ServiceControl and have been stored in the ServiceControl database.
-Due to a defect however, ServiceControl would not be able to automatically reimport them. Please run ServiceControl in the maintenance mode and use embedded RavenStudio available by default at http://localhost:33333/storage to examine the payloads of failed messages to ensure no information has been lost.
-Delete the failed import documents afterwards so that you don't see this warning message again.";
+The import of these messages could have failed for a number of reasons and ServiceControl is not able to automatically reimport them. For guidance on how to resolve this see https://docs.particular.net/search?q=import%20failed%20audit%20messages";
 
                         Logger.Warn(message);
                         return CheckResult.Failed(message);

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -413,6 +413,8 @@
     <Compile Include="Operations\AuditImporter.cs" />
     <Compile Include="Operations\FailedTransportMessage.cs" />
     <Compile Include="Operations\ImportFailedAudits.cs" />
+    <Compile Include="Operations\FailedErrorImportCustomCheck.cs" />
+    <Compile Include="Operations\FailedAuditImportCustomCheck.cs" />
     <Compile Include="Recoverability\API\UnacknowledgedGroupsApi.cs" />
     <Compile Include="Recoverability\Archiving\ArchiveDocumentManager.cs" />
     <Compile Include="Recoverability\Archiving\Raven\ArchiveOperation.cs" />

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -415,6 +415,7 @@
     <Compile Include="Operations\ImportFailedAudits.cs" />
     <Compile Include="Operations\FailedErrorImportCustomCheck.cs" />
     <Compile Include="Operations\FailedAuditImportCustomCheck.cs" />
+    <Compile Include="Operations\FailedErrorImportCustomCheck.cs" />
     <Compile Include="Recoverability\API\UnacknowledgedGroupsApi.cs" />
     <Compile Include="Recoverability\Archiving\ArchiveDocumentManager.cs" />
     <Compile Include="Recoverability\Archiving\Raven\ArchiveOperation.cs" />

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -415,7 +415,6 @@
     <Compile Include="Operations\ImportFailedAudits.cs" />
     <Compile Include="Operations\FailedErrorImportCustomCheck.cs" />
     <Compile Include="Operations\FailedAuditImportCustomCheck.cs" />
-    <Compile Include="Operations\FailedErrorImportCustomCheck.cs" />
     <Compile Include="Recoverability\API\UnacknowledgedGroupsApi.cs" />
     <Compile Include="Recoverability\Archiving\ArchiveDocumentManager.cs" />
     <Compile Include="Recoverability\Archiving\Raven\ArchiveOperation.cs" />


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/1593

Adds custom checks to monitor the failed audit and failed error imports. Custom checks provide feedback to users via SP instead of forcing them to read and monitor log files.

The removal of the `DetectFailedMessageImportsFeature` is a separate commit as I'm not sure if we want to remove it or not.

The messages will change as the rest of https://github.com/Particular/PlatformDevelopment/issues/1593
 is completed