### PR TITLE
Enrich default logging

### DIFF
--- a/src/ServiceControl.UnitTests/Recoverability/Retry_State_Tests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/Retry_State_Tests.cs
@@ -330,7 +330,7 @@
         {
         }
 
-        public override Task Run(Predicate<MessageContext> filter, CancellationToken cancellationToken, int? expectedMessageCount = null)
+        public override Task Run(string forwardingBatchId, Predicate<MessageContext> filter, CancellationToken cancellationToken, int? expectedMessageCount = null)
         {
             return Task.FromResult(0);
         }

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/EventLogItemsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/EventLogItemsCleaner.cs
@@ -68,20 +68,28 @@
 
             var deletionCount = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
-                logger.InfoFormat("Batching deletion of {0}-{1} eventlogitem documents.", s, e);
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} event log documents.");
+                }
+
                 var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
-                logger.InfoFormat("Batching deletion of {0}-{1} eventlogitem documents completed.", s, e);
+
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} event log documents completed.");
+                }
 
                 return results.Count(x => x.Deleted == true);
             }, items, database, token);
 
             if (deletionCount == 0)
             {
-                logger.Info("No expired eventlogitem documents found");
+                logger.Info("No expired event log documents found");
             }
             else
             {
-                logger.InfoFormat("Deleted {0} expired eventlogitem documents. Batch execution took {1}ms", deletionCount, stopwatch.ElapsedMilliseconds);
+                logger.Info($"Deleted {deletionCount} expired event log documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
             }
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/SagaHistoryCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/SagaHistoryCleaner.cs
@@ -68,10 +68,16 @@
 
             var deletionCount = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
-                logger.InfoFormat("Batching deletion of {0}-{1} saga history documents.", s, e);
-                var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
-                logger.InfoFormat("Batching deletion of {0}-{1} saga history documents completed.", s, e);
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} saga history documents.");
+                }
 
+                var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} saga history documents completed.");
+                }
                 return results.Count(x => x.Deleted == true);
             }, items, database, token);
 
@@ -81,7 +87,7 @@
             }
             else
             {
-                logger.InfoFormat("Deleted {0} expired saga history documents. Batch execution took {1}ms", deletionCount, stopwatch.ElapsedMilliseconds);
+                logger.Info($"Deleted {deletionCount} expired saga history documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
             }
         }
 

--- a/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
@@ -9,7 +9,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
     {
         public LoggingSettings(string serviceName, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null)
         {
-            LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Warn);
+            LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
             RavenDBLogLevel = InitializeLevel("RavenDBLogLevel", defaultRavenDBLevel ?? LogLevel.Warn);
             LogPath = Environment.ExpandEnvironmentVariables(ConfigFileSettingsReader<string>.Read("LogPath", logPath ?? DefaultLogPathForInstance(serviceName)));
         }

--- a/src/ServiceControl/Operations/ImportFailedAudits.cs
+++ b/src/ServiceControl/Operations/ImportFailedAudits.cs
@@ -55,7 +55,10 @@ namespace ServiceControl.Operations
                             await store.AsyncDatabaseCommands.DeleteAsync(ie.Current.Key, null, token)
                                 .ConfigureAwait(false);
                             succeeded++;
-                            Logger.Info($"Successfully re-imported failed audit message {dto.Id}.");
+                            if (Logger.IsDebugEnabled)
+                            {
+                                Logger.Debug($"Successfully re-imported failed audit message {dto.Id}.");
+                            }
                         }
                         catch (Exception e)
                         {

--- a/src/ServiceControl/Recoverability/Retrying/RetriesGateway.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetriesGateway.cs
@@ -66,7 +66,7 @@ namespace ServiceControl.Recoverability
             where TIndex : AbstractIndexCreationTask, new()
             where TType : IHaveStatus
         {
-            log.InfoFormat("Enqueuing index based bulk retry '{0}'", originator);
+            log.Info($"Enqueuing index based bulk retry '{originator}'");
 
             var request = new IndexBasedBulkRetryRequest<TType, TIndex>(requestId, retryType, originator, classifier, startTime, filter);
 
@@ -75,7 +75,7 @@ namespace ServiceControl.Recoverability
 
         public async Task StartRetryForSingleMessage(string uniqueMessageId)
         {
-            log.InfoFormat("Retrying a single message {0}", uniqueMessageId);
+            log.Info($"Retrying a single message {uniqueMessageId}");
 
             var requestId = uniqueMessageId;
             var retryType = RetryType.SingleMessage;
@@ -91,7 +91,7 @@ namespace ServiceControl.Recoverability
 
         public async Task StartRetryForMessageSelection(string[] uniqueMessageIds)
         {
-            log.InfoFormat("Retrying a selection of {0} messages", uniqueMessageIds.Length);
+            log.Info($"Retrying a selection of {uniqueMessageIds.Length} messages");
 
             var requestId = Guid.NewGuid().ToString();
             var retryType = RetryType.MultipleMessages;
@@ -109,7 +109,7 @@ namespace ServiceControl.Recoverability
         {
             if (messageIds == null || !messageIds.Any())
             {
-                log.DebugFormat("Batch '{0}' contains no messages", batchName);
+                log.Info($"Batch '{batchName}' contains no messages");
                 return;
             }
 
@@ -118,7 +118,7 @@ namespace ServiceControl.Recoverability
             var batchDocumentId = await retryDocumentManager.CreateBatchDocument(requestId, retryType, failedMessageRetryIds, originator, startTime, last, batchName, classifier)
                 .ConfigureAwait(false);
 
-            log.InfoFormat("Created Batch '{0}' with {1} messages for '{2}'", batchDocumentId, messageIds.Length, batchName);
+            log.Info($"Created Batch '{batchDocumentId}' with {messageIds.Length} messages for '{batchName}'.");
 
             var commands = new ICommandData[messageIds.Length];
             for (var i = 0; i < messageIds.Length; i++)
@@ -131,7 +131,7 @@ namespace ServiceControl.Recoverability
 
             await retryDocumentManager.MoveBatchToStaging(batchDocumentId).ConfigureAwait(false);
 
-            log.InfoFormat("Moved Batch '{0}' to Staging", batchDocumentId);
+            log.Info($"Moved Batch '{batchDocumentId}' to Staging");
         }
 
         internal async Task<bool> ProcessNextBulkRetry()

--- a/src/ServiceControl/Recoverability/Retrying/RetryDocumentManager.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetryDocumentManager.cs
@@ -110,12 +110,12 @@ namespace ServiceControl.Recoverability
                 .ToListAsync()
                 .ConfigureAwait(false);
 
-            log.InfoFormat("Found {0} orphaned retry batches from previous sessions", orphanedBatches.Count);
+            log.Info($"Found {orphanedBatches.Count} orphaned retry batches from previous sessions.");
 
             // let's leave Task.Run for now due to sync sends
             await Task.WhenAll(orphanedBatches.Select(b => Task.Run(async () =>
             {
-                log.InfoFormat("Adopting retry batch {0} from previous session with {1} messages", b.Id, b.FailureRetries.Count);
+                log.Info($"Adopting retry batch {b.Id} with {b.FailureRetries.Count} messages.");
                 await MoveBatchToStaging(b.Id).ConfigureAwait(false);
             }))).ConfigureAwait(false);
 


### PR DESCRIPTION
Fixes #1486 

 * Switch default log level to `Info`
 * Downgrade and clean up some expired document cleaner logging 
 * Upgrade and clean up some recoverability logging
 * Change `InfoFormat` to `Info`
 * Change `DebugFormat` to `IsDebugEnabled` + `Debug`
