### PR TITLE
Track migration through restarts

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
@@ -72,31 +72,43 @@
                        Text="MONITORING INSTANCE" />
 
         </StackPanel>
-        <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="0 0 0 10">
-            <ContentControl Margin="0,0,0,0"
-                            VerticalAlignment="Center"
-                            Template="{StaticResource RunningIcon}"
-                            Visibility="{Binding IsRunning,
+        <StackPanel Grid.Row="2" Grid.Column="1" Margin="0 0 0 10">
+            <StackPanel Orientation="Horizontal">
+                <ContentControl Margin="0,0,0,0"
+                                VerticalAlignment="Center"
+                                Template="{StaticResource RunningIcon}"
+                                Visibility="{Binding IsRunning,
                                                  Converter={StaticResource boolToVis}}" />
 
-            <ContentControl Margin="0,0,0,0"
-                            VerticalAlignment="Center"
-                            Template="{StaticResource StoppedIcon}"
-                            Visibility="{Binding IsStopped,
+                <ContentControl Margin="0,0,0,0"
+                                VerticalAlignment="Center"
+                                Template="{StaticResource StoppedIcon}"
+                                Visibility="{Binding IsStopped,
                                                  Converter={StaticResource boolToVis}}" />
+
+                <TextBlock Margin="3,0,0,0"
+                           VerticalAlignment="Center"
+                           FontSize="13px"
+                           Foreground="{StaticResource Gray40Brush}"
+                           Text="{Binding Status}" />
+
+                <TextBlock  Margin="3,0,0,0" 
+                            VerticalAlignment="Center"  
+                            FontSize="13px"
+                            Visibility="{Binding InMaintenanceMode, Converter={StaticResource boolToVis}}"
+                >
+                    <Hyperlink Foreground="DarkOrange" Command="{Binding AdvancedOptionsCommand}" CommandParameter="{Binding DataContext, ElementName=root}">IN MAINTENANCE MODE</Hyperlink>
+                </TextBlock>
+
+            </StackPanel>
 
             <TextBlock Margin="3,0,0,0"
                        VerticalAlignment="Center"
                        FontSize="13px"
-                       Foreground="{StaticResource Gray40Brush}"
-                       Text="{Binding Status}" />
-
-            <TextBlock  Margin="3,0,0,0" 
-                        VerticalAlignment="Center"  
-                        FontSize="13px"
-                        Visibility="{Binding InMaintenanceMode, Converter={StaticResource boolToVis}}">
-                <Hyperlink Foreground="DarkOrange" Command="{Binding AdvancedOptionsCommand}" CommandParameter="{Binding DataContext, ElementName=root}">IN MAINTENANCE MODE</Hyperlink>
-            </TextBlock>
+                       Foreground="{StaticResource Gray60Brush}"
+                       Text="• UPDATING DATA STORE" 
+                       Visibility="{Binding IsUpdatingDataStore, Converter={StaticResource boolToVis}}"
+                       />
         </StackPanel>
 
         <StackPanel Grid.Row="1"

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
@@ -92,6 +92,8 @@
 
         public string Transport => ((ITransportConfig) ServiceInstance).TransportPackage;
 
+        public bool IsUpdatingDataStore => ServiceControlInstance?.IsUpdatingDataStore ?? false;
+
         public string Status
         {
             get
@@ -274,7 +276,7 @@
 
         void UpdateServiceProperties()
         {
-            ServiceInstance.Service.Refresh();
+            ServiceInstance.RefreshServiceProperties();
 
             NotifyOfPropertyChange("Status");
             NotifyOfPropertyChange("AllowStop");
@@ -282,6 +284,7 @@
             NotifyOfPropertyChange("IsRunning");
             NotifyOfPropertyChange("IsStopped");
             NotifyOfPropertyChange("InMaintenanceMode");
+            NotifyOfPropertyChange("IsUpdatingDataStore");
         }
     }
 }

--- a/src/ServiceControl/DatabaseMigrationsBootstrapper.cs
+++ b/src/ServiceControl/DatabaseMigrationsBootstrapper.cs
@@ -1,6 +1,7 @@
 namespace Particular.ServiceControl
 {
     using Autofac;
+    using global::ServiceControl.Infrastructure;
     using global::ServiceControl.Infrastructure.RavenDB;
     using Particular.ServiceControl.DbMigrations;
     using Raven.Client;
@@ -21,10 +22,12 @@ namespace Particular.ServiceControl
             containerBuilder.RegisterInstance(settings);
             containerBuilder.RegisterModule<MigrationsModule>();
 
+            var markerFileService = new MarkerFileService(loggingSettings.LogPath);
+
             using (documentStore)
             using (var container = containerBuilder.Build())
             {
-                new RavenBootstrapper().StartRaven(documentStore, settings, true);
+                new RavenBootstrapper().StartRaven(documentStore, settings, markerFileService, true);
                 container.Resolve<MigrationsManager>().ApplyMigrations();
             }
         }

