### PR TITLE
Raven35 upgrade monitoring

### DIFF
--- a/gitversionconfig.yaml
+++ b/gitversionconfig.yaml
@@ -1,2 +1,2 @@
 assembly-versioning-scheme: MajorMinor
-next-version: 1.45
+next-version: 2.0

--- a/src/DatabaseMigrationsTester/DatabaseMigrationsTester.csproj
+++ b/src/DatabaseMigrationsTester/DatabaseMigrationsTester.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net452</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/DatabaseMigrationsTester/Program.cs
+++ b/src/DatabaseMigrationsTester/Program.cs
@@ -24,6 +24,12 @@ namespace DatabaseMigrationsTester
                 case Command.Timeout:
                     Thread.Sleep(100000);
                     return 0;
+                case Command.UpdateProgress:
+                    Console.Out.WriteLine("Updating schema from version: 1");
+                    Console.Out.WriteLine("Updating schema from version: 2");
+                    Console.Out.WriteLine("Updating schema from version: 3");
+                    Console.Out.WriteLine("OK Upgrading");
+                    return 0;
             }
 
             return 0;
@@ -37,6 +43,7 @@ namespace DatabaseMigrationsTester
         Return0,
         WriteToErrorAndExitNonZero,
         WriteToErrorAndExitZero,
+        UpdateProgress,
     }
 }
 

--- a/src/DatabaseMigrationsTester/Program.cs
+++ b/src/DatabaseMigrationsTester/Program.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace DatabaseMigrationsTester
+{
+    using System.Threading;
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            var command = (Command)Enum.Parse(typeof(Command), args[0]);
+            switch (command)
+            {
+                case Command.Throw:
+                    throw new Exception("Boom!");
+                case Command.Return0:
+                    return 0;
+                case Command.WriteToErrorAndExitNonZero:
+                    Console.Error.WriteLine("Some error message");
+                    return 1;
+                case Command.WriteToErrorAndExitZero:
+                    Console.Error.WriteLine("Some error message");
+                    return 0;
+                case Command.Timeout:
+                    Thread.Sleep(100000);
+                    return 0;
+            }
+
+            return 0;
+        }
+    }
+
+    enum Command
+    {
+        Throw,
+        Timeout,
+        Return0,
+        WriteToErrorAndExitNonZero,
+        WriteToErrorAndExitZero,
+    }
+}
+

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -1,15 +1,20 @@
 ﻿namespace ServiceControl.Config.Commands
 {
     using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
     using System.ServiceProcess;
     using System.Threading.Tasks;
     using Caliburn.Micro;
+    using FluentValidation;
     using Framework;
     using Framework.Commands;
     using ServiceControl.Config.Events;
     using ServiceControl.Config.Framework.Modules;
     using ServiceControl.Config.UI.InstanceDetails;
     using ServiceControl.Config.UI.MessageBox;
+    using ServiceControl.Config.Validation;
     using ServiceControl.Config.Xaml.Controls;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
@@ -45,15 +50,15 @@
             }
 
             var instance = InstanceFinder.FindServiceControlInstance(model.Name);
-            
+
 
             instance.Service.Refresh();
 
             var upgradeOptions = new ServiceControlUpgradeOptions();
-            
+
             if (!instance.AppConfig.AppSettingExists(SettingsList.ForwardErrorMessages.Name))
             {
-                var result  = windowManager.ShowYesNoCancelDialog("UPGRADE QUESTION - DISABLE ERROR FORWARDING", "Error messages can be forwarded to a secondary error queue known as the Error Forwarding Queue. This queue exists to allow external tools to receive error messages. If you do not have a tool processing messages from the Error Forwarding Queue this setting should be disabled.", "So what do you want to do ?", "Do NOT forward", "Yes I want to forward");
+                var result = windowManager.ShowYesNoCancelDialog("UPGRADE QUESTION - DISABLE ERROR FORWARDING", "Error messages can be forwarded to a secondary error queue known as the Error Forwarding Queue. This queue exists to allow external tools to receive error messages. If you do not have a tool processing messages from the Error Forwarding Queue this setting should be disabled.", "So what do you want to do ?", "Do NOT forward", "Yes I want to forward");
                 if (!result.HasValue)
                 {
                     //Dialog was cancelled
@@ -62,7 +67,7 @@
                 }
                 upgradeOptions.OverrideEnableErrorForwarding = !result.Value;
             }
-            
+
             //Grab old setting if it exists
             if (!instance.AppConfig.AppSettingExists(SettingsList.AuditRetentionPeriod.Name))
             {
@@ -102,6 +107,8 @@
                 }
             }
 
+
+
             if (!instance.AppConfig.AppSettingExists(SettingsList.ErrorRetentionPeriod.Name))
             {
                 var viewModel = new SliderDialogViewModel("UPGRADE QUESTION - DATABASE RETENTION",
@@ -127,22 +134,42 @@
                 }
             }
 
+
+            if (!instance.AppConfig.AppSettingExists(SettingsList.DatabaseMaintenancePort.Name))
+            {
+                var viewModel = new TextBoxDialogViewModel("UPGRADE QUESTION - MAINTENANCE PORT",
+                    "When in the maintenance mode Service Control exposes the RavenDB database on a specified port.",
+                    "MAINTENANCE PORT",
+                    "", new MaintenancePortValidator());
+
+                if (windowManager.ShowTextBoxDialog(viewModel))
+                {
+                    upgradeOptions.MaintenancePort = int.Parse(viewModel.Value);
+                }
+                else
+                {
+                    //Dialog was cancelled
+                    eventAggregator.PublishOnUIThread(new RefreshInstances());
+                    return;
+                }
+            }
+
             bool confirm;
             if (instance.Version.Major != installer.ZipInfo.Version.Major) //Upgrade to different major -> recommend DB backup
             {
-                confirm = windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}", 
-                    $"{model.Name} is going to be upgraded to version {installer.ZipInfo.Version} which uses a different storage format. Database migration will be conducted " 
+                confirm = windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}",
+                    $"{model.Name} is going to be upgraded to version {installer.ZipInfo.Version} which uses a different storage format. Database migration will be conducted "
                     + " as part of the upgrade. It is recommended that you back up the database before upgrading. To read more about the back up process "
-                    + " see https://docs.particular.net/servicecontrol/backup-sc-database.", 
-                    "Do you want to proceed?", 
+                    + " see https://docs.particular.net/servicecontrol/backup-sc-database.",
+                    "Do you want to proceed?",
                     "Yes I backed up the database and I want to proceed", "No");
             }
             else
             {
                 confirm = instance.Service.Status == ServiceControllerStatus.Stopped ||
-                          windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}", 
-                          $"{model.Name} needs to be stopped in order to upgrade to version {installer.ZipInfo.Version}.", 
-                          "Do you want to proceed?", 
+                          windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}",
+                          $"{model.Name} needs to be stopped in order to upgrade to version {installer.ZipInfo.Version}.",
+                          "Do you want to proceed?",
                           "Yes I want to proceed", "No");
             }
 
@@ -176,7 +203,7 @@
                     {
                         if (restartAgain)
                         {
-                           var serviceStarted =  await model.StartService(progress);
+                            var serviceStarted = await model.StartService(progress);
                             if (!serviceStarted)
                             {
                                 reportCard.Errors.Add("The Service failed to start. Please consult the service control logs for this instance");
@@ -191,5 +218,29 @@
 
         [FeatureToggle(Feature.LicenseChecks)]
         public bool LicenseChecks { get; set; }
+
+        class MaintenancePortValidator : AbstractValidator<TextBoxDialogViewModel>
+        {
+            ReadOnlyCollection<ServiceControlInstance> ServiceControlInstances;
+
+            public MaintenancePortValidator()
+            {
+                ServiceControlInstances = InstanceFinder.ServiceControlInstances();
+
+                RuleFor(x => x.Value)
+                    .NotEmpty()
+                    .ValidPort()
+                    .MustNotBeIn(x => UsedPorts())
+                    .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports");
+            }
+
+            List<string> UsedPorts()
+            {
+                return ServiceControlInstances
+                    .SelectMany(p => new[] { p.Port.ToString(), p.DatabaseMaintenancePort.ToString() })
+                    .Distinct()
+                    .ToList();
+            }
+        }
     }
 }

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -127,8 +127,24 @@
                 }
             }
 
-            var confirm = instance.Service.Status == ServiceControllerStatus.Stopped ||
-                          windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}", $"{model.Name} needs to be stopped in order to upgrade to version {installer.ZipInfo.Version}.", "Do you want to proceed?", "Yes I want to proceed", "No");
+            bool confirm;
+            if (instance.Version.Major != installer.ZipInfo.Version.Major) //Upgrade to different major -> recommend DB backup
+            {
+                confirm = windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}", 
+                    $"{model.Name} is going to be upgraded to version {installer.ZipInfo.Version} which uses a different storage format. Database migration will be conducted " 
+                    + " as part of the upgrade. It is recommended that you back up the database before upgrading. To read more about the back up process "
+                    + " see https://docs.particular.net/servicecontrol/backup-sc-database.", 
+                    "Do you want to proceed?", 
+                    "Yes I backed up the database and I want to proceed", "No");
+            }
+            else
+            {
+                confirm = instance.Service.Status == ServiceControllerStatus.Stopped ||
+                          windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}", 
+                          $"{model.Name} needs to be stopped in order to upgrade to version {installer.ZipInfo.Version}.", 
+                          "Do you want to proceed?", 
+                          "Yes I want to proceed", "No");
+            }
 
             if (confirm)
             {

--- a/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
@@ -19,7 +19,7 @@
             builder.RegisterType<MonitoringInstanceInstaller>().SingleInstance();
         }
     }
