### PR TITLE
Api facade instanceids

### DIFF
--- a/src/ServiceControl.AcceptanceTests/MultiInstance/When_issuing_retry_on_master.cs
+++ b/src/ServiceControl.AcceptanceTests/MultiInstance/When_issuing_retry_on_master.cs
@@ -69,8 +69,7 @@
                         new RemoteInstanceSetting
                         {
                             ApiUri = addressOfRemote,
-                            QueueAddress = Remote1,
-                            InstanceName = Remote1,
+                            QueueAddress = Remote1
                         }
                     };
                     settings.AuditQueue = Address.Parse(AuditMaster);

--- a/src/ServiceControl.UnitTests/Infrastructure/Settings/SettingsTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/Settings/SettingsTests.cs
@@ -14,7 +14,7 @@
             var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
             config.AppSettings.Settings.Clear();
             // Remote instances
-            config.AppSettings.Settings.Add("ServiceControl/RemoteInstances", "[{'api_uri':'http://instance1', 'queue_address':'instance1@pc1', 'instance_name':'instance1'},{'api_uri':'http://instance2', 'queue_address':'instance1@pc2', 'instance_name':'instance2'}]'");
+            config.AppSettings.Settings.Add("ServiceControl/RemoteInstances", "[{'api_uri':'http://instance1', 'queue_address':'instance1@pc1'},{'api_uri':'http://instance2', 'queue_address':'instance1@pc2'}]'");
             // Various mandatory settings
             config.AppSettings.Settings.Add("ServiceControl/ForwardAuditMessages", "false");
             config.AppSettings.Settings.Add("ServiceControl/ForwardErrorMessages", "false");
@@ -31,8 +31,8 @@
             var remoteInstances = settings.RemoteInstances;
             CollectionAssert.AreEqual(remoteInstances, new []
             {
-                new RemoteInstanceSetting { ApiUri = "http://instance1", QueueAddress = "instance1@pc1", InstanceName = "instance1" },
-                new RemoteInstanceSetting { ApiUri = "http://instance2", QueueAddress = "instance1@pc2", InstanceName = "instance2" }
+                new RemoteInstanceSetting { ApiUri = "http://instance1", QueueAddress = "instance1@pc1" },
+                new RemoteInstanceSetting { ApiUri = "http://instance2", QueueAddress = "instance1@pc2" }
             }, new RemoteInstanceSettingComparer());
         }
 
@@ -40,7 +40,7 @@
         {
             public override int Compare(RemoteInstanceSetting x, RemoteInstanceSetting y)
             {
-                return x.QueueAddress.Equals(y.QueueAddress) && x.ApiUri.Equals(y.ApiUri) && x.InstanceName.Equals(y.InstanceName) ? 0 : 1;
+                return x.QueueAddress.Equals(y.QueueAddress) && x.ApiUri.Equals(y.ApiUri) ? 0 : 1;
             }
         }
     }