--- a/src/ServiceControl/Infrastructure/MarkerFile.cs
+++ b/src/ServiceControl/Infrastructure/MarkerFile.cs
@@ -1,0 +1,45 @@
+﻿namespace ServiceControl.Infrastructure
+{
+    using System;
+    using System.IO;
+
+    public class MarkerFileService
+    {
+        private string rootPath;
+        public MarkerFileService(string rootPath)
+        {
+            this.rootPath = rootPath;
+        }
+
+        public IDisposable CreateMarker(string name)
+        {
+            var path = Path.Combine(rootPath, name);
+            using (File.Open(path, FileMode.OpenOrCreate))
+            {
+                return new MarkerFile(path);
+            }
+        }
+
+        class MarkerFile : IDisposable
+        {
+            private string fileName;
+
+            public MarkerFile(string fileName)
+            {
+                this.fileName = fileName;
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    File.Delete(fileName);
+                }
+                catch (IOException)
+                {
+
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
@@ -8,6 +8,7 @@ namespace ServiceBus.Management.Infrastructure
     using NServiceBus.Features;
     using NServiceBus.Logging;
     using Raven.Client;
+    using ServiceBus.Management.Infrastructure.Settings;
     using ServiceControl.Infrastructure;
     using ServiceControl.Infrastructure.DomainEvents;
 
@@ -24,6 +25,7 @@ namespace ServiceBus.Management.Infrastructure
             // HACK: Yes I know, I am hacking it to pass it to RavenBootstrapper!
             configuration.GetSettings().Set("ServiceControl.EmbeddableDocumentStore", documentStore);
             configuration.GetSettings().Set("ServiceControl.Settings", settings);
+            configuration.GetSettings().Set("ServiceControl.MarkerFileService", new MarkerFileService(new LoggingSettings(settings.ServiceName).LogPath));
 
             // Disable Auditing for the service control endpoint
             configuration.DisableFeature<Audit>();

--- a/src/ServiceControl/MaintenanceBootstrapper.cs
+++ b/src/ServiceControl/MaintenanceBootstrapper.cs
@@ -1,6 +1,7 @@
 namespace Particular.ServiceControl
 {
     using System;
+    using global::ServiceControl.Infrastructure;
     using global::ServiceControl.Infrastructure.RavenDB;
     using Particular.ServiceControl.Hosting;
     using Raven.Client.Embedded;
@@ -12,8 +13,9 @@ namespace Particular.ServiceControl
         {
             var settings = new Settings(args.ServiceName);
             var documentStore = new EmbeddableDocumentStore();
+            var markerFileService = new MarkerFileService(new LoggingSettings(settings.ServiceName).LogPath);
 
-            new RavenBootstrapper().StartRaven(documentStore, settings, true);
+            new RavenBootstrapper().StartRaven(documentStore, settings, markerFileService, true);
 
             if (Environment.UserInteractive)
             {

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -314,6 +314,7 @@
     <Compile Include="Infrastructure\DomainEvents\IDomainEvent.cs" />
     <Compile Include="Infrastructure\DomainEvents\IDomainEvents.cs" />
     <Compile Include="Infrastructure\DomainEvents\IDomainHandler.cs" />
+    <Compile Include="Infrastructure\MarkerFile.cs" />
     <Compile Include="Infrastructure\RavenDB\Extensions.cs" />
     <Compile Include="Infrastructure\SignalR\IUserInterfaceEvent.cs" />
     <Compile Include="Infrastructure\SignalR\ServicePulseNotifier.cs" />

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -131,5 +131,10 @@
                 return new Version(0, 0, 0);
             }
         }
+
+        public virtual void RefreshServiceProperties()
+        {
+            Service.Refresh();
+        }
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -38,6 +38,7 @@ namespace ServiceControlInstaller.Engine.Instances
         public string ConnectionString { get; set; }
         public TimeSpan ErrorRetentionPeriod { get; set; }
         public TimeSpan AuditRetentionPeriod { get; set; }
+        public bool IsUpdatingDataStore { get; set; }
         public bool InMaintenanceMode { get; set; }
         public bool SkipQueueCreation { get; set; }
         public AppConfig AppConfig;
@@ -82,6 +83,19 @@ namespace ServiceControlInstaller.Engine.Instances
             {
                 AuditRetentionPeriod = auditRetentionPeriod;
             }
+
+            UpdateDataMigrationMarker();
+        }
+
+        private void UpdateDataMigrationMarker()
+        {
+            IsUpdatingDataStore = File.Exists(Path.Combine(LogPath, "datamigration.marker"));
+        }
+
+        public override void RefreshServiceProperties()
+        {
+            base.RefreshServiceProperties();
+            UpdateDataMigrationMarker();
         }
 
         public string Url

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlNewInstance.cs
@@ -47,6 +47,8 @@ namespace ServiceControlInstaller.Engine.Instances
         public string DisplayName { get; set; }
         public string ServiceDescription { get; set; }
         public bool SkipQueueCreation { get; set; }
+        public bool IsUpdatingDataStore { get; set; }
+
 
         [XmlIgnore]
         public Version Version { get; set; }

--- a/src/ServiceControlInstaller.Engine/Interfaces.cs
+++ b/src/ServiceControlInstaller.Engine/Interfaces.cs
@@ -80,5 +80,6 @@
         bool ForwardErrorMessages { get; }
         TimeSpan AuditRetentionPeriod { get; }
         TimeSpan ErrorRetentionPeriod { get; }
+        bool IsUpdatingDataStore { get; set; }
     }
 }


### PR DESCRIPTION
Tracks migrations though restarts. If the SCMU stops and restarts during the upgrade process, this will display a label next to the instance showing that it is going through data migration. 