### PR TITLE
Check remaining disk space

### DIFF
--- a/src/ServiceControl/Operations/CheckFreeDiskSpace.cs
+++ b/src/ServiceControl/Operations/CheckFreeDiskSpace.cs
@@ -1,0 +1,47 @@
+﻿namespace ServiceControl.Operations
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using NServiceBus.CustomChecks;
+    using NServiceBus.Logging;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    class CheckFreeDiskSpace : CustomCheck
+    {
+        static readonly ILog Logger = LogManager.GetLogger(typeof(CheckFreeDiskSpace));
+        const decimal PercentageThreshold = 20m / 100m;
+        readonly string dataPath;
+    
+        public CheckFreeDiskSpace(Settings settings) : base("Message database", "Storage space", TimeSpan.FromMinutes(5))
+        {
+            Logger.Debug($"Check ServiceControl data drive space remaining custom check starting. Threshold {PercentageThreshold:P0}");
+            dataPath = settings.DbPath;
+        }
+
+        public override Task<CheckResult> PerformCheck()
+        {
+            var dataPathRoot = Path.GetPathRoot(dataPath);
+
+            if (dataPathRoot == null)
+            {
+                throw new Exception($"Unable to find the root of the data path {dataPath}");
+            }
+
+            var dataDriveInfo = new DriveInfo(dataPathRoot);
+            var availableFreeSpace = (decimal)dataDriveInfo.AvailableFreeSpace;
+            var totalSpace = (decimal)dataDriveInfo.TotalSize;
+
+            var percentRemaining = (decimal) dataDriveInfo.AvailableFreeSpace / dataDriveInfo.TotalSize;
+
+            if (Logger.IsDebugEnabled)
+            {
+                Logger.Debug($"Free space: {availableFreeSpace} | Total: {totalSpace} | Percent remaining {percentRemaining:P0}");
+            }
+
+            return percentRemaining > PercentageThreshold 
+                ? CheckResult.Pass 
+                : CheckResult.Failed($"{percentRemaining:P0} disk space remaining on data drive {dataDriveInfo.VolumeLabel} on {Environment.MachineName}.");
+        }
+    }
+}


### PR DESCRIPTION
If disk space runs out on the drive where ServiceControl stores it's data directory, then it can no longer ingest new messages. It also causes the retention indexes to get stopped so old data is retained forever. This custom check informs the user when the disk space remaining drops below 20%

This is what it looks like when it fires:

![Running out of Disk Space](https://user-images.githubusercontent.com/124014/57006774-fb6f5000-6c15-11e9-85cd-f63ac62d8ddd.PNG)

And if you click on it you get additional details:

![Running out of Disk Space - Details](https://user-images.githubusercontent.com/124014/57006779-06c27b80-6c16-11e9-9a3a-b4d71519c265.PNG)

For the purposes of testing and taking the screenshots, I upped the limit to 40%. 