### PR TITLE
Fix clean-up bundle

### DIFF
--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -111,6 +111,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public ServiceBus.Management.Infrastructure.Settings.RemoteInstanceSetting[] RemoteInstances { get; set; }
         public int RetryHistoryDepth { get; set; }
         public string RootUrl { get; }
+        public bool RunCleanupBundle { get; set; }
         public bool RunInMemory { get; set; }
         public string ServiceName { get; }
         public bool SkipQueueCreation { get; set; }

--- a/src/ServiceControl.UnitTests/Expiration/ChunkerTests.cs
+++ b/src/ServiceControl.UnitTests/Expiration/ChunkerTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.UnitTests.Expiration
 {
     using System.Collections.Generic;
+    using System.Threading;
     using NUnit.Framework;
     using ServiceControl.Infrastructure.RavenDB.Expiration;
 
@@ -18,7 +19,7 @@
                 startList.Add(s);
                 endList.Add(e);
                 return 1;
-            }, starts, ends);
+            }, starts, ends, CancellationToken.None);
 
             Assert.AreEqual(0, starts[0]);
             Assert.AreEqual(499, ends[0]);
@@ -45,7 +46,7 @@
                 startList.Add(s);
                 endList.Add(e);
                 return 1;
-            }, starts, ends);
+            }, starts, ends, CancellationToken.None);
 
             Assert.AreEqual(0, starts[0]);
             Assert.AreEqual(0, ends[0]);
@@ -66,7 +67,7 @@
                 startList.Add(s);
                 endList.Add(e);
                 return 1;
-            }, starts, ends);
+            }, starts, ends, CancellationToken.None);
 
             Assert.AreEqual(0, starts[0]);
             Assert.AreEqual(499, ends[0]);

--- a/src/ServiceControl.UnitTests/Expiration/ProcessedMessageExpirationTests.cs
+++ b/src/ServiceControl.UnitTests/Expiration/ProcessedMessageExpirationTests.cs
@@ -107,7 +107,7 @@
         {
             new ExpiryProcessedMessageIndex().Execute(documentStore);
             documentStore.WaitForIndexing();
-            AuditMessageCleaner.Clean(doctestrange, documentStore.DocumentDatabase, expiryThreshold);
+            AuditMessageCleaner.Clean(doctestrange, documentStore.DocumentDatabase, expiryThreshold, CancellationToken.None);
             documentStore.WaitForIndexing();
         }
 

--- a/src/ServiceControl.UnitTests/Expiration/SagaAuditExpirationTests.cs
+++ b/src/ServiceControl.UnitTests/Expiration/SagaAuditExpirationTests.cs
@@ -101,7 +101,7 @@
         {
             new ExpirySagaAuditIndex().Execute(documentStore);
             documentStore.WaitForIndexing();
-            SagaHistoryCleaner.Clean(100, documentStore.DocumentDatabase, expiryThreshold);
+            SagaHistoryCleaner.Clean(100, documentStore.DocumentDatabase, expiryThreshold, CancellationToken.None);
             documentStore.WaitForIndexing();
         }
 

--- a/src/ServiceControl/Hosting/Host.cs
+++ b/src/ServiceControl/Hosting/Host.cs
@@ -37,7 +37,11 @@
 
             var loggingSettings = new LoggingSettings(ServiceName);
 
