### PR TITLE
Raven query statistics to query result

### DIFF
--- a/src/ServiceControl/CompositeViews/Endpoints/GetKnownEndpointsApi.cs
+++ b/src/ServiceControl/CompositeViews/Endpoints/GetKnownEndpointsApi.cs
@@ -15,7 +15,7 @@
         public override Task<QueryResult<List<KnownEndpointsView>>> LocalQuery(Request request, NoInput input, string instanceId)
         {
             var result = EndpointInstanceMonitoring.GetKnownEndpoints();
-            return Task.FromResult(Results(result, instanceId));
+            return Task.FromResult(new QueryResult<List<KnownEndpointsView>>(result, instanceId, new QueryStatsInfo(string.Empty, result.Count)));
         }
 
         protected override List<KnownEndpointsView> ProcessResults(Request request, QueryResult<List<KnownEndpointsView>>[] results)

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
@@ -24,7 +24,7 @@ namespace ServiceControl.CompositeViews.Messages
                     .ToListAsync()
                     .ConfigureAwait(false);
 
-                return Results(results.ToList(), instanceId, stats);
+                return new QueryResult<List<MessagesView>>(results.ToList(), instanceId, stats.ToQueryStatsInfo());
             }
         }
     }

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
@@ -26,7 +26,7 @@ namespace ServiceControl.CompositeViews.Messages
                     .ToListAsync()
                     .ConfigureAwait(false);
 
-                return Results(results.ToList(), instanceId, stats);
+                return new QueryResult<List<MessagesView>>(results.ToList(), instanceId, stats.ToQueryStatsInfo());
             }
 
         }

--- a/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
@@ -25,7 +25,7 @@ namespace ServiceControl.CompositeViews.Messages
                     .ToListAsync()
                     .ConfigureAwait(false);
 
-                return Results(results.ToList(), instanceId, stats);
+                return new QueryResult<List<MessagesView>>(results.ToList(), instanceId, stats.ToQueryStatsInfo());
             }
         }
     }

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
@@ -80,13 +80,6 @@ namespace ServiceControl.CompositeViews.Messages
 
         protected abstract TOut ProcessResults(Request request, QueryResult<TOut>[] results);
 
-        protected QueryResult<TOut> Results(TOut results, string instanceId, RavenQueryStatistics stats = null)
-        {
-            return stats != null
-                ? new QueryResult<TOut>(results, instanceId, new QueryStatsInfo(stats.IndexEtag, stats.TotalResults))
-                : new QueryResult<TOut>(results, instanceId, QueryStatsInfo.Zero);
-        }
-
         protected virtual QueryStatsInfo AggregateStats(IEnumerable<QueryResult<TOut>> results, TOut processedResults)
         {
             var infos = results.OrderBy(x => x.InstanceId, StringComparer.InvariantCultureIgnoreCase).Select(x => x.QueryStats).ToArray();

--- a/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
@@ -27,7 +27,7 @@ namespace ServiceControl.CompositeViews.Messages
 
                 results.ForEach(msg => msg.InstanceId = instanceId);
 
-                return Results(results.ToList(), instanceId, stats);
+                return new QueryResult<List<MessagesView>>(results.ToList(), instanceId, stats.ToQueryStatsInfo());
             }
         }
     }

--- a/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
@@ -32,7 +32,7 @@ namespace ServiceControl.CompositeViews.Messages
                     .ToListAsync()
                     .ConfigureAwait(false);
 
-                return Results(results.ToList(), instanceId, stats);
+                return new QueryResult<List<MessagesView>>(results.ToList(), instanceId, stats.ToQueryStatsInfo());
             }
         }
     }

--- a/src/ServiceControl/Infrastructure/Extensions/NegotiatorExtensions.cs
+++ b/src/ServiceControl/Infrastructure/Extensions/NegotiatorExtensions.cs
@@ -147,6 +147,11 @@ namespace ServiceBus.Management.Infrastructure.Extensions
 
         public static Negotiator WithDeterministicEtag(this Negotiator negotiator, string data)
         {
+            if (string.IsNullOrEmpty(data))
+            {
+                return negotiator;
+            }
+
             var guid = DeterministicGuid.MakeId(data);
             return negotiator
                 .WithHeader("ETag", guid.ToString());

--- a/src/ServiceControl/Infrastructure/Extensions/RavenQueryStatisticsExtensions.cs
+++ b/src/ServiceControl/Infrastructure/Extensions/RavenQueryStatisticsExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace ServiceControl.Infrastructure.Extensions
+{
+    using Raven.Client;
+    using ServiceControl.CompositeViews.Messages;
+
+    internal static class RavenQueryStatisticsExtensions
+    {
+        public static QueryStatsInfo ToQueryStatsInfo(this RavenQueryStatistics stats)
+        {
+            return new QueryStatsInfo(stats.IndexEtag, stats.TotalResults);
+        }
+    }
+}

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -315,6 +315,7 @@
     </Compile>
     <Compile Include="Infrastructure\DomainEvents\DomainEvents.cs" />
     <Compile Include="Infrastructure\EndpointInstanceId.cs" />
+    <Compile Include="Infrastructure\Extensions\RavenQueryStatisticsExtensions.cs" />
     <Compile Include="Infrastructure\Extensions\WaitHandleExtensions.cs" />
     <Compile Include="Infrastructure\Nancy\NotFoundOverride.cs" />
     <Compile Include="Infrastructure\RavenDB\Expiration\EventLogItemsCleaner.cs" />


### PR DESCRIPTION
Connects to #1096 (Mike's comments)

Addresses https://github.com/Particular/ServiceControl/pull/1069#discussion_r169548502 to ensure we do not sent empty ETag and Count headers.