### PR TITLE
Load ravenstudio directly to system DB

### DIFF
--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -114,7 +114,7 @@ namespace ServiceControlInstaller.Engine.Instances
                         host = HostName;
                         break;
                 }
-                return $"http://{host}:{DatabaseMaintenancePort}/";
+                return $"http://{host}:{DatabaseMaintenancePort}/studio/index.html#databases/documents?&database=%3Csystem%3E";
             }
         }
 


### PR DESCRIPTION
In Raven35 with embedded databases, the form shows no databases as it treats the embedded DB as the system DB. This changes the url that opens to be one that navigates directly to the system DB. The user is presented with a warning that tampering with the system DB is dangerous.