### PR TITLE
[WIP]Add netstandard2.0 ref to ServiceControl.exe

### DIFF
--- a/src/NetStandard20Ref/NetStandard20Ref.csproj
+++ b/src/NetStandard20Ref/NetStandard20Ref.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -67,7 +67,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.LoadTests.Re
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Transports.ASBS", "ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj", "{D3BA37DC-FB3C-4ACC-9A4D-4CBBB7BF6A99}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Transports.Learning", "ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj", "{DEDC8155-F9EF-4A8D-9476-B44610AABCA1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Transports.Learning", "ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj", "{DEDC8155-F9EF-4A8D-9476-B44610AABCA1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetStandard20Ref", "NetStandard20Ref\NetStandard20Ref.csproj", "{DE50C422-7730-4ACE-997C-EB9DDAF8FB4A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -163,14 +165,18 @@ Global
 		{E1F20A07-DA6E-460C-ADC8-87BD1D1D8300}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E1F20A07-DA6E-460C-ADC8-87BD1D1D8300}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1F20A07-DA6E-460C-ADC8-87BD1D1D8300}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D3BA37DC-FB3C-4ACC-9A4D-4CBBB7BF6A99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D3BA37DC-FB3C-4ACC-9A4D-4CBBB7BF6A99}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3BA37DC-FB3C-4ACC-9A4D-4CBBB7BF6A99}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3BA37DC-FB3C-4ACC-9A4D-4CBBB7BF6A99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE50C422-7730-4ACE-997C-EB9DDAF8FB4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE50C422-7730-4ACE-997C-EB9DDAF8FB4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE50C422-7730-4ACE-997C-EB9DDAF8FB4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE50C422-7730-4ACE-997C-EB9DDAF8FB4A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -194,8 +200,8 @@ Global
 		{3D9E3A53-164F-4430-A6A4-D35551F5DC88} = {A21A1A89-0B07-4E87-8E3C-41D9C280DCB8}
 		{EFB42D88-E935-4601-AC62-62E68F81B3C3} = {A21A1A89-0B07-4E87-8E3C-41D9C280DCB8}
 		{E1F20A07-DA6E-460C-ADC8-87BD1D1D8300} = {B05ACC74-412F-470C-872F-D1ABD75885B5}
-		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1} = {A21A1A89-0B07-4E87-8E3C-41D9C280DCB8}
 		{D3BA37DC-FB3C-4ACC-9A4D-4CBBB7BF6A99} = {A21A1A89-0B07-4E87-8E3C-41D9C280DCB8}
+		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1} = {A21A1A89-0B07-4E87-8E3C-41D9C280DCB8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3B9E5B72-F580-465A-A22C-2D2148AF4EB4}

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- This reference can be removed as soon as the target is > net4.7.1 -->
+    <ProjectReference Include="..\NetStandard20Ref\NetStandard20Ref.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
To make sure needed facade assemblies needed for net4.6/net4.6.2 will be included.

Closes #1489 

WIP until we know what exact version this will be released in (this PR will be retargeted to a the relevant release branch)