### PR TITLE
Add setting for free disk space threhsold

### DIFF
--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -50,5 +50,6 @@
   "ProcessRetryBatchesFrequency": "00:00:30",
   "MaximumConcurrencyLevel": 10,
   "RetryHistoryDepth": 10,
-  "RemoteInstances": []
+  "RemoteInstances": [],
+  "DataSpaceRemainingThreshold": 20
 }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -86,6 +86,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public System.TimeSpan AuditRetentionPeriod { get; }
         public int DatabaseMaintenancePort { get; set; }
         public string DatabaseMaintenanceUrl { get; }
+        public int DataSpaceRemainingThreshold { get; set; }
         public string DbPath { get; set; }
         public bool DisableRavenDBPerformanceCounters { get; set; }
         public string ErrorLogQueue { get; set; }

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -186,6 +186,7 @@ Selected Transport Customization:   {settings.TransportCustomizationType}
                     settings.AuditQueue,
                     settings.DatabaseMaintenancePort,
                     settings.ErrorLogQueue,
+                    settings.DataSpaceRemainingThreshold,
                     settings.DisableRavenDBPerformanceCounters,
                     settings.DbPath,
                     settings.ErrorQueue,

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -51,6 +51,7 @@
             HttpDefaultConnectionLimit = SettingsReader<int>.Read("HttpDefaultConnectionLimit", 100);
             DisableRavenDBPerformanceCounters = SettingsReader<bool>.Read("DisableRavenDBPerformanceCounters", true);
             RemoteInstances = GetRemoteInstances();
+            DataSpaceRemainingThreshold = GetDataSpaceRemainingThreshold();
         }
 
         public Func<string, Dictionary<string, string>, byte[], Func<Task>, Task> OnMessage { get; set; } = (messageId, headers, body, next) => next();
@@ -201,6 +202,8 @@
         public int RetryHistoryDepth { get; set; }
 
         public RemoteInstanceSetting[] RemoteInstances { get; set; }
+
+        public int DataSpaceRemainingThreshold { get; set; }
 
         public TransportCustomization LoadTransportCustomization()
         {
@@ -501,6 +504,27 @@
             return $"{queue}.log@{machine}";
         }
 
+        int GetDataSpaceRemainingThreshold()
+        {
+            string message;
+            var threshold = SettingsReader<int>.Read("DataSpaceRemainingThreshold", DataSpaceRemainingThresholdDefault);
+            if (threshold < 0)
+            {
+                message = $"{nameof(DataSpaceRemainingThreshold)} is invalid, minimum value is 0.";
+                logger.Fatal(message);
+                throw new Exception(message);
+            }
+
+            if (threshold > 100)
+            {
+                message = $"{nameof(DataSpaceRemainingThreshold)} is invalid, maximum value is 100.";
+                logger.Fatal(message);
+                throw new Exception(message);
+            }
+
+            return threshold;
+        }
+
 
         ILog logger = LogManager.GetLogger(typeof(Settings));
         int expirationProcessBatchSize = SettingsReader<int>.Read("ExpirationProcessBatchSize", ExpirationProcessBatchSizeDefault);
@@ -513,5 +537,6 @@
         const int ExpirationProcessBatchSizeDefault = 65512;
         const int ExpirationProcessBatchSizeMinimum = 10240;
         const int MaxBodySizeToStoreDefault = 102400; //100 kb
+        const int DataSpaceRemainingThresholdDefault = 20;
     }
 }

--- a/src/ServiceControl/Operations/CheckFreeDiskSpace.cs
+++ b/src/ServiceControl/Operations/CheckFreeDiskSpace.cs
@@ -10,13 +10,14 @@
     class CheckFreeDiskSpace : CustomCheck
     {
         static readonly ILog Logger = LogManager.GetLogger(typeof(CheckFreeDiskSpace));
-        const decimal PercentageThreshold = 20m / 100m;
+        decimal percentageThreshold;
         readonly string dataPath;
     
         public CheckFreeDiskSpace(Settings settings) : base("Message database", "Storage space", TimeSpan.FromMinutes(5))
         {
-            Logger.Debug($"Check ServiceControl data drive space remaining custom check starting. Threshold {PercentageThreshold:P0}");
             dataPath = settings.DbPath;
+            percentageThreshold = settings.DataSpaceRemainingThreshold / 100m;
+            Logger.Debug($"Check ServiceControl data drive space remaining custom check starting. Threshold {percentageThreshold:P0}");
         }
 
         public override Task<CheckResult> PerformCheck()
@@ -39,7 +40,7 @@
                 Logger.Debug($"Free space: {availableFreeSpace} | Total: {totalSpace} | Percent remaining {percentRemaining:P0}");
             }
 
-            return percentRemaining > PercentageThreshold 
+            return percentRemaining > percentageThreshold 
                 ? CheckResult.Pass 
                 : CheckResult.Failed($"{percentRemaining:P0} disk space remaining on data drive {dataDriveInfo.VolumeLabel} on {Environment.MachineName}.");
         }


### PR DESCRIPTION
Adds a setting for setting the threshold of the free disk space custom check. This setting is an integer percentage (0-100). If the amount of remaining disk space drops below that percentage (of total space) then the custom check triggers an error warning the user to check their space.

Doco https://github.com/Particular/docs.particular.net/pull/4374