### PR TITLE
Hotfix 3.3.1

### DIFF
--- a/src/ServiceControl.AcceptanceTests/MessageFailures/FailedErrorsModule.cs
+++ b/src/ServiceControl.AcceptanceTests/MessageFailures/FailedErrorsModule.cs
@@ -1,0 +1,37 @@
+﻿namespace ServiceBus.Management.AcceptanceTests
+{
+    using Infrastructure.Extensions;
+    using Infrastructure.Nancy.Modules;
+    using Nancy;
+    using Raven.Client;
+    using ServiceControl.Operations;
+
+    public class FailedErrorsCountReponse
+    {
+        public int Count { get; set; }
+    }
+
+    class FailedErrorsModule : BaseModule
+    {
+        public FailedErrorsModule()
+        {
+            Get["/failederrors/count", true] = async (_, token) =>
+            {
+                using (var session = Store.OpenAsyncSession())
+                {
+                    var query =
+                        session.Query<FailedErrorImport, FailedErrorImportIndex>().Statistics(out var stats);
+
+                    var count = await query.CountAsync();
+
+                    return Negotiate
+                        .WithModel(new FailedErrorsCountReponse
+                        {
+                            Count = count
+                        })
+                        .WithEtag(stats);
+                }
+            };
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/ServiceControlComponentRunner.cs
@@ -189,7 +189,11 @@ namespace ServiceBus.Management.AcceptanceTests
                         };
                         context.Logs.Enqueue(logitem);
                         ctx.Stop().GetAwaiter().GetResult();
-                    }, settings, configuration, loggingSettings, builder => builder.RegisterType<FailedAuditsModule>().As<INancyModule>());
+                    }, settings, configuration, loggingSettings, builder =>
+                    {
+                        builder.RegisterType<FailedAuditsModule>().As<INancyModule>();
+                        builder.RegisterType<FailedErrorsModule>().As<INancyModule>();
+                    });
                     bootstrappers[instanceName] = bootstrapper;
                     bootstrapper.HttpClientFactory = HttpClientFactory;
                 }

--- a/src/ServiceControl/Operations/AuditPersister.cs
+++ b/src/ServiceControl/Operations/AuditPersister.cs
@@ -1,0 +1,69 @@
+﻿namespace ServiceControl.Operations
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using BodyStorage;
+    using Infrastructure;
+    using MessageAuditing;
+    using NServiceBus;
+    using NServiceBus.Transport;
+    using Raven.Client;
+
+    class AuditPersister
+    {
+        public AuditPersister(IDocumentStore store, BodyStorageFeature.BodyStorageEnricher bodyStorageEnricher, IEnrichImportedMessages[] enrichers)
+        {
+            this.store = store;
+            this.bodyStorageEnricher = bodyStorageEnricher;
+            this.enrichers = enrichers.Where(e => e.EnrichAudits).ToArray();
+        }
+
+        public async Task Persist(MessageContext message)
+        {
+            if (!message.Headers.TryGetValue(Headers.MessageId, out var messageId))
+            {
+                messageId = DeterministicGuid.MakeId(message.MessageId).ToString();
+            }
+
+            var metadata = new ConcurrentDictionary<string, object>
+            {
+                ["MessageId"] = messageId,
+                ["MessageIntent"] = message.Headers.MessageIntent(),
+            };
+
+            var enricherTasks = new List<Task>(enrichers.Length);
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            foreach (var enricher in enrichers)
+            {
+                enricherTasks.Add(enricher.Enrich(message.Headers, metadata));
+            }
+
+            await Task.WhenAll(enricherTasks)
+                .ConfigureAwait(false);
+
+            await bodyStorageEnricher.StoreAuditMessageBody(message.Body, message.Headers, metadata)
+                .ConfigureAwait(false);
+
+            var auditMessage = new ProcessedMessage(message.Headers, new Dictionary<string, object>(metadata))
+            {
+                // We do this so Raven does not spend time assigning a hilo key
+                Id = $"ProcessedMessages/{Guid.NewGuid()}"
+            };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(auditMessage)
+                    .ConfigureAwait(false);
+                await session.SaveChangesAsync()
+                    .ConfigureAwait(false);
+            }
+        }
+
+        readonly IEnrichImportedMessages[] enrichers;
+        readonly IDocumentStore store;
+        readonly BodyStorageFeature.BodyStorageEnricher bodyStorageEnricher;
+    }
+}

--- a/src/ServiceControl/Operations/ErrorIngestor.cs
+++ b/src/ServiceControl/Operations/ErrorIngestor.cs
@@ -8,9 +8,9 @@
 
     class ErrorIngestor
     {
-        public ErrorIngestor(FailedMessagePersister failedMessagePersister, FailedMessageAnnouncer failedMessageAnnouncer, IForwardMessages messageForwarder, Settings settings)
+        public ErrorIngestor(ErrorPersister errorPersister, FailedMessageAnnouncer failedMessageAnnouncer, IForwardMessages messageForwarder, Settings settings)
         {
-            this.failedMessagePersister = failedMessagePersister;
+            this.errorPersister = errorPersister;
             this.failedMessageAnnouncer = failedMessageAnnouncer;
             this.messageForwarder = messageForwarder;
             this.settings = settings;
@@ -24,7 +24,7 @@
                 log.Debug($"Ingesting error message {message.MessageId} (original message id: {originalMessageId ?? string.Empty})");
             }
 
-            var failureDetails = await failedMessagePersister.Persist(message)
+            var failureDetails = await errorPersister.Persist(message)
                 .ConfigureAwait(false);
 
             await failedMessageAnnouncer.Announce(message.Headers, failureDetails)
@@ -40,7 +40,7 @@
         IForwardMessages messageForwarder;
         Settings settings;
         FailedMessageAnnouncer failedMessageAnnouncer;
-        FailedMessagePersister failedMessagePersister;
+        ErrorPersister errorPersister;
         static ILog log = LogManager.GetLogger<ErrorIngestor>();
     }
 }

--- a/src/ServiceControl/Operations/ErrorPersister.cs
+++ b/src/ServiceControl/Operations/ErrorPersister.cs
@@ -18,9 +18,9 @@
     using Recoverability;
     using JsonSerializer = Raven.Imports.Newtonsoft.Json.JsonSerializer;
 
-    class FailedMessagePersister
+    class ErrorPersister
     {
-        static FailedMessagePersister()
+        static ErrorPersister()
         {
             Serializer = JsonExtensions.CreateDefaultJsonSerializer();
             Serializer.TypeNameHandling = TypeNameHandling.Auto;
@@ -32,7 +32,7 @@
                                     }}");
         }
 
-        public FailedMessagePersister(IDocumentStore store, BodyStorageFeature.BodyStorageEnricher bodyStorageEnricher, IEnrichImportedMessages[] enrichers, IFailedMessageEnricher[] failedMessageEnrichers)
+        public ErrorPersister(IDocumentStore store, BodyStorageFeature.BodyStorageEnricher bodyStorageEnricher, IEnrichImportedMessages[] enrichers, IFailedMessageEnricher[] failedMessageEnrichers)
         {
             this.store = store;
             this.bodyStorageEnricher = bodyStorageEnricher;


### PR DESCRIPTION
Brings back hotfix 3.3.1 to develop

* Do not use container for SatelliteImportFailuresHandler

* Add error detection to the failed audit reimporter

* Simplified test

* Align StartupTask initialization trickery to do the same for ingestors to avoid building at runtime

* Simplified test When_a_message_fails_to_import

* Failing test

* Really failing test

* Clean up the test

* Rename the test

* Address review comments