### PR TITLE
WIP [SPIKE] Dense Audit

### DIFF
--- a/src/ServiceControl/Data/HeaderId.cs
+++ b/src/ServiceControl/Data/HeaderId.cs
@@ -1,0 +1,120 @@
+﻿namespace Particular.ServiceControl.Data
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using NServiceBus;
+
+    /// <summary>
+    /// Static class containing headers used by NServiceBus.
+    /// </summary>
+    public static class HeaderId
+    {
+        public const byte NotRegistered = byte.MaxValue;
+
+        static readonly Dictionary<string, byte> NameToId;
+        static readonly Dictionary<string, byte[]> NameToIdAsByteArray;
+        static readonly Dictionary<byte, string> IDToName;
+
+        static HeaderId()
+        {
+            NameToId = new Dictionary<string, byte>();
+            byte i = 1;
+
+            void Add(string value, ref byte id)
+            {
+                NameToId.Add(value, id);
+                id += 1;
+            }
+
+            Add(Headers.HttpFrom, ref i);
+            Add(Headers.HttpTo, ref i);
+            Add(Headers.RouteTo, ref i);
+            Add(Headers.DestinationSites, ref i);
+            Add(Headers.OriginatingSite, ref i);
+            Add(Headers.SagaId, ref i);
+            Add(Headers.MessageId, ref i);
+            Add(Headers.CorrelationId, ref i);
+            Add(Headers.ReplyToAddress, ref i);
+            Add(Headers.HeaderName, ref i);
+            Add(Headers.NServiceBusVersion, ref i);
+            Add(Headers.ReturnMessageErrorCodeHeader, ref i);
+            Add(Headers.ControlMessageHeader, ref i);
+            Add(Headers.SagaType, ref i);
+            Add(Headers.OriginatingSagaId, ref i);
+            Add(Headers.OriginatingSagaType, ref i);
+            Add(Headers.Retries, ref i);
+            Add(Headers.FLRetries, ref i);
+            Add(Headers.Retries, ref i);
+            Add(Headers.ProcessingStarted, ref i);
+            Add(Headers.ProcessingEnded, ref i);
+            Add(Headers.TimeSent, ref i);
+            Add(Headers.RelatedTo, ref i);
+            Add(Headers.EnclosedMessageTypes, ref i);
+            Add(Headers.ContentType, ref i);
+            Add(Headers.SubscriptionMessageType, ref i);
+            Add("NServiceBus.SubscriberAddress", ref i);
+            Add("NServiceBus.SubscriberEndpoint", ref i);
+            Add(Headers.IsSagaTimeoutMessage, ref i);
+            Add(Headers.IsDeferredMessage, ref i);
+            Add(Headers.OriginatingEndpoint, ref i);
+            Add(Headers.OriginatingMachine, ref i);
+            Add(Headers.OriginatingHostId, ref i);
+            Add(Headers.ProcessingEndpoint, ref i);
+            Add(Headers.ProcessingMachine, ref i);
+            Add(Headers.HostDisplayName, ref i);
+            Add(Headers.HostId, ref i);
+            Add(Headers.HasLicenseExpired, ref i);
+            Add(Headers.OriginatingAddress, ref i);
+            Add(Headers.ConversationId, ref i);
+            Add(Headers.MessageIntent, ref i);
+            Add("NServiceBus.TimeToBeReceived", ref i);
+            Add("NServiceBus.NonDurableMessage", ref i);
+
+            NameToIdAsByteArray = NameToId.ToDictionary(kvp => kvp.Key, kvp => new[] { kvp.Value });
+            IDToName = NameToId.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+        }
+
+        public static bool TryGetId(string headerName, out byte id) => NameToId.TryGetValue(headerName, out id);
+        public static string GetName(byte id) => IDToName[id];
+
+        static readonly UTF8Encoding NoBom = new UTF8Encoding(false);
+
+        public static byte[] EncodeName(string name)
+        {
+            if (NameToIdAsByteArray.TryGetValue(name, out var id))
+            {
+                return id;
+            }
+
+            using (var ms = new MemoryStream())
+            {
+                using (var writer = new BinaryWriter(ms, NoBom, true))
+                {
+                    writer.Write(NotRegistered);
+                    writer.Write(name);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        public static string DecodeName(byte[] name)
+        {
+            if (name.Length == 1)
+            {
+                return IDToName[name[0]];
+            }
+
+            using (var ms = new MemoryStream(name))
+            {
+                using (var reader = new BinaryReader(ms, NoBom))
+                {
+                    reader.ReadByte(); // NotRegistered
+                    return reader.ReadString();
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl/Data/MetadataSerializer.cs
+++ b/src/ServiceControl/Data/MetadataSerializer.cs
@@ -1,0 +1,40 @@
+﻿namespace Particular.ServiceControl.Data
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using ProtoBuf;
+
+    /// <summary>
+    /// This class provides a serializer for a dictionary of metadata values, that is written in a space efficient manner.
+    /// </summary>
+    public static class MetadataSerializer
+    {
+        public static long Serialize(MemoryStream stream, Dictionary<string, MetadataValue> values)
+        {
+            var toSerialize = values.Select(kvp => new KeyValue
+            {
+                Key = HeaderId.EncodeName(kvp.Key),
+                Value = kvp.Value
+            }).ToArray();
+
+            var start = stream.Position;
+
+            Serializer.Serialize(stream, toSerialize);
+
+            var end = stream.Position;
+
+            return end - start;
+        }
+
+        [ProtoContract]
+        public class KeyValue
+        {
+            [ProtoMember(1, IsPacked = true)]
+            public byte[] Key { get; set; }
+
+            [ProtoMember(2)]
+            public MetadataValue Value { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl/Data/MetadataValue.cs
+++ b/src/ServiceControl/Data/MetadataValue.cs
@@ -1,0 +1,85 @@
+﻿namespace Particular.ServiceControl.Data
+{
+    using System;
+    using global::ServiceControl.Contracts.Operations;
+    using global::ServiceControl.SagaAudit;
+    using ProtoBuf;
+
+    /// <summary>
+    /// This class provides a data structure for a distriminated union of metadata values.
+    /// </summary>
+    /// <remarks>
+    /// Using protobuf with low tag number introduce just 1 byte of overhead for writing the value, making it possible to write a union with:
+    /// - <see cref="Bool"/> to be written on 2 bytes
+    /// - small <see cref="Int"/> to be written on 2 bytes
+    /// 
+    /// </remarks>
+    [ProtoContract]
+    public class MetadataValue
+    {
+        [ProtoMember(1)] public string String { get; set; }
+        [ProtoMember(2)] public int Int { get; set; }
+        [ProtoMember(3)] public bool Bool { get; set; }
+        [ProtoMember(4)] public EndpointDetails EndpointDetails { get; set; }
+        [ProtoMember(5)] public DateTime DateTime { get; set; }
+        [ProtoMember(6)] public TimeSpan TimeSpan { get; set; }
+
+        [ProtoMember(7)] public SagaInfo SagaInfo { get; set; }
+
+        public static implicit operator MetadataValue(string value)
+        {
+            return new MetadataValue
+            {
+                String = value
+            };
+        }
+
+        public static implicit operator MetadataValue(int value)
+        {
+            return new MetadataValue
+            {
+                Int = value
+            };
+        }
+
+        public static implicit operator MetadataValue(bool value)
+        {
+            return new MetadataValue
+            {
+                Bool = value
+            };
+        }
+
+        public static implicit operator MetadataValue(EndpointDetails value)
+        {
+            return new MetadataValue
+            {
+                EndpointDetails = value
+            };
+        }
+
+        public static implicit operator MetadataValue(DateTime value)
+        {
+            return new MetadataValue
+            {
+                DateTime = value
+            };
+        }
+
+        public static implicit operator MetadataValue(TimeSpan value)
+        {
+            return new MetadataValue
+            {
+                TimeSpan = value
+            };
+        }
+
+        public static implicit operator MetadataValue(SagaInfo value)
+        {
+            return new MetadataValue
+            {
+                SagaInfo = value
+            };
+        }
+    }
+}

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -43,7 +43,7 @@
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -177,6 +177,9 @@
       <HintPath>..\packages\Owin.Metrics.0.3.7\lib\net45\Owin.Metrics.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="protobuf-net, Version=2.3.3.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.3.3\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
     <Reference Include="Raven.Abstractions, Version=2.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Database.2.5.2996\lib\net45\Raven.Abstractions.dll</HintPath>
       <Private>True</Private>
@@ -284,6 +287,9 @@
     <Compile Include="Contracts\HeartbeatMonitoring\HeartbeatsUpdated.cs" />
     <Compile Include="Contracts\MessageFailures\FailedMessageArchived.cs" />
     <Compile Include="Contracts\MessageFailures\FailedMessagesUnArchived.cs" />
+    <Compile Include="Data\HeaderId.cs" />
+    <Compile Include="Data\MetadataSerializer.cs" />
+    <Compile Include="Data\MetadataValue.cs" />
     <Compile Include="DbMigrations\1.41.3\AddEndpontDetailsClassifiers.cs" />
     <Compile Include="DbMigrations\1.39\RerunClassifiersMigration.cs" />
     <Compile Include="DbMigrations\Migrations.cs" />

--- a/src/ServiceControl/ServiceControl.csproj.DotSettings
+++ b/src/ServiceControl/ServiceControl.csproj.DotSettings
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp70</s:String></wpf:ResourceDictionary>

--- a/src/ServiceControl/packages.config
+++ b/src/ServiceControl/packages.config
@@ -29,6 +29,7 @@
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Owin.Metrics" version="0.3.7" targetFramework="net452" />
   <package id="Particular.Licensing.Sources" version="1.0.0" targetFramework="net452" />
+  <package id="protobuf-net" version="2.3.3" targetFramework="net452" />
   <package id="RavenDB.Client" version="2.5.2996" targetFramework="net452" />
   <package id="RavenDB.Database" version="2.5.2996" targetFramework="net452" />
   <package id="RavenDB.Embedded" version="2.5.2996" targetFramework="net452" />


### PR DESCRIPTION
This PR is a spike of a more dense way of storing audits. My assumption was, that once we want to move away from Raven and move into a new storage, we could use a dense format and some append-only structures (for instance, AppenBlob in Azure) to make audits work. This is just a sketch to get some buy-in. If you want me to elaborate more, I can make the description more concrete.

### Azure deployment

The general premise would be to use two sets of AppendBlobs (if a blob fills up, one of the worker creates a new one with a name incremented by 1). The first set would be responsible for storying metadata, the second - bodies. To audit a message following actions would occur:
- serialize metadata with the new dense serialization
- append body to the second set (returns the file id + position + length => `long/int/int`)
- write serialized metadata with the `long/int/int` body id to the first set

This would not address the indexing. If needed, we could run a function that periodically reads the metadata stream and writes secondary index entries to a table, in a similar way to the azure storage persistence:
- PartitionKey is `PropertyName_value`
- RowKey is `messageId`

The scavenging would be not so hard: 
- read the oldest metadata file
- reindex data, but now, use values to remove them from the table
- remove bodies accordingly (I know, what if there was out of order append etc. we can keep 1 blob more just in case)

### Other deployments

AppendOnly blob can be replaced by any store. A date prefix could be used to get "some ordering" allowing prunning old data. 
Indexing can be done with any Key-Value as it's similar to RAMP transactions, just pointing to a document