### PR TITLE
Upgrade license package

### DIFF
--- a/src/ServiceControl/Licensing/ActiveLicense.cs
+++ b/src/ServiceControl/Licensing/ActiveLicense.cs
@@ -24,7 +24,9 @@
             sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ParticularPlatformLicense.xml")));
             var result = Particular.Licensing.ActiveLicense.Find("ServiceControl", sources.ToArray());
 
-            if (result.HasExpired)
+            IsValid = !result.License.HasExpired();
+
+            if (!IsValid)
             {
                 foreach (var report in result.Report)
                 {
@@ -35,7 +37,6 @@
             }
 
             Details = result.License;
-            IsValid = !result.HasExpired;
         }
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(ActiveLicense));

--- a/src/ServiceControl/Licensing/LicenseModule.cs
+++ b/src/ServiceControl/Licensing/LicenseModule.cs
@@ -23,7 +23,9 @@
                     RegisteredTo = ActiveLicense.Details.RegisteredTo ?? string.Empty,
                     UpgradeProtectionExpiration = ActiveLicense.Details.UpgradeProtectionExpiration?.ToString("O") ?? string.Empty,
                     ExpirationDate = ActiveLicense.Details.ExpirationDate?.ToString("O") ?? string.Empty,
-                    Status = ActiveLicense.IsValid ? "valid" : "invalid"
+                    Status = ActiveLicense.IsValid ? "valid" : "invalid",
+                    LicenseType = ActiveLicense.Details.LicenseType ?? string.Empty,
+                    InstanceName = Settings.ServiceName ?? string.Empty
                 };
                 return Negotiate.WithModel(licenseInfo);
             };
@@ -39,6 +41,8 @@
             public string UpgradeProtectionExpiration { get; set; }
             public string ExpirationDate { get; set; }
             public string Status { get; set; }
+            public string LicenseType { get; set; }
+            public string InstanceName { get; set; }
         }
     }
 }

--- a/src/ServiceControl/Licensing/LicenseModule.cs
+++ b/src/ServiceControl/Licensing/LicenseModule.cs
@@ -25,7 +25,8 @@
                     ExpirationDate = ActiveLicense.Details.ExpirationDate?.ToString("O") ?? string.Empty,
                     Status = ActiveLicense.IsValid ? "valid" : "invalid",
                     LicenseType = ActiveLicense.Details.LicenseType ?? string.Empty,
-                    InstanceName = Settings.ServiceName ?? string.Empty
+                    InstanceName = Settings.ServiceName ?? string.Empty,
+                    LicenseStatus = ActiveLicense.Details.GetLicenseStatus().ToString()
                 };
                 return Negotiate.WithModel(licenseInfo);
             };
@@ -43,6 +44,7 @@
             public string Status { get; set; }
             public string LicenseType { get; set; }
             public string InstanceName { get; set; }
+            public string LicenseStatus { get; set; }
         }
     }
 }

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Owin.Cors" Version="3.0.1" />
     <PackageReference Include="Owin.Metrics" Version="0.3.7" />
     <PackageReference Include="StackTraceParser.Source" Version="1.3.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Upgrades the licensing package so that SP can simply look at the `GetLicenseStatus()` method without us having to re-implement the logic. This is likely going to cause conflicts with the maintenance release as @SzymonPobiega did the same upgrade on that branch. Should this wait until the maintenance release is merged to develop to make the conflicts easier to deal with?