### PR TITLE
Stop checking for !disable queue name duplicates

### DIFF
--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
@@ -42,7 +42,7 @@ namespace ServiceControl.Config.Validation
                     p.ErrorQueue,
                     p.AuditQueue,
                     p.AuditLogQueue
-                }).Where(queuename => string.Compare(queuename, "!disable", true) != 0)
+                }).Where(queuename => string.Compare(queuename, "!disable", StringComparison.OrdinalIgnoreCase) != 0)
                 .Distinct()
                 .ToList();
         }

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
@@ -42,7 +42,7 @@ namespace ServiceControl.Config.Validation
                     p.ErrorQueue,
                     p.AuditQueue,
                     p.AuditLogQueue
-                })
+                }).Where(queuename => string.Compare(queuename, "!disabled", true) != 0)
                 .Distinct()
                 .ToList();
         }

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
@@ -42,7 +42,7 @@ namespace ServiceControl.Config.Validation
                     p.ErrorQueue,
                     p.AuditQueue,
                     p.AuditLogQueue
-                }).Where(queuename => string.Compare(queuename, "!disabled", true) != 0)
+                }).Where(queuename => string.Compare(queuename, "!disable", true) != 0)
                 .Distinct()
                 .ToList();
         }


### PR DESCRIPTION
Prevents installer errors when more than one instance wants to disable queue creation