### PR TITLE
Storing FailedMessageRetryIds in RetryBatch on creation

### DIFF
--- a/src/ServiceControl.UnitTests/Recoverability/Retry_State_Tests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/Retry_State_Tests.cs
@@ -276,14 +276,6 @@ namespace ServiceControl.UnitTests.Recoverability
             RetrySessionId = Guid.NewGuid().ToString();
             this.progressToStaged = progressToStaged;
         }
-
-        public override void MoveBatchToStaging(string batchDocumentId, string[] failedMessageRetryIds)
-        {
-            if (progressToStaged)
-            {
-                base.MoveBatchToStaging(batchDocumentId, failedMessageRetryIds);
-            }
-        }
     }
 
     public class TestReturnToSenderDequeuer : ReturnToSenderDequeuer

--- a/src/ServiceControl.UnitTests/Recoverability/Retry_State_Tests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/Retry_State_Tests.cs
@@ -58,7 +58,7 @@ namespace ServiceControl.UnitTests.Recoverability
                 };
 
                 var orphanage = new FailedMessageRetries.AdoptOrphanBatchesFromPreviousSession(documentManager, null, documentStore);
-                orphanage.AdoptOrphanedBatches();
+                orphanage.AdoptOrphanedBatchesAsync().GetAwaiter().GetResult();
 
                 var status = retryManager.GetStatusForRetryOperation("Test-group", RetryType.FailureGroup);
                 Assert.True(status.Failed);
@@ -275,6 +275,14 @@ namespace ServiceControl.UnitTests.Recoverability
         {
             RetrySessionId = Guid.NewGuid().ToString();
             this.progressToStaged = progressToStaged;
+        }
+
+        public override void MoveBatchToStaging(string batchDocumentId)
+        {
+            if (progressToStaged)
+            {
+                base.MoveBatchToStaging(batchDocumentId);
+            }
         }
     }
 

--- a/src/ServiceControl.UnitTests/Recoverability/Retry_State_Tests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/Retry_State_Tests.cs
@@ -38,7 +38,7 @@ namespace ServiceControl.UnitTests.Recoverability
         }
 
         [Test]
-        public void When_a_group_is_prepared_and_SC_is_started_the_group_is_marked_as_failed()
+        public async Task When_a_group_is_prepared_and_SC_is_started_the_group_is_marked_as_failed()
         {
             var retryManager = new RetryingManager();
             RetryingManager.RetryOperations = new Dictionary<string, InMemoryRetry>();
@@ -58,7 +58,7 @@ namespace ServiceControl.UnitTests.Recoverability
                 };
 
                 var orphanage = new FailedMessageRetries.AdoptOrphanBatchesFromPreviousSession(documentManager, null, documentStore);
-                orphanage.AdoptOrphanedBatchesAsync().GetAwaiter().GetResult();
+                await orphanage.AdoptOrphanedBatchesAsync();
 
                 var status = retryManager.GetStatusForRetryOperation("Test-group", RetryType.FailureGroup);
                 Assert.True(status.Failed);

--- a/src/ServiceControl/Monitoring/InMemoryMonitoring.cs
+++ b/src/ServiceControl/Monitoring/InMemoryMonitoring.cs
@@ -44,10 +44,10 @@
             protected override void OnStart()
             {
                 persistence.WarmupMonitoringFromPersistence();
-                timer = timeKeeper.NewTimer(CheckEndpoints, TimeSpan.Zero, TimeSpan.FromSeconds(5));
+                timer = timeKeeper.New(CheckEndpoints, TimeSpan.Zero, TimeSpan.FromSeconds(5));
             }
 
-            private bool CheckEndpoints()
+            private void CheckEndpoints()
             {
                 try
                 {
@@ -59,7 +59,6 @@
                 {
                     log.Error("Exception occurred when monitoring endpoint instances", exception);
                 }
-                return true;
             }
 
             protected override void OnStop()

--- a/src/ServiceControl/Recoverability/Retrying/FailedMessageRetries.cs
+++ b/src/ServiceControl/Recoverability/Retrying/FailedMessageRetries.cs
@@ -107,9 +107,9 @@
                 startTime = DateTime.UtcNow;
             }
 
