### PR TITLE
Filter out null failedmessages

### DIFF
--- a/src/ServiceControl/ExternalIntegrations/MessageFailedPublisher.cs
+++ b/src/ServiceControl/ExternalIntegrations/MessageFailedPublisher.cs
@@ -27,10 +27,9 @@ namespace ServiceControl.ExternalIntegrations
             var failedMessages = new List<object>(failedMessageData.Length);
             foreach (var entity in failedMessageData)
             {
-                session.Advanced.Evict(entity);
-
                 if (entity != null)
                 {
+                    session.Advanced.Evict(entity);
                     failedMessages.Add(entity.ToEvent());
                 }
             }

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.9.8" />
+    <PackageReference Include="DotNetZip" Version="1.11.0" />
     <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceControl/pull/1465

2 Commits. One to bump the zip package version (I can remove this?) and a second to filter out null failed messages.

I can't figure out how to force the expired documents to run in an acceptance test so am not sure how to add a test around this. Any suggestions?