### PR TITLE
Update base instance from vm

### DIFF
--- a/src/ServiceControl.Config/Commands/EditServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/EditServiceControlInstanceCommand.cs
@@ -1,21 +1,25 @@
 namespace ServiceControl.Config.Commands
 {
     using System;
+    using Caliburn.Micro;
+    using ServiceControl.Config.Events;
     using ServiceControl.Config.Framework;
     using ServiceControl.Config.Framework.Commands;
     using ServiceControl.Config.UI.InstanceDetails;
     using ServiceControl.Config.UI.InstanceEdit;
     using ServiceControlInstaller.Engine.Instances;
-    
+
     class EditServiceControlInstanceCommand : AbstractCommand<InstanceDetailsViewModel>
     {
         private readonly Func<ServiceControlInstance, ServiceControlEditViewModel> editViewModel;
+        private readonly IEventAggregator eventAggregator;
         private readonly IWindowManagerEx windowManager;
 
-        public EditServiceControlInstanceCommand(IWindowManagerEx windowManager, Func<ServiceControlInstance, ServiceControlEditViewModel> editViewModel) : base(null)
+        public EditServiceControlInstanceCommand(IWindowManagerEx windowManager, Func<ServiceControlInstance, ServiceControlEditViewModel> editViewModel, IEventAggregator eventAggregator) : base(null)
         {
             this.windowManager = windowManager;
             this.editViewModel = editViewModel;
+            this.eventAggregator = eventAggregator;
         }
 
         public override void Execute(InstanceDetailsViewModel viewModel)
@@ -23,6 +27,10 @@ namespace ServiceControl.Config.Commands
             var editVM = editViewModel((ServiceControlInstance)viewModel.ServiceInstance);
 
             windowManager.ShowInnerDialog(editVM);
+
+            editVM.UpdateInstanceFromViewModel((ServiceControlInstance)viewModel.ServiceInstance);
+
+            eventAggregator.PublishOnUIThread(new RefreshInstances());
         }
     }
 }

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
@@ -74,8 +74,6 @@
 
         public string BrowsableUrl => ((IURLInfo)ServiceInstance).BrowsableUrl;
         
-        //public string StorageUrl => ServiceControlInstance?.StorageUrl;
-
         public string InstallPath => ((IServicePaths)ServiceInstance).InstallPath;
 
         public string DBPath => ServiceControlInstance?.DBPath;
@@ -209,6 +207,7 @@
             NotifyOfPropertyChange("HasNewVersion");
             NotifyOfPropertyChange("Transport");
             NotifyOfPropertyChange("BrowsableUrl");
+            NotifyOfPropertyChange("InMaintenanceMode");
             NotifyOfPropertyChange("InMaintenanceMode");
         }
 

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
@@ -207,8 +207,6 @@
             NotifyOfPropertyChange("HasNewVersion");
             NotifyOfPropertyChange("Transport");
             NotifyOfPropertyChange("BrowsableUrl");
-            NotifyOfPropertyChange("InMaintenanceMode");
-            NotifyOfPropertyChange("InMaintenanceMode");
         }
 
         public async Task<bool> StartService(IProgressObject progress = null)

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditAttachment.cs
@@ -100,8 +100,6 @@ namespace ServiceControl.Config.UI.InstanceEdit
             }
 
             viewModel.TryClose(true);
-
-            eventAggregator.PublishOnUIThread(new RefreshInstances());
         }
     }
 }

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModel.cs
@@ -59,6 +59,19 @@
             RetentionPeriodsVisible = instance.Version >= SettingsList.ErrorRetentionPeriod.SupportedFrom;
         }
 
+        public void UpdateInstanceFromViewModel(ServiceControlInstance instance)
+        {
+            instance.HostName = HostName;
+            instance.Port = Convert.ToInt32(PortNumber);
+            instance.DatabaseMaintenancePort = Convert.ToInt32(DatabaseMaintenancePortNumber);
+            instance.LogPath = LogPath;
+            instance.AuditLogQueue = AuditForwardingQueueName;
+            instance.AuditQueue = AuditQueueName;
+            instance.ErrorQueue = ErrorQueueName;
+            instance.ErrorLogQueue = ErrorForwardingQueueName;
+            instance.ConnectionString = ConnectionString;
+        }
+
         public bool ErrorForwardingVisible { get; set; }
         public bool RetentionPeriodsVisible { get; set; }
 


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceControl/issues/1165

Updates the service instance from the edited viewmodel details and only after updating those properties does it publish the `RefreshInstances` command, this ensures that the UI is updated only after the new properties have been applied