-            bootstrapper = new Bootstrapper(ctx => Stop(), new Settings(ServiceName), busConfiguration, loggingSettings);
+            var settings = new Settings(ServiceName)
+            {
+                RunCleanupBundle = true
+            };
+            bootstrapper = new Bootstrapper(ctx => Stop(), settings, busConfiguration, loggingSettings);
             bootstrapper.Start().GetAwaiter().GetResult();
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/Chunker.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/Chunker.cs
@@ -1,10 +1,11 @@
 ﻿namespace ServiceControl.Infrastructure.RavenDB.Expiration
 {
     using System;
+    using System.Threading;
 
     static class Chunker
     {
-        public static int ExecuteInChunks<T1, T2>(int total, Func<T1, T2, int, int, int> action, T1 t1, T2 t2)
+        public static int ExecuteInChunks<T1, T2>(int total, Func<T1, T2, int, int, int> action, T1 t1, T2 t2, CancellationToken token)
         {
             if (total == 0)
             {
@@ -28,7 +29,7 @@
                 {
                     end = total - 1;
                 }
-            } while (start < total);
+            } while (start < total && !token.IsCancellationRequested);
 
             return chunkCount;
         }

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
@@ -1,7 +1,8 @@
 ﻿namespace ServiceControl.Infrastructure.RavenDB.Expiration
 {
-    using System;
     using System.Globalization;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Raven.Abstractions;
     using Raven.Abstractions.Logging;
     using Raven.Database;
@@ -9,30 +10,25 @@
 
     class ExpiredDocumentsCleaner
     {
-        public static void RunCleanup(int deletionBatchSize, DocumentDatabase database, Settings settings)
+        public static Task<TimerJobExecutionResult> RunCleanup(int deletionBatchSize, DocumentDatabase database, Settings settings, CancellationToken token)
         {
-            try
-            {
-                var threshold = SystemTime.UtcNow.Add(-settings.AuditRetentionPeriod);
+            var threshold = SystemTime.UtcNow.Add(-settings.AuditRetentionPeriod);
 
-                logger.Debug("Trying to find expired ProcessedMessage and SagaHistory documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
-                AuditMessageCleaner.Clean(deletionBatchSize, database, threshold);
-                SagaHistoryCleaner.Clean(deletionBatchSize, database, threshold);
+            logger.Debug("Trying to find expired ProcessedMessage and SagaHistory documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+            AuditMessageCleaner.Clean(deletionBatchSize, database, threshold, token);
+            SagaHistoryCleaner.Clean(deletionBatchSize, database, threshold, token);
 
-                threshold = SystemTime.UtcNow.Add(-settings.ErrorRetentionPeriod);
+            threshold = SystemTime.UtcNow.Add(-settings.ErrorRetentionPeriod);
 
-                logger.Debug("Trying to find expired FailedMessage documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
-                ErrorMessageCleaner.Clean(deletionBatchSize, database, threshold);
+            logger.Debug("Trying to find expired FailedMessage documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+            ErrorMessageCleaner.Clean(deletionBatchSize, database, threshold, token);
 
-                threshold = SystemTime.UtcNow.Add(-settings.EventsRetentionPeriod);
+            threshold = SystemTime.UtcNow.Add(-settings.EventsRetentionPeriod);
 
-                logger.Debug("Trying to find expired EventLogItem documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
-                EventLogItemsCleaner.Clean(deletionBatchSize, database, threshold);
-            }
-            catch (Exception e)
-            {
-                logger.ErrorException("Error when trying to find expired documents", e);
-            }
+            logger.Debug("Trying to find expired EventLogItem documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+            EventLogItemsCleaner.Clean(deletionBatchSize, database, threshold, token);
+
+            return Task.FromResult(TimerJobExecutionResult.ScheduleNextExecution);
         }
 
         static ILog logger = LogManager.GetLogger(typeof(ExpiredDocumentsCleaner));

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.ComponentModel.Composition;
-    using System.Threading;
+    using System.Threading.Tasks;
     using Raven.Abstractions.Logging;
     using Raven.Database;
     using Raven.Database.Plugins;
@@ -13,18 +13,27 @@
     {
         public void Dispose()
         {
-            if (timer != null)
+            lock (this)
             {
-                lock (timer)
+                if (timer == null)
                 {
-                    using (var manualResetEvent = new ManualResetEvent(false))
-                    {
-                        timer.Dispose(manualResetEvent);
-                        manualResetEvent.WaitOne();
-                    }
-
-                    timer = null;
+                    return;
                 }
+
+                var stopTask = timer.Stop();
+                var delayTask = Task.Delay(TimeSpan.FromSeconds(30));
+                var composite = Task.WhenAny(stopTask, delayTask);
+
+                var finishedTask = composite.GetAwaiter().GetResult();
+                if (finishedTask == delayTask)
+                {
+                    logger.Error("Cleanup process did not finish on time. Forcing shutdown.");
+                }
+                else
+                {
+                    logger.Info("Expired documents cleanup process stopped.");
+                }
+                timer = null;
             }
         }
 
@@ -37,30 +46,22 @@
                 return;
             }
 
+            var due = TimeSpan.FromSeconds(deleteFrequencyInSeconds);
             var deletionBatchSize = RavenBootstrapper.Settings.ExpirationProcessBatchSize;
 
             logger.Info("Running deletion of expired documents every {0} seconds", deleteFrequencyInSeconds);
             logger.Info("Deletion batch size set to {0}", deletionBatchSize);
-            logger.Info("Retention period for audits and sagahistory is {0}", RavenBootstrapper.Settings.AuditRetentionPeriod);
+            logger.Info("Retention period for audits and saga history is {0}", RavenBootstrapper.Settings.AuditRetentionPeriod);
             logger.Info("Retention period for errors is {0}", RavenBootstrapper.Settings.ErrorRetentionPeriod);
 
-            var due = TimeSpan.FromSeconds(deleteFrequencyInSeconds);
-            timer = new Timer(executor =>
+            timer = new AsyncTimer(
+                token => ExpiredDocumentsCleaner.RunCleanup(deletionBatchSize, database, RavenBootstrapper.Settings, token), due, due, e =>
             {
-                ExpiredDocumentsCleaner.RunCleanup(deletionBatchSize, database, RavenBootstrapper.Settings);
-
-                try
-                {
-                    timer.Change(due, Timeout.InfiniteTimeSpan);
-                }
-                catch (ObjectDisposedException)
-                {
-                    //Ignored, we are shuting down
-                }
-            }, null, due, Timeout.InfiniteTimeSpan);
+                logger.ErrorException("Error when trying to find expired documents", e);
+            });
         }
 
         ILog logger = LogManager.GetLogger(typeof(ExpiredDocumentsCleanerBundle));
-        Timer timer;
+        AsyncTimer timer;
     }
 }

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/SagaHistoryCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/SagaHistoryCleaner.cs
@@ -13,7 +13,7 @@
 
     static class SagaHistoryCleaner
     {
-        public static void Clean(int deletionBatchSize, DocumentDatabase database, DateTime expiryThreshold)
+        public static void Clean(int deletionBatchSize, DocumentDatabase database, DateTime expiryThreshold, CancellationToken token)
         {
             var stopwatch = Stopwatch.StartNew();
             var items = new List<ICommandData>(deletionBatchSize);
@@ -40,7 +40,7 @@
                     }
                 };
                 var indexName = new ExpirySagaAuditIndex().IndexName;
-                database.Query(indexName, query, database.WorkContext.CancellationToken,
+                database.Query(indexName, query, token,
                     (doc, commands) =>
                     {
                         var id = doc.Value<string>("__document_id");
@@ -57,25 +57,31 @@
             }
             catch (OperationCanceledException)
             {
-                //Ignore
+                logger.Info("Cleanup operation cancelled");
+                return;
+            }
+
+            if (token.IsCancellationRequested)
+            {
+                return;
             }
 
             var deletionCount = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
-                logger.InfoFormat("Batching deletion of {0}-{1} sagahistory documents.", s, e);
+                logger.InfoFormat("Batching deletion of {0}-{1} saga history documents.", s, e);
                 var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
-                logger.InfoFormat("Batching deletion of {0}-{1} sagahistory documents completed.", s, e);
+                logger.InfoFormat("Batching deletion of {0}-{1} saga history documents completed.", s, e);
 
                 return results.Count(x => x.Deleted == true);
-            }, items, database);
+            }, items, database, token);
 
             if (deletionCount == 0)
             {
-                logger.Info("No expired sagahistory documents found");
+                logger.Info("No expired saga history documents found");
             }
             else
             {
-                logger.InfoFormat("Deleted {0} expired sagahistory documents. Batch execution took {1}ms", deletionCount, stopwatch.ElapsedMilliseconds);
+                logger.InfoFormat("Deleted {0} expired saga history documents. Batch execution took {1}ms", deletionCount, stopwatch.ElapsedMilliseconds);
             }
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/RavenBootstrapper.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/RavenBootstrapper.cs
@@ -21,6 +21,8 @@
     {
         public static Settings Settings { get; set; }
 
+        public bool RunCleanup { get; set; }
+
         public void Customize(EndpointConfiguration configuration)
         {
             var documentStore = configuration.GetSettings().Get<EmbeddableDocumentStore>();
@@ -78,7 +80,7 @@
             documentStore.Configuration.Settings["Raven/AnonymousAccess"] = "Admin";
             documentStore.Configuration.Settings["Raven/Licensing/AllowAdminAnonymousAccessForCommercialUse"] = "true";
 
-            if (!maintenanceMode)
+            if (Settings.RunCleanupBundle)
             {
                 documentStore.Configuration.Settings.Add("Raven/ActiveBundles", "CustomDocumentExpiration");
             }

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -65,6 +65,8 @@
 
         public bool SkipQueueCreation { get; set; }
 
+        public bool RunCleanupBundle { get; set; }
+
         public string RootUrl
         {
             get


### PR DESCRIPTION
Requires https://github.com/Particular/ServiceControl/pull/1509
Fixes https://github.com/Particular/ServiceControl/issues/980

Uses the newly added `AsyncTimer` to manage the cleaners. Passes the timer's cancellation token down the line to chunkers and cleaners