### PR TITLE
Known endpoints relative URI

### DIFF
--- a/src/ServiceControl/Infrastructure/Nancy/Modules/RootModule.cs
+++ b/src/ServiceControl/Infrastructure/Nancy/Modules/RootModule.cs
@@ -16,7 +16,7 @@
                 var model = new RootUrls
                 {
                     EndpointsUrl = BaseUrl + "/endpoints",
-                    KnownEndpointsUrl = BaseUrl + "/endpoints/known",
+                    KnownEndpointsUrl = "/endpoints/known", // relative URI to allow proxying
                     SagasUrl = BaseUrl + "/sagas",
                     ErrorsUrl = BaseUrl + "/errors/{?page,per_page,direction,sort}",
                     EndpointsErrorUrl = BaseUrl + "/endpoints/{name}/errors/{?page,per_page,direction,sort}",


### PR DESCRIPTION
Based on the discussion on https://github.com/Particular/ServiceInsight/issues/787 @adamralph and I think the new API endpoint should be relative. SI uses the connection string provided in the API and then can just add the relative part to the URI