### PR TITLE
MessageForwarder resets TTBR if present

### DIFF
--- a/src/ServiceControl.UnitTests/Operations/MessageForwarderTests.cs
+++ b/src/ServiceControl.UnitTests/Operations/MessageForwarderTests.cs
@@ -1,0 +1,51 @@
+﻿namespace ServiceControl.UnitTests.Operations
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Transport;
+    using NUnit.Framework;
+    using ServiceControl.Operations;
+
+    [TestFixture]
+    public class MessageForwarderTests
+    {
+        FakeDispatcher dispatcher;
+        MessageForwarder forwarder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            dispatcher = new FakeDispatcher();
+            forwarder = new MessageForwarder(dispatcher);
+        }
+
+        [Test]
+        public async Task Messages_should_last_as_long_as_possible()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.TimeToBeReceived, TimeSpan.FromMinutes(12).ToString() }
+            };
+            
+            var context = new MessageContext("messageId", headers, Array.Empty<byte>(), new TransportTransaction(), new CancellationTokenSource(), new ContextBag());
+            await forwarder.Forward(context, "forwardingAddress");
+            
+            Assert.IsFalse(dispatcher.TransportOperations.UnicastTransportOperations[0].Message.Headers.ContainsKey(Headers.TimeToBeReceived), "TimeToBeReceived header should be removed if present");
+        }
+
+        class FakeDispatcher : IDispatchMessages
+        {
+            public TransportOperations TransportOperations { get; private set; }
+
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
+            {
+                TransportOperations = outgoingMessages;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/ServiceControl/Operations/AuditIngestor.cs
+++ b/src/ServiceControl/Operations/AuditIngestor.cs
@@ -33,7 +33,6 @@
 
             if (settings.ForwardAuditMessages)
             {
-                // TODO: Clean the time to be received header? The old implementation went through TransportMessageCleaner
                 await messageForwarder.Forward(context, settings.AuditLogQueue)
                     .ConfigureAwait(false);
             }

--- a/src/ServiceControl/Operations/MessageForwarder.cs
+++ b/src/ServiceControl/Operations/MessageForwarder.cs
@@ -1,6 +1,8 @@
 ﻿namespace ServiceControl.Operations
 {
+    using System;
     using System.Threading.Tasks;
+    using NServiceBus;
     using NServiceBus.Routing;
     using NServiceBus.Transport;
 
@@ -22,6 +24,11 @@
                 messageContext.MessageId,
                 messageContext.Headers,
                 messageContext.Body);
+
+            if (outgoingMessage.Headers.ContainsKey(Headers.TimeToBeReceived))
+            {
+                outgoingMessage.Headers[Headers.TimeToBeReceived] = TimeSpan.MaxValue.ToString();
+            }
 
             var transportOperations = new TransportOperations(
                 new TransportOperation(outgoingMessage, new UnicastAddressTag(forwardingAddress))

--- a/src/ServiceControl/Operations/MessageForwarder.cs
+++ b/src/ServiceControl/Operations/MessageForwarder.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceControl.Operations
 {
-    using System;
     using System.Threading.Tasks;
     using NServiceBus;
     using NServiceBus.Routing;
@@ -25,10 +24,8 @@
                 messageContext.Headers,
                 messageContext.Body);
 
-            if (outgoingMessage.Headers.ContainsKey(Headers.TimeToBeReceived))
-            {
-                outgoingMessage.Headers[Headers.TimeToBeReceived] = TimeSpan.MaxValue.ToString();
-            }
+            // Forwarded messages should last as long as possible
+            outgoingMessage.Headers.Remove(Headers.TimeToBeReceived);
 
             var transportOperations = new TransportOperations(
                 new TransportOperation(outgoingMessage, new UnicastAddressTag(forwardingAddress))


### PR DESCRIPTION
The previous version did a reset of the TTBR, see

https://github.com/Particular/ServiceControl/blob/33b4e74e7357e3daef5f16ebe80dbc56f3a7b461/src/ServiceControl/Operations/ErrorQueueImport.cs#L160
and
https://github.com/Particular/ServiceControl/blob/7f46be452a66877eca8c960e545c46dee40c16f3/src/ServiceControl/Operations/AuditQueueImport.cs#L105

See documented core behavior https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/Headers.cs#L221-L222

This does it now consistently in the forwarder and removes the TODO