### PR TITLE
Remove additional headers

### DIFF
--- a/src/ServiceControl/Recoverability/Retrying/RetryProcessor.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetryProcessor.cs
@@ -343,7 +343,9 @@ namespace ServiceControl.Recoverability
             "NServiceBus.ExceptionInfo.ExceptionType",
             "NServiceBus.ExceptionInfo.AuditMessage",
             "NServiceBus.ExceptionInfo.Source",
-            "NServiceBus.ExceptionInfo.StackTrace"
+            "NServiceBus.ExceptionInfo.StackTrace",
+            "NServiceBus.ExceptionInfo.HelpLink",
+            "NServiceBus.ExceptionInfo.Message"
         };
 
         static ILog Log = LogManager.GetLogger(typeof(RetryProcessor));


### PR DESCRIPTION
ExceptionInfo also contains HelpLink and Message which should be removed

```
{
    "IdForCorrelation": null,
    "Id": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
    "MessageIntent": 1,
    "ReplyToAddress": "samples-azure-storagequeue-fa38d2dd-3521-3b52-012a-481912b5addc@UseDevelopmentStorage=true",
    "TimeToBeReceived": "00:00:00",
    "Headers": {
        "NServiceBus.MessageId": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
        "NServiceBus.MessageIntent": "Send",
        "NServiceBus.ConversationId": "b2afad5f-9769-4902-8194-aa3100ae8d3e",
        "NServiceBus.CorrelationId": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
        "NServiceBus.OriginatingMachine": "BF108680",
        "NServiceBus.OriginatingEndpoint": "Samples.Azure.StorageQueues.Endpoint1.With.A.Very.Long.Name.And.Invalid.Characters",
        "$.diagnostics.originating.hostid": "68830db6402ef34076669bfdd1a4569f",
        "NServiceBus.ReplyToAddress": "samples-azure-storagequeue-fa38d2dd-3521-3b52-012a-481912b5addc@UseDevelopmentStorage=true",
        "NServiceBus.ContentType": "application/json",
        "NServiceBus.EnclosedMessageTypes": "Message1, Shared, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
        "NServiceBus.Version": "7.1.7",
        "NServiceBus.TimeSent": "2019-04-16 10:35:31:448150 Z",
        "NServiceBus.ExceptionInfo.ExceptionType": "System.InvalidOperationException",
        "NServiceBus.ExceptionInfo.HelpLink": null,
        "NServiceBus.ExceptionInfo.Message": "Operation is not valid due to the current state of the object.",
        "NServiceBus.ExceptionInfo.Source": "Endpoint2",
        "NServiceBus.ExceptionInfo.StackTrace": "System.InvalidOperationException: Operation is not valid due to the current state of the object.\r\n   at Message1Handler.Handle(Message1 message, IMessageHandlerContext context)\r\n   at NServiceBus.InvokeHandlerTerminator.Terminate(IInvokeHandlerContext context)\r\n   at (Closure`2 , IInvokeHandlerContext )\r\n   at NServiceBus.LoadHandlersConnector.<Invoke>d__1.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at NServiceBus.MutateIncomingMessageBehavior.<InvokeIncomingMessageMutators>d__2.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at NServiceBus.DeserializeLogicalMessagesConnector.<Invoke>d__1.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at NServiceBus.UnitOfWorkBehavior.<InvokeUnitsOfWork>d__1.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at NServiceBus.UnitOfWorkBehavior.<InvokeUnitsOfWork>d__1.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at NServiceBus.MutateIncomingTransportMessageBehavior.<InvokeIncomingTransportMessagesMutators>d__2.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at NServiceBus.ProcessingStatisticsBehavior.<Invoke>d__0.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at NServiceBus.TransportReceiveToPhysicalMessageProcessingConnector.<Invoke>d__1.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at NServiceBus.MainPipelineExecutor.<Invoke>d__1.MoveNext()\r\n--- End of stack trace from previous location where exception was thrown ---\r\n   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)\r\n   at NServiceBus.Transport.AzureStorageQueues.AtLeastOnceReceiveStrategy.<Receive>d__1.MoveNext()",
        "NServiceBus.TimeOfFailure": "2019-04-16 10:35:34:142152 Z",
        "NServiceBus.FailedQ": "samples-azure-storagequeues-endpoint2",
        "NServiceBus.ProcessingMachine": "BF108680",
        "NServiceBus.ProcessingEndpoint": "Samples.Azure.StorageQueues.Endpoint2",
        "$.diagnostics.hostid": "4519f1b3a3e06657b7724611f16d9b28",
        "$.diagnostics.hostdisplayname": "BF108680"
    },
    "Body": "77u/eyJQcm9wZXJ0eSI6IkhlbGxvIGZyb20gRW5kcG9pbnQxIn0=",
    "CorrelationId": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
    "Recoverable": true
}
```

turned into 

```
{
    "IdForCorrelation": null,
    "Id": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
    "MessageIntent": 1,
    "ReplyToAddress": "samples-azure-storagequeue-fa38d2dd-3521-3b52-012a-481912b5addc@UseDevelopmentStorage=true",
    "TimeToBeReceived": "00:00:00",
    "Headers": {
        "NServiceBus.MessageId": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
        "NServiceBus.MessageIntent": "Send",
        "NServiceBus.ConversationId": "b2afad5f-9769-4902-8194-aa3100ae8d3e",
        "NServiceBus.CorrelationId": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
        "NServiceBus.OriginatingMachine": "BF108680",
        "NServiceBus.OriginatingEndpoint": "Samples.Azure.StorageQueues.Endpoint1.With.A.Very.Long.Name.And.Invalid.Characters",
        "$.diagnostics.originating.hostid": "68830db6402ef34076669bfdd1a4569f",
        "NServiceBus.ReplyToAddress": "samples-azure-storagequeue-fa38d2dd-3521-3b52-012a-481912b5addc@UseDevelopmentStorage=true",
        "NServiceBus.ContentType": "application/json",
        "NServiceBus.EnclosedMessageTypes": "Message1, Shared, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
        "NServiceBus.Version": "7.1.7",
        "NServiceBus.TimeSent": "2019-04-16 10:35:31:448150 Z",
        "NServiceBus.ExceptionInfo.HelpLink": null,
        "NServiceBus.ExceptionInfo.Message": "Operation is not valid due to the current state of the object.",
        "NServiceBus.ProcessingMachine": "BF108680",
        "NServiceBus.ProcessingEndpoint": "Samples.Azure.StorageQueues.Endpoint2",
        "$.diagnostics.hostid": "4519f1b3a3e06657b7724611f16d9b28",
        "$.diagnostics.hostdisplayname": "BF108680"
    },
    "Body": "77u/eyJQcm9wZXJ0eSI6IkhlbGxvIGZyb20gRW5kcG9pbnQxIn0=",
    "CorrelationId": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
    "Recoverable": true
}
```

with this fix into

```
{
    "IdForCorrelation": null,
    "Id": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
    "MessageIntent": 1,
    "ReplyToAddress": "samples-azure-storagequeue-fa38d2dd-3521-3b52-012a-481912b5addc@UseDevelopmentStorage=true",
    "TimeToBeReceived": "00:00:00",
    "Headers": {
        "NServiceBus.MessageId": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
        "NServiceBus.MessageIntent": "Send",
        "NServiceBus.ConversationId": "b2afad5f-9769-4902-8194-aa3100ae8d3e",
        "NServiceBus.CorrelationId": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
        "NServiceBus.OriginatingMachine": "BF108680",
        "NServiceBus.OriginatingEndpoint": "Samples.Azure.StorageQueues.Endpoint1.With.A.Very.Long.Name.And.Invalid.Characters",
        "$.diagnostics.originating.hostid": "68830db6402ef34076669bfdd1a4569f",
        "NServiceBus.ReplyToAddress": "samples-azure-storagequeue-fa38d2dd-3521-3b52-012a-481912b5addc@UseDevelopmentStorage=true",
        "NServiceBus.ContentType": "application/json",
        "NServiceBus.EnclosedMessageTypes": "Message1, Shared, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
        "NServiceBus.Version": "7.1.7",
        "NServiceBus.TimeSent": "2019-04-16 10:35:31:448150 Z",
        "NServiceBus.ProcessingMachine": "BF108680",
        "NServiceBus.ProcessingEndpoint": "Samples.Azure.StorageQueues.Endpoint2",
        "$.diagnostics.hostid": "4519f1b3a3e06657b7724611f16d9b28",
        "$.diagnostics.hostdisplayname": "BF108680"
    },
    "Body": "77u/eyJQcm9wZXJ0eSI6IkhlbGxvIGZyb20gRW5kcG9pbnQxIn0=",
    "CorrelationId": "3a326f1b-d4ad-4b3d-a766-aa3100ae8d3d",
    "Recoverable": true
}
```