--- a/src/ServiceControl/CompositeViews/Endpoints/GetKnownEndpointsApi.cs
+++ b/src/ServiceControl/CompositeViews/Endpoints/GetKnownEndpointsApi.cs
@@ -12,7 +12,7 @@
     {
         public EndpointInstanceMonitoring EndpointInstanceMonitoring { get; set; }
 
-        public override Task<QueryResult<List<KnownEndpointsView>>> LocalQuery(Request request, NoInput input)
+        public override Task<QueryResult<List<KnownEndpointsView>>> LocalQuery(Request request, NoInput input, string instanceId)
         {
             var result = EndpointInstanceMonitoring.GetKnownEndpoints();
             return Task.FromResult(Results(result));

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
@@ -4,6 +4,7 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Linq;
     using System.Threading.Tasks;
     using Nancy;
+    using Raven.Abstractions.Extensions;
     using Raven.Client;
     using ServiceControl.Infrastructure.Extensions;
 
@@ -23,6 +24,8 @@ namespace ServiceControl.CompositeViews.Messages
                     .TransformWith<MessagesViewTransformer, MessagesView>()
                     .ToListAsync()
                     .ConfigureAwait(false);
+
+                results.ForEach(r => r.InstanceId  = instanceId);
 
                 return Results(results.ToList(), stats);
             }

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
@@ -9,7 +9,7 @@ namespace ServiceControl.CompositeViews.Messages
 
     public class GetAllMessagesApi : ScatterGatherApiMessageView<NoInput>
     {
-        public override async Task<QueryResult<List<MessagesView>>> LocalQuery(Request request, NoInput input)
+        public override async Task<QueryResult<List<MessagesView>>> LocalQuery(Request request, NoInput input, string instanceId)
         {
             using (var session = Store.OpenAsyncSession())
             {

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
@@ -4,6 +4,7 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Linq;
     using System.Threading.Tasks;
     using Nancy;
+    using Raven.Abstractions.Extensions;
     using Raven.Client;
     using Raven.Client.Linq;
     using ServiceControl.Infrastructure.Extensions;

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
@@ -10,7 +10,7 @@ namespace ServiceControl.CompositeViews.Messages
 
     public class GetAllMessagesForEndpointApi : ScatterGatherApiMessageView<string>
     {
-        public override async Task<QueryResult<List<MessagesView>>> LocalQuery(Request request, string input)
+        public override async Task<QueryResult<List<MessagesView>>> LocalQuery(Request request, string input, string instanceId)
         {
             using (var session = Store.OpenAsyncSession())
             {
@@ -25,6 +25,8 @@ namespace ServiceControl.CompositeViews.Messages
                     .TransformWith<MessagesViewTransformer, MessagesView>()
                     .ToListAsync()
                     .ConfigureAwait(false);
+
+                results.ForEach(r => r.InstanceId = instanceId);
 
                 return Results(results.ToList(), stats);
             }

--- a/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
@@ -10,7 +10,7 @@ namespace ServiceControl.CompositeViews.Messages
 
     public class MessagesByConversationApi : ScatterGatherApiMessageView<string>
     {
-        public override async Task<QueryResult<List<MessagesView>>> LocalQuery(Request request, string input)
+        public override async Task<QueryResult<List<MessagesView>>> LocalQuery(Request request, string input, string instanceId)
         {
             using (var session = Store.OpenAsyncSession())
             {

--- a/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
@@ -4,6 +4,7 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Linq;
     using System.Threading.Tasks;
     using Nancy;
+    using Raven.Abstractions.Extensions;
     using Raven.Client;
     using Raven.Client.Linq;
     using ServiceControl.Infrastructure.Extensions;
@@ -24,6 +25,8 @@ namespace ServiceControl.CompositeViews.Messages
                     .TransformWith<MessagesViewTransformer, MessagesView>()
                     .ToListAsync()
                     .ConfigureAwait(false);
+
+                results.ForEach(msg => msg.InstanceId = instanceId);
 
                 return Results(results.ToList(), stats);
             }

--- a/src/ServiceControl/CompositeViews/Messages/MessagesView.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesView.cs
@@ -27,6 +27,7 @@ namespace ServiceControl.CompositeViews.Messages
         public int BodySize { get; set; }
         public List<SagaInfo> InvokedSagas { get; set; }
         public SagaInfo OriginatesFromSaga { get; set; }
+        public string InstanceId { get; set; }
     }
 
 }

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
@@ -16,6 +16,7 @@ namespace ServiceControl.CompositeViews.Messages
     using ServiceBus.Management.Infrastructure.Nancy;
     using ServiceBus.Management.Infrastructure.Nancy.Modules;
     using ServiceBus.Management.Infrastructure.Settings;
+    using ServiceControl.Infrastructure.Settings;
     using HttpStatusCode = System.Net.HttpStatusCode;
 
     public interface IApi
@@ -51,7 +52,7 @@ namespace ServiceControl.CompositeViews.Messages
 
             var tasks = new List<Task<QueryResult<TOut>>>(remotes.Length + 1)
             {
-                LocalQuery(currentRequest, input)
+                LocalQuery(currentRequest, input, InstanceIdGenerator.FromApiUrl(Settings.ApiUrl))
             };
             foreach (var remote in remotes)
             {
@@ -64,7 +65,7 @@ namespace ServiceControl.CompositeViews.Messages
             return negotiate.WithPartialQueryResult(response, currentRequest);
         }
 
-        public abstract Task<QueryResult<TOut>> LocalQuery(Request request, TIn input);
+        public abstract Task<QueryResult<TOut>> LocalQuery(Request request, TIn input, string instanceId);
 
         public virtual QueryResult<TOut> AggregateResults(Request request, QueryResult<TOut>[] results)
         {

--- a/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
@@ -9,7 +9,7 @@ namespace ServiceControl.CompositeViews.Messages
 
     public class SearchApi : ScatterGatherApiMessageView<string>
     {
-        public override async Task<QueryResult<List<MessagesView>>> LocalQuery(Request request, string input)
+        public override async Task<QueryResult<List<MessagesView>>> LocalQuery(Request request, string input, string instanceId)
         {
             using (var session = Store.OpenAsyncSession())
             {

--- a/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
@@ -4,6 +4,7 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Linq;
     using System.Threading.Tasks;
     using Nancy;
+    using Raven.Abstractions.Extensions;
     using Raven.Client;
     using ServiceControl.Infrastructure.Extensions;
 
@@ -23,6 +24,8 @@ namespace ServiceControl.CompositeViews.Messages
                     .TransformWith<MessagesViewTransformer, MessagesView>()
                     .ToListAsync()
                     .ConfigureAwait(false);
+
+                results.ForEach(msg => msg.InstanceId = instanceId);
 
                 return Results(results.ToList(), stats);
             }

--- a/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
@@ -4,6 +4,7 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Linq;
     using System.Threading.Tasks;
     using Nancy;
+    using Raven.Abstractions.Extensions;
     using Raven.Client;
     using Raven.Client.Linq;
     using ServiceControl.Infrastructure.Extensions;
@@ -31,6 +32,8 @@ namespace ServiceControl.CompositeViews.Messages
                     .TransformWith<MessagesViewTransformer, MessagesView>()
                     .ToListAsync()
                     .ConfigureAwait(false);
+
+                results.ForEach(msg => msg.InstanceId = instanceId);
 
                 return Results(results.ToList(), stats);
             }

--- a/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
@@ -17,7 +17,7 @@ namespace ServiceControl.CompositeViews.Messages
             public string Endpoint { get; set; }
         }
 
-        public override async Task<QueryResult<List<MessagesView>>> LocalQuery(Request request, Input input)
+        public override async Task<QueryResult<List<MessagesView>>> LocalQuery(Request request, Input input, string instanceId)
         {
             using (var session = Store.OpenAsyncSession())
             {

--- a/src/ServiceControl/Infrastructure/Settings/InstanceIdGenerator.cs
+++ b/src/ServiceControl/Infrastructure/Settings/InstanceIdGenerator.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Converts a string to a base64 encoded string using UTF8
         /// </summary>
-        public static string FromApiUrl(string apiUrl) => Convert.ToBase64String(Encoding.UTF8.GetBytes(apiUrl));
+        public static string FromApiUrl(string apiUrl) => Convert.ToBase64String(Encoding.UTF8.GetBytes(apiUrl.ToLowerInvariant()));
 
         /// <summary>
         /// Converts from a base64 encoded string value using UTF8

--- a/src/ServiceControl/Infrastructure/Settings/InstanceIdGenerator.cs
+++ b/src/ServiceControl/Infrastructure/Settings/InstanceIdGenerator.cs
@@ -1,0 +1,18 @@
+﻿namespace ServiceControl.Infrastructure.Settings
+{
+    using System;
+    using System.Text;
+
+    static class InstanceIdGenerator
+    {
+        /// <summary>
+        /// Converts a string to a base64 encoded string using UTF8
+        /// </summary>
+        public static string FromApiUrl(string apiUrl) => Convert.ToBase64String(Encoding.UTF8.GetBytes(apiUrl));
+
+        /// <summary>
+        /// Converts from a base64 encoded string value using UTF8
+        /// </summary>
+        public static string ToApiUrl(string instanceId) => Encoding.UTF8.GetString(Convert.FromBase64String(instanceId));
+    }
+}

--- a/src/ServiceControl/Infrastructure/Settings/RemoteInstanceSetting.cs
+++ b/src/ServiceControl/Infrastructure/Settings/RemoteInstanceSetting.cs
@@ -4,6 +4,5 @@
     {
         public string ApiUri { get; set; }
         public string QueueAddress { get; set; }
-        public string InstanceName { get; set; }
     }
 }

--- a/src/ServiceControl/SagaAudit/GetSagaByIdApi.cs
+++ b/src/ServiceControl/SagaAudit/GetSagaByIdApi.cs
@@ -9,7 +9,7 @@ namespace ServiceControl.SagaAudit
 
     public class GetSagaByIdApi : ScatterGatherApi<Guid, SagaHistory>
     {
-        public override async Task<QueryResult<SagaHistory>> LocalQuery(Request request, Guid sagaId)
+        public override async Task<QueryResult<SagaHistory>> LocalQuery(Request request, Guid sagaId, string instanceId)
         {
             using (var session = Store.OpenAsyncSession())
             {

--- a/src/ServiceControl/SagaAudit/ListSagasApi.cs
+++ b/src/ServiceControl/SagaAudit/ListSagasApi.cs
@@ -10,7 +10,7 @@ namespace ServiceControl.SagaAudit
 
     public class ListSagasApi : ScatterGatherApi<NoInput, List<SagaListIndex.Result>>
     {
-        public override async Task<QueryResult<List<SagaListIndex.Result>>> LocalQuery(Request request, NoInput input)
+        public override async Task<QueryResult<List<SagaListIndex.Result>>> LocalQuery(Request request, NoInput input, string instanceId)
         {
             using (var session = Store.OpenAsyncSession())
             {

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -326,6 +326,7 @@
     <Compile Include="Infrastructure\RavenDB\Subscriptions\SubscriptionPersister.cs" />
     <Compile Include="Infrastructure\RavenDB\Subscriptions\SubscriptionStorage.cs" />
     <Compile Include="Infrastructure\Settings\ConfigFileSettingsReader.cs" />
+    <Compile Include="Infrastructure\Settings\InstanceIdGenerator.cs" />
     <Compile Include="Infrastructure\Settings\RemoteInstanceSetting.cs" />
     <Compile Include="Licensing\LicenseCheckFeature.cs" />
     <Compile Include="Licensing\LicenseModule.cs" />


### PR DESCRIPTION
- @SeanFeldman and I implemented an `InstanceId` attribute to each `MessageView` returned, which is simply the Base64 encoded string representing the APIUrl for the instance delivering the view. 
- We modified the Retries API to use the InstanceId instead of instance name, and removed that setting.
- We added tests for all including checking for population of `InstanceId`, and added coverage for missing MessageView APIs.