### PR TITLE
Reload config before maintainence mode changes

### DIFF
--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -464,11 +464,14 @@ namespace ServiceControlInstaller.Engine.Instances
 
         public void DisableMaintenanceMode()
         {
+            AppConfig = new AppConfig(this);
             AppConfig.DisableMaintenanceMode();
             InMaintenanceMode = false;
         }
+
         public void EnableMaintenanceMode()
         {
+            AppConfig = new AppConfig(this);
             AppConfig.EnableMaintenanceMode();
             InMaintenanceMode = true;
         }


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceControl/issues/1166

Reloads the app.config setting before trying to change into and out of maintenance mode