### PR TITLE
Skip over empty archive batches instead of terminating the archive process

### DIFF
--- a/src/ServiceControl.UnitTests/Archiving/ArchiveGroupTests.cs
+++ b/src/ServiceControl.UnitTests/Archiving/ArchiveGroupTests.cs
@@ -1,0 +1,68 @@
+﻿using NUnit.Framework;
+using Raven.Client;
+using ServiceControl.Contracts.Operations;
+using ServiceControl.MessageFailures;
+using ServiceControl.Recoverability;
+using ServiceControl.UnitTests.Recoverability;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ServiceControl.UnitTests.Archiving
+{
+    [TestFixture]
+    public class ArchiveGroupTests
+    {
+        [Test]
+        public void ArchiveGroup_skips_over_empty_batches_but_still_completes()
+        {
+            // Arrange
+            using (var documentStore = InMemoryStoreBuilder.GetInMemoryStore())
+            {
+                var groupId = "TestGroup";
+
+                using (var session = documentStore.OpenSession())
+                {
+                    var secondAchiveBatch = new ArchiveBatch { Id = ArchiveBatch.MakeId(groupId, ArchiveType.FailureGroup, 1) };
+                    session.Store(secondAchiveBatch);
+
+                    var archiveOperation = new ArchiveOperation
+                    {
+                        Id = ArchiveOperation.MakeId(groupId, ArchiveType.FailureGroup),
+                        RequestId = groupId,
+                        ArchiveType = ArchiveType.FailureGroup,
+                        TotalNumberOfMessages = 2,
+                        NumberOfMessagesArchived = 0,
+                        Started = DateTime.Now,
+                        GroupName = "Test Group",
+                        NumberOfBatches = 3,
+                        CurrentBatch = 0
+                    };
+                    session.Store(archiveOperation);
+
+                    session.SaveChanges();
+                }
+
+                var testBus = new TestBus();
+                var documentManager = new ArchiveDocumentManager();
+                var archivingManager = new ArchivingManager();
+                var retryingManager = new RetryingManager();
+                var handler = new ArchiveAllInGroupHandler(testBus, documentStore, documentManager, archivingManager, retryingManager);
+
+                var message = new ArchiveAllInGroup { GroupId = groupId };
+
+                // Act
+                handler.Handle(message);
+
+                // Assert
+                using (var session = documentStore.OpenSession())
+                {
+                    var loadedBatch = session.Load<ArchiveBatch>(ArchiveBatch.MakeId(groupId, ArchiveType.FailureGroup, 1));
+                    Assert.IsNull(loadedBatch);
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/Archiving/ArchiveGroupTests.cs
+++ b/src/ServiceControl.UnitTests/Archiving/ArchiveGroupTests.cs
@@ -1,14 +1,7 @@
 ﻿using NUnit.Framework;
-using Raven.Client;
-using ServiceControl.Contracts.Operations;
-using ServiceControl.MessageFailures;
 using ServiceControl.Recoverability;
 using ServiceControl.UnitTests.Recoverability;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ServiceControl.UnitTests.Archiving
 {
@@ -22,10 +15,11 @@ namespace ServiceControl.UnitTests.Archiving
             using (var documentStore = InMemoryStoreBuilder.GetInMemoryStore())
             {
                 var groupId = "TestGroup";
+                var emptyArchiveBatchId = ArchiveBatch.MakeId(groupId, ArchiveType.FailureGroup, 1);
 
                 using (var session = documentStore.OpenSession())
                 {
-                    var secondAchiveBatch = new ArchiveBatch { Id = ArchiveBatch.MakeId(groupId, ArchiveType.FailureGroup, 1) };
+                    var secondAchiveBatch = new ArchiveBatch { Id = emptyArchiveBatchId };
                     session.Store(secondAchiveBatch);
 
                     var archiveOperation = new ArchiveOperation
@@ -59,7 +53,7 @@ namespace ServiceControl.UnitTests.Archiving
                 // Assert
                 using (var session = documentStore.OpenSession())
                 {
-                    var loadedBatch = session.Load<ArchiveBatch>(ArchiveBatch.MakeId(groupId, ArchiveType.FailureGroup, 1));
+                    var loadedBatch = session.Load<ArchiveBatch>(emptyArchiveBatchId);
                     Assert.IsNull(loadedBatch);
                 }
             }

--- a/src/ServiceControl.UnitTests/Archiving/ArchiveGroupTests.cs
+++ b/src/ServiceControl.UnitTests/Archiving/ArchiveGroupTests.cs
@@ -15,14 +15,14 @@ namespace ServiceControl.UnitTests.Archiving
             using (var documentStore = InMemoryStoreBuilder.GetInMemoryStore())
             {
                 var groupId = "TestGroup";
-                var emptyArchiveBatchId = ArchiveBatch.MakeId(groupId, ArchiveType.FailureGroup, 1);
+                var previousArchiveBatchId = ArchiveBatch.MakeId(groupId, ArchiveType.FailureGroup, 1);
 
                 using (var session = documentStore.OpenSession())
                 {
-                    var secondAchiveBatch = new ArchiveBatch { Id = emptyArchiveBatchId };
-                    session.Store(secondAchiveBatch);
+                    var previousAchiveBatch = new ArchiveBatch { Id = previousArchiveBatchId };
+                    session.Store(previousAchiveBatch);
 
-                    var archiveOperation = new ArchiveOperation
+                    var previousArchiveOperation = new ArchiveOperation
                     {
                         Id = ArchiveOperation.MakeId(groupId, ArchiveType.FailureGroup),
                         RequestId = groupId,
@@ -34,7 +34,7 @@ namespace ServiceControl.UnitTests.Archiving
                         NumberOfBatches = 3,
                         CurrentBatch = 0
                     };
-                    session.Store(archiveOperation);
+                    session.Store(previousArchiveOperation);
 
                     session.SaveChanges();
                 }
@@ -53,7 +53,7 @@ namespace ServiceControl.UnitTests.Archiving
                 // Assert
                 using (var session = documentStore.OpenSession())
                 {
-                    var loadedBatch = session.Load<ArchiveBatch>(emptyArchiveBatchId);
+                    var loadedBatch = session.Load<ArchiveBatch>(previousArchiveBatchId);
                     Assert.IsNull(loadedBatch);
                 }
             }

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -120,6 +120,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApprovalTestConfig.cs" />
+    <Compile Include="Archiving\ArchiveGroupTests.cs" />
     <Compile Include="CompositeViews\FailedMessagesTests.cs" />
     <Compile Include="EventHierarchy.cs" />
     <Compile Include="Expiration\ChunkerTests.cs" />

--- a/src/ServiceControl/Recoverability/Archiving/ArchiveAllInGroupHandler.cs
+++ b/src/ServiceControl/Recoverability/Archiving/ArchiveAllInGroupHandler.cs
@@ -71,21 +71,26 @@ namespace ServiceControl.Recoverability
                     {
                         // We're only here in the case where Raven indexes are stale
                         logger.Warn($"Attempting to archive a batch ({archiveOperation.Id}/{archiveOperation.CurrentBatch}) which appears to already have been archived.");
-                        break;
                     }
-
-                    logger.Info($"Archiving {nextBatch.DocumentIds.Count} messages from group {message.GroupId} starting");
+                    else
+                    {
+                        logger.Info($"Archiving {nextBatch.DocumentIds.Count} messages from group {message.GroupId} starting");
+                    }
 
                     documentManager.ArchiveMessageGroupBatch(batchSession, nextBatch);
 
-                    archiveOperationManager.BatchArchived(archiveOperation.RequestId, archiveOperation.ArchiveType, nextBatch.DocumentIds.Count);
+                    archiveOperationManager.BatchArchived(archiveOperation.RequestId, archiveOperation.ArchiveType, nextBatch?.DocumentIds.Count ?? 0);
+
                     archiveOperation = archiveOperationManager.GetStatusForArchiveOperation(archiveOperation.RequestId, archiveOperation.ArchiveType).ToArchiveOperation();
 
                     documentManager.UpdateArchiveOperation(batchSession, archiveOperation);
 
                     batchSession.SaveChanges();
 
-                    logger.Info($"Archiving of {nextBatch.DocumentIds.Count} messages from group {message.GroupId} completed");
+                    if (nextBatch != null)
+                    {
+                        logger.Info($"Archiving of {nextBatch.DocumentIds.Count} messages from group {message.GroupId} completed");
+                    }
                 }
             }
 


### PR DESCRIPTION
Resolves https://github.com/Particular/ServicePulse/issues/592

Adds a test to reproduce the behavior and then proposes a fix which is to simply skip over empty archive batches so that the rest of the archive operation continues as it should instead of terminating.