### PR TITLE
Add ability to control upgrades based on current and target versions

### DIFF
--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -204,7 +204,7 @@
                     return;
                 }
 
-                reportCard = await Task.Run(() => installer.Upgrade(model.Name, upgradeOptions, progress));
+                reportCard = await Task.Run(() => installer.Upgrade(instance, upgradeOptions, progress));
 
                 if (reportCard.HasErrors || reportCard.HasWarnings)
                 {

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -171,7 +171,7 @@
                 }
             }
 
-            if (instance.Version.Major != installer.ZipInfo.Version.Major) //Upgrade to different major -> recommend DB backup
+            if (upgradeInfo.DataBaseUpdate) //Database is being updated -> recommend DB backup
             {
                 if (!windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}",
                     $"{model.Name} is going to be upgraded to version {installer.ZipInfo.Version} which uses a different storage format. Database migration will be conducted "

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -52,7 +52,9 @@
 
             instance.Service.Refresh();
 
-            var upgradeOptions = new ServiceControlUpgradeOptions();
+            var upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(installer.ZipInfo.Version, instance.Version);
+
+            var upgradeOptions = new ServiceControlUpgradeOptions {UpgradeInfo = upgradeInfo};
 
             if (!instance.AppConfig.AppSettingExists(SettingsList.ForwardErrorMessages.Name))
             {

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -56,6 +56,24 @@
 
             var upgradeOptions = new ServiceControlUpgradeOptions {UpgradeInfo = upgradeInfo};
 
+            if (instance.Version < upgradeInfo.CurrentMinimumVersion)
+            {
+                windowManager.ShowMessage("VERSION UPGRADE INCOMPATIBLE",
+                    "<Section xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" xml:space=\"preserve\" TextAlignment=\"Left\" LineHeight=\"Auto\" IsHyphenationEnabled=\"False\" xml:lang=\"en-us\">\r\n" +
+                    $"<Paragraph>You must upgrade to version {upgradeInfo.RecommendedUpgradeVersion} before upgrading to version {installer.ZipInfo.Version}:</Paragraph>\r\n" +
+                    "<List MarkerStyle=\"Decimal\" Margin=\"0,0,0,0\" Padding=\"0,0,0,0\">\r\n" +
+                    $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Uninstall version {installer.ZipInfo.Version}.</Paragraph></ListItem>\r\n" +
+                    $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install version {upgradeInfo.RecommendedUpgradeVersion} from https://github.com/Particular/ServiceControl/releases/tag/{upgradeInfo.RecommendedUpgradeVersion}</Paragraph></ListItem>" +
+                    $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Upgrade this instance to version {upgradeInfo.RecommendedUpgradeVersion}.</Paragraph></ListItem>\r\n" +
+                    "<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install the latest version from https://particular.net/start-servicecontrol-download</Paragraph></ListItem>\r\n" +
+                    "<ListItem Margin=\"48,0,0,0\"><Paragraph>Upgrade this instance to the latest version of ServiceControl.</Paragraph></ListItem>\r\n" +
+                    "</List>\r\n" +
+                    "</Section>",
+                    hideCancel: true);
+
+                return;
+            }
+
             if (!instance.AppConfig.AppSettingExists(SettingsList.ForwardErrorMessages.Name))
             {
                 var result = windowManager.ShowYesNoCancelDialog("UPGRADE QUESTION - DISABLE ERROR FORWARDING", "Error messages can be forwarded to a secondary error queue known as the Error Forwarding Queue. This queue exists to allow external tools to receive error messages. If you do not have a tool processing messages from the Error Forwarding Queue this setting should be disabled.", "So what do you want to do ?", "Do NOT forward", "Yes I want to forward");

--- a/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
@@ -71,11 +71,10 @@
             return instanceInstaller.ReportCard;
         }
 
-        internal ReportCard Upgrade(string instanceName, ServiceControlUpgradeOptions upgradeOptions, IProgress<ProgressDetails> progress = null)
+        internal ReportCard Upgrade(ServiceControlInstance instance, ServiceControlUpgradeOptions upgradeOptions, IProgress<ProgressDetails> progress = null)
         {
             progress = progress ?? new Progress<ProgressDetails>();
 
-            var instance = InstanceFinder.FindServiceControlInstance(instanceName);
             instance.ReportCard = new ReportCard();
             ZipInfo.ValidateZip();
 

--- a/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
@@ -78,7 +78,10 @@
             instance.ReportCard = new ReportCard();
             ZipInfo.ValidateZip();
 
-            progress.Report(0, 7, "Stopping instance...");
+            var totalSteps = 7 - (upgradeOptions.UpgradeInfo.DeleteIndexes ? 0 : 1) - (upgradeOptions.UpgradeInfo.DataBaseUpdate ? 0 : 1);
+            var currentStep = 0;
+
+            progress.Report(currentStep++, totalSteps, "Stopping instance...");
             if (!instance.TryStopService())
             {
                 return new ReportCard
@@ -88,28 +91,29 @@
                 };
             }
 
-            progress.Report(1, 7, "Backing up app.config...");
+            progress.Report(currentStep++, totalSteps, "Backing up app.config...");
             var backupFile = instance.BackupAppConfig();
             try
             {
-                progress.Report(2, 7, "Upgrading Files...");
+                progress.Report(currentStep++, totalSteps, "Upgrading Files...");
                 instance.UpgradeFiles(ZipInfo.FilePath);
             }
             finally
             {
-                progress.Report(3, 7, "Restoring app.config...");
+                progress.Report(currentStep++, totalSteps, "Restoring app.config...");
                 instance.RestoreAppConfig(backupFile);
             }
 
             upgradeOptions.ApplyChangesToInstance(instance);
 
-            progress.Report(4, 6, "Removing database indexes...");
+            progress.Report(currentStep++, totalSteps, "Removing database indexes...");
             instance.RemoveDatabaseIndexes();
 
-            progress.Report(4, 6, "Updating Database...");
-            instance.UpdateDatabase(msg => progress.Report(5, 7, $"Updating Database...{Environment.NewLine}{msg}"));
+            progress.Report(currentStep, totalSteps, "Updating Database...");
+            // ReSharper disable once AccessToModifiedClosure
+            instance.UpdateDatabase(msg => progress.Report(currentStep, totalSteps, $"Updating Database...{Environment.NewLine}{msg}"));
 
-            progress.Report(6, 7, "Running Queue Creation...");
+            progress.Report(++currentStep, totalSteps, "Running Queue Creation...");
             instance.SetupInstance();
 
             instance.ReportCard.SetStatus();

--- a/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
@@ -106,8 +106,11 @@
 
             upgradeOptions.ApplyChangesToInstance(instance);
 
-            progress.Report(currentStep++, totalSteps, "Removing database indexes...");
-            instance.RemoveDatabaseIndexes();
+            if (upgradeOptions.UpgradeInfo.DeleteIndexes)
+            {
+                progress.Report(currentStep++, totalSteps, "Removing database indexes...");
+                instance.RemoveDatabaseIndexes();
+            }
 
             if (upgradeOptions.UpgradeInfo.DataBaseUpdate)
             {

--- a/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
@@ -109,9 +109,12 @@
             progress.Report(currentStep++, totalSteps, "Removing database indexes...");
             instance.RemoveDatabaseIndexes();
 
-            progress.Report(currentStep, totalSteps, "Updating Database...");
-            // ReSharper disable once AccessToModifiedClosure
-            instance.UpdateDatabase(msg => progress.Report(currentStep, totalSteps, $"Updating Database...{Environment.NewLine}{msg}"));
+            if (upgradeOptions.UpgradeInfo.DataBaseUpdate)
+            {
+                progress.Report(currentStep, totalSteps, "Updating Database...");
+                // ReSharper disable once AccessToModifiedClosure
+                instance.UpdateDatabase(msg => progress.Report(currentStep, totalSteps, $"Updating Database...{Environment.NewLine}{msg}"));
+            }
 
             progress.Report(++currentStep, totalSteps, "Running Queue Creation...");
             instance.SetupInstance();

--- a/src/ServiceControl.Config/Xaml/Behaviours/RichTextBoxHelper.cs
+++ b/src/ServiceControl.Config/Xaml/Behaviours/RichTextBoxHelper.cs
@@ -50,7 +50,14 @@
                             parser.XmlnsDictionary.Add("x", "http://schemas.microsoft.com/winfx/2006/xaml");
                             var doc = new FlowDocument();
 
-                            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes($"<Paragraph>{GetDocumentXaml(richTextBox)}</Paragraph>")))
+                            var xaml = GetDocumentXaml(richTextBox);
+
+                            if (!xaml.Contains("</"))
+                            {
+                                xaml = $"<Paragraph>{xaml}</Paragraph>";
+                            }
+
+                            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(xaml)))
                             {
                                 var block = (Block)XamlReader.Load(stream, parser);
                                 doc.Blocks.Add(block);

--- a/src/ServiceControlInstaller.CustomActions/CustomActionsInstall.cs
+++ b/src/ServiceControlInstaller.CustomActions/CustomActionsInstall.cs
@@ -92,6 +92,10 @@
             {
                 if (zipInfo.Version > instance.Version)
                 {
+                    var upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(zipInfo.Version, instance.Version);
+
+                    options.UpgradeInfo = upgradeInfo;
+
                     if (!instance.AppConfig.AppSettingExists(SettingsList.ForwardErrorMessages.Name) & !options.OverrideEnableErrorForwarding.Value)
                     {
                         logger.Warn($"Unattend upgrade {instance.Name} to {zipInfo.Version} not attempted. FORWARDERRORMESSAGES MSI parameter was required because appsettings needed a value for '{SettingsList.ForwardErrorMessages.Name}'");

--- a/src/ServiceControlInstaller.CustomActions/CustomActionsInstall.cs
+++ b/src/ServiceControlInstaller.CustomActions/CustomActionsInstall.cs
@@ -75,6 +75,26 @@
                 options.ErrorRetentionPeriod = null;
             }
 
+            var confirmDatabaseHasBeenBackedUpValue = session["CONFIRMDATABASEHASBEENBACKEDUP"];
+            try
+            {
+                options.ConfirmDatabaseHasBeenBackedUp = bool.Parse(confirmDatabaseHasBeenBackedUpValue);
+            }
+            catch
+            {
+                options.ConfirmDatabaseHasBeenBackedUp = false;
+            }
+
+            var allowLargeDatabaseUpgradeValue = session["ALLOWLARGEDATABASEUPGRADE"];
+            try
+            {
+                options.AllowLargeDatabaseUpdate = bool.Parse(allowLargeDatabaseUpgradeValue);
+            }
+            catch
+            {
+                options.ConfirmDatabaseHasBeenBackedUp = false;
+            }
+
             //determine what to upgrade
             var instancesToUpgrade = new List<ServiceControlInstance>();
             if (upgradeInstancesPropertyValue.Equals("*", StringComparison.OrdinalIgnoreCase) || upgradeInstancesPropertyValue.Equals("ALL", StringComparison.OrdinalIgnoreCase))
@@ -127,6 +147,24 @@
                     {
                         logger.Warn($"Unattend upgrade {instance.Name} to {zipInfo.Version} not attempted. ERRORRETENTIONPERIOD MSI parameter was required because appsettings needed a value for '{SettingsList.ErrorRetentionPeriod.Name}'");
                         continue;
+                    }
+
+                    if (upgradeInfo.DataBaseUpdate) //Database is being updated -> recommend DB backup
+                    {
+                        if (!options.ConfirmDatabaseHasBeenBackedUp)
+                        {
+                            logger.Warn($"Unattend upgrade {instance.Name} to {zipInfo.Version} not attempted. This upgrade requires a database update and the database should be backed up prior to updating. CONFIRMDATABASEHASBEENBACKEDUP MSI parameter was required to allow the database upgrade.'");
+                            continue;
+                        }
+
+                        var dbSize = instance.GetDatabaseSizeInGb();
+                        if (dbSize >= 100) // 100GB
+                        {
+                            logger.Warn($"Unattend upgrade {instance.Name} to {zipInfo.Version} not attempted. Upgrade requires a database update and the database being upgraded is {dbSize:N0} GB. " +
+                                        "Migrating this much data could take a long time and ServiceControl will be stopped for that entire duration. It is recommended that you consider one of the other upgrade approaches instead. " +
+                                        "ALLOWLARGEDATABASEUPGRADE MSI parameter can be used to allow an unattended database upgrade.'");
+                            continue;
+                        }
                     }
 
                     if (!unattendedInstaller.Upgrade(instance, options))

--- a/src/ServiceControlInstaller.Engine.UnitTests/Configuration/ServiceControl/UpgradeControlDetailsTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Configuration/ServiceControl/UpgradeControlDetailsTests.cs
@@ -1,0 +1,48 @@
+﻿namespace ServiceControlInstaller.Engine.UnitTests.Configuration.ServiceControl
+{
+    using System;
+    using System.Linq;
+    using NUnit.Framework;
+    using ServiceControlInstaller.Engine.Configuration.ServiceControl;
+
+    [TestFixture]
+
+    public class UpgradeControlDetailsTests
+    {
+        [Test]
+        public void DetailsAreValid()
+        {
+            //No duplicates
+            Assert.AreEqual(UpgradeControl.details.Length, UpgradeControl.details.GroupBy(d => d.TargetMinimumVersion).Count(), "Duplicate TargetMinimumVersion entries");
+
+            //No overlaps
+            foreach (var upgradeInfo in UpgradeControl.details)
+            {
+                var details = UpgradeControl.details.Where(d => d != upgradeInfo);
+
+                var failures = details.Where(d => d.TargetMinimumVersion > upgradeInfo.TargetMinimumVersion && d.CurrentMinimumVersion < upgradeInfo.TargetMinimumVersion).ToList();
+                Assert.IsEmpty(failures, $"{string.Join(",", failures)} overlap with {upgradeInfo}");
+            }
+        }
+
+        [Test]
+        public void ValidateVersion2UpgradeData()
+        {
+            var tooOldVersion = new Version(1, 41, 0);
+
+            var minimumVersion = new Version(1, 41, 3);
+
+            var recommendedVersion = new Version(1, 48, 0);
+
+            var version2 = new Version(2, 0, 0);
+
+            //Test current is too old
+            var upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(version2, tooOldVersion);
+            Assert.AreEqual(minimumVersion, upgradeInfo.CurrentMinimumVersion, "CurrentMinimumVersion mismatch");
+            Assert.AreEqual(version2, upgradeInfo.TargetMinimumVersion, "TargetMinimumVersion mismatch");
+            Assert.AreEqual(recommendedVersion, upgradeInfo.RecommendedUpgradeVersion, "RecommendedUpgradeVersion mismatch");
+            Assert.IsTrue(upgradeInfo.DataBaseUpdate, "DataBaseUpdate is false");
+            Assert.IsTrue(upgradeInfo.DeleteIndexes, "DeleteIndexes is false");
+        }
+    }
+}

--- a/src/ServiceControlInstaller.Engine.UnitTests/Configuration/ServiceControl/UpgradeControlTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Configuration/ServiceControl/UpgradeControlTests.cs
@@ -1,0 +1,56 @@
+﻿namespace ServiceControlInstaller.Engine.UnitTests.Configuration.ServiceControl
+{
+    using System;
+    using NUnit.Framework;
+    using ServiceControlInstaller.Engine.Configuration.ServiceControl;
+
+    [TestFixture]
+    public class UpgradeControlTests
+    {
+        [Test]
+        public void TestGetUpgradeInfoForTargetVersion()
+        {
+            var upgrade1Info = new UpgradeInfo(new Version(1, 5, 0), new Version(1, 0, 0))
+            {
+                RecommendedUpgradeVersion = new Version(1, 4, 9)
+            };
+
+            var upgrade2Info = new UpgradeInfo(new Version(2, 0, 0), new Version(1, 5, 0))
+            {
+                RecommendedUpgradeVersion = new Version(1, 9, 0)
+            };
+
+            UpgradeControl.details = new[]
+            {
+                upgrade1Info,
+                upgrade2Info
+            };
+
+            var target = new Version(4, 0, 0);
+
+            var upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(target, new Version(0, 1, 0));
+            Assert.AreSame(upgrade1Info, upgradeInfo, "Incorrect UpgradeInfro, expected upgrade1Info (below current)");
+
+            upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(target, new Version(1, 4, 0));
+            Assert.AreSame(upgrade1Info, upgradeInfo, "Incorrect UpgradeInfro, expected upgrade1Info (above current)");
+
+            upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(target, new Version(1, 5, 0));
+            Assert.AreSame(upgrade2Info, upgradeInfo, "Incorrect UpgradeInfro, expected upgrade2Info");
+
+            upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(target, new Version(2, 0, 0));
+
+            var defaultUpgradeInfo = new UpgradeInfo(target, new Version(0, 0));
+            Assert.AreEqual(defaultUpgradeInfo.TargetMinimumVersion, upgradeInfo.TargetMinimumVersion, $"TargetMinimumVersion mismatch {target}");
+            Assert.AreEqual(defaultUpgradeInfo.CurrentMinimumVersion, upgradeInfo.CurrentMinimumVersion, $"CurrentMinimumVersion mismatch {target}");
+            Assert.AreEqual(defaultUpgradeInfo.RecommendedUpgradeVersion, upgradeInfo.RecommendedUpgradeVersion, $"RecommendedUpgradeVersion mismatch {target}");
+
+            target = upgrade2Info.TargetMinimumVersion;
+            upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(target, new Version(2, 0, 0));
+            defaultUpgradeInfo = new UpgradeInfo(target, new Version(0, 0));
+            Assert.AreEqual(defaultUpgradeInfo.TargetMinimumVersion, upgradeInfo.TargetMinimumVersion, $"TargetMinimumVersion mismatch {target}");
+            Assert.AreEqual(defaultUpgradeInfo.CurrentMinimumVersion, upgradeInfo.CurrentMinimumVersion, $"CurrentMinimumVersion mismatch {target}");
+            Assert.AreEqual(defaultUpgradeInfo.RecommendedUpgradeVersion, upgradeInfo.RecommendedUpgradeVersion, $"RecommendedUpgradeVersion mismatch {target}");
+        }
+    }
+}
+

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeControl.Details.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeControl.Details.cs
@@ -1,0 +1,17 @@
+﻿namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
+{
+    using System;
+
+    public partial class UpgradeControl
+    {
+        internal static UpgradeInfo[] details =
+        {
+            new UpgradeInfo(new Version(2, 0), new Version(1, 41, 3)) //https://github.com/Particular/ServiceControl/issues/1228
+            {
+                RecommendedUpgradeVersion = new Version(1, 48, 0),
+                DataBaseUpdate = true,
+                DeleteIndexes = true
+            }
+        };
+    }
+}

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeControl.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeControl.cs
@@ -1,0 +1,69 @@
+﻿namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
+{
+    using System;
+    using System.Linq;
+
+    public partial class UpgradeControl
+    {
+        public static UpgradeInfo GetUpgradeInfoForTargetVersion(Version target, Version current)
+        {
+            return details.Where(r => r.TargetMinimumVersion <= target && current < r.TargetMinimumVersion)
+                .DefaultIfEmpty(new UpgradeInfo(target, new Version(0, 0)))
+                .OrderBy(r => r.CurrentMinimumVersion)
+                .First();
+        }
+    }
+
+    public class UpgradeInfo
+    {
+        /// <summary>
+        /// Minimum version targeted for install that will trigger this
+        /// </summary>
+        public Version TargetMinimumVersion { get; }
+
+        /// <summary>
+        /// Minimum version instance must be to satisfy target version pre-conditions
+        /// </summary>
+        public Version CurrentMinimumVersion { get; }
+
+        public UpgradeInfo(Version targetMinimum, Version currentMinimum)
+        {
+            TargetMinimumVersion = ConvertToCleanVersion(targetMinimum);
+            CurrentMinimumVersion = ConvertToCleanVersion(currentMinimum);
+        }
+
+        /// <summary>
+        /// Version recommended for upgrade if instance version does not meet the CurrentMinimumVersion
+        /// </summary>
+        public Version RecommendedUpgradeVersion
+        {
+            get => recommendedUpgradeVersion ?? TargetMinimumVersion;
+            set => recommendedUpgradeVersion = ConvertToCleanVersion(value);
+        }
+
+        /// <summary>
+        /// Version requires a database upgrade
+        /// </summary>
+        public bool DataBaseUpdate { get; set; }
+
+        /// <summary>
+        /// Inidicates indexes should be removed, prompting recreation, for this upgrade
+        /// </summary>
+        public bool DeleteIndexes { get; set; }
+
+        Version recommendedUpgradeVersion;
+
+        static Version ConvertToCleanVersion(Version version)
+        {
+            return new Version(
+                version.Major > -1 ? version.Major : 0,
+                version.Minor > -1 ? version.Minor : 0,
+                version.Build > -1 ? version.Build : 0);
+        }
+
+        public override string ToString()
+        {
+            return $"[{CurrentMinimumVersion} -> {TargetMinimumVersion}]";
+        }
+    }
+}

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlUpgradeOptions.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlUpgradeOptions.cs
@@ -1,6 +1,7 @@
 namespace ServiceControlInstaller.Engine.Instances
 {
     using System;
+    using ServiceControlInstaller.Engine.Configuration.ServiceControl;
 
     public class ServiceControlUpgradeOptions
     {
@@ -9,6 +10,7 @@ namespace ServiceControlInstaller.Engine.Instances
         public TimeSpan? AuditRetentionPeriod { get; set; }
         public int? MaintenancePort { get; set; }
         public bool SkipQueueCreation { get; set; }
+        public UpgradeInfo UpgradeInfo { get; set; }
 
         public void ApplyChangesToInstance(ServiceControlInstance instance)
         {

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlUpgradeOptions.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlUpgradeOptions.cs
@@ -11,6 +11,8 @@ namespace ServiceControlInstaller.Engine.Instances
         public int? MaintenancePort { get; set; }
         public bool SkipQueueCreation { get; set; }
         public UpgradeInfo UpgradeInfo { get; set; }
+        public bool ConfirmDatabaseHasBeenBackedUp { get; set; }
+        public bool AllowLargeDatabaseUpdate { get; set; }
 
         public void ApplyChangesToInstance(ServiceControlInstance instance)
         {

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
@@ -133,6 +133,17 @@ namespace ServiceControlInstaller.Engine.Unattended
                 }
 
                 options.ApplyChangesToInstance(instance);
+
+                if (options.UpgradeInfo.DeleteIndexes)
+                {
+                    instance.RemoveDatabaseIndexes();
+                }
+
+                if (options.UpgradeInfo.DataBaseUpdate)
+                {
+                    instance.UpdateDatabase(msg => { });
+                }
+
                 instance.SetupInstance();
 
                 if (instance.ReportCard.HasErrors)

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
@@ -97,6 +97,12 @@ namespace ServiceControlInstaller.Engine.Unattended
 
         public bool Upgrade(ServiceControlInstance instance, ServiceControlUpgradeOptions options)
         {
+            if (instance.Version < options.UpgradeInfo.CurrentMinimumVersion)
+            {
+                logger.Error($"Upgrade aborted. An interim upgrade to version {options.UpgradeInfo.RecommendedUpgradeVersion} is required before upgrading to version {ZipInfo.Version}. Download available at https://github.com/Particular/ServiceControl/releases/tag/{options.UpgradeInfo.RecommendedUpgradeVersion}");
+                return false;
+            }
+
             ZipInfo.ValidateZip();
 
             var checkLicenseResult = CheckLicenseIsValid();


### PR DESCRIPTION
Fixes #1228
Fixes #1288 

What it looks like when you are stopped from upgrading. All the text is selectable / copyable.
![image](https://user-images.githubusercontent.com/2546913/43032888-6efbf022-8c75-11e8-8bbb-a7b533c775fc.png)

```
You must upgrade to version 1.48.0 before upgrading to version 2.2.0:
1.	Uninstall version 2.2.0.
2.	Download and install version 1.48.0 from https://github.com/Particular/ServiceControl/releases/tag/1.48.0
3.	Upgrade this instance to version 1.48.0.
4.	Download and install the latest version from https://particular.net/start-servicecontrol-download
5.	Upgrade this instance to the latest version of ServiceControl.
```