### PR TITLE
Less allocations when archiving

### DIFF
--- a/src/ServiceControl/Recoverability/Archiving/ArchiveDocumentManager.cs
+++ b/src/ServiceControl/Recoverability/Archiving/ArchiveDocumentManager.cs
@@ -39,7 +39,6 @@
             var docQuery = indexQuery
                 .Where(failure => failure.FailureGroupId == groupId)
                 .Where(failure => failure.Status == FailedMessageStatus.Unresolved)
-                .ProjectFromIndexFieldsInto<FailureGroupMessageView>()
                 .Select(document => document.Id);
 
             var docs = await StreamResults(session, docQuery).ConfigureAwait(false);
@@ -129,7 +128,7 @@
 
                 var docQuery = indexQuery
                     .Where(failure => failure.FailureGroupId == requestId)
-                    .ProjectFromIndexFieldsInto<FailureGroupMessageView>();
+                    .Select(document => document.Id);
 
                 try
                 {

--- a/src/ServiceControl/Recoverability/Archiving/ArchiveDocumentManager.cs
+++ b/src/ServiceControl/Recoverability/Archiving/ArchiveDocumentManager.cs
@@ -94,21 +94,7 @@
 
         public async Task ArchiveMessageGroupBatch(IAsyncDocumentSession session, ArchiveBatch batch)
         {
-            var patchCommands = batch?.DocumentIds
-                .Select(documentId =>
-                    new PatchCommandData
-                    {
-                        Key = documentId,
-                        Patches = new[]
-                        {
-                            new PatchRequest
-                            {
-                                Type = PatchCommandType.Set,
-                                Name = "Status",
-                                Value = (int)FailedMessageStatus.Archived
-                            }
-                        }
-                    });
+            var patchCommands = batch?.DocumentIds.Select(documentId => new PatchCommandData { Key = documentId, Patches = patchRequest });
 
             if (patchCommands != null)
             {
@@ -159,6 +145,16 @@
                     .ConfigureAwait(false);
             }
         }
+
+        static PatchRequest[] patchRequest =
+        {
+            new PatchRequest
+            {
+                Type = PatchCommandType.Set,
+                Name = "Status",
+                Value = (int)FailedMessageStatus.Archived
+            }
+        };
 
         public class GroupDetails
         {


### PR DESCRIPTION
The patch request command object is always the same and can be cached together with the array

It is not necessary to map all the fields via reflection into FailureGroupMessageView when all we need from the server is IDs from documents