### PR TITLE
Adding learning transport to packaging to simplify platform sample

### DIFF
--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -64,6 +64,8 @@
     <AddToZip IncludeMask="AWSSDK.*" ZipFolder="Transports\AmazonSQS" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
     <AddToZip IncludeMask="NServiceBus.AmazonSQS.dll" ZipFolder="Transports\AmazonSQS" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
     <AddToZip IncludeMask="ServiceControl.Transports.SQS.dll" ZipFolder="Transports\AmazonSQS" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
+    <!-- LearningTransport -->
+    <AddToZip IncludeMask="ServiceControl.Transports.Learning.*" ZipFolder="Transports\LearningTransport" SourceFolder="$(OutputPath)" ZipFileName="$(ZipToCreate)" />
     <!-- ServiceControl  -->
     <AddToZip IncludeMask="*.*" ExcludeMask="*.config" ZipFolder="ServiceControl" SourceFolder="..\ServiceControl\bin\$(Configuration)\$(TargetFramework)" ZipFileName="$(ZipToCreate)" />
   </Target>


### PR DESCRIPTION
The readme would become quite complex to update the ServiceControl binaries

https://github.com/Particular/Particular.PlatformSample/blob/master/README.md

by adding it to the package we can write into the readme

Extract zip, copy SC binaries, copy LearningTransport binaries into root folder

If that is not present the one that is maintaining the platform package has to checkout a specific tag, release build SC and then copy over the adapter for the learning transport

It would be great to have this in a maintenance release. The idea is to just package but not expose on UI.