### PR TITLE
Do not serialize dictionary keys using the property name strategy

### DIFF
--- a/src/ServiceControl/Infrastructure/SignalR/UnderscoreMappingResolver.cs
+++ b/src/ServiceControl/Infrastructure/SignalR/UnderscoreMappingResolver.cs
@@ -6,6 +6,11 @@
 
     class UnderscoreMappingResolver : DefaultContractResolver
     {
+        protected override string ResolveDictionaryKey(string dictionaryKey)
+        {
+            return dictionaryKey;
+        }
+
         protected override string ResolvePropertyName(string propertyName)
         {
             return Regex.Replace(


### PR DESCRIPTION
This is a bit of a long shot but it actually seems to work. That way, dictionary keys won't be changed by the `ResolvePropertyName` method (as this is what the default implementation does) and it will retain the original key value.

I didn't find any other place where this would have an impact on the API but I need to admit that I'm not sure about that.