### PR TITLE
Avoid subscription versioning

### DIFF
--- a/src/ServiceControl.UnitTests/Infrastructure/RavenDB/SubscriptionPersisterTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/RavenDB/SubscriptionPersisterTests.cs
@@ -1,0 +1,71 @@
+﻿namespace ServiceControl.UnitTests.Infrastructure.RavenDB
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Settings;
+    using NServiceBus.Unicast.Subscriptions;
+    using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+    using Raven.Client;
+    using ServiceControl.Infrastructure.RavenDB.Subscriptions;
+
+    [TestFixture]
+    public class SubscriptionPersisterTests
+    {
+        [Test]
+        public async Task ShouldReturnSubscriptionsForOlderVersionsOfSameMessageType()
+        {
+            var settings = new SettingsHolder();
+            var subscriptionPersister = new SubscriptionPersister(documentStore, settings, "NServiceBus.Routing.EndpointName", "TestEndpoint", new MessageType[0]);
+
+            var v1MessageType = new MessageType(typeof(SampleMessageType).FullName, new Version(1, 0, 0));
+            var v2MessageType = new MessageType(typeof(SampleMessageType).FullName, new Version(2, 0, 0));
+            var v1Subscriber = new Subscriber("V1SubscriberAddress", "V1Subscriber");
+
+            await subscriptionPersister.Subscribe(v1Subscriber, v1MessageType, new ContextBag());
+
+            var foundSubscriptions = await subscriptionPersister.GetSubscriberAddressesForMessage(new[] {v2MessageType}, new ContextBag());
+
+            var foundSubscriber = foundSubscriptions.Single();
+            Assert.AreEqual(v1Subscriber.Endpoint, foundSubscriber.Endpoint);
+            Assert.AreEqual(v1Subscriber.TransportAddress, foundSubscriber.TransportAddress);
+        }
+
+        [Test]
+        public async Task ShouldReturnSubscriptionsForNewerVersionsOfSameMessageType()
+        {
+            var settings = new SettingsHolder();
+            var subscriptionPersister = new SubscriptionPersister(documentStore, settings, "NServiceBus.Routing.EndpointName", "TestEndpoint", new MessageType[0]);
+
+            var v1MessageType = new MessageType(typeof(SampleMessageType).FullName, new Version(1, 0, 0));
+            var v2MessageType = new MessageType(typeof(SampleMessageType).FullName, new Version(2, 0, 0));
+            var v2Subscriber = new Subscriber("V2SubscriberAddress", "V2Subscriber");
+
+            await subscriptionPersister.Subscribe(v2Subscriber, v2MessageType, new ContextBag());
+
+            var foundSubscriptions = await subscriptionPersister.GetSubscriberAddressesForMessage(new[] { v1MessageType }, new ContextBag());
+
+            var foundSubscriber = foundSubscriptions.Single();
+            Assert.AreEqual(v2Subscriber.Endpoint, foundSubscriber.Endpoint);
+            Assert.AreEqual(v2Subscriber.TransportAddress, foundSubscriber.TransportAddress);
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            documentStore = InMemoryStoreBuilder.GetInMemoryStore();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            documentStore.Dispose();
+        }
+
+        IDocumentStore documentStore;
+    }
+
+    public class SampleMessageType { }
+}

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Infrastructure\PreventReindexing.cs" />
     <Compile Include="Infrastructure\RavenDB\Indexes\InMemoryStoreBuilder.cs" />
     <Compile Include="Infrastructure\RavenDB\RavenBootstrapperTests.cs" />
+    <Compile Include="Infrastructure\RavenDB\SubscriptionPersisterTests.cs" />
     <Compile Include="Infrastructure\SerializationTests.cs" />
     <Compile Include="Infrastructure\Settings\SettingsTests.cs" />
     <Compile Include="MessageExtensions.cs" />

