### PR TITLE
Removed Last-Modified

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Audit/FailedAuditsModule.cs
+++ b/src/ServiceControl.AcceptanceTests/Audit/FailedAuditsModule.cs
@@ -37,7 +37,7 @@
                         {
                             Count = count
                         })
-                        .WithEtagAndLastModified(stats);
+                        .WithEtag(stats);
                 }
             };
 

--- a/src/ServiceControl/CompositeViews/Messages/QueryStatsInfo.cs
+++ b/src/ServiceControl/CompositeViews/Messages/QueryStatsInfo.cs
@@ -1,30 +1,25 @@
 namespace ServiceControl.CompositeViews.Messages
 {
-    using System;
-
     public struct QueryStatsInfo
     {
         public readonly string ETag;
-        public readonly DateTime LastModified;
         public readonly int TotalCount;
         public readonly int HighestTotalCountOfAllTheInstances;
 
-        public QueryStatsInfo(string eTag, DateTime lastModified, int totalCount)
+        public QueryStatsInfo(string eTag, int totalCount)
         {
             ETag = eTag;
-            LastModified = lastModified;
             TotalCount = totalCount;
             HighestTotalCountOfAllTheInstances = totalCount;
         }
 
-        public QueryStatsInfo(string eTag, DateTime lastModified, int totalCount, int highestTotalCountOfAllTheInstances)
+        public QueryStatsInfo(string eTag, int totalCount, int highestTotalCountOfAllTheInstances)
         {
             ETag = eTag;
-            LastModified = lastModified;
             TotalCount = totalCount;
             HighestTotalCountOfAllTheInstances = highestTotalCountOfAllTheInstances;
         }
 
-        public static readonly QueryStatsInfo Zero = new QueryStatsInfo(string.Empty, DateTime.MinValue, 0);
+        public static readonly QueryStatsInfo Zero = new QueryStatsInfo(string.Empty, 0);
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
@@ -2,7 +2,6 @@ namespace ServiceControl.CompositeViews.Messages
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Net.Http;
@@ -84,7 +83,7 @@ namespace ServiceControl.CompositeViews.Messages
         protected QueryResult<TOut> Results(TOut results, string instanceId, RavenQueryStatistics stats = null)
         {
             return stats != null
-                ? new QueryResult<TOut>(results, instanceId, new QueryStatsInfo(stats.IndexEtag, stats.IndexTimestamp, stats.TotalResults))
+                ? new QueryResult<TOut>(results, instanceId, new QueryStatsInfo(stats.IndexEtag, stats.TotalResults))
                 : new QueryResult<TOut>(results, instanceId, QueryStatsInfo.Zero);
         }
 
@@ -94,7 +93,6 @@ namespace ServiceControl.CompositeViews.Messages
 
             return new QueryStatsInfo(
                 string.Join("", infos.Select(x => x.ETag)),
-                infos.Max(x => x.LastModified),
                 infos.Sum(x => x.TotalCount),
                 infos.Max(x => x.HighestTotalCountOfAllTheInstances)
             );
@@ -144,14 +142,7 @@ namespace ServiceControl.CompositeViews.Messages
                     etag = etags.ElementAt(0);
                 }
 
-                IEnumerable<string> lastModifiedValues;
-                var lastModified = DateTime.UtcNow;
-                if (responseMessage.Headers.TryGetValues("Last-Modified", out lastModifiedValues))
-                {
-                    lastModified = DateTime.ParseExact(lastModifiedValues.ElementAt(0), "R", CultureInfo.InvariantCulture);
-                }
-
-                return new QueryResult<TOut>(remoteResults, instanceId, new QueryStatsInfo(etag, lastModified, totalCount, totalCount));
+                return new QueryResult<TOut>(remoteResults, instanceId, new QueryStatsInfo(etag, totalCount, totalCount));
             }
         }
     }

--- a/src/ServiceControl/CustomChecks/CustomChecksModule.cs
+++ b/src/ServiceControl/CustomChecks/CustomChecksModule.cs
@@ -33,7 +33,7 @@
                     return Negotiate
                         .WithModel(results)
                         .WithPagingLinksAndTotalCount(stats, Request)
