### PR TITLE
Update ServiceControl.Contracts to 1.2.0

### DIFF
--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
-  </ItemGroup>  
+  </ItemGroup>
 
   <ItemGroup>
     <Reference Include="System.Net.Http" />
@@ -28,7 +28,7 @@
     <PackageReference Include="NServiceBus.NLog" Version="3.0.0" />
     <PackageReference Include="NServiceBus.Raw" Version="3.0.0" />
     <PackageReference Include="Microsoft.Owin.Hosting" Version="3.0.1" />
-    <PackageReference Include="ServiceControl.Contracts" Version="1.1.1" />
+    <PackageReference Include="ServiceControl.Contracts" Version="1.2.0" />
     <PackageReference Include="Lucene.Net" Version="3.0.3" />
     <PackageReference Include="Rx-Linq" Version="2.2.5" />
     <PackageReference Include="Microsoft.AspNet.SignalR" Version="2.2.3" />


### PR DESCRIPTION
This updates ServiceControl.Contracts to the version that is multi-targeted to `net40` and `netstandard2.0, as mentioned in #1446.