### PR TITLE
Cleanup ServiceControl.Recoverability namespace

### DIFF
--- a/src/ServiceControl/Recoverability/API/FailureGroupsArchiveApi.cs
+++ b/src/ServiceControl/Recoverability/API/FailureGroupsArchiveApi.cs
@@ -34,7 +34,7 @@ namespace ServiceControl.Recoverability
 
             return HttpStatusCode.Accepted;
         }
-
+        
         public ArchivingManager ArchiveOperationManager { get; set; }
         public Lazy<IEndpointInstance> Bus { get; set; }
     }

--- a/src/ServiceControl/Recoverability/API/FailureGroupsRetryApi.cs
+++ b/src/ServiceControl/Recoverability/API/FailureGroupsRetryApi.cs
@@ -33,7 +33,7 @@ namespace ServiceControl.Recoverability
 
             return HttpStatusCode.Accepted;
         }
-
+        
         public Lazy<IEndpointInstance> Bus { get; set; }
         public RetryingManager RetryOperationManager { get; set; }
     }

--- a/src/ServiceControl/Recoverability/API/UnacknowledgedGroupsApi.cs
+++ b/src/ServiceControl/Recoverability/API/UnacknowledgedGroupsApi.cs
@@ -11,7 +11,7 @@ namespace ServiceControl.Recoverability
             Delete["/recoverability/unacknowledgedgroups/{groupId}", true] = (parameters, token) => AcknowledgeOperation(parameters);
         }
 
-        private async Task<dynamic> AcknowledgeOperation(dynamic parameters)
+        async Task<dynamic> AcknowledgeOperation(dynamic parameters)
         {
             var groupId = parameters.groupId;
             if (ArchiveOperationManager.IsArchiveInProgressFor(groupId))

--- a/src/ServiceControl/Recoverability/Archiving/ArchiveAllInGroupHandler.cs
+++ b/src/ServiceControl/Recoverability/Archiving/ArchiveAllInGroupHandler.cs
@@ -5,19 +5,10 @@ namespace ServiceControl.Recoverability
     using NServiceBus;
     using NServiceBus.Logging;
     using Raven.Client;
-    using ServiceControl.Infrastructure.DomainEvents;
+    using Infrastructure.DomainEvents;
 
     public class ArchiveAllInGroupHandler : IHandleMessages<ArchiveAllInGroup>
     {
-        static ILog logger = LogManager.GetLogger<ArchiveAllInGroupHandler>();
-        const int batchSize = 1000;
-
-        IDocumentStore store;
-        IDomainEvents domainEvents;
-        ArchiveDocumentManager documentManager;
-        ArchivingManager archiveOperationManager;
-        RetryingManager retryingManager;
-
         public ArchiveAllInGroupHandler(IDocumentStore store, IDomainEvents domainEvents, ArchiveDocumentManager documentManager, ArchivingManager archiveOperationManager, RetryingManager retryingManager)
         {
             this.store = store;
@@ -126,5 +117,14 @@ namespace ServiceControl.Recoverability
                 MessagesCount = archiveOperation.TotalNumberOfMessages
             }).ConfigureAwait(false);
         }
+
+        static ILog logger = LogManager.GetLogger<ArchiveAllInGroupHandler>();
+        const int batchSize = 1000;
+
+        IDocumentStore store;
+        IDomainEvents domainEvents;
+        ArchiveDocumentManager documentManager;
+        ArchivingManager archiveOperationManager;
+        RetryingManager retryingManager;
     }
 }

--- a/src/ServiceControl/Recoverability/Archiving/ArchivingManager.cs
+++ b/src/ServiceControl/Recoverability/Archiving/ArchivingManager.cs
@@ -4,14 +4,10 @@
     using System.Linq;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using ServiceControl.Infrastructure.DomainEvents;