-                        .WithEtagAndLastModified(stats);
+                        .WithEtag(stats);
                 }
             };
 

--- a/src/ServiceControl/EventLog/EventLogApiModule.cs
+++ b/src/ServiceControl/EventLog/EventLogApiModule.cs
@@ -23,7 +23,7 @@
 
                     return Negotiate.WithModel(results)
                         .WithPagingLinksAndTotalCount(stats, Request)
-                        .WithEtagAndLastModified(stats);
+                        .WithEtag(stats);
                 }
             };
         }

--- a/src/ServiceControl/Infrastructure/Extensions/NegotiatorExtensions.cs
+++ b/src/ServiceControl/Infrastructure/Extensions/NegotiatorExtensions.cs
@@ -35,8 +35,7 @@ namespace ServiceBus.Management.Infrastructure.Extensions
 
             return negotiator.WithModel(queryResult.DynamicResults)
                 .WithPagingLinksAndTotalCount(queryStats.TotalCount, queryStats.HighestTotalCountOfAllTheInstances, request)
-                .WithDeterministicEtag(queryStats.ETag)
-                .WithLastModified(queryStats.LastModified);
+                .WithDeterministicEtag(queryStats.ETag);
         }
 
         public static Negotiator WithPagingLinksAndTotalCount(this Negotiator negotiator, int totalCount,
@@ -139,12 +138,11 @@ namespace ServiceBus.Management.Infrastructure.Extensions
             links.Add($"<{url}>; rel=\"{rel}\"");
         }
 
-        public static Negotiator WithEtagAndLastModified(this Negotiator negotiator, RavenQueryStatistics stats)
+        public static Negotiator WithEtag(this Negotiator negotiator, RavenQueryStatistics stats)
         {
             var etag = stats.IndexEtag;
-            var responseLastModified = stats.IndexTimestamp;
 
-            return WithEtagAndLastModified(negotiator, etag, responseLastModified);
+            return WithEtag(negotiator, etag);
         }
 
         public static Negotiator WithDeterministicEtag(this Negotiator negotiator, string data)
@@ -154,25 +152,19 @@ namespace ServiceBus.Management.Infrastructure.Extensions
                 .WithHeader("ETag", guid.ToString());
         }
 
-        public static Negotiator WithEtagAndLastModified(this Negotiator negotiator, string etag, DateTime responseLastModified)
+        public static Negotiator WithEtag(this Negotiator negotiator, string etag)
         {
             if (etag != null)
             {
                 negotiator.WithHeader("ETag", etag);
             }
-            return negotiator
-                .WithHeader("Last-Modified", responseLastModified.ToString("R"));
+
+            return negotiator;
         }
 
-        public static Negotiator WithEtagAndLastModified(this Negotiator negotiator, Etag etag, DateTime responseLastModified)
+        public static Negotiator WithEtag(this Negotiator negotiator, Etag etag)
         {
-            return negotiator.WithEtagAndLastModified(etag?.ToString(), responseLastModified);
-        }
-
-        public static Negotiator WithLastModified(this Negotiator negotiator, DateTime responseLastModified)
-        {
-            return negotiator
-                .WithHeader("Last-Modified", responseLastModified.ToString("R"));
+            return negotiator.WithEtag(etag?.ToString());
         }
     }
 }

--- a/src/ServiceControl/MessageFailures/Api/GetAllErrors.cs
+++ b/src/ServiceControl/MessageFailures/Api/GetAllErrors.cs
@@ -26,7 +26,7 @@
 
                     return Negotiate
                         .WithTotalCount(queryResult.TotalResults)
-                        .WithEtagAndLastModified(queryResult.IndexEtag, queryResult.IndexTimestamp);
+                        .WithEtag(queryResult.IndexEtag);
                 }
             };
 
@@ -51,7 +51,7 @@
                     return Negotiate
                         .WithModel(results)
                         .WithPagingLinksAndTotalCount(stats, Request)
-                        .WithEtagAndLastModified(stats);
+                        .WithEtag(stats);
                 }
             };
 