--- a/src/ServiceControl/Infrastructure/RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -47,9 +47,6 @@
 
         public async Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context)
         {
-            // Use same MessageType version across all messages to ensure backward compatibility
-            messageType = new MessageType(messageType.TypeName, StableSubscriptionMessageVersion);
-
             if (subscriber.Endpoint == localClient.Endpoint)
             {
                 return;
@@ -213,8 +210,6 @@
 
         public async Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context)
         {
-            // Use same MessageType version across all messages to ensure backward compatibility
-            messageType = new MessageType(messageType.TypeName, StableSubscriptionMessageVersion);
             try
             {
                 await subscriptionsLock.WaitAsync().ConfigureAwait(false);
@@ -243,8 +238,6 @@
 
         public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context)
         {
-            // Use same MessageType version across all messages to ensure backward compatibility
-            messageTypes = messageTypes.Select(m => new MessageType(m.TypeName, StableSubscriptionMessageVersion));
             return Task.FromResult(messageTypes.SelectMany(x => subscriptionsLookup[x]).Distinct());
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -240,8 +240,6 @@
         {
             return Task.FromResult(messageTypes.SelectMany(x => subscriptionsLookup[x]).Distinct());
         }
-
-        private static readonly Version StableSubscriptionMessageVersion = new Version(1, 0, 0);
     }
 
     class Subscriptions

--- a/src/ServiceControl/Infrastructure/RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -25,16 +25,21 @@
 
         private SemaphoreSlim subscriptionsLock = new SemaphoreSlim(1);
 
-        public SubscriptionPersister(IDocumentStore store, ReadOnlySettings settings)
+        public SubscriptionPersister(IDocumentStore store, ReadOnlySettings settings) : 
+            this(store, settings, settings.EndpointName(), settings.LocalAddress(), settings.GetAvailableTypes().Implementing<IEvent>().Select(e => new MessageType(e)).ToArray())
+        {
+        }
+
+        public SubscriptionPersister(IDocumentStore store, ReadOnlySettings settings, string endpointName, string localAddress, MessageType[] locallyHandledEventTypes)
         {
             this.store = store;
             localClient = new SubscriptionClient()
             {
-                Endpoint = settings.EndpointName(),
-                TransportAddress = settings.LocalAddress()
+                Endpoint = endpointName,
+                TransportAddress = localAddress
             };
 
-            locallyHandledEventTypes = settings.GetAvailableTypes().Implementing<IEvent>().Select(e => new MessageType(e)).ToArray();
+            this.locallyHandledEventTypes = locallyHandledEventTypes;
 
 
             SetSubscriptions(new Subscriptions()).GetAwaiter().GetResult();

--- a/src/ServiceControl/Infrastructure/RavenDB/Subscriptions/SubscriptionPersister.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Subscriptions/SubscriptionPersister.cs
@@ -42,6 +42,9 @@
 
         public async Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context)
         {
+            // Use same MessageType version across all messages to ensure backward compatibility
+            messageType = new MessageType(messageType.TypeName, StableSubscriptionMessageVersion);
+
             if (subscriber.Endpoint == localClient.Endpoint)
             {
                 return;
@@ -205,6 +208,8 @@
 
         public async Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context)
         {
+            // Use same MessageType version across all messages to ensure backward compatibility
+            messageType = new MessageType(messageType.TypeName, StableSubscriptionMessageVersion);
             try
             {
                 await subscriptionsLock.WaitAsync().ConfigureAwait(false);
@@ -233,8 +238,12 @@
 
         public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context)
         {
+            // Use same MessageType version across all messages to ensure backward compatibility
+            messageTypes = messageTypes.Select(m => new MessageType(m.TypeName, StableSubscriptionMessageVersion));
             return Task.FromResult(messageTypes.SelectMany(x => subscriptionsLookup[x]).Distinct());
         }
+
+        private static readonly Version StableSubscriptionMessageVersion = new Version(1, 0, 0);
     }
 
     class Subscriptions


### PR DESCRIPTION
Newer versions of subscription storages and broker based transport no longer use subscription versioning. Using subscription versioning, this would not publish events to subscriber running on an older SC instance (major version) than the publisher as the custom persister uses basically RavenDB persistence's old subscription versioning logic.

This PR adds a hack to always set the `MessageType` version to `1.0.0`. This allows older SC instances still receiving events declared in the SC dll across major versions.

This should be tested somehow but I'm not sure how to setup such a scenario. Maybe @WilliamBZA can help with that?