### PR TITLE
Change asbs zip folder so that asb folder is not it's prefix

### DIFF
--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
@@ -42,7 +42,7 @@
             {
                 Name = "AzureServiceBus .NET Standard",
                 TypeName = "ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS",
-                ZipName = "AzureServiceBusNetStandard",
+                ZipName = "NetStandardAzureServiceBus",
                 SampleConnectionString = "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>",
                 Matches = name => name.Equals("ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS", StringComparison.OrdinalIgnoreCase)
             },*/

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -49,10 +49,10 @@
     <AddToZip IncludeMask="ServiceControl.Transports.ASB.*" ZipFolder="Transports\AzureServiceBus" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
     <AddToZip IncludeMask="Microsoft.ServiceBus.*" ZipFolder="Transports\AzureServiceBus" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
     <!--AzureServiceBus .NET Standard-->
-    <AddToZip IncludeMask="NServiceBus.Transport.AzureServiceBus.*" ZipFolder="Transports\AzureServiceBusNetStandard" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
-    <AddToZip IncludeMask="Microsoft.*" ZipFolder="Transports\AzureServiceBusNetStandard" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
-    <AddToZip IncludeMask="ServiceControl.Transports.ASBS.*" ZipFolder="Transports\AzureServiceBusNetStandard" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
-    <AddToZip IncludeMask="System.Diagnostics.*" ZipFolder="Transports\AzureServiceBusNetStandard" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
+    <AddToZip IncludeMask="NServiceBus.Transport.AzureServiceBus.*" ZipFolder="Transports\NetStandardAzureServiceBus" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
+    <AddToZip IncludeMask="Microsoft.*" ZipFolder="Transports\NetStandardAzureServiceBus" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
+    <AddToZip IncludeMask="ServiceControl.Transports.ASBS.*" ZipFolder="Transports\NetStandardAzureServiceBus" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
+    <AddToZip IncludeMask="System.Diagnostics.*" ZipFolder="Transports\NetStandardAzureServiceBus" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
     <!-- RabbitMQ -->
     <AddToZip IncludeMask="NServiceBus.Transport.RabbitMQ.*" ZipFolder="Transports\RabbitMQ" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
     <AddToZip IncludeMask="RabbitMQ.Client.*" ZipFolder="Transports\RabbitMQ" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />


### PR DESCRIPTION
The code which is responsible for extracting the transport specific files from zip package assumes that there is a single subfolder that has transport name as a prefix.

Before changes in this PR that was not true. `AzureServiceBusNetStandard` subfolder had a prefix `AzureServiceBus` that was also a valid transport name. When installing any of the two ASB topologies unzipping would incorrectly try to extract ASBS subfolder in [FileUtils.cs](https://github.com/Particular/ServiceControl/blob/develop/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs#L891)