### PR TITLE
Reduce allocations when expiring documents

### DIFF
--- a/src/ServiceControl.UnitTests/Expiration/ChunkerTests.cs
+++ b/src/ServiceControl.UnitTests/Expiration/ChunkerTests.cs
@@ -13,11 +13,12 @@
             var starts = new List<int>();
             var ends = new List<int>();
 
-            Chunker.ExecuteInChunks(1500, (s, e) =>
+            var count = Chunker.ExecuteInChunks(1500, (startList, endList, s, e) =>
             {
-                starts.Add(s);
-                ends.Add(e);
-            });
+                startList.Add(s);
+                endList.Add(e);
+                return 1;
+            }, starts, ends);
 
             Assert.AreEqual(0, starts[0]);
             Assert.AreEqual(499, ends[0]);
@@ -30,6 +31,7 @@
 
             Assert.AreEqual(3, starts.Count);
             Assert.AreEqual(3, ends.Count);
+            Assert.AreEqual(3, count);
         }
 
         [Test]
@@ -38,17 +40,19 @@
             var starts = new List<int>();
             var ends = new List<int>();
 
-            Chunker.ExecuteInChunks(1, (s, e) =>
+            var count = Chunker.ExecuteInChunks(1, (startList, endList, s, e) =>
             {
-                starts.Add(s);
-                ends.Add(e);
-            });
+                startList.Add(s);
+                endList.Add(e);
+                return 1;
+            }, starts, ends);
 
             Assert.AreEqual(0, starts[0]);
             Assert.AreEqual(0, ends[0]);
 
             Assert.AreEqual(1, starts.Count);
             Assert.AreEqual(1, ends.Count);
+            Assert.AreEqual(1, count);
         }
 
         [Test]
@@ -57,11 +61,12 @@
             var starts = new List<int>();
             var ends = new List<int>();
 
-            Chunker.ExecuteInChunks(1001, (s, e) =>
+            var count = Chunker.ExecuteInChunks(1001, (startList, endList, s, e) =>
             {
-                starts.Add(s);
-                ends.Add(e);
-            });
+                startList.Add(s);
+                endList.Add(e);
+                return 1;
+            }, starts, ends);
 
             Assert.AreEqual(0, starts[0]);
             Assert.AreEqual(499, ends[0]);
@@ -74,6 +79,7 @@
 
             Assert.AreEqual(3, starts.Count);
             Assert.AreEqual(3, ends.Count);
