### PR TITLE
WIP Scatter-gather bypassing when instance_id present

### DIFF
--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
@@ -41,22 +41,74 @@ namespace ServiceControl.CompositeViews.Messages
         static JsonSerializer jsonSerializer = JsonSerializer.Create(JsonNetSerializer.CreateDefault());
         static ILog logger = LogManager.GetLogger(typeof(ScatterGatherApi<TIn, TOut>));
 
+        private Dictionary<string, string> instanceIdToApiUri;
+        private Dictionary<string, string> apiUriToInstanceId;
+
         public IDocumentStore Store { get; set; }
         public Settings Settings { get; set; }
         public Func<HttpClient> HttpClientFactory { get; set; }
+        public string CurrentInstanceId { get; set; }
+
+        public Dictionary<string, string> InstanceIdToApiUri
+        {
+            get
+            {
+                if (instanceIdToApiUri == null)
+                {
+                    instanceIdToApiUri = Settings.RemoteInstances.ToDictionary(k => InstanceIdGenerator.FromApiUrl(k.ApiUri), v => v.ApiUri.ToLowerInvariant());
+                    CurrentInstanceId = InstanceIdGenerator.FromApiUrl(Settings.ApiUrl);
+                    instanceIdToApiUri.Add(CurrentInstanceId, Settings.ApiUrl.ToLowerInvariant());
+                }
+
+                return instanceIdToApiUri;
+            }
+        }
+
+        public Dictionary<string, string> ApiUriToInstanceId
+        {
+            get
+            {
+                if (apiUriToInstanceId == null)
+                {
+                    apiUriToInstanceId = Settings.RemoteInstances.ToDictionary(k => k.ApiUri.ToLowerInvariant(), v => InstanceIdGenerator.FromApiUrl(v.ApiUri));
+                    apiUriToInstanceId.Add(Settings.ApiUrl.ToLowerInvariant(), InstanceIdGenerator.FromApiUrl(Settings.ApiUrl));
+                }
+
+                return apiUriToInstanceId;
+            }
+        }
 
         public async Task<dynamic> Execute(BaseModule module, TIn input)
         {
             var remotes = Settings.RemoteInstances;
             var currentRequest = module.Request;
+            var query = (DynamicDictionary)module.Request.Query;
 
-            var tasks = new List<Task<QueryResult<TOut>>>(remotes.Length + 1)
+            var tasks = new List<Task<QueryResult<TOut>>>(remotes.Length + 1);
+            dynamic instanceId;
+            if (query.TryGetValue("instance_id", out instanceId))
             {
-                LocalQuery(currentRequest, input, InstanceIdGenerator.FromApiUrl(Settings.ApiUrl))
-            };
-            foreach (var remote in remotes)
+                var id = (string) instanceId;
+                if (id == CurrentInstanceId)
+                {
+                    tasks.Add(LocalQuery(currentRequest, input, ApiUriToInstanceId[Settings.ApiUrl.ToLowerInvariant()]));
+                }
+                else
+                {
+                    string remoteUri;
+                    if (InstanceIdToApiUri.TryGetValue(id, out remoteUri))
+                    {
+                        tasks.Add(FetchAndParse(currentRequest, remoteUri));
+                    }
+                }
+            }
+            else
             {
-                tasks.Add(FetchAndParse(currentRequest, remote.ApiUri));
+                tasks.Add(LocalQuery(currentRequest, input, ApiUriToInstanceId[Settings.ApiUrl.ToLowerInvariant()]));
+                foreach (var remote in remotes)
+                {
+                    tasks.Add(FetchAndParse(currentRequest, remote.ApiUri));
+                }
             }
 
             var response = AggregateResults(currentRequest, await Task.WhenAll(tasks));

--- a/src/ServiceControl/SagaAudit/ListSagasApi.cs
+++ b/src/ServiceControl/SagaAudit/ListSagasApi.cs
@@ -4,6 +4,7 @@ namespace ServiceControl.SagaAudit
     using System.Linq;
     using System.Threading.Tasks;
     using Nancy;
+    using Raven.Abstractions.Extensions;
     using Raven.Client;
     using ServiceControl.CompositeViews.Messages;
     using ServiceControl.Infrastructure.Extensions;
@@ -20,6 +21,8 @@ namespace ServiceControl.SagaAudit
                     .Paging(request)
                     .ToListAsync()
                     .ConfigureAwait(false);
+
+                results.ForEach(r => r.Uri = $"{r.Uri}?instance_id={instanceId}");
 
                 return Results(results.ToList(), stats);
             }


### PR DESCRIPTION
This would technically allow bypassing the scatter-gather when the instance id is present. Originally it was intended to be there for the saga list. Unfortunately, the saga list is not used from Service Insight. The question is would we still want this change despite the complexity it introduces into the scatter-gather API?