### PR TITLE
Switch to 3.5.7 stable of RavenDB

### DIFF
--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Nancy" Version="1.4.3" />
     <PackageReference Include="Nancy.Bootstrappers.Autofac" Version="1.4.1" />
     <PackageReference Include="Nancy.Owin" Version="1.4.1" />
-    <PackageReference Include="RavenDB.Database" Version="3.5.7-patch-35266" />
+    <PackageReference Include="RavenDB.Database" Version="3.5.7" />
     <PackageReference Include="NServiceBus" Version="7.0.1" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.0.0" />
     <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.0" />


### PR DESCRIPTION
When a customer opens up the management studio in maintenance mode the first thing they'll see is the studio informing them about a RavenDB upgrade. This update switches to the latest stable version of RavenDB 3.5.x and thus gets rid of that message as well. See change log https://ravendb.net/docs/article-page/3.5/csharp/start%2fwhats-new?page=1#35274