### PR TITLE
Add connection switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ installer/[F|f]iles
 installer/[C|c]ustom[A|a]ctions
 installer/ServiceControl-cache
 
+# Development Connection File
+src/connection.txt
+
 # Created by https://www.gitignore.io
 
 ### VisualStudio ###

--- a/docs/running-acceptance-tests.md
+++ b/docs/running-acceptance-tests.md
@@ -1,0 +1,43 @@
+When the acceptance test projects are run they will try to connect to a specific transport.
+
+To figure this out the projects:
+- Look for a connection file
+- Look for environment variables
+- Default to MSMQ
+
+## Connection file
+
+Create a file named `connection.txt` in the same folder as the Solution file. 
+
+WARNING: This file must not be checked in. It has been added to the .gitignore.
+
+This file must have the format:
+
+```
+Human Readable Name
+TypeNameOfTransportConfigurationClass
+Connection String
+```
+
+For instance
+
+```
+SQL
+ConfigureEndpointSqlServerTransport
+Data Source=localhost;Initial Catalog=ServiceControl;Integrated Security=SSPI;
+```
+
+Only the first 3 lines are read so it is possible to keep other connections below that in the same file and quickly switch between them.
+
+NOTE: The Acceptance Test projects will delete all of the other transport assemblies. The project must be re-built when changing connections using the connection.txt file.
+
+## Environment variables
+
+You can specify the transport and connection string by setting the following two environment variables:
+
+- ServiceControl.AcceptanceTests.TransportCustomization
+- ServiceControl.AcceptanceTests.ConnectionString
+
+This is the method that the build server uses.
+
+NOTE: After updating the environment variables, you will need to start the process running the acceptance tests for them to get the updated values.

