### PR TITLE
Unable to parse the `TimeSent` metadata information resulted in InvalidCastException

### DIFF
--- a/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_message_sent_from_third_party_endpoint_with_missing_metadata_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_message_sent_from_third_party_endpoint_with_missing_metadata_failed.cs
@@ -4,7 +4,6 @@ namespace ServiceBus.Management.AcceptanceTests.MessageFailures
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Threading.Tasks;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
@@ -45,7 +44,6 @@ namespace ServiceBus.Management.AcceptanceTests.MessageFailures
         {
             FailedMessageView failure = null;
 
-            
             var sentTime = DateTime.Parse("2014-11-11T02:26:58.000462Z");
             var context = new MyContext
             {

--- a/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_message_sent_from_third_party_endpoint_with_missing_metadata_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_message_sent_from_third_party_endpoint_with_missing_metadata_failed.cs
@@ -4,6 +4,7 @@ namespace ServiceBus.Management.AcceptanceTests.MessageFailures
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Threading.Tasks;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
@@ -44,7 +45,8 @@ namespace ServiceBus.Management.AcceptanceTests.MessageFailures
         {
             FailedMessageView failure = null;
 
-            var sentTime = DateTime.Parse("2014-11-11 02:26:58:000462 Z");
+            
+            var sentTime = DateTime.Parse("2014-11-11T02:26:58.000462Z");
             var context = new MyContext
             {
                 TimeSent = sentTime

--- a/src/ServiceControl/Infrastructure/MetadataExtensions.cs
+++ b/src/ServiceControl/Infrastructure/MetadataExtensions.cs
@@ -29,11 +29,12 @@
         public static DateTime? GetAsNullableDatetime(this IDictionary<string, object> metadata, string key)
         {
             var datetimeAsString = metadata.GetAsStringOrNull(key);
-            DateTime dt;
-            if (datetimeAsString != null && DateTime.TryParse(datetimeAsString, out dt))
+
+            if (datetimeAsString != null)
             {
-                return dt;
+                return DateTime.Parse(datetimeAsString);
             }
+            
             return null;
         }
     }

--- a/src/ServiceControl/Infrastructure/MetadataExtensions.cs
+++ b/src/ServiceControl/Infrastructure/MetadataExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl
 {
+    using System;
     using System.Collections.Generic;
 
     static class MetadataExtensions
@@ -22,6 +23,17 @@
                 return foundValue?.ToString();
             }
 
+            return null;
+        }
+
+        public static DateTime? GetAsNullableDatetime(this IDictionary<string, object> metadata, string key)
+        {
+            var datetimeAsString = metadata.GetAsStringOrNull(key);
+            DateTime dt;
+            if (datetimeAsString != null && DateTime.TryParse(datetimeAsString, out dt))
+            {
+                return dt;
+            }
             return null;
         }
     }

--- a/src/ServiceControl/MessageFailures/Api/GetErrorById.cs
+++ b/src/ServiceControl/MessageFailures/Api/GetErrorById.cs
@@ -63,7 +63,7 @@
                 IsSystemMessage = metadata.GetOrDefault<bool>("IsSystemMessage"),
                 SendingEndpoint = metadata.GetOrDefault<EndpointDetails>("SendingEndpoint"),
                 ReceivingEndpoint = metadata.GetOrDefault<EndpointDetails>("ReceivingEndpoint"),
-                TimeSent = metadata.GetOrDefault<DateTime?>("TimeSent"),
+                TimeSent = metadata.GetAsNullableDatetime("TimeSent"),
                 MessageId = metadata.GetAsStringOrNull("MessageId"),
                 Exception = failureDetails.Exception,
                 QueueAddress = failureDetails.AddressOfFailingEndpoint,


### PR DESCRIPTION
As part of #1119 a regression was introduced that makes ServiceControl unable to parse the `TimeSent` metadata information

## Who's affected

All customers

## Stacktrace

```
2018-04-13 08:29:47.3031|76|Error|ServiceBus.Management.Infrastructure.Nancy.NServiceBusContainerBootstrapper|Http call failed
System.InvalidCastException: Specified cast is not valid.
at ServiceControl.MetadataExtensions.GetOrDefault[T](IDictionary`2 metadata, String key) in C:\sources\ServiceControl\src\ServiceControl\Infrastructure\MetadataExtensions.cs:line 12
at ServiceControl.MessageFailures.Api.GetErrorById.Map(FailedMessage message, IAsyncDocumentSession session) in C:\sources\ServiceControl\src\ServiceControl\MessageFailures\Api\GetErrorById.cs:line 59
at ServiceControl.MessageFailures.Api.GetErrorById.<<-ctor>b__0_1>d.MoveNext() in C:\sources\ServiceControl\src\ServiceControl\MessageFailures\Api\GetErrorById.cs:line 44
```