-            bool AdoptOrphanedBatches()
+            async Task<bool> AdoptOrphanedBatches()
             {
-                var hasMoreWork = AdoptOrphanedBatchesAsync().GetAwaiter().GetResult();
+                var hasMoreWork = await AdoptOrphanedBatchesAsync().ConfigureAwait(false);
 
                 if (!hasMoreWork)
                 {
@@ -133,7 +133,7 @@
 
             protected override void OnStart()
             {
-                timer = timeKeeper.NewTimer(AdoptOrphanedBatches, TimeSpan.Zero, TimeSpan.FromMinutes(2));
+                timer = timeKeeper.NewTimer(() => AdoptOrphanedBatches(), TimeSpan.Zero, TimeSpan.FromMinutes(2));
             }
 
             protected override void OnStop()

--- a/src/ServiceControl/Recoverability/Retrying/RetryDocumentManager.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetryDocumentManager.cs
@@ -1,7 +1,6 @@
 namespace ServiceControl.Recoverability
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -37,7 +36,7 @@ namespace ServiceControl.Recoverability
             notifier.Register(() => { abort = true; });
         }
 
-        public string CreateBatchDocument(string requestId, RetryType retryType, int initialBatchSize, string originator, DateTime startTime, DateTime? last = null, string batchName = null, string classifier = null)
+        public string CreateBatchDocument(string requestId, RetryType retryType, string[] failedMessageRetryIds, string originator, DateTime startTime, DateTime? last = null, string batchName = null, string classifier = null)
         {
             var batchDocumentId = RetryBatch.MakeDocumentId(Guid.NewGuid().ToString());
             using (var session = store.OpenSession())
@@ -52,8 +51,9 @@ namespace ServiceControl.Recoverability
                     Classifier = classifier,
                     StartTime = startTime,
                     Last = last,
-                    InitialBatchSize = initialBatchSize,
+                    InitialBatchSize = failedMessageRetryIds.Length,
                     RetrySessionId = RetrySessionId,
+                    FailureRetries = failedMessageRetryIds,
                     Status = RetryBatchStatus.MarkingDocuments
                 });
                 session.SaveChanges();
@@ -61,10 +61,8 @@ namespace ServiceControl.Recoverability
             return batchDocumentId;
         }
 
-        public ICommandData CreateFailedMessageRetryDocument(string batchDocumentId, string messageUniqueId)
+        public ICommandData CreateFailedMessageRetryDocument(string batchDocumentId, string messageId)
         {
-            var failureRetryId = FailedMessageRetry.MakeDocumentId(messageUniqueId);
-
             return new PatchCommandData
             {
                 Patches = patchRequestsEmpty,
@@ -74,7 +72,7 @@ namespace ServiceControl.Recoverability
                     {
                         Name = "FailedMessageId",
                         Type = PatchCommandType.Set,
-                        Value = FailedMessage.MakeDocumentId(messageUniqueId)
+                        Value = FailedMessage.MakeDocumentId(messageId)
                     },
                     new PatchRequest
                     {
@@ -83,12 +81,12 @@ namespace ServiceControl.Recoverability
                         Value = batchDocumentId
                     }
                 },
-                Key = failureRetryId,
+                Key = FailedMessageRetry.MakeDocumentId(messageId),
                 Metadata = defaultMetadata
             };
         }
 
