### PR TITLE
Fix ASQ Acceptence Test

### DIFF
--- a/src/ServiceControl.AcceptanceTests/ConfigureEndpointAzureServiceBusNetStandardTransport.g.cs
+++ b/src/ServiceControl.AcceptanceTests/ConfigureEndpointAzureServiceBusNetStandardTransport.g.cs
@@ -4,6 +4,7 @@ using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
 using ServiceBus.Management.AcceptanceTests;
 using ServiceControl.Transports.ASBS;
+using ServiceControlInstaller.Engine.Instances;
 
 public class ConfigureEndpointAzureServiceBusNetStandardTransport : ITransportIntegration
 {
@@ -29,7 +30,7 @@ public class ConfigureEndpointAzureServiceBusNetStandardTransport : ITransportIn
         return Task.FromResult(0);
     }
 
-    public string Name => ServiceControlInstaller.Engine.Instances.TransportNames.AzureServiceBus;
+    public string Name => TransportNames.AzureServiceBus;
     public string TypeName => $"{typeof(ServiceControl.Transports.ASBS.ASBSTransportCustomization).AssemblyQualifiedName}";
     public string ConnectionString { get; set; }
 }

--- a/src/ServiceControl.AcceptanceTests/ConfigureEndpointAzureServiceBusNetStandardTransport.g.cs
+++ b/src/ServiceControl.AcceptanceTests/ConfigureEndpointAzureServiceBusNetStandardTransport.g.cs
@@ -29,7 +29,7 @@ public class ConfigureEndpointAzureServiceBusNetStandardTransport : ITransportIn
         return Task.FromResult(0);
     }
 
-    public string Name => "AzureServiceBus .NET Standard";
+    public string Name => ServiceControlInstaller.Engine.Instances.TransportNames.AzureServiceBus;
     public string TypeName => $"{typeof(ServiceControl.Transports.ASBS.ASBSTransportCustomization).AssemblyQualifiedName}";
     public string ConnectionString { get; set; }
 }

--- a/src/ServiceControl.AcceptanceTests/ConfigureEndpointAzureStorageQueueTransport.cs
+++ b/src/ServiceControl.AcceptanceTests/ConfigureEndpointAzureStorageQueueTransport.cs
@@ -4,6 +4,7 @@ using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
 using ServiceBus.Management.AcceptanceTests;
 using ServiceControl.Transports.ASQ;
+using ServiceControlInstaller.Engine.Instances;
 
 public class ConfigureEndpointAzureStorageQueueTransport : ITransportIntegration
 {
@@ -36,7 +37,7 @@ public class ConfigureEndpointAzureStorageQueueTransport : ITransportIntegration
         return Task.FromResult(0);
     }
 
-    public string Name => "AzureStorageQueues";
+    public string Name => TransportNames.AzureStorageQueue;
     public string TypeName => $"{typeof(ASQTransportCustomization).AssemblyQualifiedName}";
     public string ConnectionString { get; set; }
 }

--- a/src/ServiceControl.AcceptanceTests/ConfigureEndpointMsmqTransport .cs
+++ b/src/ServiceControl.AcceptanceTests/ConfigureEndpointMsmqTransport .cs
@@ -9,6 +9,7 @@ using NServiceBus.Configuration.AdvancedExtensibility;
 using NServiceBus.Transport;
 using ServiceBus.Management.AcceptanceTests;
 using ServiceControl.Transports.Msmq;
+using ServiceControlInstaller.Engine.Instances;
 
 public class ConfigureEndpointMsmqTransport : ITransportIntegration
 {
@@ -77,7 +78,7 @@ public class ConfigureEndpointMsmqTransport : ITransportIntegration
         return Task.FromResult(0);
     }
 
-    public string Name => "Msmq";
+    public string Name => TransportNames.MSMQ;
     public string TypeName => $"{typeof(MsmqTransportCustomization).AssemblyQualifiedName}";
     public string ConnectionString { get; set; }
 

--- a/src/ServiceControl.AcceptanceTests/ConfigureEndpointSQSTransport.cs
+++ b/src/ServiceControl.AcceptanceTests/ConfigureEndpointSQSTransport.cs
@@ -7,6 +7,7 @@ using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
 using ServiceBus.Management.AcceptanceTests;
 using ServiceControl.Transports.SQS;
+using ServiceControlInstaller.Engine.Instances;
 
 public class ConfigureEndpointSQSTransport : ITransportIntegration
 {
@@ -42,7 +43,7 @@ public class ConfigureEndpointSQSTransport : ITransportIntegration
         return Task.FromResult(0);
     }
 
-    public string Name => "SQS";
+    public string Name => TransportNames.AmazonSQS;
 
     public string TypeName => $"{typeof(SQSTransportCustomization).AssemblyQualifiedName}";
 

--- a/src/ServiceControl.AcceptanceTests/ConfigureEndpointSqlServerTransport.cs
+++ b/src/ServiceControl.AcceptanceTests/ConfigureEndpointSqlServerTransport.cs
@@ -8,6 +8,7 @@ using NServiceBus.Configuration.AdvancedExtensibility;
 using NServiceBus.Transport;
 using ServiceBus.Management.AcceptanceTests;
 using ServiceControl.Transports.SqlServer;
+using ServiceControlInstaller.Engine.Instances;
 
 public class ConfigureEndpointSqlServerTransport : ITransportIntegration
 {
@@ -50,7 +51,7 @@ public class ConfigureEndpointSqlServerTransport : ITransportIntegration
         }
     }
 
-    public string Name => "SqlServer";
+    public string Name => TransportNames.SQLServer;
     public string TypeName => $"{typeof(SqlServerTransportCustomization).AssemblyQualifiedName}";
     public string ConnectionString { get; set; }
 


### PR DESCRIPTION
[This test](https://github.com/Particular/ServiceControl/blob/develop/src/ServiceControl.AcceptanceTests/Recoverability/When_a_native_integration_message_is_retried.cs#L37) is trying to skip an assertion for the Azure Storage Queues transport but the strings didn't match because they were coming from different sources. 

This PR should fix that test.

I moved all of the other transports across too so that this sort of issue doesn't happen again.

I didn't move the Learning transport because it's not in the source list.