### PR TITLE
Passing the instance id into query result to also take into account data that might have come from remote instances without id

### DIFF
--- a/src/ServiceControl/CompositeViews/Endpoints/GetKnownEndpointsApi.cs
+++ b/src/ServiceControl/CompositeViews/Endpoints/GetKnownEndpointsApi.cs
@@ -15,12 +15,12 @@
         public override Task<QueryResult<List<KnownEndpointsView>>> LocalQuery(Request request, NoInput input, string instanceId)
         {
             var result = EndpointInstanceMonitoring.GetKnownEndpoints();
-            return Task.FromResult(Results(result));
+            return Task.FromResult(Results(result, instanceId));
         }
 
         protected override List<KnownEndpointsView> ProcessResults(Request request, QueryResult<List<KnownEndpointsView>>[] results)
         {
-            return results.SelectMany(p => p.Results).DistinctBy(e => e.Id).ToList();
+            return results.Where(p => p.Results != null).SelectMany(p => p.Results).DistinctBy(e => e.Id).ToList();
         }
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
@@ -4,7 +4,6 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Linq;
     using System.Threading.Tasks;
     using Nancy;
-    using Raven.Abstractions.Extensions;
     using Raven.Client;
     using ServiceControl.Infrastructure.Extensions;
 
@@ -25,9 +24,7 @@ namespace ServiceControl.CompositeViews.Messages
                     .ToListAsync()
                     .ConfigureAwait(false);
 
-                results.ForEach(r => r.InstanceId  = instanceId);
-
-                return Results(results.ToList(), stats);
+                return Results(results.ToList(), instanceId, stats);
             }
         }
     }

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
@@ -4,7 +4,6 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Linq;
     using System.Threading.Tasks;
     using Nancy;
-    using Raven.Abstractions.Extensions;
     using Raven.Client;
     using Raven.Client.Linq;
     using ServiceControl.Infrastructure.Extensions;
@@ -27,9 +26,7 @@ namespace ServiceControl.CompositeViews.Messages
                     .ToListAsync()
                     .ConfigureAwait(false);
 
-                results.ForEach(r => r.InstanceId = instanceId);
-
-                return Results(results.ToList(), stats);
+                return Results(results.ToList(), instanceId, stats);
             }
 
         }

--- a/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
@@ -4,7 +4,6 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Linq;
     using System.Threading.Tasks;
     using Nancy;
-    using Raven.Abstractions.Extensions;
     using Raven.Client;
     using Raven.Client.Linq;
     using ServiceControl.Infrastructure.Extensions;
@@ -26,9 +25,7 @@ namespace ServiceControl.CompositeViews.Messages
                     .ToListAsync()
                     .ConfigureAwait(false);
 
-                results.ForEach(msg => msg.InstanceId = instanceId);
-
-                return Results(results.ToList(), stats);
+                return Results(results.ToList(), instanceId, stats);
             }
         }
     }

