### PR TITLE
update transport names for IgnoreTransports attribute

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_is_retried_with_a_replyTo_header.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_is_retried_with_a_replyTo_header.cs
@@ -16,7 +16,12 @@
     public class When_a_message_is_retried_with_a_replyTo_header : AcceptanceTest
     {
         // TODO: Add these transports back if/when then are updated to match this behavior
-        [Test, IgnoreTransports("AzureServiceBus", "AzureStorageQueues", "RabbitMq")]
+        [Test, IgnoreTransports(
+             "AzureServiceBus - Endpoint Topology", 
+             "AzureServiceBus - Forwarding Topology", 
+             "AzureStorageQueues", 
+             "RabbitMq - Conventional Routing Topology",
+             "RabbitMq - Direct Routing Topology")]
         public async Task The_header_should_not_be_changed()
         {
             var context = await Define<ReplyToContext>(ctx => { ctx.ReplyToAddress = "ReplyToAddress@SOMEMACHINE"; })

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_is_retried_with_a_replyTo_header.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_is_retried_with_a_replyTo_header.cs
@@ -15,13 +15,7 @@
 
     public class When_a_message_is_retried_with_a_replyTo_header : AcceptanceTest
     {
-        // TODO: Add these transports back if/when then are updated to match this behavior
-        [Test, IgnoreTransports(
-             "AzureServiceBus - Endpoint Topology", 
-             "AzureServiceBus - Forwarding Topology", 
-             "AzureStorageQueues", 
-             "RabbitMq - Conventional Routing Topology",
-             "RabbitMq - Direct Routing Topology")]
+        [Test]
         public async Task The_header_should_not_be_changed()
         {
             var context = await Define<ReplyToContext>(ctx => { ctx.ReplyToAddress = "ReplyToAddress@SOMEMACHINE"; })


### PR DESCRIPTION
not sure whether all transport topologies are affected by this, maybe @Particular/rabbitmq-transport-maintainers and @Particular/azure-maintainers can confirm this?