### PR TITLE
Align required ravendb.database package version

### DIFF
--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -42,10 +42,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(NuGetPackageRoot)ravendb.database\3.5.7-patch-35266\tools\Raven.Studio.Html5.zip" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Remove="Hosting\Help.txt" />
     <EmbeddedResource Include="Hosting\Help.txt" />
   </ItemGroup>
@@ -54,5 +50,11 @@
     <None Remove="Infrastructure\RavenDB\RavenLicense.xml" />
     <EmbeddedResource Include="Infrastructure\RavenDB\RavenLicense.xml" />
   </ItemGroup>
+
+  <Target Name="CopyRavenStudio" BeforeTargets="AssignTargetPaths">
+    <ItemGroup>
+      <None Include="$(NuGetPackageRoot)%(PackageReference.Identity)\%(PackageReference.Version)\tools\Raven.Studio.Html5.zip" CopyToOutputDirectory="PreserveNewest" Condition="'%(PackageReference.Identity)' == 'RavenDB.Database'" />
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
allowing the build to work correctly on a machine without the patch version being in the nuget cache.