--- a/src/ServiceControl/CompositeViews/Messages/QueryResult.cs
+++ b/src/ServiceControl/CompositeViews/Messages/QueryResult.cs
@@ -2,13 +2,16 @@ namespace ServiceControl.CompositeViews.Messages
 {
     public class QueryResult
     {
-        protected QueryResult(object results, QueryStatsInfo queryStatsInfo)
+        protected QueryResult(object results, string instanceId, QueryStatsInfo queryStatsInfo)
         {
+            InstanceId = instanceId;
             DynamicResults = results;
             QueryStats = queryStatsInfo;
         }
 
+
         public object DynamicResults { get; }
+        public string InstanceId { get; }
 
         public QueryStatsInfo QueryStats { get; }
     }
@@ -16,13 +19,13 @@ namespace ServiceControl.CompositeViews.Messages
     public class QueryResult<TOut> : QueryResult
         where TOut: class 
     {
-        public QueryResult(TOut results, QueryStatsInfo queryStatsInfo) : base(results, queryStatsInfo)
+        public QueryResult(TOut results, string instanceId, QueryStatsInfo queryStatsInfo) : base(results, instanceId, queryStatsInfo)
         {
             Results = results;
         }
 
         public TOut Results { get; }
 
-        public static QueryResult<TOut> Empty = new QueryResult<TOut>(null, QueryStatsInfo.Zero);
+        public static QueryResult<TOut> Empty(string instanceId) => new QueryResult<TOut>(null, instanceId, QueryStatsInfo.Zero);
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
@@ -36,7 +36,7 @@ namespace ServiceControl.CompositeViews.Messages
     }
 
     public abstract class ScatterGatherApi<TIn, TOut> : IApi
-        where TOut: class
+        where TOut : class
     {
         static JsonSerializer jsonSerializer = JsonSerializer.Create(JsonNetSerializer.CreateDefault());
         static ILog logger = LogManager.GetLogger(typeof(ScatterGatherApi<TIn, TOut>));
@@ -50,16 +50,17 @@ namespace ServiceControl.CompositeViews.Messages
             var remotes = Settings.RemoteInstances;
             var currentRequest = module.Request;
 
+            var instanceId = InstanceIdGenerator.FromApiUrl(Settings.ApiUrl);
             var tasks = new List<Task<QueryResult<TOut>>>(remotes.Length + 1)
             {
-                LocalQuery(currentRequest, input, InstanceIdGenerator.FromApiUrl(Settings.ApiUrl))
+                LocalQuery(currentRequest, input, instanceId)
             };
             foreach (var remote in remotes)
             {
-                tasks.Add(FetchAndParse(currentRequest, remote.ApiUri));
+                tasks.Add(FetchAndParse(currentRequest, remote.ApiUri, InstanceIdGenerator.FromApiUrl(remote.ApiUri)));
             }
 
-            var response = AggregateResults(currentRequest, await Task.WhenAll(tasks));
+            var response = AggregateResults(currentRequest, instanceId, await Task.WhenAll(tasks));
 
             var negotiate = module.Negotiate;
             return negotiate.WithPartialQueryResult(response, currentRequest);
@@ -67,20 +68,30 @@ namespace ServiceControl.CompositeViews.Messages
 
         public abstract Task<QueryResult<TOut>> LocalQuery(Request request, TIn input, string instanceId);
 
-        public virtual QueryResult<TOut> AggregateResults(Request request, QueryResult<TOut>[] results)
+        private QueryResult<TOut> AggregateResults(Request request, string instanceId, QueryResult<TOut>[] results)
         {
             var combinedResults = ProcessResults(request, results);
 
             return new QueryResult<TOut>(
                 combinedResults,
-                AggregateStats(results.Select(x => x.QueryStats).ToArray())
+                instanceId,
+                AggregateStats(results)
             );
         }
 
         protected abstract TOut ProcessResults(Request request, QueryResult<TOut>[] results);
 
-        protected virtual QueryStatsInfo AggregateStats(QueryStatsInfo[] infos)
+        protected QueryResult<TOut> Results(TOut results, string instanceId, RavenQueryStatistics stats = null)
         {
+            return stats != null
+                ? new QueryResult<TOut>(results, instanceId, new QueryStatsInfo(stats.IndexEtag, stats.IndexTimestamp, stats.TotalResults))
+                : new QueryResult<TOut>(results, instanceId, QueryStatsInfo.Zero);
+        }
+
+        private QueryStatsInfo AggregateStats(IEnumerable<QueryResult<TOut>> results)
+        {
+            var infos = results.OrderBy(x => x.InstanceId, StringComparer.InvariantCultureIgnoreCase).Select(x => x.QueryStats).ToArray();
+
             return new QueryStatsInfo(
                 string.Join("", infos.Select(x => x.ETag)),
                 infos.Max(x => x.LastModified),
@@ -89,15 +100,8 @@ namespace ServiceControl.CompositeViews.Messages
             );
         }
 
-        protected QueryResult<TOut> Results(TOut results, RavenQueryStatistics stats = null)
-        {
-            return stats != null 
-                ? new QueryResult<TOut>(results, new QueryStatsInfo(stats.IndexEtag, stats.IndexTimestamp, stats.TotalResults)) 
-                : new QueryResult<TOut>(results, QueryStatsInfo.Zero);
-        }
 
-
-        async Task<QueryResult<TOut>> FetchAndParse(Request currentRequest, string remoteUri)
+        async Task<QueryResult<TOut>> FetchAndParse(Request currentRequest, string remoteUri, string instanceId)
         {
             var instanceUri = new Uri($"{remoteUri}{currentRequest.Path}?{currentRequest.Url.Query}");
             var httpClient = HttpClientFactory();
@@ -107,19 +111,19 @@ namespace ServiceControl.CompositeViews.Messages
                 // special case - queried by conversation ID and nothing was found
                 if (rawResponse.StatusCode == HttpStatusCode.NotFound)
                 {
-                    return QueryResult<TOut>.Empty;
+                    return QueryResult<TOut>.Empty(instanceId);
                 }
 
-                return await ParseResult(rawResponse).ConfigureAwait(false);
+                return await ParseResult(rawResponse, instanceId).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
                 logger.Warn($"Failed to query remote instance at {remoteUri}.", exception);
-                return QueryResult<TOut>.Empty;
+                return QueryResult<TOut>.Empty(instanceId);
             }
         }
 
-        static async Task<QueryResult<TOut>> ParseResult(HttpResponseMessage responseMessage)
+        static async Task<QueryResult<TOut>> ParseResult(HttpResponseMessage responseMessage, string instanceId)
         {
             using (var responseStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false))
             using (var jsonReader = new JsonTextReader(new StreamReader(responseStream)))
@@ -147,7 +151,7 @@ namespace ServiceControl.CompositeViews.Messages
                     lastModified = DateTime.ParseExact(lastModifiedValues.ElementAt(0), "R", CultureInfo.InvariantCulture);
                 }
 
