### PR TITLE
Update to 3.5.9-patch-35280 which fixes the cancellation warnings in the logs

### DIFF
--- a/src/ServiceControl.UnitTests/BodyStorage/BodyStorageTests.cs
+++ b/src/ServiceControl.UnitTests/BodyStorage/BodyStorageTests.cs
@@ -18,7 +18,7 @@
                 var messageId = "messagebodies/3f0240a7-9b2e-4e2a-ab39-6114932adad1\\2055783";
                 var contentType = "NotImportant";
                 var body = new byte[] { 1, 2, 3 };
-                
+
                 await bodyStore.Store(messageId, contentType, body.Length, new MemoryStream(body));
 
                 var retrieved = await bodyStore.TryFetch(messageId);

--- a/src/ServiceControl/Operations/BodyStorage/RavenAttachments/RavenAttachmentsBodyStorage.cs
+++ b/src/ServiceControl/Operations/BodyStorage/RavenAttachments/RavenAttachmentsBodyStorage.cs
@@ -5,7 +5,6 @@
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Nancy.Helpers;
     using Raven.Client;
     using Raven.Json.Linq;
 
@@ -52,7 +51,7 @@
         {
             //We want to continue using attachments for now
 #pragma warning disable 618
-            var attachment = await DocumentStore.AsyncDatabaseCommands.GetAttachmentAsync($"messagebodies/{HttpUtility.UrlEncode(bodyId)}").ConfigureAwait(false);
+            var attachment = await DocumentStore.AsyncDatabaseCommands.GetAttachmentAsync($"messagebodies/{bodyId}").ConfigureAwait(false);
 #pragma warning restore 618
 
             return attachment == null

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Nancy" Version="1.4.5" />
     <PackageReference Include="Nancy.Bootstrappers.Autofac" Version="1.4.1" />
     <PackageReference Include="Nancy.Owin" Version="1.4.1" />
-    <PackageReference Include="RavenDB.Database" Version="3.5.8" />
+    <PackageReference Include="RavenDB.Database" Version="3.5.9-patch-35280" />
     <PackageReference Include="NServiceBus" Version="7.1.6" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.0.0" />
     <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.0" />


### PR DESCRIPTION
Should contain

https://github.com/ravendb/ravendb/pull/8512
and 
https://github.com/ravendb/ravendb/pull/8452