### PR TITLE
Used service name from command line when importing failed messages

### DIFF
--- a/src/ServiceControl/Hosting/Commands/ImportFailedAuditsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/ImportFailedAuditsCommand.cs
@@ -17,7 +17,7 @@
 
         void RunAndWait(HostArguments args)
         {
-            var settings = new Settings
+            var settings = new Settings(args.ServiceName)
             {
                 IngestAuditMessages = false,
                 IngestErrorMessages = false


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceControl/issues/1511