@@ -79,7 +79,7 @@
                     return Negotiate
                         .WithModel(results)
                         .WithPagingLinksAndTotalCount(stats, Request)
-                        .WithEtagAndLastModified(stats);
+                        .WithEtag(stats);
                 }
             };
 

--- a/src/ServiceControl/MessageFailures/Api/QueueAddressModule.cs
+++ b/src/ServiceControl/MessageFailures/Api/QueueAddressModule.cs
@@ -27,7 +27,7 @@
                     return Negotiate
                         .WithModel(addresses)
                         .WithPagingLinksAndTotalCount(stats, Request)
-                        .WithEtagAndLastModified(stats);
+                        .WithEtag(stats);
                 }
             };
 
@@ -61,7 +61,7 @@
                     return Negotiate
                         .WithModel(failedMessageQueues)
                         .WithPagingLinksAndTotalCount(stats, Request)
-                        .WithEtagAndLastModified(stats);
+                        .WithEtag(stats);
                 }
             };
         }

--- a/src/ServiceControl/MessageRedirects/Api/MessageRedirectsModule.cs
+++ b/src/ServiceControl/MessageRedirects/Api/MessageRedirectsModule.cs
@@ -169,7 +169,7 @@
                     var redirects = await MessageRedirectsCollection.GetOrCreate(session).ConfigureAwait(false);
 
                     return Negotiate
-                        .WithEtagAndLastModified(redirects.ETag, redirects.LastModified)
+                        .WithEtag(redirects.ETag)
                         .WithTotalCount(redirects.Redirects.Count);
                 }
             };
@@ -193,7 +193,7 @@
 
                     return Negotiate
                         .WithModel(queryResult)
-                        .WithEtagAndLastModified(redirects.ETag, redirects.LastModified)
+                        .WithEtag(redirects.ETag)
                         .WithPagingLinksAndTotalCount(redirects.Redirects.Count, Request);
                 }
             };

--- a/src/ServiceControl/Recoverability/API/FailureGroupsApi.cs
+++ b/src/ServiceControl/Recoverability/API/FailureGroupsApi.cs
@@ -109,7 +109,7 @@ namespace ServiceControl.Recoverability
 
                 return Negotiate
                          .WithModel(queryResult.FirstOrDefault())
-                         .WithEtagAndLastModified(stats);
+                         .WithEtag(stats);
             }
         }
 
@@ -134,7 +134,7 @@ namespace ServiceControl.Recoverability
 
                 return Negotiate.WithModel(results)
                     .WithPagingLinksAndTotalCount(stats, Request)
-                    .WithEtagAndLastModified(stats);
+                    .WithEtag(stats);
             }
         }
 
@@ -152,7 +152,7 @@ namespace ServiceControl.Recoverability
 
                 return Negotiate
                          .WithTotalCount(queryResult.TotalResults)
-                         .WithEtagAndLastModified(queryResult.IndexEtag, queryResult.IndexTimestamp);
+                         .WithEtag(queryResult.IndexEtag);
             }
         }
     }

--- a/src/ServiceControl/SagaAudit/GetSagaByIdApi.cs
+++ b/src/ServiceControl/SagaAudit/GetSagaByIdApi.cs
@@ -25,11 +25,7 @@ namespace ServiceControl.SagaAudit
                     return QueryResult<SagaHistory>.Empty(instanceId);
                 }
 
-                var lastModified = sagaHistory.Changes.OrderByDescending(x => x.FinishTime)
-                    .Select(y => y.FinishTime)
-                    .First();
-
-                return new QueryResult<SagaHistory>(sagaHistory, instanceId, new QueryStatsInfo(stats.IndexEtag, lastModified, stats.TotalResults));
+                return new QueryResult<SagaHistory>(sagaHistory, instanceId, new QueryStatsInfo(stats.IndexEtag, stats.TotalResults));
             }
         }
 


### PR DESCRIPTION
@Particular/servicecontrol-maintainers @Particular/servicepulse-maintainers @Particular/serviceinsight-maintainers 

@boblangley and I discussed this today and we are thinking we can remove Last-Modified entirely. ServiceInsight doesn't use it and neither does ServicePulse. They all rely on ETag.

Do you see any blockers?