### PR TITLE
Do not publish `MessageFailed` on the bus

### DIFF
--- a/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_retry_for_a_failed_message_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_retry_for_a_failed_message_fails.cs
@@ -64,7 +64,7 @@
                     return true;
                 })
                 .Do("DetectThirdFailure", async ctx => await CheckProcessingAttemptsIs(ctx, 2))
-                .Do("RetryFourthTime", async ctx =>
+                .Do("RetryThirdTime", async ctx =>
                 {
                     ctx.Succeed = true;
                     await this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry");

--- a/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_retry_for_a_failed_message_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_retry_for_a_failed_message_fails.cs
@@ -15,59 +15,70 @@
         [Test]
         public async Task It_should_be_marked_as_unresolved()
         {
-            FailedMessage failure = null;
-
-            await Define<MyContext>(ctx => { ctx.Succeed = false; })
+            var result = await Define<MyContext>(ctx => { ctx.Succeed = false; })
                 .WithEndpoint<FailureEndpoint>(b =>
                     b.When(bus => bus.SendLocal(new MyMessage()))
-                        .When(async ctx => await CheckProcessingAttemptsIs(ctx, 1),
-                            (bus, ctx) => this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry"))
-                        .When(async ctx => await CheckProcessingAttemptsIs(ctx, 2),
-                            (bus, ctx) => this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry"))
                         .DoNotFailOnErrorMessages()
                 )
-                .Done(async ctx =>
+                .Do("DetectFirstFailure", async ctx => await CheckProcessingAttemptsIs(ctx, 1))
+                .Do("RetryFirstTime", async ctx =>
                 {
-                    var result = await GetFailedMessage(ctx, f => f.ProcessingAttempts.Count == 3);
-                    failure = result;
-                    return result;
+                    await this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry");
+                    return true;
                 })
-                .Run(TimeSpan.FromMinutes(1));
+                .Do("DetectSecondFailure", async ctx => await CheckProcessingAttemptsIs(ctx, 2))
+                .Do("RetrySecondTime", async ctx =>
+                {
+                    await this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry");
+                    return true;
+                })
+                .Do("DetectThirdFailure", async ctx =>
+                {
+                    ctx.Result = await this.TryGet<FailedMessage>($"/api/errors/{ctx.UniqueMessageId}");
+                    return ctx.Result.ProcessingAttempts.Count == 3;
+                })
+                .Done()
+                .Run(TimeSpan.FromMinutes(2));
 
-            Assert.IsNotNull(failure, "Failure should not be null");
-            Assert.AreEqual(FailedMessageStatus.Unresolved, failure.Status);
+            Assert.AreEqual(FailedMessageStatus.Unresolved, result.Result.Status);
         }
 
         [Test]
         public async Task It_should_be_able_to_be_retried_successfully()
         {
-            FailedMessage failure = null;
-
-            await Define<MyContext>(ctx => { ctx.Succeed = false; })
+            var result = await Define<MyContext>(ctx => { ctx.Succeed = false; })
                 .WithEndpoint<FailureEndpoint>(b =>
                     b.When(bus => bus.SendLocal(new MyMessage()))
-                        .When(async ctx => await CheckProcessingAttemptsIs(ctx, 1),
-                            (bus, ctx) => this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry"))
-                        .When(async ctx => await CheckProcessingAttemptsIs(ctx, 2),
-                            (bus, ctx) => this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry"))
-                        .When(async ctx => await CheckProcessingAttemptsIs(ctx, 3),
-                            async (bus, ctx) =>
-                            {
-                                ctx.Succeed = true;
-                                await this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry");
-                            })
                         .DoNotFailOnErrorMessages()
                 )
-                .Done(async ctx =>
+                .Do("DetectFirstFailure", async ctx => await CheckProcessingAttemptsIs(ctx, 1))
+                .Do("RetryFirstTime", async ctx =>
                 {
-                    var result = await GetFailedMessage(ctx, f => f.Status == FailedMessageStatus.Resolved);
-                    failure = result;
-                    return result;
+                    await this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry");
+                    return true;
                 })
-                .Run(TimeSpan.FromMinutes(1));
+                .Do("DetectSecondFailure", async ctx => await CheckProcessingAttemptsIs(ctx, 2))
+                .Do("RetrySecondTime", async ctx =>
+                {
+                    await this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry");
+                    return true;
+                })
+                .Do("DetectThirdFailure", async ctx => await CheckProcessingAttemptsIs(ctx, 2))
+                .Do("RetryFourthTime", async ctx =>
+                {
+                    ctx.Succeed = true;
+                    await this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry");
+                    return true;
+                })
+                .Do("DetectSuccess", async ctx =>
+                {
+                    ctx.Result = await GetFailedMessage(ctx, f => f.Status == FailedMessageStatus.Resolved);
+                    return ctx.Result != null;
+                })
+                .Done()
+                .Run(TimeSpan.FromMinutes(2));
 
-            Assert.IsNotNull(failure, "Failure should not be null");
-            Assert.AreEqual(FailedMessageStatus.Resolved, failure.Status);
+            Assert.AreEqual(FailedMessageStatus.Resolved, result.Result.Status);
         }
 
         Task<SingleResult<FailedMessage>> CheckProcessingAttemptsIs(MyContext ctx, int count)
@@ -121,7 +132,7 @@
         {
         }
 
-        public class MyContext : ScenarioContext
+        public class MyContext : ScenarioContext, ISequenceContext
         {
             public string MessageId { get; set; }
 
@@ -130,6 +141,9 @@
             public bool Succeed { get; set; }
 
             public string UniqueMessageId => DeterministicGuid.MakeId(MessageId, EndpointNameOfReceivingEndpoint).ToString();
+            public int Step { get; set; }
+
+            public FailedMessage Result { get; set; }
         }
     }
 }

--- a/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_retry_for_a_failed_message_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageFailures/When_a_retry_for_a_failed_message_fails.cs
@@ -32,7 +32,7 @@
                     failure = result;
                     return result;
                 })
-                .Run(TimeSpan.FromMinutes(4));
+                .Run(TimeSpan.FromMinutes(1));
 
             Assert.IsNotNull(failure, "Failure should not be null");
             Assert.AreEqual(FailedMessageStatus.Unresolved, failure.Status);
@@ -64,7 +64,7 @@
                     failure = result;
                     return result;
                 })
-                .Run(TimeSpan.FromMinutes(4));
+                .Run(TimeSpan.FromMinutes(1));
 
             Assert.IsNotNull(failure, "Failure should not be null");
             Assert.AreEqual(FailedMessageStatus.Resolved, failure.Status);
@@ -89,7 +89,7 @@
         {
             public FailureEndpoint()
             {
-                EndpointSetup<DefaultServerWithAudit>(c => { c.NoDelayedRetries(); });
+                EndpointSetup<DefaultServerWithAudit>(c => { c.NoRetries(); });
             }
 
             public class MyMessageHandler : IHandleMessages<MyMessage>

--- a/src/ServiceControl.AcceptanceTests/ScenarioWithEndpointBehaviorExtensions.cs
+++ b/src/ServiceControl.AcceptanceTests/ScenarioWithEndpointBehaviorExtensions.cs
@@ -49,10 +49,10 @@
             return this;
         }
 
-        public IScenarioWithEndpointBehavior<TContext> Done(Func<TContext, bool> doneCriteria)
+        public IScenarioWithEndpointBehavior<TContext> Done(Func<TContext, bool> doneCriteria = null)
         {
             var behavior = new ServiceControlClient<TContext>(context => sequence.Continue(context));
-            return endpointBehavior.WithComponent(behavior).Done(ctx => sequence.IsFinished(ctx) && doneCriteria(ctx));
+            return endpointBehavior.WithComponent(behavior).Done(ctx => sequence.IsFinished(ctx) && (doneCriteria == null || doneCriteria(ctx)));
         }
 
         IScenarioWithEndpointBehavior<TContext> endpointBehavior;

--- a/src/ServiceControl/Infrastructure/DomainEvents/DomainEventBusPublisher.cs
+++ b/src/ServiceControl/Infrastructure/DomainEvents/DomainEventBusPublisher.cs
@@ -14,12 +14,6 @@ namespace ServiceControl.Infrastructure.DomainEvents
             {
                 return messageSession.Publish(busEvent);
             }
-
-            if (domainEvent is IMessage busCommand)
-            {
-                return messageSession.SendLocal(busCommand);
-            }
-
             return Task.FromResult(0);
         }
 

--- a/src/ServiceControl/Recoverability/Retrying/FailedMessageRetryCleaner.cs
+++ b/src/ServiceControl/Recoverability/Retrying/FailedMessageRetryCleaner.cs
@@ -1,0 +1,21 @@
+namespace ServiceControl.Recoverability
+{
+    using System.Threading.Tasks;
+    using Contracts.MessageFailures;
+    using Infrastructure.DomainEvents;
+
+    public class FailedMessageRetryCleaner : IDomainHandler<MessageFailed>
+    {
+        public RetryDocumentManager RetryDocumentManager { get; set; }
+
+        public Task Handle(MessageFailed message)
+        {
+            if (message.RepeatedFailure)
+            {
+                return RetryDocumentManager.RemoveFailedMessageRetryDocument(message.FailedMessageId);
+            }
+
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/ServiceControl/Recoverability/Retrying/Handlers/RetriesHandler.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Handlers/RetriesHandler.cs
@@ -11,13 +11,16 @@ namespace ServiceControl.Recoverability
     public class RetriesHandler : IHandleMessages<RequestRetryAll>,
         IHandleMessages<RetryMessagesById>,
         IHandleMessages<RetryMessage>,
-        IHandleMessages<MessageFailedRepeatedly>,
         IHandleMessages<MessageFailed>,
+        IHandleMessages<MessageFailedRepeatedly>,
         IHandleMessages<RetryMessagesByQueueAddress>
     {
         public RetriesGateway Retries { get; set; }
         public RetryDocumentManager RetryDocumentManager { get; set; }
 
+        /// <summary>
+        /// For handling leftover messages. MessageFailed are no longer published on the bus and the code is moved to <see cref="FailedMessageRetryCleaner"/>.
+        /// </summary>
         public Task Handle(MessageFailed message, IMessageHandlerContext context)
         {
             if (message.RepeatedFailure)

--- a/src/ServiceControl/Recoverability/Retrying/RetryingFeature.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetryingFeature.cs
@@ -16,6 +16,7 @@
             context.Container.ConfigureComponent<RetryingManager>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<GroupFetcher>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<StoreHistoryHandler>(DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent<FailedMessageRetryCleaner>(DependencyLifecycle.SingleInstance);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceControl/issues/1235

Use DomainHandler to react on the `MessageFailed` instead of a message handler. Removes the race condition in some tests and removes one round unnecessary roundtrip.