### PR TITLE
Disable recoverability if error queue name equals !disable

### DIFF
--- a/src/ServiceControl/Operations/ErrorQueueImport.cs
+++ b/src/ServiceControl/Operations/ErrorQueueImport.cs
@@ -98,7 +98,7 @@
 
         public Address InputAddress => settings.ErrorQueue;
 
-        public bool Disabled => InputAddress == Address.Undefined || !settings.IngestErrorMessages;
+        public bool Disabled => InputAddress == Address.Undefined || InputAddress == null || !settings.IngestErrorMessages;
 
         public Action<TransportReceiver> GetReceiverCustomization()
         {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/174258/36281776-30cca896-129f-11e8-8297-fdfd8c5f881e.png)

The disable entry in the error queue field overrides even the error log forwarding. That is not visible in the installer but SC will automatically take it into account. So in essence `!disable` disables the error queue which also disables error forwarding. We'd argue this makes sense.

![image](https://user-images.githubusercontent.com/174258/36281794-44bb99de-129f-11e8-81c3-a0261593f8ff.png)

Leads to no error queue will be created.

We were unable to create a test that checks the absence of the error queue without falling back to transport specific behavior.