-                return new QueryResult<TOut>(remoteResults, new QueryStatsInfo(etag, lastModified, totalCount, totalCount));
+                return new QueryResult<TOut>(remoteResults, instanceId, new QueryStatsInfo(etag, lastModified, totalCount, totalCount));
             }
         }
     }

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApiMessageView.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApiMessageView.cs
@@ -1,14 +1,25 @@
 namespace ServiceControl.CompositeViews.Messages
 {
     using System.Collections.Generic;
-    using System.Linq;
     using Nancy;
 
     public abstract class ScatterGatherApiMessageView<TInput> : ScatterGatherApi<TInput, List<MessagesView>>
     {
         protected override List<MessagesView> ProcessResults(Request request, QueryResult<List<MessagesView>>[] results)
         {
-            var combined = results.Where(x => x.Results != null).SelectMany(x => x.Results).ToList();
+            var combined = new List<MessagesView>();
+            foreach (var queryResult in results)
+            {
+                var messagesViews = queryResult?.Results ?? new List<MessagesView>();
+                foreach (var result in messagesViews)
+                {
+                    if (result.InstanceId == null)
+                    {
+                        result.InstanceId = queryResult.InstanceId;
+                    }
+                }
+                combined.AddRange(messagesViews);
+            }
             var comparer = FinalOrder(request);
             if (comparer != null)
             {

--- a/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
@@ -27,7 +27,7 @@ namespace ServiceControl.CompositeViews.Messages
 
                 results.ForEach(msg => msg.InstanceId = instanceId);
 
-                return Results(results.ToList(), stats);
+                return Results(results.ToList(), instanceId, stats);
             }
         }
     }

--- a/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
@@ -4,7 +4,6 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Linq;
     using System.Threading.Tasks;
     using Nancy;
-    using Raven.Abstractions.Extensions;
     using Raven.Client;
     using Raven.Client.Linq;
     using ServiceControl.Infrastructure.Extensions;
@@ -33,9 +32,7 @@ namespace ServiceControl.CompositeViews.Messages
                     .ToListAsync()
                     .ConfigureAwait(false);
 
-                results.ForEach(msg => msg.InstanceId = instanceId);
-
-                return Results(results.ToList(), stats);
+                return Results(results.ToList(), instanceId, stats);
             }
         }
     }

--- a/src/ServiceControl/Infrastructure/Settings/InstanceIdGenerator.cs
+++ b/src/ServiceControl/Infrastructure/Settings/InstanceIdGenerator.cs
@@ -8,11 +8,11 @@
         /// <summary>
         /// Converts a string to a base64 encoded string using UTF8
         /// </summary>
-        public static string FromApiUrl(string apiUrl) => Convert.ToBase64String(Encoding.UTF8.GetBytes(apiUrl.ToLowerInvariant()));
+        public static string FromApiUrl(string apiUrl) => Convert.ToBase64String(Encoding.UTF8.GetBytes(apiUrl.ToLowerInvariant())).Replace('+','-').Replace('/','_').Replace('=','.');
 
         /// <summary>
         /// Converts from a base64 encoded string value using UTF8
         /// </summary>
-        public static string ToApiUrl(string instanceId) => Encoding.UTF8.GetString(Convert.FromBase64String(instanceId));
+        public static string ToApiUrl(string instanceId) => Encoding.UTF8.GetString(Convert.FromBase64String(instanceId.Replace('-', '+').Replace('_', '/').Replace('.', '=')));
     }
 }

--- a/src/ServiceControl/SagaAudit/GetSagaByIdApi.cs
+++ b/src/ServiceControl/SagaAudit/GetSagaByIdApi.cs
@@ -22,14 +22,14 @@ namespace ServiceControl.SagaAudit
 
                 if (sagaHistory == null)
                 {
-                    return QueryResult<SagaHistory>.Empty;
+                    return QueryResult<SagaHistory>.Empty(instanceId);
                 }
 
                 var lastModified = sagaHistory.Changes.OrderByDescending(x => x.FinishTime)
                     .Select(y => y.FinishTime)
                     .First();
 
-                return new QueryResult<SagaHistory>(sagaHistory, new QueryStatsInfo(stats.IndexEtag, lastModified, stats.TotalResults));
+                return new QueryResult<SagaHistory>(sagaHistory, instanceId, new QueryStatsInfo(stats.IndexEtag, lastModified, stats.TotalResults));
             }
         }
 

--- a/src/ServiceControl/SagaAudit/ListSagasApi.cs
+++ b/src/ServiceControl/SagaAudit/ListSagasApi.cs
@@ -21,7 +21,7 @@ namespace ServiceControl.SagaAudit
                     .ToListAsync()
                     .ConfigureAwait(false);
 
-                return Results(results.ToList(), stats);
+                return Results(results.ToList(), instanceId, stats);
             }
         }
 


### PR DESCRIPTION
- If a ServiceControl version is used as a remote instance that doesn't add the remoteInstanceId it has to be added by the master.
- Will make sure the etag is always ordered in the right way