+    using Infrastructure.DomainEvents;
 
     public class ArchivingManager
     {
-        IDomainEvents domainEvents;
-
-        Dictionary<string, InMemoryArchive> archiveOperations = new Dictionary<string, InMemoryArchive>();
-
         public ArchivingManager(IDomainEvents domainEvents)
         {
             this.domainEvents = domainEvents;
@@ -29,8 +25,7 @@
 
         public bool IsOperationInProgressFor(string requestId, ArchiveType archiveType)
         {
-            InMemoryArchive summary;
-            if (!archiveOperations.TryGetValue(InMemoryArchive.MakeId(requestId, archiveType), out summary))
+            if (!archiveOperations.TryGetValue(InMemoryArchive.MakeId(requestId, archiveType), out var summary))
             {
                 return false;
             }
@@ -38,10 +33,9 @@
             return summary.ArchiveState != ArchiveState.ArchiveCompleted;
         }
 
-        private InMemoryArchive GetOrCreate(ArchiveType archiveType, string requestId)
+        InMemoryArchive GetOrCreate(ArchiveType archiveType, string requestId)
         {
-            InMemoryArchive summary;
-            if (!archiveOperations.TryGetValue(InMemoryArchive.MakeId(requestId, archiveType), out summary))
+            if (!archiveOperations.TryGetValue(InMemoryArchive.MakeId(requestId, archiveType), out var summary))
             {
                 summary = new InMemoryArchive(requestId, archiveType, domainEvents);
                 archiveOperations[InMemoryArchive.MakeId(requestId, archiveType)] = summary;
@@ -79,8 +73,7 @@
 
         public InMemoryArchive GetStatusForArchiveOperation(string requestId, ArchiveType archiveType)
         {
-            InMemoryArchive summary;
-            archiveOperations.TryGetValue(InMemoryArchive.MakeId(requestId, archiveType), out summary);
+            archiveOperations.TryGetValue(InMemoryArchive.MakeId(requestId, archiveType), out var summary);
 
             return summary;
         }
@@ -113,5 +106,9 @@
         {
             archiveOperations.Remove(InMemoryArchive.MakeId(requestId, archiveType));
         }
+
+        IDomainEvents domainEvents;
+
+        Dictionary<string, InMemoryArchive> archiveOperations = new Dictionary<string, InMemoryArchive>();
     }
 }

--- a/src/ServiceControl/Recoverability/Archiving/InMemoryArchive.cs
+++ b/src/ServiceControl/Recoverability/Archiving/InMemoryArchive.cs
@@ -1,31 +1,17 @@
 ﻿namespace ServiceControl.Recoverability
 {
-    using ServiceControl.Infrastructure.DomainEvents;
+    using Infrastructure.DomainEvents;
     using System;
     using System.Threading.Tasks;
 
     public class InMemoryArchive // in memory
     {
-        IDomainEvents domainEvents;
-
         public InMemoryArchive(string requestId, ArchiveType archiveType, IDomainEvents domainEvents)
         {
             RequestId = requestId;
             ArchiveType = archiveType;
             this.domainEvents = domainEvents;
         }
-
-        public int TotalNumberOfMessages { get; set; }
-        public int NumberOfMessagesArchived { get; set; }
-        public int NumberOfBatches { get; set; }
-        public int CurrentBatch { get; set; }
-        public DateTime? CompletionTime { get; set; }
-        public DateTime? Last { get; set; }
-        public DateTime Started { get; set; }
-        public ArchiveState ArchiveState { get; set; }
-        public string GroupName { get; set; }
-        public string RequestId { get; set; }
-        public ArchiveType ArchiveType { get; set; }
 
         public static string MakeId(string requestId, ArchiveType archiveType)
         {
@@ -128,5 +114,18 @@
         {
             return ArchiveState == ArchiveState.ArchiveCompleted;
         }
+
+        IDomainEvents domainEvents;
+        public int TotalNumberOfMessages { get; set; }
+        public int NumberOfMessagesArchived { get; set; }
+        public int NumberOfBatches { get; set; }
+        public int CurrentBatch { get; set; }
+        public DateTime? CompletionTime { get; set; }
+        public DateTime? Last { get; set; }
+        public DateTime Started { get; set; }
+        public ArchiveState ArchiveState { get; set; }
+        public string GroupName { get; set; }
+        public string RequestId { get; set; }
+        public ArchiveType ArchiveType { get; set; }
     }
 }

--- a/src/ServiceControl/Recoverability/Archiving/Messages/ArchiveOperationBatchCompleted.cs
+++ b/src/ServiceControl/Recoverability/Archiving/Messages/ArchiveOperationBatchCompleted.cs
@@ -1,8 +1,8 @@
 ﻿namespace ServiceControl.Recoverability
 {
     using System;
-    using ServiceControl.Infrastructure.DomainEvents;
-    using ServiceControl.Infrastructure.SignalR;
+    using Infrastructure.DomainEvents;
+    using Infrastructure.SignalR;
 
     public class ArchiveOperationBatchCompleted : IDomainEvent, IUserInterfaceEvent
     {

--- a/src/ServiceControl/Recoverability/Archiving/Messages/ArchiveOperationCompleted.cs
+++ b/src/ServiceControl/Recoverability/Archiving/Messages/ArchiveOperationCompleted.cs
@@ -1,8 +1,8 @@
 ﻿namespace ServiceControl.Recoverability
 {
     using System;
-    using ServiceControl.Infrastructure.DomainEvents;
-    using ServiceControl.Infrastructure.SignalR;
+    using Infrastructure.DomainEvents;
+    using Infrastructure.SignalR;
 
     public class ArchiveOperationCompleted : IDomainEvent, IUserInterfaceEvent
     {

--- a/src/ServiceControl/Recoverability/Archiving/Messages/ArchiveOperationFinalizing.cs
+++ b/src/ServiceControl/Recoverability/Archiving/Messages/ArchiveOperationFinalizing.cs
@@ -1,8 +1,8 @@
 ﻿namespace ServiceControl.Recoverability
 {
     using System;
-    using ServiceControl.Infrastructure.DomainEvents;
-    using ServiceControl.Infrastructure.SignalR;
+    using Infrastructure.DomainEvents;
+    using Infrastructure.SignalR;
 
     public class ArchiveOperationFinalizing : IDomainEvent, IUserInterfaceEvent
     {

--- a/src/ServiceControl/Recoverability/Archiving/Messages/ArchiveOperationStarting.cs
+++ b/src/ServiceControl/Recoverability/Archiving/Messages/ArchiveOperationStarting.cs
@@ -1,8 +1,8 @@
 ﻿namespace ServiceControl.Recoverability
 {
     using System;
-    using ServiceControl.Infrastructure.DomainEvents;
-    using ServiceControl.Infrastructure.SignalR;
+    using Infrastructure.DomainEvents;
+    using Infrastructure.SignalR;
 
     public class ArchiveOperationStarting : IDomainEvent, IUserInterfaceEvent
     {

--- a/src/ServiceControl/Recoverability/Archiving/Messages/FailedMessageGroupArchived.cs
+++ b/src/ServiceControl/Recoverability/Archiving/Messages/FailedMessageGroupArchived.cs
@@ -1,7 +1,7 @@
 namespace ServiceControl.Recoverability
 {
-    using ServiceControl.Infrastructure.DomainEvents;
-    using ServiceControl.Infrastructure.SignalR;
+    using Infrastructure.DomainEvents;
+    using Infrastructure.SignalR;
 
     public class FailedMessageGroupArchived : IDomainEvent, IUserInterfaceEvent
     {

--- a/src/ServiceControl/Recoverability/Archiving/Raven/ArchiveBatch.cs
+++ b/src/ServiceControl/Recoverability/Archiving/Raven/ArchiveBatch.cs
@@ -4,12 +4,12 @@
 
     public class ArchiveBatch //raven
     {
-        public string Id { get; set; }
-        public List<string> DocumentIds { get; set; } = new List<string>();
-
         public static string MakeId(string requestId, ArchiveType archiveType, int batchNumber)
         {
             return $"ArchiveOperations/{(int)archiveType}/{requestId}/{batchNumber}";
         }
+
+        public string Id { get; set; }
+        public List<string> DocumentIds { get; set; } = new List<string>();
     }
 }

--- a/src/ServiceControl/Recoverability/Archiving/Raven/ArchiveOperation.cs
+++ b/src/ServiceControl/Recoverability/Archiving/Raven/ArchiveOperation.cs
@@ -4,6 +4,11 @@
 
     public class ArchiveOperation // raven
     {
+        public static string MakeId(string requestId, ArchiveType archiveType)
+        {
+            return $"ArchiveOperations/{(int)archiveType}/{requestId}";
+        }
+
         public string Id { get; set; }
         public string RequestId { get; set; }
         public string GroupName { get; set; }
@@ -13,10 +18,5 @@
         public DateTime Started { get; set; }
         public int NumberOfBatches { get; set; }
         public int CurrentBatch { get; set; }
-
-        public static string MakeId(string requestId, ArchiveType archiveType)
-        {
-            return $"ArchiveOperations/{(int)archiveType}/{requestId}";
-        }
     }
 }


### PR DESCRIPTION
One thing I'm not sure about is `ArchiveDocumentManager.WaitForIndexUpdateOfArchiveOperation` method, should I remove the unused parameter or is it a mistake and that parameter should be used?