--- a/src/ServiceControl.AcceptanceTests/TestSupport/TestSuiteConstraints.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/TestSuiteConstraints.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus.AcceptanceTests
 {
     using System;
+    using System.IO;
+    using System.Linq;
     using AcceptanceTesting.Support;
     using ServiceBus.Management.AcceptanceTests;
 
@@ -11,15 +13,61 @@
         public bool SupportsNativePubSub => true;
         public bool SupportsNativeDeferral => true;
         public bool SupportsOutbox => false;
-        public IConfigureEndpointTestExecution CreateTransportConfiguration() => GetTransportIntegrationFromEnvironmentVar();
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => 
+            GetTransportIntegrationFromConnectionFile()
+            ?? GetTransportIntegrationFromEnvironmentVar()
+            ?? new ConfigureEndpointMsmqTransport();
+
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointInMemoryPersistence();
 
-        static ITransportIntegration GetTransportIntegrationFromEnvironmentVar()
-        {
-            var transportCustomizationToUseString = Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.TransportCustomization") ?? typeof(ConfigureEndpointMsmqTransport).Name;
-            var transportToUse = (ITransportIntegration)Activator.CreateInstance(Type.GetType(transportCustomizationToUseString));
+        static ITransportIntegration GetTransportIntegrationFromEnvironmentVar() => CreateTransportIntegration(
+                Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.TransportCustomization"),
+                Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.ConnectionString")
+            );
 
-            var connectionString = Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.ConnectionString");
+        static ITransportIntegration GetTransportIntegrationFromConnectionFile()
+        {
+            var connectionFile = GetConnectionFile();
+            if (connectionFile == null || !File.Exists(connectionFile))
+            {
+                return null;
+            }
+            
+            var lines = File.ReadLines(connectionFile)
+                .Skip(1) // Name
+                .Take(2) // TransportCustomizationTypeName, ConnectionString
+                .ToArray();
+
+            return CreateTransportIntegration(lines[0], lines[1]);
+
+        }
+
+        static string GetConnectionFile()
+        {
+            var directory = AppDomain.CurrentDomain.BaseDirectory;
+            while (directory != null)
+            {
+                if (Directory.EnumerateFiles(directory).Any(file => file.EndsWith(".sln")))
+                {
+                    return Path.Combine(directory, "connection.txt");
+                }
+
+                var parent = Directory.GetParent(directory);
+
+                directory = parent?.FullName;
+            }
+
+            return null;
+        }
+
+        static ITransportIntegration CreateTransportIntegration(string transportCustomizationToUseString, string connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(transportCustomizationToUseString))
+            {
+                return null;
+            }
+
+            var transportToUse = (ITransportIntegration)Activator.CreateInstance(Type.GetType(transportCustomizationToUseString));
             if (!string.IsNullOrWhiteSpace(connectionString))
             {
                 transportToUse.ConnectionString = connectionString;

--- a/src/ServiceControl.Audit.AcceptanceTests/TestSupport/TestSuiteConstraints.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/TestSupport/TestSuiteConstraints.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus.AcceptanceTests
 {
     using System;
+    using System.IO;
+    using System.Linq;
     using AcceptanceTesting.Support;
     using ServiceBus.Management.AcceptanceTests;
 
@@ -11,15 +13,61 @@
         public bool SupportsNativePubSub => true;
         public bool SupportsNativeDeferral => true;
         public bool SupportsOutbox => false;
-        public IConfigureEndpointTestExecution CreateTransportConfiguration() => GetTransportIntegrationFromEnvironmentVar();
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => 
+            GetTransportIntegrationFromConnectionFile()
+            ?? GetTransportIntegrationFromEnvironmentVar()
+            ?? new ConfigureEndpointMsmqTransport();
+
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointInMemoryPersistence();
 
-        static ITransportIntegration GetTransportIntegrationFromEnvironmentVar()
-        {
-            var transportCustomizationToUseString = Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.TransportCustomization") ?? typeof(ConfigureEndpointMsmqTransport).Name;
-            var transportToUse = (ITransportIntegration)Activator.CreateInstance(Type.GetType(transportCustomizationToUseString));
+        static ITransportIntegration GetTransportIntegrationFromEnvironmentVar() => CreateTransportIntegration(
+                Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.TransportCustomization"),
+                Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.ConnectionString")
+            );
 
-            var connectionString = Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.ConnectionString");
+        static ITransportIntegration GetTransportIntegrationFromConnectionFile()
+        {
+            var connectionFile = GetConnectionFile();
+            if (connectionFile == null || !File.Exists(connectionFile))
+            {
+                return null;
+            }
+            
+            var lines = File.ReadLines(connectionFile)
+                .Skip(1) // Name
+                .Take(2) // TransportCustomizationTypeName, ConnectionString
+                .ToArray();
+
+            return CreateTransportIntegration(lines[0], lines[1]);
+
+        }
+
+        static string GetConnectionFile()
+        {
+            var directory = AppDomain.CurrentDomain.BaseDirectory;
+            while (directory != null)
+            {
+                if (Directory.EnumerateFiles(directory).Any(file => file.EndsWith(".sln")))
+                {
+                    return Path.Combine(directory, "connection.txt");
+                }
+
+                var parent = Directory.GetParent(directory);
+
+                directory = parent?.FullName;
+            }
+
+            return null;
+        }
+
+        static ITransportIntegration CreateTransportIntegration(string transportCustomizationToUseString, string connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(transportCustomizationToUseString))
+            {
+                return null;
+            }
+
+            var transportToUse = (ITransportIntegration)Activator.CreateInstance(Type.GetType(transportCustomizationToUseString));
             if (!string.IsNullOrWhiteSpace(connectionString))
             {
                 transportToUse.ConnectionString = connectionString;

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/TestSuiteConstraints.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/TestSuiteConstraints.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus.AcceptanceTests
 {
     using System;
+    using System.IO;
+    using System.Linq;
     using AcceptanceTesting.Support;
     using ServiceBus.Management.AcceptanceTests;
 
@@ -11,15 +13,61 @@
         public bool SupportsNativePubSub => true;
         public bool SupportsNativeDeferral => true;
         public bool SupportsOutbox => false;
-        public IConfigureEndpointTestExecution CreateTransportConfiguration() => GetTransportIntegrationFromEnvironmentVar();
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => 
+            GetTransportIntegrationFromConnectionFile()
+            ?? GetTransportIntegrationFromEnvironmentVar()
+            ?? new ConfigureEndpointMsmqTransport();
+
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointInMemoryPersistence();
 
-        static ITransportIntegration GetTransportIntegrationFromEnvironmentVar()
-        {
-            var transportCustomizationToUseString = Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.TransportCustomization") ?? typeof(ConfigureEndpointMsmqTransport).Name;
-            var transportToUse = (ITransportIntegration)Activator.CreateInstance(Type.GetType(transportCustomizationToUseString));
+        static ITransportIntegration GetTransportIntegrationFromEnvironmentVar() => CreateTransportIntegration(
+                Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.TransportCustomization"),
+                Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.ConnectionString")
+            );
 
-            var connectionString = Environment.GetEnvironmentVariable("ServiceControl.AcceptanceTests.ConnectionString");
+        static ITransportIntegration GetTransportIntegrationFromConnectionFile()
+        {
+            var connectionFile = GetConnectionFile();
+            if (connectionFile == null || !File.Exists(connectionFile))
+            {
+                return null;
+            }
+            
+            var lines = File.ReadLines(connectionFile)
+                .Skip(1) // Name
+                .Take(2) // TransportCustomizationTypeName, ConnectionString
+                .ToArray();
+
+            return CreateTransportIntegration(lines[0], lines[1]);
+
+        }
+
+        static string GetConnectionFile()
+        {
+            var directory = AppDomain.CurrentDomain.BaseDirectory;
+            while (directory != null)
+            {
+                if (Directory.EnumerateFiles(directory).Any(file => file.EndsWith(".sln")))
+                {
+                    return Path.Combine(directory, "connection.txt");
+                }
+
+                var parent = Directory.GetParent(directory);
+
+                directory = parent?.FullName;
+            }
+
+            return null;
+        }
+
+        static ITransportIntegration CreateTransportIntegration(string transportCustomizationToUseString, string connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(transportCustomizationToUseString))
+            {
+                return null;
+            }
+
+            var transportToUse = (ITransportIntegration)Activator.CreateInstance(Type.GetType(transportCustomizationToUseString));
             if (!string.IsNullOrWhiteSpace(connectionString))
             {
                 transportToUse.ConnectionString = connectionString;


### PR DESCRIPTION
Lets all of the acceptance test projects get their connection details from a file called `connection.txt` in the same folder as the solution. If the file is missing, then it falls back to the old behavior (check environment variables and then fall back to MSMQ).

This lets you switch transport/connection quickly in development. You will need to rebuild after a change of transport type as the ATTs delete the non-selected transport assemblies at startup.