+            Assert.AreEqual(3, count);
         }
     }
 }

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
@@ -31,7 +31,8 @@
                     FieldsToFetch = new[]
                     {
                         "__document_id",
-                        "MessageMetadata"
+                        "MessageMetadata.MessageId",
+                        "MessageMetadata.BodyNotStored",
                     },
                     SortedFields = new[]
                     {

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
@@ -113,19 +113,18 @@
         static bool TryGetBodyId(RavenJObject doc, out string bodyId)
         {
             bodyId = null;
-            var bodyNotStored = doc.SelectToken("MessageMetadata.BodyNotStored", false);
-            if (bodyNotStored != null && bodyNotStored.Value<bool>())
+            if (doc.Value<bool>("MessageMetadata.BodyNotStored"))
             {
                 return false;
             }
 
-            var messageId = doc.SelectToken("MessageMetadata.MessageId", false);
+            var messageId = doc.Value<string>("MessageMetadata.MessageId");
             if (messageId == null)
             {
                 return false;
             }
 
-            bodyId = "messagebodies/" + messageId.Value<string>();
+            bodyId = $"messagebodies/{messageId}";
             return true;
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/Chunker.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/Chunker.cs
@@ -4,24 +4,23 @@
 
     static class Chunker
     {
-        public static void ExecuteInChunks(int total, Action<int, int> action)
+        public static int ExecuteInChunks<T1, T2>(int total, Func<T1, T2, int, int, int> action, T1 t1, T2 t2)
         {
             if (total == 0)
             {
-                return;
+                return 0;
             }
 
             if (total < CHUNK_SIZE)
             {
-                action(0, total - 1);
-                return;
+                return action(t1, t2, 0, total - 1);
             }
 
             int start = 0, end = CHUNK_SIZE - 1;
-
+            var chunkCount = 0;
             do
             {
-                action(start, end);
+                chunkCount += action(t1, t2, start, end);
 
                 start = end + 1;
                 end += CHUNK_SIZE;
@@ -30,6 +29,8 @@
                     end = total - 1;
                 }
             } while (start < total);
+
+            return chunkCount;
         }
 
         const int CHUNK_SIZE = 500;

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/EventLogItemsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/EventLogItemsCleaner.cs
@@ -60,16 +60,14 @@
                 //Ignore
             }
 
-            var deletionCount = 0;
-
-            Chunker.ExecuteInChunks(items.Count, (s, e) =>
+            var deletionCount = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
                 logger.InfoFormat("Batching deletion of {0}-{1} eventlogitem documents.", s, e);
-                var results = database.Batch(items.GetRange(s, e - s + 1), CancellationToken.None);
+                var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
                 logger.InfoFormat("Batching deletion of {0}-{1} eventlogitem documents completed.", s, e);
 
-                deletionCount += results.Count(x => x.Deleted == true);
-            });
+                return results.Count(x => x.Deleted == true);
+            }, items, database);
 
             if (deletionCount == 0)
             {

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/EventLogItemsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/EventLogItemsCleaner.cs
@@ -41,7 +41,7 @@
                 };
                 var indexName = new ExpiryEventLogItemsIndex().IndexName;
                 database.Query(indexName, query, database.WorkContext.CancellationToken,
-                    doc =>
+                    (doc, commands) =>
                     {
                         var id = doc.Value<string>("__document_id");
                         if (string.IsNullOrEmpty(id))
@@ -49,11 +49,11 @@
                             return;
                         }
 
-                        items.Add(new DeleteCommandData
+                        commands.Add(new DeleteCommandData
                         {
                             Key = id
                         });
-                    });
+                    }, items);
             }
             catch (OperationCanceledException)
             {

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/SagaHistoryCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/SagaHistoryCleaner.cs
@@ -60,16 +60,14 @@
                 //Ignore
             }
 
-            var deletionCount = 0;
-
-            Chunker.ExecuteInChunks(items.Count, (s, e) =>
+            var deletionCount = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
                 logger.InfoFormat("Batching deletion of {0}-{1} sagahistory documents.", s, e);
-                var results = database.Batch(items.GetRange(s, e - s + 1), CancellationToken.None);
+                var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
                 logger.InfoFormat("Batching deletion of {0}-{1} sagahistory documents completed.", s, e);
 
-                deletionCount += results.Count(x => x.Deleted == true);
-            });
+                return results.Count(x => x.Deleted == true);
+            }, items, database);
 
             if (deletionCount == 0)
             {

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/SagaHistoryCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/SagaHistoryCleaner.cs
@@ -41,7 +41,7 @@
                 };
                 var indexName = new ExpirySagaAuditIndex().IndexName;
                 database.Query(indexName, query, database.WorkContext.CancellationToken,
-                    doc =>
+                    (doc, commands) =>
                     {
                         var id = doc.Value<string>("__document_id");
                         if (string.IsNullOrEmpty(id))
@@ -49,11 +49,11 @@
                             return;
                         }
 
-                        items.Add(new DeleteCommandData
+                        commands.Add(new DeleteCommandData
                         {
                             Key = id
                         });
-                    });
+                    }, items);
             }
             catch (OperationCanceledException)
             {

--- a/src/ServiceControl/Infrastructure/RavenDB/Extensions.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Extensions.cs
@@ -8,12 +8,12 @@
 
     static class Extensions
     {
-        public static void Query(this DocumentDatabase db, string index, IndexQuery query, CancellationToken externalCancellationToken, Action<RavenJObject> onItem)
+        public static void Query<TState>(this DocumentDatabase db, string index, IndexQuery query, CancellationToken externalCancellationToken, Action<RavenJObject, TState> onItem, TState state)
         {
             var results = db.Queries.Query(index, query, externalCancellationToken);
             foreach (var doc in results.Results)
             {
-                onItem(doc);
+                onItem(doc, state);
             }
         }
     }


### PR DESCRIPTION
While investigating a customer case I stumbled over large portions of allocations in the expired documents cleaner.

This PR removes some of them. The closure allocations are removed as well as the MessageMetadata allocations are reduced to only what is needed
