### PR TITLE
RavenDB 3.5.8

### DIFF
--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Nancy" Version="1.4.5" />
     <PackageReference Include="Nancy.Bootstrappers.Autofac" Version="1.4.1" />
     <PackageReference Include="Nancy.Owin" Version="1.4.1" />
-    <PackageReference Include="RavenDB.Database" Version="3.5.7" />
+    <PackageReference Include="RavenDB.Database" Version="3.5.8" />
     <PackageReference Include="NServiceBus" Version="7.1.6" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.0.0" />
     <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.0" />


### PR DESCRIPTION
Fixes on Server

- [Replication] fixed 'Topology-Id' header validation that could prevent attachment replication to other nodes
- [Streaming] Fixed timeout issue when streaming results of expensive queries
- fixed issue with 'LoadStartingWith' returning only first page of results when 'matches' parameter is passed

Other fixes are RavenFS which are not interesting for us

Fixes on Client

- Fixed possible hang when using async API in full .NET Framework project that uses ASP.NET Core