### PR TITLE
Queue name prefix

### DIFF
--- a/src/ServiceControl.Transports.SQS/SQSTransportCustomization.cs
+++ b/src/ServiceControl.Transports.SQS/SQSTransportCustomization.cs
@@ -41,14 +41,14 @@
                 throw new ArgumentException($"Unknown region: \"{region}\"");
             }
 
-            if (builder.TryGetValue("queuenameprefix", out var queuenameprefix))
+            if (builder.TryGetValue("QueueNamePrefix", out var queueNamePrefix))
             {
-                var queuenameprefixAsString = (string)queuenameprefix;
-                if (!string.IsNullOrEmpty(queuenameprefixAsString))
+                var queueNamePrefixAsString = (string)queueNamePrefix;
+                if (!string.IsNullOrEmpty(queueNamePrefixAsString))
                 {
-                    transport.QueueNamePrefix(queuenameprefixAsString);
+                    transport.QueueNamePrefix(queueNamePrefixAsString);
                 }
-            };
+            }
 
             //HINT: This is needed to make Core doesn't load a connection string value from the app.config.
             //      This prevents SQS from throwing on startup.

--- a/src/ServiceControl.Transports.SQS/SQSTransportCustomization.cs
+++ b/src/ServiceControl.Transports.SQS/SQSTransportCustomization.cs
@@ -41,6 +41,15 @@
                 throw new ArgumentException($"Unknown region: \"{region}\"");
             }
 
+            if (builder.TryGetValue("queuenameprefix", out var queuenameprefix))
+            {
+                var queuenameprefixAsString = (string)queuenameprefix;
+                if (!string.IsNullOrEmpty(queuenameprefixAsString))
+                {
+                    transport.QueueNamePrefix(queuenameprefixAsString);
+                }
+            };
+
             //HINT: This is needed to make Core doesn't load a connection string value from the app.config.
             //      This prevents SQS from throwing on startup.
             var connectionString = transport.GetSettings().Get("NServiceBus.TransportConnectionString");

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
@@ -14,7 +14,7 @@
                 ZipName = "AmazonSQS",
                 TypeName = "ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS",
                 SampleConnectionString = "AccessKeyId=<ACCESSKEYID>;SecretAccessKey=<SECRETACCESSKEY>;Region=<REGION>;QueueNamePrefix=<prefix>",
-                Help = "The 'QueueNamePrefix' is optional and can be left out. All other values are mandatory.",
+                Help = "'AccessKeyId', 'SecretAccessKey' and 'Region' are mandatory configurations.",
                 Matches = name => name.Equals("ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS", StringComparison.OrdinalIgnoreCase)
                                 || name.Equals("AmazonSQS", StringComparison.OrdinalIgnoreCase)
             },

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
@@ -13,7 +13,7 @@
                 Name = "AmazonSQS",
                 ZipName = "AmazonSQS",
                 TypeName = "ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS",
-                SampleConnectionString = "AccessKeyId=<ACCESSKEYID>;SecretAccessKey=<SECRETACCESSKEY>;Region=<REGION>",
+                SampleConnectionString = "AccessKeyId=<ACCESSKEYID>;SecretAccessKey=<SECRETACCESSKEY>;Region=<REGION>;QueueNamePrefix=<prefix>",
                 Matches = name => name.Equals("ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS", StringComparison.OrdinalIgnoreCase)
                                 || name.Equals("AmazonSQS", StringComparison.OrdinalIgnoreCase)
             },

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
@@ -14,6 +14,7 @@
                 ZipName = "AmazonSQS",
                 TypeName = "ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS",
                 SampleConnectionString = "AccessKeyId=<ACCESSKEYID>;SecretAccessKey=<SECRETACCESSKEY>;Region=<REGION>;QueueNamePrefix=<prefix>",
+                Help = "The 'QueueNamePrefix' is optional and can be left out. All other values are mandatory.",
                 Matches = name => name.Equals("ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS", StringComparison.OrdinalIgnoreCase)
                                 || name.Equals("AmazonSQS", StringComparison.OrdinalIgnoreCase)
             },


### PR DESCRIPTION
Closes #1452 

### Configuration UI
![image](https://user-images.githubusercontent.com/174258/46792597-06c76080-cd44-11e8-861e-68ffddcbf4aa.png)

Added a hint to indicate the mandatory settings
It also verified that it is possible to edit an existing instance with a prefix. 

## Prefixed Queues

![prefixedqueues](https://user-images.githubusercontent.com/174258/46792233-33c74380-cd43-11e8-9050-f0f27aeb7202.PNG)

## Failures and Retries

![failedmessages](https://user-images.githubusercontent.com/174258/46792275-4e99b800-cd43-11e8-8d91-44fc483105da.PNG)
![retriedgroup](https://user-images.githubusercontent.com/174258/46792276-4e99b800-cd43-11e8-98eb-9b22cd896d47.PNG)

