### PR TITLE
A few more OpenSession turned into OpenSessionAsync

### DIFF
--- a/src/ServiceControl/DbMigrations/1.41.3/AddEndpontDetailsClassifiers.cs
+++ b/src/ServiceControl/DbMigrations/1.41.3/AddEndpontDetailsClassifiers.cs
@@ -17,7 +17,7 @@
         {
             var reclassifier = new Reclassifier(null);
 
-            var failedMessagesReclassified = reclassifier.ReclassifyFailedMessages(store, true, classifiers);
+            var failedMessagesReclassified = reclassifier.ReclassifyFailedMessages(store, true, classifiers).GetAwaiter().GetResult();
 
             return $"Reclassified {failedMessagesReclassified} messages";
         }

--- a/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
+++ b/src/ServiceControl/Operations/FailedAuditImportCustomCheck.cs
@@ -4,6 +4,7 @@
     using NServiceBus.Logging;
     using Raven.Client;
     using System;
+    using System.Threading.Tasks;
 
     class FailedAuditImportCustomCheck : CustomCheck
     {
@@ -15,12 +16,18 @@
 
         public override CheckResult PerformCheck()
         {
-            using (var session = store.OpenSession())
+            return PerformCheckAsync().GetAwaiter().GetResult();
+        }
+
+        private async Task<CheckResult> PerformCheckAsync()
+        {
+            using (var session = store.OpenAsyncSession())
             {
                 var query = session.Query<FailedAuditImport, FailedAuditImportIndex>();
-                using (var ie = session.Advanced.Stream(query))
+                using (var ie = await session.Advanced.StreamAsync(query)
+                    .ConfigureAwait(false))
                 {
-                    if (ie.MoveNext())
+                    if (await ie.MoveNextAsync().ConfigureAwait(false))
                     {
                         var message = @"One or more audit messages have failed to import properly into ServiceControl and have been stored in the ServiceControl database.
 The import of these messages could have failed for a number of reasons and ServiceControl is not able to automatically reimport them. For guidance on how to resolve this see https://docs.particular.net/servicecontrol/import-failed-audit-messages";

--- a/src/ServiceControl/Recoverability/Grouping/Groupers/ReclassifyErrorsHandler.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/ReclassifyErrorsHandler.cs
@@ -44,7 +44,8 @@ namespace ServiceControl.Recoverability
 
             try
             {
-                var failedMessagesReclassified = reclassifier.ReclassifyFailedMessages(store, message.Force, classifiers);
+                var failedMessagesReclassified = await reclassifier.ReclassifyFailedMessages(store, message.Force, classifiers)
+                    .ConfigureAwait(false);
 
                 if (failedMessagesReclassified > 0)
                 {

--- a/src/ServiceControl/Recoverability/Retrying/RetriesGateway.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetriesGateway.cs
@@ -24,6 +24,7 @@ namespace ServiceControl.Recoverability
         private RetryDocumentManager retryDocumentManager;
         public RetryingManager OperationManager { get; set; }
         private ConcurrentQueue<IBulkRetryRequest> bulkRequests = new ConcurrentQueue<IBulkRetryRequest>();
+
         public RetriesGateway(IDocumentStore store, RetryDocumentManager documentManager)
         {
             this.store = store;
@@ -135,7 +136,7 @@ namespace ServiceControl.Recoverability
 
             await OperationManager.Prepairing(requestId, retryType, numberOfMessages)
                 .ConfigureAwait(false);
-            await StageRetryByUniqueMessageIds(requestId, retryType, new[] { uniqueMessageId }, DateTime.UtcNow)
+            await StageRetryByUniqueMessageIds(requestId, retryType, new[] {uniqueMessageId}, DateTime.UtcNow)
                 .ConfigureAwait(false);
             await OperationManager.PreparedBatch(requestId, retryType, numberOfMessages)
                 .ConfigureAwait(false);
@@ -167,7 +168,8 @@ namespace ServiceControl.Recoverability
 
             var failedMessageRetryIds = messageIds.Select(FailedMessageRetry.MakeDocumentId).ToArray();
 
-            var batchDocumentId = retryDocumentManager.CreateBatchDocument(requestId, retryType, failedMessageRetryIds, originator, startTime, last, batchName, classifier);
+            var batchDocumentId = await retryDocumentManager.CreateBatchDocument(requestId, retryType, failedMessageRetryIds, originator, startTime, last, batchName, classifier)
+                .ConfigureAwait(false);
 
             log.InfoFormat("Created Batch '{0}' with {1} messages for '{2}'", batchDocumentId, messageIds.Length, batchName);
 

--- a/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
+++ b/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using EndpointPlugin.Messages.SagaState;
     using NServiceBus;
     using Raven.Client;
@@ -16,6 +17,11 @@
         }
 
         public void Handle(SagaUpdatedMessage message)
+        {
+            HandleAsync(message).GetAwaiter().GetResult();
+        }
+
+        private async Task HandleAsync(SagaUpdatedMessage message)
         {
             var sagaHistory = new SagaSnapshot
             {
@@ -46,10 +52,10 @@
 
             AddResultingMessages(message.ResultingMessages, sagaHistory);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(sagaHistory);
-                session.SaveChanges();
+                await session.StoreAsync(sagaHistory).ConfigureAwait(false);
+                await session.SaveChangesAsync().ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
This does not replace all `OpenSession` call with `OpenSessionAsync` some are still used in the migration process and in the tests where it makes sense