### PR TITLE
Allow disabling both error and audit

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
@@ -59,7 +59,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
                 .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
                 .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted);
+                .When(x => x.SubmitAttempted && x.ErrorQueueName != "!disable");
 
             RuleFor(x => x.ErrorForwardingQueueName)
                 .NotEmpty()
@@ -75,7 +75,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
                 .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
                 .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted);
+                .When(x => x.SubmitAttempted && x.AuditQueueName != "!disable");
 
             RuleFor(x => x.AuditForwardingQueueName)
                 .NotEmpty()

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
@@ -55,9 +55,9 @@ namespace ServiceControl.Config.UI.InstanceAdd
 
             RuleFor(x => x.ErrorQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit")
-                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Error Forwarding")
-                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit Forwarding")
+                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
+                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
                 .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
                 .When(x => x.SubmitAttempted);
 

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModelValidator.cs
@@ -26,7 +26,7 @@ namespace ServiceControl.Config.UI.InstanceEdit
                 .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
                 .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
                 .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted);
+                .When(x => x.SubmitAttempted && x.ErrorQueueName != "!disable");
 
             RuleFor(x => x.ErrorForwardingQueueName)
                 .NotEmpty()
@@ -42,7 +42,7 @@ namespace ServiceControl.Config.UI.InstanceEdit
                 .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
                 .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
                 .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted);
+                .When(x => x.SubmitAttempted && x.AuditQueueName != "!disable");
 
             RuleFor(x => x.AuditForwardingQueueName)
                 .NotEmpty()

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModelValidator.cs
@@ -22,9 +22,9 @@ namespace ServiceControl.Config.UI.InstanceEdit
 
             RuleFor(x => x.ErrorQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit")
-                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Error Forwarding")
-                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit Forwarding")
+                .NotEqual(x => x.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .NotEqual(x => x.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
+                .NotEqual(x => x.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
                 .MustNotBeIn(x => UsedQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
                 .When(x => x.SubmitAttempted);
 

--- a/src/ServiceControlInstaller.Engine/Validation/ServiceControlQueueNameValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/ServiceControlQueueNameValidator.cs
@@ -87,7 +87,10 @@
 
         internal void CheckQueueNamesAreUniqueWithinInstance()
         {
-            if (queues.Select(p => p.QueueName.ToLower()).Distinct().Count() != queues.Count)
+            var duplicatedQueues = queues.ToLookup(x => x.QueueName.ToLower())
+                .Where(x => x.Key != "!disable" && x.Key != "!disable.log" && x.Count() > 1);
+
+            if (duplicatedQueues.Any())
             {
                 throw new EngineValidationException("Each of the queue names specified for a instance should be unique");
             }


### PR DESCRIPTION
It was not possible to set both error and audit input queues to the special value `!disable`.

![image](https://user-images.githubusercontent.com/124014/41211434-effd9cfa-6d69-11e8-9033-f833a8558093.png)

Additionally, the error message provided for the error queue was wrong.

Fixes #1173 
Fixes #1174