### PR TITLE
Update RavenDB to latest 3.5.7-patch-35266

### DIFF
--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Nancy" Version="1.4.3" />
     <PackageReference Include="Nancy.Bootstrappers.Autofac" Version="1.4.1" />
     <PackageReference Include="Nancy.Owin" Version="1.4.1" />
-    <PackageReference Include="RavenDB.Embedded" Version="3.5.7-patch-35263" />
+    <PackageReference Include="RavenDB.Database" Version="3.5.7-patch-35266" />
     <PackageReference Include="NServiceBus" Version="7.0.1" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.0.0" />
     <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.0" />
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(NuGetPackageRoot)ravendb.database\3.5.7-patch-35263\tools\Raven.Studio.Html5.zip" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(NuGetPackageRoot)ravendb.database\3.5.7-patch-35266\tools\Raven.Studio.Html5.zip" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Switch from RavenDB.Embedded to RavenDB.Database because

![image](https://user-images.githubusercontent.com/174258/43260879-012fc536-90db-11e8-9451-f94ea05044ee.png)

- Update to latest patch release, changes https://ravendb.net/docs/article-page/3.5/csharp/start%2fwhats-new?page=1#35263. See

> Fixed "AlreadyClosedException: this Directory is closed" error on index recovery of database startup

I verified that this does not lead to problems with our database upgrade process by upgrading a 1.48 instance with data to 3.0