-    
+
     public class ServiceControlInstanceInstaller
     {
         public ServiceControlZipInfo ZipInfo { get; }
@@ -103,10 +103,10 @@
 
             upgradeOptions.ApplyChangesToInstance(instance);
 
-	        progress.Report(4, 6, "Updating Database...");
-	        instance.UpdateDatabase(msg => progress.Report(4, 6, $"Updating Database {msg}..."));
+            progress.Report(4, 6, "Updating Database...");
+            instance.UpdateDatabase(msg => progress.Report(4, 6, $"Updating Database {msg}..."));
 
-			progress.Report(5, 6, "Running Queue Creation...");
+            progress.Report(5, 6, "Running Queue Creation...");
             instance.SetupInstance();
 
             instance.ReportCard.SetStatus();

--- a/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
@@ -78,7 +78,7 @@
             instance.ReportCard = new ReportCard();
             ZipInfo.ValidateZip();
 
-            progress.Report(0, 5, "Stopping instance...");
+            progress.Report(0, 6, "Stopping instance...");
             if (!instance.TryStopService())
             {
                 return new ReportCard
@@ -88,23 +88,27 @@
                 };
             }
 
-            progress.Report(1, 5, "Backing up app.config...");
+            progress.Report(1, 6, "Backing up app.config...");
             var backupFile = instance.BackupAppConfig();
             try
             {
-                progress.Report(2, 5, "Upgrading Files...");
+                progress.Report(2, 6, "Upgrading Files...");
                 instance.UpgradeFiles(ZipInfo.FilePath);
             }
             finally
             {
-                progress.Report(3, 5, "Restoring app.config...");
+                progress.Report(3, 6, "Restoring app.config...");
                 instance.RestoreAppConfig(backupFile);
             }
 
             upgradeOptions.ApplyChangesToInstance(instance);
 
-            progress.Report(4, 5, "Running Queue Creation...");
+	        progress.Report(4, 6, "Updating Database...");
+	        instance.UpdateDatabase(msg => progress.Report(4, 6, $"Updating Database {msg}..."));
+
+			progress.Report(5, 6, "Running Queue Creation...");
             instance.SetupInstance();
+
             instance.ReportCard.SetStatus();
             return instance.ReportCard;
         }

--- a/src/ServiceControl.Config/Framework/WindowManagerEx.cs
+++ b/src/ServiceControl.Config/Framework/WindowManagerEx.cs
@@ -27,6 +27,8 @@ namespace ServiceControl.Config.Framework
 
         bool ShowSliderDialog(SliderDialogViewModel viewModel);
 
+        bool ShowTextBoxDialog(TextBoxDialogViewModel viewModel);
+
         bool ShowActionReport(ReportCard reportcard, string title, string errorsMessage = "", string warningsMessage = "");
 
         void ScrollFirstErrorIntoView(object viewModel, object context = null);
@@ -109,6 +111,12 @@ namespace ServiceControl.Config.Framework
         public bool ShowSliderDialog(SliderDialogViewModel viewModel)
         {
             var result =  ShowOverlayDialog(viewModel);
+            return result ?? false;
+        }
+
+        public bool ShowTextBoxDialog(TextBoxDialogViewModel viewModel)
+        {
+            var result = ShowOverlayDialog(viewModel);
             return result ?? false;
         }
 

--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -222,6 +222,10 @@
     <Compile Include="UI\MessageBox\ExceptionMessageBox.xaml.cs">
       <DependentUpon>ExceptionMessageBox.xaml</DependentUpon>
     </Compile>
+    <Compile Include="UI\MessageBox\TextBoxDialogViewModel.cs" />
+    <Compile Include="UI\MessageBox\TextBoxDialogView.xaml.cs">
+      <DependentUpon>TextBoxDialogView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UI\MessageBox\SliderDialogView.xaml.cs">
       <DependentUpon>SliderDialogView.xaml</DependentUpon>
     </Compile>
@@ -249,6 +253,7 @@
     <Compile Include="UI\Shell\NewInstancePopup.xaml.cs">
       <DependentUpon>NewInstancePopup.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Validation\IProvideValidator.cs" />
     <Compile Include="Validation\Validations.cs" />
     <Compile Include="Validation\ValidationTemplate.cs" />
     <Compile Include="Framework\Command.cs" />
@@ -374,6 +379,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="UI\InstanceEdit\MonitoringEditView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UI\MessageBox\TextBoxDialogView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
@@ -88,6 +88,14 @@ namespace ServiceControl.Config.UI.InstanceAdd
             RuleFor(x => x.ConnectionString)
                 .NotEmpty().WithMessage(Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
                 .When(x => !string.IsNullOrWhiteSpace(x.SelectedTransport?.SampleConnectionString) && x.SubmitAttempted);
+
+            RuleFor(x => x.DatabaseMaintenancePortNumber)
+                .NotEmpty()
+                .ValidPort()
+                .MustNotBeIn(x => UsedPorts(x.InstanceName))
+                .NotEqual(x => x.PortNumber)
+                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports")
+                .When(x => x.SubmitAttempted);
         }
     }
 }

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditAttachment.cs
@@ -69,7 +69,7 @@ namespace ServiceControl.Config.UI.InstanceEdit
             instance.Description = viewModel.Description;
             instance.HostName = viewModel.HostName;
             instance.Port = Convert.ToInt32(viewModel.PortNumber);
-            instance.DatabaseMaintenancePort = Convert.ToInt32(viewModel.DatabaseMaintenancePortNumber);
+            instance.DatabaseMaintenancePort = !string.IsNullOrWhiteSpace(viewModel.DatabaseMaintenancePortNumber) ? Convert.ToInt32(viewModel.DatabaseMaintenancePortNumber) : (int?)null;
             instance.VirtualDirectory = null;
             instance.AuditLogQueue = viewModel.AuditForwardingQueueName;
             instance.AuditQueue = viewModel.AuditQueueName;

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditView.xaml
@@ -88,7 +88,9 @@
                                       Text="{Binding HostName}"
                                       Warning="{Binding HostNameWarning}" />
                 <controls:FormTextBox Header="PORT NUMBER (1 - 49151)" Text="{Binding PortNumber}" />
-                <controls:FormTextBox Header="MAINTENANCE PORT NUMBER (1 - 49151)" Text="{Binding DatabaseMaintenancePortNumber}" />
+                <controls:FormTextBox Header="MAINTENANCE PORT NUMBER (1 - 49151)" 
+                                      Text="{Binding DatabaseMaintenancePortNumber}"
+                                      Visibility="{Binding DatabaseMaintenancePortNumberRequired, Converter={StaticResource boolToVis}}"/>
 
                 <Border Margin="0,40,0,20"
                         BorderBrush="{StaticResource Gray90Brush}"

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModel.cs
@@ -35,6 +35,7 @@
             HostName = instance.HostName;
             PortNumber = instance.Port.ToString();
             DatabaseMaintenancePortNumber = instance.DatabaseMaintenancePort.ToString();
+            DatabaseMaintenancePortNumberRequired = instance.Version.Major >= 2;
 
             LogPath = instance.LogPath;
 
@@ -63,6 +64,7 @@
 
         public ServiceControlInstance ServiceControlInstance { get; set; }
 
+        public bool DatabaseMaintenancePortNumberRequired { get; set; }
 
         public string ErrorQueueName { get; set; }
         public string ErrorForwardingQueueName { get; set; }

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModelValidator.cs
@@ -55,6 +55,14 @@ namespace ServiceControl.Config.UI.InstanceEdit
             RuleFor(x => x.ConnectionString)
                .NotEmpty().WithMessage(Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
                .When(x => !string.IsNullOrWhiteSpace(x.SelectedTransport?.SampleConnectionString) && x.SubmitAttempted);
+
+            RuleFor(x => x.DatabaseMaintenancePortNumber)
+                .NotEmpty()
+                .ValidPort()
+                .MustNotBeIn(x => UsedPorts(x.InstanceName))
+                .NotEqual(x => x.PortNumber)
+                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports")
+                .When(x => x.DatabaseMaintenancePortNumberRequired && x.SubmitAttempted);
         }
     }
 }

--- a/src/ServiceControl.Config/UI/MessageBox/TextBoxDialogView.xaml
+++ b/src/ServiceControl.Config/UI/MessageBox/TextBoxDialogView.xaml
@@ -1,0 +1,76 @@
+﻿<UserControl x:Class="ServiceControl.Config.UI.MessageBox.TextBoxDialogView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:behaviours="clr-namespace:ServiceControl.Config.Xaml.Behaviours"
+             xmlns:controls="clr-namespace:ServiceControl.Config.Xaml.Controls"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             d:DesignHeight="300"
+             d:DesignWidth="600"
+             mc:Ignorable="d">
+
+    <Grid Background="{StaticResource Gray10Brush}">
+        <Grid Margin="170,30,158,24">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="30" />
+                <RowDefinition Height="11*" />
+                <RowDefinition Height="34*" />
+                <RowDefinition Height="45*" />
+                <RowDefinition Height="36" />
+            </Grid.RowDefinitions>
+
+            <Border Margin="-170,0,-170,0.4"
+                    BorderBrush="{StaticResource Gray20Brush}"
+                    BorderThickness="0,0,0,1" />
+
+            <TextBlock Grid.Row="0"
+                       Margin="0,0,0,6.4"
+                       VerticalAlignment="Bottom"
+                       FontSize="14"
+                       FontWeight="Bold"
+                       Foreground="{StaticResource Gray60Brush}"
+                       Text="{Binding Title}" />
+
+            <RichTextBox Grid.Row="2"
+                         Margin="0,1.877,-10,28"
+                         behaviours:RichTextBoxHelper.DocumentXaml="{Binding Message, Mode=OneWay}"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         FontSize="14"
+                         Foreground="{StaticResource WhiteBrush}"
+                         IsReadOnly="True"
+                         IsReadOnlyCaretVisible="False" />
+
+            <controls:FormTextBox Grid.Row="3"
+                                  Margin="0,24,-10,27.4"
+                                  Background="Transparent"
+                                  Foreground="{StaticResource WhiteBrush}"
+                                  Header="{Binding Header}" 
+                                  Text="{Binding Value}" />
+
+            <StackPanel Grid.Row="4"
+                        Margin="-321,1.6,0,0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Orientation="Horizontal">
+                <Button Width="100"
+                        Height="30"
+                        Margin="0"
+                        Command="{Binding Save}"
+                        Content="Ok"
+                        FontSize="14"
+                        Padding="0"
+                        Style="{StaticResource HiliteButton}" />
+                <Button Width="100"
+                        Height="30"
+                        Margin="10,0,0,0"
+                        Command="{Binding Cancel}"
+                        Content="Cancel"
+                        FontSize="14"
+                        IsCancel="True"
+                        Padding="0" />
+            </StackPanel>
+        </Grid>
+    </Grid>
+
+</UserControl>