-        public virtual void MoveBatchToStaging(string batchDocumentId, string[] failedMessageRetryIds)
+        public virtual void MoveBatchToStaging(string batchDocumentId)
         {
             try
             {
@@ -101,12 +99,6 @@ namespace ServiceControl.Recoverability
                             Name = "Status",
                             Value = (int) RetryBatchStatus.Staging,
                             PrevVal = (int) RetryBatchStatus.MarkingDocuments
-                        },
-                        new PatchRequest
-                        {
-                            Type = PatchCommandType.Set,
-                            Name = "FailureRetries",
-                            Value = new RavenJArray((IEnumerable) failedMessageRetryIds)
                         }
                     });
             }
@@ -134,7 +126,11 @@ namespace ServiceControl.Recoverability
 
             log.InfoFormat("Found {0} orphaned retry batches from previous sessions", orphanedBatches.Count);
 
-            await AdoptBatches(session, orphanedBatches.Select(b => b.Id)).ConfigureAwait(false);
+            await Task.WhenAll(orphanedBatches.Select(b => Task.Run(() =>
+            {
+                log.InfoFormat("Adopting retry batch {0} from previous session with {1} messages", b.Id, b.FailureRetries.Count);
+                MoveBatchToStaging(b.Id);
+            })));
 
             foreach (var batch in orphanedBatches)
             {
@@ -150,34 +146,6 @@ namespace ServiceControl.Recoverability
             }
 
             return stats.IsStale || orphanedBatches.Any();
-        }
-
-        Task AdoptBatches(IAsyncDocumentSession session, IEnumerable<string> batchIds)
-        {
-            // Task.Run for offloading the while loop
-            return Task.WhenAll(batchIds.Select(batchid => Task.Run(() => AdoptBatch(session, batchid))));
-        }
-
-        async Task AdoptBatch(IAsyncDocumentSession session, string batchId)
-        {
-            var query = session.Query<FailedMessageRetry, FailedMessageRetries_ByBatch>()
-                .Where(r => r.RetryBatchId == batchId);
-
-            var messageIds = new List<string>();
-
-            using (var stream = await session.Advanced.StreamAsync(query).ConfigureAwait(false))
-            {
-                while (!abort && await stream.MoveNextAsync().ConfigureAwait(false))
-                {
-                    messageIds.Add(stream.Current.Document.Id);
-                }
-            }
-
-            if (!abort)
-            {
-                log.InfoFormat("Adopting retry batch {0} from previous session with {1} messages", batchId, messageIds.Count);
-                MoveBatchToStaging(batchId, messageIds.ToArray());
-            }
         }
 
         internal async Task RebuildRetryOperationState(IAsyncDocumentSession session)

--- a/src/ServiceControl/Recoverability/Retrying/RetryDocumentManager.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetryDocumentManager.cs
@@ -1,7 +1,6 @@
 namespace ServiceControl.Recoverability
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.Logging;


### PR DESCRIPTION
## Overview
This PR changes the way we handle `RetryBatch`es in prepare state of recoverability. Previously preparation would be done in 3 steps:
  1. Create `RetryBatch` document,
  2. Create number of `FailedMessageRetry` documents that link the batch with failed messages,
  3. Update `RetryBatch` with `FailedMessageRetry` ids from step 2 and set status to `Stagging`.

This is invalid in the context of batch adoption process which is performed on startup and is meant to finish preparation step for any batches that when past step 1. When batch is adopted we query for `FailedMessagesRetry` documents by `batchId` using index and continue with step 3. What it means is that we can get stale/incomplete set of ids so some ids might not be assigned to original batch and cause related failed messages to be filterd out if users issues any retry operation for those messages.

## Fix
This fix creates all `FailedMessageRetry` ids and uses them when creating `RetryBatch` in step 1. Step 3 now is only about setting `Stagging` status for given batch. The same goes with adoption operation which now boils down to setting the status as well.

The fact that we could have more ids in batch document than has been acutally created (we restart SC in step 2 e.g.) does not make this approach invalid as we validate the ids one more time during [stage phase](https://github.com/Particular/ServiceControl/blob/master/src/ServiceControl/Recoverability/Retrying/RetryProcessor.cs#L152).

/cc: @WilliamBZA @SzymonPobiega 