### PR TITLE
!disabled queue duplicates allowed in the installation process

### DIFF
--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
@@ -42,7 +42,8 @@ namespace ServiceControl.Config.Validation
                     p.ErrorQueue,
                     p.AuditQueue,
                     p.AuditLogQueue
-                }).Where(queuename => string.Compare(queuename, "!disable", StringComparison.OrdinalIgnoreCase) != 0)
+                }).Where(queuename => string.Compare(queuename, "!disable", StringComparison.OrdinalIgnoreCase) != 0 &&
+                                      string.Compare(queuename, "!disable.log", StringComparison.OrdinalIgnoreCase) != 0)
                 .Distinct()
                 .ToList();
         }

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -12,11 +12,13 @@
     public class Settings
     {
         public const string DEFAULT_SERVICE_NAME = "Particular.ServiceControl";
+        public const string Disabled = "!disable";
 
         private const int ExpirationProcessTimerInSecondsDefault = 600;
         private const int ExpirationProcessBatchSizeDefault = 65512;
         private const int ExpirationProcessBatchSizeMinimum = 10240;
         private const int MaxBodySizeToStoreDefault = 102400; //100 kb
+
 
         private ILog logger = LogManager.GetLogger(typeof(Settings));
         private int expirationProcessBatchSize = SettingsReader<int>.Read("ExpirationProcessBatchSize", ExpirationProcessBatchSizeDefault);
@@ -205,7 +207,7 @@
                 return Address.Undefined;
             }
 
-            if (value.Equals("!disable", StringComparison.OrdinalIgnoreCase))
+            if (value.Equals(Disabled, StringComparison.OrdinalIgnoreCase))
             {
                 logger.Info("Audit ingestion disabled.");
                 return null; // needs to be null to not create the queues
@@ -223,7 +225,7 @@
                 return Address.Undefined;
             }
 
-            if (value.Equals("!disable", StringComparison.OrdinalIgnoreCase))
+            if (value.Equals(Disabled, StringComparison.OrdinalIgnoreCase))
             {
                 logger.Info("Error ingestion disabled.");
                 return null; // needs to be null to not create the queues

--- a/src/ServiceControlInstaller.Engine/Validation/ServiceControlQueueNameValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/ServiceControlQueueNameValidator.cs
@@ -60,14 +60,14 @@
             {
                 PropertyName = "AuditLogQueue",
                 ConnectionString = connectionString,
-                QueueName = string.IsNullOrWhiteSpace(auditLog) ? audit + "log" : auditLog
+                QueueName = string.IsNullOrWhiteSpace(auditLog) ? audit + ".log" : auditLog
             };
 
             var errorLogQueueInfo = new QueueInfo
             {
                 PropertyName = "ErrorLogQueue",
                 ConnectionString = connectionString,
-                QueueName = string.IsNullOrWhiteSpace(errorLog) ? error + "log" : errorLog
+                QueueName = string.IsNullOrWhiteSpace(errorLog) ? error + ".log" : errorLog
             };
 
             queues = new List<QueueInfo>

--- a/src/ServiceControlInstaller.Engine/Validation/ServiceControlQueueNameValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/ServiceControlQueueNameValidator.cs
@@ -101,7 +101,15 @@
                 allQueues.AddRange(new ServiceControlQueueNameValidator(instance).queues);
             }
 
-            var duplicates = (from queue in queues where allQueues.Any(p => string.Equals(p.ConnectionString, queue.ConnectionString, StringComparison.OrdinalIgnoreCase) && string.Equals(p.QueueName, queue.QueueName, StringComparison.OrdinalIgnoreCase)) select queue.PropertyName).ToList();
+            var duplicates = (
+                from queue in queues
+                where allQueues.Any(p => 
+                      string.Equals(p.ConnectionString, queue.ConnectionString, StringComparison.OrdinalIgnoreCase) && 
+                      string.Equals(p.QueueName, queue.QueueName, StringComparison.OrdinalIgnoreCase) &&
+                      string.Compare("!disable", queue.QueueName, StringComparison.OrdinalIgnoreCase) != 0 &&
+                      string.Compare("!disable.log", queue.QueueName, StringComparison.OrdinalIgnoreCase) != 0)
+                select queue.PropertyName
+            ).ToList();
 
             if (duplicates.Count == 1)
             {


### PR DESCRIPTION
## Overview
This PR is a fix to #1126. It turns of duplicated detection in the installer steps (#1126 did that only for the UI validation). 

In addition it removes duplicate validation for `!disabled.log` queues which previously prevented endpoints with `!disabled` queue to be saved after configuration changes.