--- a/src/ServiceControl.Config/UI/MessageBox/TextBoxDialogView.xaml.cs
+++ b/src/ServiceControl.Config/UI/MessageBox/TextBoxDialogView.xaml.cs
@@ -1,0 +1,13 @@
+﻿namespace ServiceControl.Config.UI.MessageBox
+{
+    /// <summary>
+    /// Interaction logic for TextBoxDialogView.xaml
+    /// </summary>
+    public partial class TextBoxDialogView
+    {
+        public TextBoxDialogView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/ServiceControl.Config/UI/MessageBox/TextBoxDialogViewModel.cs
+++ b/src/ServiceControl.Config/UI/MessageBox/TextBoxDialogViewModel.cs
@@ -1,0 +1,41 @@
+﻿namespace ServiceControl.Config.UI.MessageBox
+{
+    using System.Windows.Input;
+    using Caliburn.Micro;
+    using FluentValidation;
+    using ServiceControl.Config.Framework;
+    using ServiceControl.Config.Framework.Rx;
+    using ServiceControl.Config.Validation;
+    using Validar;
+
+    [InjectValidation]
+    public class TextBoxDialogViewModel : RxScreen, IProvideValidator
+    {
+        public TextBoxDialogViewModel(string title,
+                                    string message,
+                                    string header,
+                                    string currentValue,
+                                    IValidator validator)
+        {
+            Title = title;
+            Message = message;
+            Value = currentValue;
+            Validator = validator;
+            Header = header;
+            Cancel = Command.Create(() =>{Result = null;((IDeactivate)this).Deactivate(true);});
+            Save = Command.Create(() =>{Result = true; ((IDeactivate)this).Deactivate(true);}, () => Validator.Validate(this).IsValid);
+        }
+
+        public string Header { get; set; }
+
+        public string Value { get; set; }
+
+        public string Title { get; set; }
+
+        public string Message { get; set; }
+
+        public ICommand Cancel { get; }
+        public ICommand Save { get; }
+        public IValidator Validator { get; }
+    }
+}

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
@@ -78,14 +78,6 @@ namespace ServiceControl.Config.Validation
                 .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports")
                 .When(x => x.SubmitAttempted);
 
-            RuleFor(x => x.DatabaseMaintenancePortNumber)
-                .NotEmpty()
-                .ValidPort()
-                .MustNotBeIn(x => UsedPorts(x.InstanceName))
-                .NotEqual(x => x.PortNumber)
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports")
-                .When(x => x.SubmitAttempted);
-
             RuleFor(x => x.LogPath)
                 .NotEmpty()
                 .ValidPath()

--- a/src/ServiceControl.Config/Validation/IProvideValidator.cs
+++ b/src/ServiceControl.Config/Validation/IProvideValidator.cs
@@ -1,0 +1,9 @@
+﻿namespace ServiceControl.Config.Validation
+{
+    using FluentValidation;
+
+    public interface IProvideValidator
+    {
+        IValidator Validator { get; }
+    }
+}

--- a/src/ServiceControl.Config/Validation/ValidationTemplate.cs
+++ b/src/ServiceControl.Config/Validation/ValidationTemplate.cs
@@ -25,7 +25,15 @@
         public ValidationTemplate(RxPropertyChanged target)
         {
             this.target = target;
-            validator = GetValidator(target.GetType());
+            var providesValidator = target as IProvideValidator;
+            if (providesValidator != null)
+            {
+                validator = providesValidator.Validator;
+            }
+            else
+            {
+                validator = GetValidator(target.GetType());
+            }
             errorsChangedSubject = new Subject<DataErrorsChangedEventArgs>();
             target.PropertyChanged += Validate;
             properties = new HashSet<string>(target.GetType().GetProperties().Select(p => p.Name));

--- a/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
+++ b/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
@@ -12,15 +12,15 @@
     [TestFixture]
     public class DatabaseMigrationsTest
     {
-        StringBuilder debugLog;
+        StringBuilder traceLog;
 
         [SetUp]
         public void Setup()
         {
-            debugLog = new StringBuilder();
-            Debug.AutoFlush = true;
-            Debug.Listeners.Remove("DatabaseMigrationsTest");
-            Debug.Listeners.Add(new TextWriterTraceListener(new StringWriter(debugLog), "DatabaseMigrationsTest"));
+            traceLog = new StringBuilder();
+            Trace.AutoFlush = true;
+            Trace.Listeners.Remove("DatabaseMigrationsTest");
+            Trace.Listeners.Add(new TextWriterTraceListener(new StringWriter(traceLog), "DatabaseMigrationsTest"));
         }
 
         [Test]
@@ -28,7 +28,7 @@
         {
             RunDataMigration("Return0");
 
-            StringAssert.DoesNotContain("Attempt 2", debugLog.ToString());
+            StringAssert.DoesNotContain("Attempt 2", traceLog.ToString());
         }
 
         [Test]
@@ -50,7 +50,7 @@
         {
             RunDataMigration("Throw", "Return0");
 
-            var actual = debugLog.ToString();
+            var actual = traceLog.ToString();
             StringAssert.Contains("Attempt 1", actual);
             StringAssert.Contains("Attempt 2", actual);
         }

--- a/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
+++ b/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
@@ -95,7 +95,7 @@
 
         List<string> RunDataMigration(params string[] commands)
         {
-            return RunDataMigration(10000, commands);
+            return RunDataMigration(100000, commands);
         }
     }
 }

--- a/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
+++ b/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
@@ -28,7 +28,7 @@
         {
             RunDataMigration("Return0");
 
-            Assert.IsFalse(debugLog.ToString().Contains("Attempt 2"));
+            StringAssert.DoesNotContain("Attempt 2", debugLog.ToString());
         }
 
         [Test]
@@ -50,8 +50,9 @@
         {
             RunDataMigration("Throw", "Return0");
 
-            Assert.IsTrue(debugLog.ToString().Contains("Attempt 1"));
-            Assert.IsTrue(debugLog.ToString().Contains("Attempt 2"));
+            var actual = debugLog.ToString();
+            StringAssert.Contains("Attempt 1", actual);
+            StringAssert.Contains("Attempt 2", actual);
         }
 
         [Test]

--- a/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
+++ b/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
@@ -1,0 +1,87 @@
+﻿namespace ServiceControl.UnitTests.Migrations
+
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Text;
+    using NUnit.Framework;
+    using ServiceControlInstaller.Engine.Database;
+
+    [TestFixture]
+    public class DatabaseMigrationsTest
+    {
+        StringBuilder debugLog;
+
+        [SetUp]
+        public void Setup()
+        {
+            Debug.Listeners.Clear();
+            debugLog = new StringBuilder();
+            Debug.Listeners.Add(new TextWriterTraceListener(new StringWriter(debugLog)));
+            Debug.Listeners.Add(new ConsoleTraceListener());
+        }
+
+        [Test]
+        public void It_finishes_after_first_successful_attempt()
+        {
+            RunDataMigration("Return0");
+
+            Assert.IsFalse(debugLog.ToString().Contains("Attempt 2"));
+        }
+
+        [Test]
+        public void If_first_attempt_throws_it_runs_second_attempt()
+        {
+            RunDataMigration("Throw", "Return0");
+
+            Assert.IsTrue(debugLog.ToString().Contains("Attempt 1"));
+            Assert.IsTrue(debugLog.ToString().Contains("Attempt 2"));
+        }
+
+        [Test]
+        public void It_captures_error_stream_when_returning_non_zero()
+        {
+            var ex = Assert.Throws<DatabaseMigrationsException>(() =>
+            {
+                RunDataMigration("WriteToErrorAndExitNonZero");
+            });
+
+            StringAssert.Contains("Some error message", ex.Message);
+        }
+
+        [Test]
+        public void It_ignores_error_output_when_returning_zero()
+        {
+            RunDataMigration("WriteToErrorAndExitZero");
+        }
+
+        [Test]
+        public void It_handles_timeouts()
+        {
+            Assert.Throws<DatabaseMigrationsTimeoutException>(() =>
+            {
+                RunDataMigration(1000, "Timeout");
+            });
+        }
+
+        List<string> RunDataMigration(int timeoutMilliseconds, params string[] commands)
+        {
+            var progressLog = new List<string>();
+            var index = 0;
+            DatabaseMigrations.RunDataMigration(s => { progressLog.Add(s); }, AppDomain.CurrentDomain.BaseDirectory, "DatabaseMigrationsTester.exe", timeoutMilliseconds, () =>
+            {
+                var nextCommand = commands[index % commands.Length];
+                index++;
+                return nextCommand;
+            });
+            return progressLog;
+        }
+
+        List<string> RunDataMigration(params string[] commands)
+        {
+            return RunDataMigration(10000, commands);
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
+++ b/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
@@ -1,5 +1,4 @@
-﻿namespace ServiceControl.UnitTests.Migrations
-
+namespace ServiceControl.UnitTests.Migrations
 {
     using System;
     using System.Collections.Generic;

--- a/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
+++ b/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
@@ -32,6 +32,20 @@
         }
 
         [Test]
+        public void It_parses_progress_information()
+        {
+            var progressLog = RunDataMigration("UpdateProgress");
+
+            CollectionAssert.AreEquivalent(new []
+            {
+                "Updating schema from version 1",
+                "Updating schema from version 2",
+                "Updating schema from version 3",
+                ""
+            }, progressLog);
+        }
+
+        [Test]
         public void If_first_attempt_throws_it_runs_second_attempt()
         {
             RunDataMigration("Throw", "Return0");

--- a/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
+++ b/src/ServiceControl.UnitTests/Migrations/DatabaseMigrationsTest.cs
@@ -17,10 +17,10 @@
         [SetUp]
         public void Setup()
         {
-            Debug.Listeners.Clear();
             debugLog = new StringBuilder();
-            Debug.Listeners.Add(new TextWriterTraceListener(new StringWriter(debugLog)));
-            Debug.Listeners.Add(new ConsoleTraceListener());
+            Debug.AutoFlush = true;
+            Debug.Listeners.Remove("DatabaseMigrationsTest");
+            Debug.Listeners.Add(new TextWriterTraceListener(new StringWriter(debugLog), "DatabaseMigrationsTest"));
         }
 
         [Test]

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Infrastructure\Settings\SettingsTests.cs" />
     <Compile Include="MessageExtensions.cs" />
     <Compile Include="Migrations\1.27\SplitFailedMessageDocumentsMigrationTests.cs" />
+    <Compile Include="Migrations\DatabaseMigrationsTest.cs" />
     <Compile Include="ObjectApprover.cs" />
     <Compile Include="RavenIndexAwaiter.cs" />
     <Compile Include="Infrastructure\TransportMessageExtensionsTests.cs" />
@@ -162,6 +163,14 @@
     <Compile Include="ScatterGather\MessageView_ScatterGatherTest.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DatabaseMigrationsTester\DatabaseMigrationsTester.csproj">
+      <Project>{276c38d4-734e-4c0b-9cdb-71b62550ede7}</Project>
+      <Name>DatabaseMigrationsTester</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj">
+      <Project>{e2f41605-f664-4ec6-9d64-1f142cc3b7b2}</Project>
+      <Name>ServiceControlInstaller.Engine</Name>
+    </ProjectReference>
     <ProjectReference Include="..\ServiceControl\ServiceControl.csproj">
       <Project>{4C6B71B2-74EF-4B9E-88FF-C56532727C6D}</Project>
       <Name>ServiceControl</Name>

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2010
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.UnitTests", "ServiceControl.UnitTests\ServiceControl.UnitTests.csproj", "{4F65FAE1-4C51-4BEF-956E-97C6A96807F9}"
 EndProject
@@ -47,6 +47,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.MSMQ.DLQMonitor", "ServiceControl.MSMQ.DLQMonitor\ServiceControl.MSMQ.DLQMonitor.csproj", "{46F65684-6439-4199-806E-9EA4CA0AC31C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.ASB.DLQMonitor", "ServiceControl.ASB.DLQMonitor\ServiceControl.ASB.DLQMonitor.csproj", "{70BE1AF0-4739-43E9-864E-4104A5781614}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DatabaseMigrationsTester", "DatabaseMigrationsTester\DatabaseMigrationsTester.csproj", "{276C38D4-734E-4C0B-9CDB-71B62550EDE7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -118,6 +120,10 @@ Global
 		{70BE1AF0-4739-43E9-864E-4104A5781614}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70BE1AF0-4739-43E9-864E-4104A5781614}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70BE1AF0-4739-43E9-864E-4104A5781614}.Release|Any CPU.Build.0 = Release|Any CPU
+		{276C38D4-734E-4C0B-9CDB-71B62550EDE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{276C38D4-734E-4C0B-9CDB-71B62550EDE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{276C38D4-734E-4C0B-9CDB-71B62550EDE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{276C38D4-734E-4C0B-9CDB-71B62550EDE7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ServiceControl/DatabaseMigrationsBootstrapper.cs
+++ b/src/ServiceControl/DatabaseMigrationsBootstrapper.cs
@@ -1,32 +1,32 @@
 namespace Particular.ServiceControl
 {
-	using Autofac;
-	using global::ServiceControl.Infrastructure.RavenDB;
-	using Particular.ServiceControl.DbMigrations;
-	using Raven.Client;
-	using Raven.Client.Embedded;
+    using Autofac;
+    using global::ServiceControl.Infrastructure.RavenDB;
+    using Particular.ServiceControl.DbMigrations;
+    using Raven.Client;
+    using Raven.Client.Embedded;
     using ServiceBus.Management.Infrastructure.Settings;
 
     public class DatabaseMigrationsBootstrapper
     {
         public void Run(Settings settings)
         {
-	        var containerBuilder = new ContainerBuilder();
+            var containerBuilder = new ContainerBuilder();
 
-	        var loggingSettings = new LoggingSettings(settings.ServiceName);
-	        containerBuilder.RegisterInstance(loggingSettings);
+            var loggingSettings = new LoggingSettings(settings.ServiceName);
+            containerBuilder.RegisterInstance(loggingSettings);
 
-	        var documentStore = new EmbeddableDocumentStore();
-	        containerBuilder.RegisterInstance(documentStore).As<IDocumentStore>().ExternallyOwned();
-	        containerBuilder.RegisterInstance(settings);
-	        containerBuilder.RegisterModule<MigrationsModule>();
+            var documentStore = new EmbeddableDocumentStore();
+            containerBuilder.RegisterInstance(documentStore).As<IDocumentStore>().ExternallyOwned();
+            containerBuilder.RegisterInstance(settings);
+            containerBuilder.RegisterModule<MigrationsModule>();
 
-			using (documentStore)
-	        using (var container = containerBuilder.Build())
-	        {
-				new RavenBootstrapper().StartRaven(documentStore, settings, true);
-				container.Resolve<MigrationsManager>().ApplyMigrations();
-	        }
+            using (documentStore)
+            using (var container = containerBuilder.Build())
+            {
+                new RavenBootstrapper().StartRaven(documentStore, settings, true);
+                container.Resolve<MigrationsManager>().ApplyMigrations();
+            }
         }
     }
 }

--- a/src/ServiceControl/DatabaseMigrationsBootstrapper.cs
+++ b/src/ServiceControl/DatabaseMigrationsBootstrapper.cs
@@ -1,0 +1,32 @@
+namespace Particular.ServiceControl
+{
+	using Autofac;
+	using global::ServiceControl.Infrastructure.RavenDB;
+	using Particular.ServiceControl.DbMigrations;
+	using Raven.Client;
+	using Raven.Client.Embedded;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    public class DatabaseMigrationsBootstrapper
+    {
+        public void Run(Settings settings)
+        {
+	        var containerBuilder = new ContainerBuilder();
+
+	        var loggingSettings = new LoggingSettings(settings.ServiceName);
+	        containerBuilder.RegisterInstance(loggingSettings);
+
+	        var documentStore = new EmbeddableDocumentStore();
+	        containerBuilder.RegisterInstance(documentStore).As<IDocumentStore>().ExternallyOwned();
+	        containerBuilder.RegisterInstance(settings);
+	        containerBuilder.RegisterModule<MigrationsModule>();
+
+			using (documentStore)
+	        using (var container = containerBuilder.Build())
+	        {
+				new RavenBootstrapper().StartRaven(documentStore, settings, true);
+				container.Resolve<MigrationsManager>().ApplyMigrations();
+	        }
+        }
+    }
+}

--- a/src/ServiceControl/Hosting/Commands/DatabaseMigrationsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/DatabaseMigrationsCommand.cs
@@ -1,13 +1,13 @@
 ﻿namespace Particular.ServiceControl.Commands
 {
-	using Particular.ServiceControl.Hosting;
-	using ServiceBus.Management.Infrastructure.Settings;
+    using Particular.ServiceControl.Hosting;
+    using ServiceBus.Management.Infrastructure.Settings;
 
-	class DatabaseMigrationsCommand : AbstractCommand
-	{
-		public override void Execute(HostArguments args)
-		{
-			new DatabaseMigrationsBootstrapper().Run(new Settings(args.ServiceName));
-		}
-	}
+    class DatabaseMigrationsCommand : AbstractCommand
+    {
+        public override void Execute(HostArguments args)
+        {
+            new DatabaseMigrationsBootstrapper().Run(new Settings(args.ServiceName));
+        }
+    }
 }

--- a/src/ServiceControl/Hosting/Commands/DatabaseMigrationsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/DatabaseMigrationsCommand.cs
@@ -1,0 +1,13 @@
+﻿namespace Particular.ServiceControl.Commands
+{
+	using Particular.ServiceControl.Hosting;
+	using ServiceBus.Management.Infrastructure.Settings;
+
+	class DatabaseMigrationsCommand : AbstractCommand
+	{
+		public override void Execute(HostArguments args)
+		{
+			new DatabaseMigrationsBootstrapper().Run(new Settings(args.ServiceName));
+		}
+	}
+}

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -56,6 +56,26 @@ namespace Particular.ServiceControl.Hosting
                                            };
 
             // Not documented in help - Used by SC installer only
+
+	        var databaseMigrationsOptions = new OptionSet
+	        {
+		        {
+			        "d|database",
+			        @"Internal use - for installer"
+			        , s =>
+			        {
+
+				        Commands = new List<Type>{typeof(DatabaseMigrationsCommand) };
+				        executionMode = ExecutionMode.DatabaseMigrations;
+			        }
+		        },
+		        {
+			        "serviceName=",
+			        @"Specify the service name for the installed service."
+			        , s => { ServiceName = s; }
+		        },
+			};
+
             var externalInstallerOptions = new OptionSet
             {
                 {
@@ -115,6 +135,12 @@ namespace Particular.ServiceControl.Hosting
                     return;
                 }
 
+	            databaseMigrationsOptions.Parse(args);
+	            if (executionMode == ExecutionMode.DatabaseMigrations)
+	            {
+		            return;
+	            }
+
                 maintenanceOptions.Parse(args);
                 if (executionMode == ExecutionMode.Maintenance)
                 {
@@ -164,6 +190,7 @@ namespace Particular.ServiceControl.Hosting
         RunInstallers,
         Run,
         ImportFailedAudits,
-        Maintenance
+        Maintenance,
+	    DatabaseMigrations
     }
 }

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -57,24 +57,24 @@ namespace Particular.ServiceControl.Hosting
 
             // Not documented in help - Used by SC installer only
 
-	        var databaseMigrationsOptions = new OptionSet
-	        {
-		        {
-			        "d|database",
-			        @"Internal use - for installer"
-			        , s =>
-			        {
+            var databaseMigrationsOptions = new OptionSet
+            {
+                {
+                    "d|database",
+                    @"Internal use - for installer"
+                    , s =>
+                    {
 
-				        Commands = new List<Type>{typeof(DatabaseMigrationsCommand) };
-				        executionMode = ExecutionMode.DatabaseMigrations;
-			        }
-		        },
-		        {
-			        "serviceName=",
-			        @"Specify the service name for the installed service."
-			        , s => { ServiceName = s; }
-		        },
-			};
+                        Commands = new List<Type>{typeof(DatabaseMigrationsCommand) };
+                        executionMode = ExecutionMode.DatabaseMigrations;
+                    }
+                },
+                {
+                    "serviceName=",
+                    @"Specify the service name for the installed service."
+                    , s => { ServiceName = s; }
+                },
+            };
 
             var externalInstallerOptions = new OptionSet
             {
@@ -135,11 +135,11 @@ namespace Particular.ServiceControl.Hosting
                     return;
                 }
 
-	            databaseMigrationsOptions.Parse(args);
-	            if (executionMode == ExecutionMode.DatabaseMigrations)
-	            {
-		            return;
-	            }
+                databaseMigrationsOptions.Parse(args);
+                if (executionMode == ExecutionMode.DatabaseMigrations)
+                {
+                    return;
+                }
 
                 maintenanceOptions.Parse(args);
                 if (executionMode == ExecutionMode.Maintenance)
@@ -191,6 +191,6 @@ namespace Particular.ServiceControl.Hosting
         Run,
         ImportFailedAudits,
         Maintenance,
-	    DatabaseMigrations
+        DatabaseMigrations
     }
 }

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -302,6 +302,7 @@
     <Compile Include="DbMigrations\MigrationsModule.cs" />
     <Compile Include="DbMigrations\1.27\SplitFailedMessageDocumentsMigration.cs" />
     <Compile Include="HeartbeatMonitoring\LegacyHandler.cs" />
+    <Compile Include="Hosting\Commands\DatabaseMigrationsCommand.cs" />
     <Compile Include="Hosting\Commands\ImportFailedAuditsCommand.cs" />
     <Compile Include="Hosting\MaintenanceHost.cs">
       <SubType>Component</SubType>
@@ -336,6 +337,7 @@
     <Compile Include="Licensing\LicenseCheckFeature.cs" />
     <Compile Include="Licensing\LicenseModule.cs" />
     <Compile Include="LoggingConfigurator.cs" />
+    <Compile Include="DatabaseMigrationsBootstrapper.cs" />
     <Compile Include="MaintenanceBootstrapper.cs" />
     <Compile Include="Infrastructure\MetadataExtensions.cs" />
     <Compile Include="MessageFailures\Api\PendingRetryMessages.cs" />

--- a/src/ServiceControl/SetupBootstrapper.cs
+++ b/src/ServiceControl/SetupBootstrapper.cs
@@ -4,7 +4,6 @@ namespace Particular.ServiceControl
     using global::ServiceControl.Infrastructure.DomainEvents;
     using NServiceBus;
     using NServiceBus.Logging;
-    using Particular.ServiceControl.DbMigrations;
     using Raven.Client;
     using Raven.Client.Embedded;
     using ServiceBus.Management.Infrastructure;
@@ -41,13 +40,10 @@ namespace Particular.ServiceControl
             containerBuilder.RegisterInstance(documentStore).As<IDocumentStore>().ExternallyOwned();
             containerBuilder.RegisterInstance(settings);
 
-            containerBuilder.RegisterModule<MigrationsModule>();
-
             using (documentStore)
             using (var container = containerBuilder.Build())
             using (NServiceBusFactory.Create(settings, container, null, documentStore, configuration, false))
             {
-                container.Resolve<MigrationsManager>().ApplyMigrations();
             }
         }
 

--- a/src/ServiceControlInstaller.Engine/Configuration/AppConfigWrapper.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/AppConfigWrapper.cs
@@ -23,7 +23,8 @@
         {
             if (Config.AppSettings.Settings.AllKeys.Contains(key, StringComparer.OrdinalIgnoreCase))
             {
-                return (T)Convert.ChangeType(Config.AppSettings.Settings[key].Value, typeof(T));
+                var nonNullableType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+                return (T)Convert.ChangeType(Config.AppSettings.Settings[key].Value, nonNullableType);
             }
 
             try

--- a/src/ServiceControlInstaller.Engine/Database/DatabaseMigrations.cs
+++ b/src/ServiceControlInstaller.Engine/Database/DatabaseMigrations.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Diagnostics;
     using System.IO;
+    using System.Text;
+    using System.Threading;
     using ServiceControlInstaller.Engine.Instances;
 
     internal class DatabaseMigrations
@@ -16,52 +18,103 @@
 
         static void RunDataMigration(Action<string> updateProgress, string installPath, string exeName, string serviceName)
         {
-            var processStartupInfo = new ProcessStartInfo
-            {
-                CreateNoWindow = true,
-                UseShellExecute = false,
-                FileName = Path.Combine(installPath, exeName),
-                Arguments = $"--database --serviceName={serviceName}",
-                WorkingDirectory = installPath,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true
-            };
+            var fileName = Path.Combine(installPath, exeName);
+            var args = $"--database --serviceName={serviceName}";
 
             var attempts = 0;
-            Process p;
-            var updatingSchema = false;
+            var timeout = (int) TimeSpan.FromMinutes(20).TotalMilliseconds;
+
             do
             {
-                attempts++;
-
-                p = Process.Start(processStartupInfo);
-                if (p == null)
+                using (var p = new Process())
                 {
-                    throw new Exception($"Attempt to launch {exeName} failed.");
+                    p.StartInfo.CreateNoWindow = true;
+                    p.StartInfo.UseShellExecute = false;
+                    p.StartInfo.FileName = fileName;
+                    p.StartInfo.Arguments = args;
+                    p.StartInfo.WorkingDirectory = installPath;
+                    p.StartInfo.RedirectStandardOutput = true;
+                    p.StartInfo.RedirectStandardError = true;
+
+                    var error = new StringBuilder();
+
+                    var updatingSchema = false;
+
+                    using (var outputWaitHandle = new AutoResetEvent(false))
+                    using (var errorWaitHandle = new AutoResetEvent(false))
+                    {
+                        p.OutputDataReceived += (sender, eventArgs) =>
+                        {
+                            if (eventArgs.Data == null)
+                            {
+                                outputWaitHandle.Set();
+                            }
+                            else
+                            {
+
+                                Debug.WriteLine(eventArgs.Data);
+
+                                if (eventArgs.Data.StartsWith("Updating schema from version"))
+                                {
+                                    updatingSchema = true;
+                                    updateProgress(eventArgs.Data.Replace(":", string.Empty));
+                                }
+                                else if (updatingSchema && eventArgs.Data.StartsWith("OK"))
+                                {
+                                    updatingSchema = false;
+                                    updateProgress(string.Empty);
+                                }
+                            }
+                        };
+
+                        p.ErrorDataReceived += (sender, e) =>
+                        {
+                            if (e.Data == null)
+                            {
+                                errorWaitHandle.Set();
+                            }
+                            else
+                            {
+                                error.AppendLine(e.Data);
+                            }
+                        };
+
+                        attempts++;
+
+                        Debug.WriteLine($"Attempt {attempts}");
+
+                        p.Start();
+
+                        p.BeginOutputReadLine();
+                        p.BeginErrorReadLine();
+
+                        if (p.WaitForExit(timeout) &&
+                            outputWaitHandle.WaitOne(timeout) &&
+                            errorWaitHandle.WaitOne(timeout))
+                        {
+                            Debug.WriteLine($"Attempt {attempts} exited with code {p.ExitCode}");
+                            if (p.ExitCode == 0)
+                            {
+                                break;
+                            }
+
+                            if (attempts < 2)
+                            {
+                                continue;
+                            }
+
+                            if (p.ExitCode != 0)
+                            {
+                                throw new DatabaseMigrationsException($"{exeName} threw an error when migrating data. Please contact Particular support. The error output from {exeName} was:\r\n {error}");
+                            }
+                        }
+                        else
+                        {
+                            throw new DatabaseMigrationsTimeoutException($"{exeName} timed out while migrating data.");
+                        }
+                    }
                 }
-
-                p.OutputDataReceived += (sender, eventArgs) =>
-                {
-                    if (eventArgs.Data.StartsWith("Updating schema from version"))
-                    {
-                        updatingSchema = true;
-                        updateProgress(eventArgs.Data.Remove(':'));
-                    }
-                    else if (updatingSchema && eventArgs.Data.StartsWith("OK"))
-                    {
-                        updatingSchema = false;
-                        updateProgress(string.Empty);
-                    }
-                };
-
-                p.WaitForExit((int)TimeSpan.FromMinutes(20).TotalMilliseconds);
-            } while (p.ExitCode > 0 && attempts < 2);
-
-            if (p.ExitCode != 0)
-            {
-                var error = p.StandardError.ReadToEnd();
-                throw new DatabaseMigrationsException($"{exeName} threw an error when migrating data. Please contact Particular support. The error output from {exeName} was:\r\n {error}");
-            }
+            } while (attempts < 2);
         }
     }
 }

--- a/src/ServiceControlInstaller.Engine/Database/DatabaseMigrations.cs
+++ b/src/ServiceControlInstaller.Engine/Database/DatabaseMigrations.cs
@@ -1,0 +1,67 @@
+﻿namespace ServiceControlInstaller.Engine.Database
+{
+	using System;
+	using System.Diagnostics;
+	using System.IO;
+	using ServiceControlInstaller.Engine.Instances;
+
+	internal class DatabaseMigrations
+	{
+		public static void RunDatabaseMigrations(IServiceControlInstance instance, Action<string> updateProgress)
+		{
+			RunDataMigration(updateProgress, instance.InstallPath,
+				Constants.ServiceControlExe,
+				instance.Name);
+		}
+
+		static void RunDataMigration(Action<string> updateProgress, string installPath, string exeName, string serviceName)
+		{
+			var processStartupInfo = new ProcessStartInfo
+			{
+				CreateNoWindow = true,
+				UseShellExecute = false,
+				FileName = Path.Combine(installPath, exeName),
+				Arguments = $"--database --serviceName={serviceName}",
+				WorkingDirectory = installPath,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true
+			};
+
+			var attempts = 0;
+			Process p;
+			var updatingSchema = false;
+			do
+			{
+				attempts++;
+
+				p = Process.Start(processStartupInfo);
+				if (p == null)
+				{
+					throw new Exception($"Attempt to launch {exeName} failed.");
+				}
+
+				p.OutputDataReceived += (sender, eventArgs) =>
+				{
+					if (eventArgs.Data.StartsWith("Updating schema from version"))
+					{
+						updatingSchema = true;
+						updateProgress(eventArgs.Data.Remove(':'));
+					}
+					else if (updatingSchema && eventArgs.Data.StartsWith("OK"))
+					{
+						updatingSchema = false;
+						updateProgress(string.Empty);
+					}
+				};
+
+				p.WaitForExit((int)TimeSpan.FromMinutes(20).TotalMilliseconds);
+			} while (p.ExitCode > 0 && attempts < 2);
+
+			if (p.ExitCode != 0)
+			{
+				var error = p.StandardError.ReadToEnd();
+				throw new DatabaseMigrationsException($"{exeName} threw an error when migrating data. Please contact Particular support. The error output from {exeName} was:\r\n {error}");
+			}
+		}
+	}
+}

--- a/src/ServiceControlInstaller.Engine/Database/DatabaseMigrations.cs
+++ b/src/ServiceControlInstaller.Engine/Database/DatabaseMigrations.cs
@@ -78,7 +78,7 @@
 
                         attempts++;
 
-                        Debug.WriteLine($"Attempt {attempts}");
+                        Trace.WriteLine($"Attempt {attempts}");
 
                         p.Start();
 
@@ -89,7 +89,7 @@
                             outputWaitHandle.WaitOne(timeoutMilliseconds) &&
                             errorWaitHandle.WaitOne(timeoutMilliseconds))
                         {
-                            Debug.WriteLine($"Attempt {attempts} exited with code {p.ExitCode}");
+                            Trace.WriteLine($"Attempt {attempts} exited with code {p.ExitCode}");
                             if (p.ExitCode == 0)
                             {
                                 break;

--- a/src/ServiceControlInstaller.Engine/Database/DatabaseMigrations.cs
+++ b/src/ServiceControlInstaller.Engine/Database/DatabaseMigrations.cs
@@ -1,67 +1,67 @@
 ﻿namespace ServiceControlInstaller.Engine.Database
 {
-	using System;
-	using System.Diagnostics;
-	using System.IO;
-	using ServiceControlInstaller.Engine.Instances;
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using ServiceControlInstaller.Engine.Instances;
 
-	internal class DatabaseMigrations
-	{
-		public static void RunDatabaseMigrations(IServiceControlInstance instance, Action<string> updateProgress)
-		{
-			RunDataMigration(updateProgress, instance.InstallPath,
-				Constants.ServiceControlExe,
-				instance.Name);
-		}
+    internal class DatabaseMigrations
+    {
+        public static void RunDatabaseMigrations(IServiceControlInstance instance, Action<string> updateProgress)
+        {
+            RunDataMigration(updateProgress, instance.InstallPath,
+                Constants.ServiceControlExe,
+                instance.Name);
+        }
 
-		static void RunDataMigration(Action<string> updateProgress, string installPath, string exeName, string serviceName)
-		{
-			var processStartupInfo = new ProcessStartInfo
-			{
-				CreateNoWindow = true,
-				UseShellExecute = false,
-				FileName = Path.Combine(installPath, exeName),
-				Arguments = $"--database --serviceName={serviceName}",
-				WorkingDirectory = installPath,
-				RedirectStandardOutput = true,
-				RedirectStandardError = true
-			};
+        static void RunDataMigration(Action<string> updateProgress, string installPath, string exeName, string serviceName)
+        {
+            var processStartupInfo = new ProcessStartInfo
+            {
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                FileName = Path.Combine(installPath, exeName),
+                Arguments = $"--database --serviceName={serviceName}",
+                WorkingDirectory = installPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
 
-			var attempts = 0;
-			Process p;
-			var updatingSchema = false;
-			do
-			{
-				attempts++;
+            var attempts = 0;
+            Process p;
+            var updatingSchema = false;
+            do
+            {
+                attempts++;
 
-				p = Process.Start(processStartupInfo);
-				if (p == null)
-				{
-					throw new Exception($"Attempt to launch {exeName} failed.");
-				}
+                p = Process.Start(processStartupInfo);
+                if (p == null)
+                {
+                    throw new Exception($"Attempt to launch {exeName} failed.");
+                }
 
-				p.OutputDataReceived += (sender, eventArgs) =>
-				{
-					if (eventArgs.Data.StartsWith("Updating schema from version"))
-					{
-						updatingSchema = true;
-						updateProgress(eventArgs.Data.Remove(':'));
-					}
-					else if (updatingSchema && eventArgs.Data.StartsWith("OK"))
-					{
-						updatingSchema = false;
-						updateProgress(string.Empty);
-					}
-				};
+                p.OutputDataReceived += (sender, eventArgs) =>
+                {
+                    if (eventArgs.Data.StartsWith("Updating schema from version"))
+                    {
+                        updatingSchema = true;
+                        updateProgress(eventArgs.Data.Remove(':'));
+                    }
+                    else if (updatingSchema && eventArgs.Data.StartsWith("OK"))
+                    {
+                        updatingSchema = false;
+                        updateProgress(string.Empty);
+                    }
+                };
 
-				p.WaitForExit((int)TimeSpan.FromMinutes(20).TotalMilliseconds);
-			} while (p.ExitCode > 0 && attempts < 2);
+                p.WaitForExit((int)TimeSpan.FromMinutes(20).TotalMilliseconds);
+            } while (p.ExitCode > 0 && attempts < 2);
 
-			if (p.ExitCode != 0)
-			{
-				var error = p.StandardError.ReadToEnd();
-				throw new DatabaseMigrationsException($"{exeName} threw an error when migrating data. Please contact Particular support. The error output from {exeName} was:\r\n {error}");
-			}
-		}
-	}
+            if (p.ExitCode != 0)
+            {
+                var error = p.StandardError.ReadToEnd();
+                throw new DatabaseMigrationsException($"{exeName} threw an error when migrating data. Please contact Particular support. The error output from {exeName} was:\r\n {error}");
+            }
+        }
+    }
 }

--- a/src/ServiceControlInstaller.Engine/Database/DatabaseMigrationsException.cs
+++ b/src/ServiceControlInstaller.Engine/Database/DatabaseMigrationsException.cs
@@ -1,0 +1,11 @@
+﻿namespace ServiceControlInstaller.Engine.Database
+{
+	using System;
+
+	public class DatabaseMigrationsException : Exception
+	{
+		public DatabaseMigrationsException(string message) : base(message)
+		{
+		}
+	}
+}

--- a/src/ServiceControlInstaller.Engine/Database/DatabaseMigrationsException.cs
+++ b/src/ServiceControlInstaller.Engine/Database/DatabaseMigrationsException.cs
@@ -1,11 +1,11 @@
 ﻿namespace ServiceControlInstaller.Engine.Database
 {
-	using System;
+    using System;
 
-	public class DatabaseMigrationsException : Exception
-	{
-		public DatabaseMigrationsException(string message) : base(message)
-		{
-		}
-	}
+    public class DatabaseMigrationsException : Exception
+    {
+        public DatabaseMigrationsException(string message) : base(message)
+        {
+        }
+    }
 }

--- a/src/ServiceControlInstaller.Engine/Database/DatabaseMigrationsTimeoutException.cs
+++ b/src/ServiceControlInstaller.Engine/Database/DatabaseMigrationsTimeoutException.cs
@@ -1,11 +1,11 @@
 ﻿namespace ServiceControlInstaller.Engine.Database
 {
-	using System;
-	public class DatabaseMigrationsTimeoutException : Exception
-	{
-		public DatabaseMigrationsTimeoutException(string message) : base(message)
-		{
+    using System;
+    public class DatabaseMigrationsTimeoutException : Exception
+    {
+        public DatabaseMigrationsTimeoutException(string message) : base(message)
+        {
 
-		}
-	}
+        }
+    }
 }

--- a/src/ServiceControlInstaller.Engine/Database/DatabaseMigrationsTimeoutException.cs
+++ b/src/ServiceControlInstaller.Engine/Database/DatabaseMigrationsTimeoutException.cs
@@ -1,0 +1,11 @@
+﻿namespace ServiceControlInstaller.Engine.Database
+{
+	using System;
+	public class DatabaseMigrationsTimeoutException : Exception
+	{
+		public DatabaseMigrationsTimeoutException(string message) : base(message)
+		{
+
+		}
+	}
+}

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -418,6 +418,10 @@ namespace ServiceControlInstaller.Engine.Instances
             {
                 DatabaseMigrations.RunDatabaseMigrations(this, updateProgress);
             }
+            catch (DatabaseMigrationsException ex)
+            {
+                ReportCard.Errors.Add(ex.Message);
+            }
             catch (DatabaseMigrationsTimeoutException ex)
             {
                 ReportCard.Errors.Add(ex.Message);

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -18,10 +18,10 @@ namespace ServiceControlInstaller.Engine.Instances
     using ServiceControlInstaller.Engine.Services;
     using ServiceControlInstaller.Engine.UrlAcl;
     using ServiceControlInstaller.Engine.Validation;
-    
+
     public class ServiceControlInstance : BaseService, IServiceControlInstance
     {
-        
+
         public string LogPath { get; set; }
         public string DBPath { get; set; }
         public string HostName { get; set; }
@@ -97,7 +97,7 @@ namespace ServiceControlInstaller.Engine.Instances
         }
 
         /// <summary>
-        /// Raven management URL 
+        /// Raven management URL
         /// </summary>
         public string StorageUrl
         {
@@ -196,7 +196,7 @@ namespace ServiceControlInstaller.Engine.Instances
         {
             var accountName = string.Equals(ServiceAccount, "LocalSystem", StringComparison.OrdinalIgnoreCase) ? "System" : ServiceAccount;
             var oldSettings = InstanceFinder.FindServiceControlInstance(Name);
-            
+
             var fileSystemChanged = !string.Equals(oldSettings.LogPath, LogPath, StringComparison.OrdinalIgnoreCase);
 
             var queueNamesChanged = !(string.Equals(oldSettings.AuditQueue, AuditQueue, StringComparison.OrdinalIgnoreCase)
@@ -310,10 +310,10 @@ namespace ServiceControlInstaller.Engine.Instances
 
             return Path.Combine(profilePath, @"AppData\Local\Particular\ServiceControl\logs");
         }
-        
+
         public void RemoveUrlAcl()
         {
-            foreach (var urlReservation in UrlReservation.GetAll().Where(p => p.Url.StartsWith(AclUrl, StringComparison.OrdinalIgnoreCase) || 
+            foreach (var urlReservation in UrlReservation.GetAll().Where(p => p.Url.StartsWith(AclUrl, StringComparison.OrdinalIgnoreCase) ||
                                                                               p.Url.StartsWith(AclMaintenanceUrl, StringComparison.OrdinalIgnoreCase)))
             {
                 try
@@ -326,7 +326,7 @@ namespace ServiceControlInstaller.Engine.Instances
                 }
             }
         }
-        
+
         /// <summary>
         ///     Returns false if a reboot is required to complete deletion
         /// </summary>
@@ -383,7 +383,7 @@ namespace ServiceControlInstaller.Engine.Instances
             File.Copy(sourcePath, configFile, true);
 
             // Populate the config with common settings even if they are defaults
-            // Will not clobber other settings in the config 
+            // Will not clobber other settings in the config
             AppConfig = new AppConfig(this);
             AppConfig.Validate();
             AppConfig.Save();
@@ -395,7 +395,7 @@ namespace ServiceControlInstaller.Engine.Instances
             FileUtils.UnzipToSubdirectory(zipFilePath, InstallPath, "ServiceControl");
             FileUtils.UnzipToSubdirectory(zipFilePath, InstallPath, $@"Transports\{TransportPackage}");
         }
-        
+
         public void SetupInstance()
         {
             try
@@ -412,19 +412,19 @@ namespace ServiceControlInstaller.Engine.Instances
             }
         }
 
-	    public void UpdateDatabase(Action<string> updateProgress)
-	    {
-		    try
-		    {
-			    DatabaseMigrations.RunDatabaseMigrations(this, updateProgress);
-		    }
-		    catch (DatabaseMigrationsTimeoutException ex)
-		    {
-			    ReportCard.Errors.Add(ex.Message);
-		    }
-	    }
+        public void UpdateDatabase(Action<string> updateProgress)
+        {
+            try
+            {
+                DatabaseMigrations.RunDatabaseMigrations(this, updateProgress);
+            }
+            catch (DatabaseMigrationsTimeoutException ex)
+            {
+                ReportCard.Errors.Add(ex.Message);
+            }
+        }
 
-		public void DisableMaintenanceMode()
+        public void DisableMaintenanceMode()
         {
             AppConfig.DisableMaintenanceMode();
             InMaintenanceMode = false;

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -11,6 +11,7 @@ namespace ServiceControlInstaller.Engine.Instances
     using ServiceControlInstaller.Engine.Accounts;
     using ServiceControlInstaller.Engine.Configuration;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
+    using ServiceControlInstaller.Engine.Database;
     using ServiceControlInstaller.Engine.FileSystem;
     using ServiceControlInstaller.Engine.Queues;
     using ServiceControlInstaller.Engine.ReportCard;
@@ -411,7 +412,19 @@ namespace ServiceControlInstaller.Engine.Instances
             }
         }
 
-        public void DisableMaintenanceMode()
+	    public void UpdateDatabase(Action<string> updateProgress)
+	    {
+		    try
+		    {
+			    DatabaseMigrations.RunDatabaseMigrations(this, updateProgress);
+		    }
+		    catch (DatabaseMigrationsTimeoutException ex)
+		    {
+			    ReportCard.Errors.Add(ex.Message);
+		    }
+	    }
+
+		public void DisableMaintenanceMode()
         {
             AppConfig.DisableMaintenanceMode();
             InMaintenanceMode = false;

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -26,7 +26,7 @@ namespace ServiceControlInstaller.Engine.Instances
         public string DBPath { get; set; }
         public string HostName { get; set; }
         public int Port { get; set; }
-        public int DatabaseMaintenancePort { get; set; }
+        public int? DatabaseMaintenancePort { get; set; }
         public string VirtualDirectory { get; set; }
         public string ErrorQueue { get; set; }
         public string AuditQueue { get; set; }
@@ -55,7 +55,7 @@ namespace ServiceControlInstaller.Engine.Instances
             Service.Refresh();
             HostName = AppConfig.Read(SettingsList.HostName, "localhost");
             Port = AppConfig.Read(SettingsList.Port, 33333);
-            DatabaseMaintenancePort = AppConfig.Read(SettingsList.DatabaseMaintenancePort, 33334);
+            DatabaseMaintenancePort = AppConfig.Read<int?>(SettingsList.DatabaseMaintenancePort, null);
             VirtualDirectory = AppConfig.Read(SettingsList.VirtualDirectory, (string)null);
             LogPath = AppConfig.Read(SettingsList.LogPath, DefaultLogPath());
             DBPath = AppConfig.Read(SettingsList.DBPath, DefaultDBPath());

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlNewInstance.cs
@@ -33,7 +33,7 @@ namespace ServiceControlInstaller.Engine.Instances
 
         public string InstallPath { get; set; }
         public int Port { get; set; }
-        public int DatabaseMaintenancePort { get; set; }
+        public int? DatabaseMaintenancePort { get; set; }
         public string VirtualDirectory { get; set; }
         public string ErrorQueue { get; set; }
         public string ErrorLogQueue { get; set; }

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlUpgradeOptions.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlUpgradeOptions.cs
@@ -7,6 +7,7 @@ namespace ServiceControlInstaller.Engine.Instances
         public bool? OverrideEnableErrorForwarding { get; set; }
         public TimeSpan? ErrorRetentionPeriod { get; set; }
         public TimeSpan? AuditRetentionPeriod { get; set; }
+        public int MaintenancePort { get; set; }
         public bool SkipQueueCreation { get; set; }
 
         public void ApplyChangesToInstance(ServiceControlInstance instance)
@@ -27,7 +28,7 @@ namespace ServiceControlInstaller.Engine.Instances
             }
 
             instance.SkipQueueCreation = SkipQueueCreation;
-
+            instance.DatabaseMaintenancePort = MaintenancePort;
             instance.ApplyConfigChange();
         }
     }

--- a/src/ServiceControlInstaller.Engine/Interfaces.cs
+++ b/src/ServiceControlInstaller.Engine/Interfaces.cs
@@ -74,7 +74,7 @@
 
     public interface IServiceControlInstance : IServiceInstance,  IServiceControlPaths, IServiceControlTransportConfig, IHttpInstance, IURLInfo, IInstallable
     {
-        int DatabaseMaintenancePort { get; }
+        int? DatabaseMaintenancePort { get; }
         string VirtualDirectory { get;  }
         bool ForwardAuditMessages { get; }
         bool ForwardErrorMessages { get; }

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -112,6 +112,9 @@
     <Compile Include="Configuration\ServiceControl\SettingConstants.cs" />
     <Compile Include="Configuration\ServiceControl\SettingsList.cs" />
     <Compile Include="Configuration\SettingInfo.cs" />
+    <Compile Include="Database\DatabaseMigrations.cs" />
+    <Compile Include="Database\DatabaseMigrationsException.cs" />
+    <Compile Include="Database\DatabaseMigrationsTimeoutException.cs" />
     <Compile Include="FileSystem\ReleaseDateReader.cs" />
     <Compile Include="FileSystem\MonitoringZipInfo.cs" />
     <Compile Include="Instances\BaseService.cs" />

--- a/src/ServiceControlInstaller.Engine/Validation/DatabaseMaintenancePortValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/DatabaseMaintenancePortValidator.cs
@@ -6,12 +6,22 @@
     {
         public static void Validate(IServiceControlInstance instance)
         {
-            if (instance.DatabaseMaintenancePort < 1 || instance.DatabaseMaintenancePort > 49151)
+            if (instance.Version.Major < 2) //Maintenance port was introduced in Version 2
             {
-                throw new EngineValidationException("Port number is not between 1 and 49151");
+                return;
             }
 
-            if (!PortUtils.CheckAvailable(instance.DatabaseMaintenancePort))
+            if (!instance.DatabaseMaintenancePort.HasValue)
+            {
+                throw new EngineValidationException("Maintenance port number is not set");
+            }
+
+            if (instance.DatabaseMaintenancePort < 1 || instance.DatabaseMaintenancePort > 49151)
+            {
+                throw new EngineValidationException("Maintenance port number is not between 1 and 49151");
+            }
+
+            if (!PortUtils.CheckAvailable(instance.DatabaseMaintenancePort.Value))
                 throw new EngineValidationException($"Port {instance.DatabaseMaintenancePort} is not available");
         }
     }

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/PSServiceControl.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/PSServiceControl.cs
@@ -37,7 +37,7 @@ namespace ServiceControlInstaller.PowerShell
         public string Url { get; set; }
         public string HostName { get; set; }
         public int Port { get; set; }
-        public int DatabaseMaintenancePort { get; set; }
+        public int? DatabaseMaintenancePort { get; set; }
 
         public string InstallPath { get; set; }
         public string DBPath { get; set; }


### PR DESCRIPTION
Updates installer / SC to allow monitoring of database upgrades/migrations.

Example output during 3.5 upgrade:

```
2018-04-19 15:43:23.4548|1|Info|ServiceBus.Management.Infrastructure.Settings.Settings|No settings found for error log queue to import, default name will be used
2018-04-19 15:43:23.4718|1|Info|ServiceBus.Management.Infrastructure.Settings.Settings|No settings found for audit log queue to import, default name will be used
2018-04-19 15:43:27.0449|1|Info|ServiceControl.Infrastructure.RavenDB.RavenBootstrapper|Loading Embedded RavenDB license
Updating schema from version 4.8:
DB localhost-0: Processed -1 rows in scheduled_reductions, and done with this table
DB localhost-0: Processed 1 rows in mapped_results
DB localhost-0: Processed 9 rows in mapped_results, and done with this table
DB localhost-0: Processed -1 rows in reduce_results, and done with this table
DB localhost-0: Processed 1 rows in reduce_keys_counts
DB localhost-0: Processed 4 rows in reduce_keys_counts, and done with this table
DB localhost-0: Processed 1 rows in reduce_keys_status
DB localhost-0: Processed 4 rows in reduce_keys_status, and done with this table
DB localhost-0: Processed -1 rows in indexed_documents_references, and done with this table
DB localhost-0: Processed -1 rows in tasks, and done with this table
DB localhost-0: Processed 1 rows in indexes_stats
DB localhost-0: Processed 21 rows in indexes_stats, and done with this table
DB localhost-0: Processed 1 rows in indexes_etag
DB localhost-0: Processed 21 rows in indexes_etag, and done with this table
DB localhost-0: Processed 1 rows in indexes_stats_reduce
DB localhost-0: Processed 4 rows in indexes_stats_reduce, and done with this table
OK
Updating schema from version 5.0:
DB localhost-0: Processed 1 rows in lists
OK
Updating schema from version 5.1:
OK
Updating schema from version 5.2:
OK
Updating schema from version 5.3:
OK
2018-04-19 15:43:36.0698|1|Error|Raven.Database.DocumentDatabase|Could not create database
System.AggregateException: One or more errors occurred. ---> Lucene.Net.Store.AlreadyClosedException: this Directory is closed
   at Lucene.Net.Store.Directory.EnsureOpen() in d:\Lucene.Net\FullRepo\trunk\src\core\Store\Directory.cs:line 257
   at Lucene.Net.Store.FSDirectory.get_Directory() in d:\Lucene.Net\FullRepo\trunk\src\core\Store\FSDirectory.cs:line 486
   at Raven.Database.Indexing.LuceneCodecDirectory.GetFile(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\LuceneCodecDirectory.cs:line 94
   at Raven.Database.Indexing.LuceneCodecDirectory.CreateOutput(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\LuceneCodecDirectory.cs:line 48
   at Raven.Database.Indexing.IndexStorage.WriteIndexVersion(Directory directory, IndexDefinition indexDefinition) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 644
   at Raven.Database.Indexing.IndexStorage.RegenerateMapReduceIndex(Directory directory, IndexDefinition indexDefinition) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 567
   at Raven.Database.Indexing.IndexStorage.TryRecoveringIndex(IndexDefinition indexDefinition, Directory luceneDirectory) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 399
   at Raven.Database.Indexing.IndexStorage.OpenIndex(String indexName, Boolean onStartup, Boolean forceFullIndexCheck) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 263
   at Raven.Database.Indexing.IndexStorage.<>c__DisplayClass14_0.<.ctor>b__0(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 156
   at Raven.Database.Indexing.DefaultBackgroundTaskExecuter.<>c__DisplayClass8_1`1.<ExecuteAllInterleaved>b__0() in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Impl\BackgroundTaskExecuter\DefaultBackgroundTaskExecuter.cs:line 153
   at System.Threading.Tasks.Task.Execute()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout)
   at System.Threading.Tasks.Task.WaitAll(Task[] tasks)
   at Raven.Database.Indexing.DefaultBackgroundTaskExecuter.ExecuteAllInterleaved[T](WorkContext context, IList`1 result, Action`1 action) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Impl\BackgroundTaskExecuter\DefaultBackgroundTaskExecuter.cs:line 166
   at Raven.Database.Indexing.IndexStorage..ctor(IndexDefinitionStorage indexDefinitionStorage, InMemoryRavenConfiguration configuration, DocumentDatabase documentDatabase) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 177
   at Raven.Database.DocumentDatabase.DocumentDatabaseInitializer.InitializeIndexStorage() in C:\Builds\RavenDB-Stable-3.5\Raven.Database\DocumentDatabase.cs:line 1514
   at Raven.Database.DocumentDatabase..ctor(InMemoryRavenConfiguration configuration, DocumentDatabase systemDatabase, TransportState recievedTransportState, Action`2 onError) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\DocumentDatabase.cs:line 220
---> (Inner Exception #0) Lucene.Net.Store.AlreadyClosedException: this Directory is closed
   at Lucene.Net.Store.Directory.EnsureOpen() in d:\Lucene.Net\FullRepo\trunk\src\core\Store\Directory.cs:line 257
   at Lucene.Net.Store.FSDirectory.get_Directory() in d:\Lucene.Net\FullRepo\trunk\src\core\Store\FSDirectory.cs:line 486
   at Raven.Database.Indexing.LuceneCodecDirectory.GetFile(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\LuceneCodecDirectory.cs:line 94
   at Raven.Database.Indexing.LuceneCodecDirectory.CreateOutput(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\LuceneCodecDirectory.cs:line 48
   at Raven.Database.Indexing.IndexStorage.WriteIndexVersion(Directory directory, IndexDefinition indexDefinition) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 644
   at Raven.Database.Indexing.IndexStorage.RegenerateMapReduceIndex(Directory directory, IndexDefinition indexDefinition) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 567
   at Raven.Database.Indexing.IndexStorage.TryRecoveringIndex(IndexDefinition indexDefinition, Directory luceneDirectory) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 399
   at Raven.Database.Indexing.IndexStorage.OpenIndex(String indexName, Boolean onStartup, Boolean forceFullIndexCheck) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 263
   at Raven.Database.Indexing.IndexStorage.<>c__DisplayClass14_0.<.ctor>b__0(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 156
   at Raven.Database.Indexing.DefaultBackgroundTaskExecuter.<>c__DisplayClass8_1`1.<ExecuteAllInterleaved>b__0() in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Impl\BackgroundTaskExecuter\DefaultBackgroundTaskExecuter.cs:line 153
   at System.Threading.Tasks.Task.Execute()<---

---> (Inner Exception #1) Lucene.Net.Store.AlreadyClosedException: this Directory is closed
   at Lucene.Net.Store.Directory.EnsureOpen() in d:\Lucene.Net\FullRepo\trunk\src\core\Store\Directory.cs:line 257
   at Lucene.Net.Store.FSDirectory.get_Directory() in d:\Lucene.Net\FullRepo\trunk\src\core\Store\FSDirectory.cs:line 486
   at Raven.Database.Indexing.LuceneCodecDirectory.GetFile(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\LuceneCodecDirectory.cs:line 94
   at Raven.Database.Indexing.LuceneCodecDirectory.CreateOutput(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\LuceneCodecDirectory.cs:line 48
   at Raven.Database.Indexing.IndexStorage.WriteIndexVersion(Directory directory, IndexDefinition indexDefinition) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 644
   at Raven.Database.Indexing.IndexStorage.RegenerateMapReduceIndex(Directory directory, IndexDefinition indexDefinition) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 567
   at Raven.Database.Indexing.IndexStorage.TryRecoveringIndex(IndexDefinition indexDefinition, Directory luceneDirectory) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 399
   at Raven.Database.Indexing.IndexStorage.OpenIndex(String indexName, Boolean onStartup, Boolean forceFullIndexCheck) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 263
   at Raven.Database.Indexing.IndexStorage.<>c__DisplayClass14_0.<.ctor>b__0(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 156
   at Raven.Database.Indexing.DefaultBackgroundTaskExecuter.<>c__DisplayClass8_1`1.<ExecuteAllInterleaved>b__0() in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Impl\BackgroundTaskExecuter\DefaultBackgroundTaskExecuter.cs:line 153
   at System.Threading.Tasks.Task.Execute()<---

---> (Inner Exception #2) Lucene.Net.Store.AlreadyClosedException: this Directory is closed
   at Lucene.Net.Store.Directory.EnsureOpen() in d:\Lucene.Net\FullRepo\trunk\src\core\Store\Directory.cs:line 257
   at Lucene.Net.Store.FSDirectory.get_Directory() in d:\Lucene.Net\FullRepo\trunk\src\core\Store\FSDirectory.cs:line 486
   at Raven.Database.Indexing.LuceneCodecDirectory.GetFile(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\LuceneCodecDirectory.cs:line 94
   at Raven.Database.Indexing.LuceneCodecDirectory.CreateOutput(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\LuceneCodecDirectory.cs:line 48
   at Raven.Database.Indexing.IndexStorage.WriteIndexVersion(Directory directory, IndexDefinition indexDefinition) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 644
   at Raven.Database.Indexing.IndexStorage.RegenerateMapReduceIndex(Directory directory, IndexDefinition indexDefinition) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 567
   at Raven.Database.Indexing.IndexStorage.TryRecoveringIndex(IndexDefinition indexDefinition, Directory luceneDirectory) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 399
   at Raven.Database.Indexing.IndexStorage.OpenIndex(String indexName, Boolean onStartup, Boolean forceFullIndexCheck) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 263
   at Raven.Database.Indexing.IndexStorage.<>c__DisplayClass14_0.<.ctor>b__0(String name) in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Indexing\IndexStorage.cs:line 156
   at Raven.Database.Indexing.DefaultBackgroundTaskExecuter.<>c__DisplayClass8_1`1.<ExecuteAllInterleaved>b__0() in C:\Builds\RavenDB-Stable-3.5\Raven.Database\Impl\BackgroundTaskExecuter\DefaultBackgroundTaskExecuter.cs:line 153
   at System.Threading.Tasks.Task.Execute()<---
```