### PR TITLE
Remove HeadersForSearching from metadata and compute query array on the index

### DIFF
--- a/src/ServiceControl.UnitTests/CompositeViews/MessagesViewTests.cs
+++ b/src/ServiceControl.UnitTests/CompositeViews/MessagesViewTests.cs
@@ -36,6 +36,8 @@
 
                 session.SaveChanges();
             }
+            
+            documentStore.WaitForIndexing();
 
             using (var session = documentStore.OpenSession())
             {

--- a/src/ServiceControl/MessageAuditing/ProcessedMessage.cs
+++ b/src/ServiceControl/MessageAuditing/ProcessedMessage.cs
@@ -9,6 +9,7 @@
         public ProcessedMessage()
         {
             MessageMetadata = new Dictionary<string, object>();
+            Headers = new Dictionary<string, string>();
         }
 
         public ProcessedMessage(Dictionary<string, string> headers, Dictionary<string, object> metadata)

--- a/src/ServiceControl/MessageFailures/FailedMessage.cs
+++ b/src/ServiceControl/MessageFailures/FailedMessage.cs
@@ -31,6 +31,12 @@
 
         public class ProcessingAttempt
         {
+            public ProcessingAttempt()
+            {
+                MessageMetadata = new Dictionary<string, object>();
+                Headers = new Dictionary<string, string>();
+            }
+            
             public Dictionary<string, object> MessageMetadata { get; set; }
             public FailureDetails FailureDetails { get; set; }
             public DateTime AttemptedAt { get; set; }

--- a/src/ServiceControl/Operations/AuditImporter.cs
+++ b/src/ServiceControl/Operations/AuditImporter.cs
@@ -134,7 +134,6 @@
             {
                 ["MessageId"] = messageId,
                 ["MessageIntent"] = message.Headers.MessageIntent(),
-                ["HeadersForSearching"] = string.Join(" ", message.Headers.Values)
             };
 
             var enricherTasks = new List<Task>(enrichers.Length);

--- a/src/ServiceControl/Operations/FailedMessagePersister.cs
+++ b/src/ServiceControl/Operations/FailedMessagePersister.cs
@@ -51,7 +51,6 @@
             {
                 ["MessageId"] = messageId,
                 ["MessageIntent"] = message.Headers.MessageIntent(),
-                ["HeadersForSearching"] = string.Join(" ", message.Headers.Values)
             };
 
             var enricherTasks = new List<Task>(enrichers.Length);


### PR DESCRIPTION
For ingested audit messages and error messages we created a metadata field called `HeadersForSearching`. That metadata field is stored in the `ProcessedMessage` collection as well as the FailedMessages collection. In the `FailedMessages` collection, we might store this field redundantly for each processing attempt. The value of that field is never directly used. It is used in the `MessagesViewIndex` to precompute the `Query` array which is then stored in the index itself. This PR removes this redundant storing from the document and modifies the `MessagesViewIndex` to compute the concatenated headers field and directly store it in the index.

This means we only store the headers two times (in the document and the index) per document or processing attempt instead of three times (in the document, the metadata and the index). With that change, we are saving the kbytes of data per ingested audit and error message while still being able to fully query

This will not modify existing documents but just change newly ingested once. Old documents will expire with the expiry period. Reindexing will happen on the `MessagesViewIndex` though.

The larger the headers the bigger the savings plus we no longer allocate the concatenated strings in ServiceControl to shuffle it to RavenDB.

## Processed Message
### Before

![image](https://user-images.githubusercontent.com/174258/45372749-09705200-b5ee-11e8-97ae-e4ad89c7413a.png)

![image](https://user-images.githubusercontent.com/174258/45372782-1a20c800-b5ee-11e8-9010-f57859288c2e.png)

## After

![image](https://user-images.githubusercontent.com/174258/45372954-7c79c880-b5ee-11e8-88fb-8e2c8cafe963.png)

![image](https://user-images.githubusercontent.com/174258/45372982-90bdc580-b5ee-11e8-8b34-0d8878c8fddb.png)


## Failed Message

### Before

![image](https://user-images.githubusercontent.com/174258/45372833-33297900-b5ee-11e8-9bd4-ead7b2c2603f.png)

![image](https://user-images.githubusercontent.com/174258/45372856-3c1a4a80-b5ee-11e8-89ee-5808ee7d58e0.png)

### After

![image](https://user-images.githubusercontent.com/174258/45373030-b4810b80-b5ee-11e8-8964-bdbbb86a7e3e.png)

![image](https://user-images.githubusercontent.com/174258/45373040-bb0f8300-b5ee-11e8-856a-257c2308c840.png)

## Searching

Demonstrates how searching for custom header still works

![image](https://user-images.githubusercontent.com/174258/45372469-5f90c580-b5ed-11e8-967c-2a2b5a8e6e1d.png)

![image](https://user-images.githubusercontent.com/174258/45372510-733c2c00-b5ed-11e8-86c7-8090a6bf3eb9.png)


