### PR TITLE
Updating Sc.Monitroing refs to 1.2.0

### DIFF
--- a/src/ServiceControlInstaller.Engine/packages.config
+++ b/src/ServiceControlInstaller.Engine/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="DotNetZip" version="1.9.8" targetFramework="net40" />
   <package id="GitVersionTask" version="3.6.5" targetFramework="net40" developmentDependency="true" />
-  <package id="Packaging.ServiceControl.Monitoring" version="1.1.3" targetFramework="net40" />
+  <package id="Packaging.ServiceControl.Monitoring" version="1.2.0" targetFramework="net40" />
   <package id="Particular.Licensing.Sources" version="1.0.0" targetFramework="net40" />
 </packages>

--- a/src/ServiceControlInstaller.Engine/packages.config
+++ b/src/ServiceControlInstaller.Engine/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="DotNetZip" version="1.9.8" targetFramework="net40" />
   <package id="GitVersionTask" version="3.6.5" targetFramework="net40" developmentDependency="true" />
-  <package id="Packaging.ServiceControl.Monitoring" version="1.2.0" targetFramework="net40" />
+  <package id="Packaging.ServiceControl.Monitoring" version="1.2.1" targetFramework="net40" />
   <package id="Particular.Licensing.Sources" version="1.0.0" targetFramework="net40" />
 </packages>

--- a/src/ServiceControlInstaller.Packaging/packages.config
+++ b/src/ServiceControlInstaller.Packaging/packages.config
@@ -11,7 +11,7 @@
   <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="6.2.2" targetFramework="net452" />
   <package id="NServiceBus.RabbitMQ" version="3.5.1" targetFramework="net452" />
   <package id="NServiceBus.SqlServer" version="2.2.5" targetFramework="net452" />
-  <package id="Packaging.ServiceControl.Monitoring" version="1.2.0" targetFramework="net452" />
+  <package id="Packaging.ServiceControl.Monitoring" version="1.2.1" targetFramework="net452" />
   <package id="RabbitMQ.Client" version="4.1.0" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="2.8.2" targetFramework="net452" />

--- a/src/ServiceControlInstaller.Packaging/packages.config
+++ b/src/ServiceControlInstaller.Packaging/packages.config
@@ -11,7 +11,7 @@
   <package id="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" version="6.2.2" targetFramework="net452" />
   <package id="NServiceBus.RabbitMQ" version="3.5.1" targetFramework="net452" />
   <package id="NServiceBus.SqlServer" version="2.2.5" targetFramework="net452" />
-  <package id="Packaging.ServiceControl.Monitoring" version="1.1.3" targetFramework="net452" />
+  <package id="Packaging.ServiceControl.Monitoring" version="1.2.0" targetFramework="net452" />
   <package id="RabbitMQ.Client" version="4.1.0" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="2.8.2" targetFramework="net452" />


### PR DESCRIPTION
This is updating sc.monitoring refs to version supporting native queue length.