### PR TITLE
Report Retry Issues properly

### DIFF
--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -392,6 +392,7 @@ namespace ServiceControl.Contracts.Operations
         Successful = 3,
         ResolvedSuccessfully = 4,
         ArchivedFailure = 5,
+        RetryIssued = 6,
     }
 }
 namespace ServiceControl.CustomChecks

--- a/src/ServiceControl/CompositeViews/Messages/MessagesViewTransformer.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesViewTransformer.cs
@@ -25,7 +25,9 @@ namespace ServiceControl.CompositeViews.Messages
                 let status =
                     message.ProcessingAttempts == null
                         ? !(bool)message.MessageMetadata["IsRetried"] ? MessageStatus.Successful : MessageStatus.ResolvedSuccessfully
-                        : message.Status == FailedMessageStatus.Archived
+                        : message.Status == FailedMessageStatus.RetryIssued
+                          ? MessageStatus.RetryIssued
+                          : message.Status == FailedMessageStatus.Archived
                             ? MessageStatus.ArchivedFailure
                             : message.ProcessingAttempts.Count == 1
                                 ? MessageStatus.Failed

--- a/src/ServiceControl/Contracts/Operations/MessageStatus.cs
+++ b/src/ServiceControl/Contracts/Operations/MessageStatus.cs
@@ -6,6 +6,7 @@
         RepeatedFailure = 2,
         Successful = 3,
         ResolvedSuccessfully = 4,
-        ArchivedFailure = 5
+        ArchivedFailure = 5,
+        RetryIssued = 6
     }
 }


### PR DESCRIPTION
Retried messages looked like they were still in the Failed state in ServiceInsight. ServiceInsight knows how to render Retry Issued messages properly so we just need to return them.

https://github.com/Particular/ServiceInsight/issues/822