### PR TITLE
Make audit expiry optional

### DIFF
--- a/src/ServiceControl.AcceptanceTests/App.config
+++ b/src/ServiceControl.AcceptanceTests/App.config
@@ -4,7 +4,6 @@
     <add key="ServiceControl/ForwardErrorMessages" value="false" />
     <add key="Raven/Esent/MaxVerPages" value="4096" />
     <add key="ServiceControl/ErrorRetentionPeriod" value="10.00:00:00" />
-    <add key="ServiceControl/AuditRetentionPeriod" value="10.00:00:00" />
   </appSettings>
   <runtime>
     <gcServer enabled="true" />

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/App.config
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/App.config
@@ -7,7 +7,6 @@
     <add key="ServiceControl.Audit/ForwardAuditMessages" value="false" />
 
     <add key="ServiceControl/ErrorRetentionPeriod" value="10.00:00:00" />
-    <add key="ServiceControl/AuditRetentionPeriod" value="10.00:00:00" />
     <add key="ServiceControl/ForwardErrorMessages" value="false" />
   </appSettings>
   <runtime>

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -35,7 +35,7 @@
   "IngestErrorMessages": true,
   "RunRetryProcessor": true,
   "ExpirationProcessTimerInSeconds": 600,
-  "AuditRetentionPeriod": "10.00:00:00",
+  "AuditRetentionPeriod": null,
   "ErrorRetentionPeriod": "10.00:00:00",
   "EventsRetentionPeriod": "14.00:00:00",
   "ExpirationProcessBatchSize": 65512,

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -17,18 +17,18 @@
   "DisableRavenDBPerformanceCounters": true,
   "SkipQueueCreation": false,
   "RunCleanupBundle": false,
-  "RootUrl": "http://localhost:8888/",
+  "RootUrl": "http://localhost:33333/",
   "DatabaseMaintenanceUrl": "http://localhost:33334",
-  "ApiUrl": "http://localhost:8888/api",
-  "StorageUrl": "http://localhost:8888/storage",
-  "Port": 8888,
+  "ApiUrl": "http://localhost:33333/api",
+  "StorageUrl": "http://localhost:33333/storage",
+  "Port": 33333,
   "DatabaseMaintenancePort": 33334,
   "ExposeRavenDB": false,
   "Hostname": "localhost",
   "VirtualDirectory": "",
   "HeartbeatGracePeriod": "00:00:40",
-  "TransportCustomizationType": "ServiceControl.Transports.Learning.LearningTransportCustomization, ServiceControl.Transports.Learning",
-  "DbPath": "C:\\DB",
+  "TransportCustomizationType": "ServiceControl.Transports.Msmq.MsmqTransportCustomization, ServiceControl.Transports.Msmq",
+  "DbPath": "C:\\ProgramData\\Particular\\ServiceControl\\localhost-33333",
   "ErrorLogQueue": "error.log",
   "ErrorQueue": "error",
   "ForwardErrorMessages": false,
@@ -46,6 +46,13 @@
   "ProcessRetryBatchesFrequency": "00:00:30",
   "MaximumConcurrencyLevel": 10,
   "RetryHistoryDepth": 10,
-  "RemoteInstances": [],
+  "RemoteInstances": [
+    {
+      "ApiUri": "http://instance1"
+    },
+    {
+      "ApiUri": "http://instance2"
+    }
+  ],
   "DataSpaceRemainingThreshold": 20
 }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -17,18 +17,18 @@
   "DisableRavenDBPerformanceCounters": true,
   "SkipQueueCreation": false,
   "RunCleanupBundle": false,
-  "RootUrl": "http://localhost:33333/",
+  "RootUrl": "http://localhost:8888/",
   "DatabaseMaintenanceUrl": "http://localhost:33334",
-  "ApiUrl": "http://localhost:33333/api",
-  "StorageUrl": "http://localhost:33333/storage",
-  "Port": 33333,
+  "ApiUrl": "http://localhost:8888/api",
+  "StorageUrl": "http://localhost:8888/storage",
+  "Port": 8888,
   "DatabaseMaintenancePort": 33334,
   "ExposeRavenDB": false,
   "Hostname": "localhost",
   "VirtualDirectory": "",
   "HeartbeatGracePeriod": "00:00:40",
-  "TransportCustomizationType": "ServiceControl.Transports.Msmq.MsmqTransportCustomization, ServiceControl.Transports.Msmq",
-  "DbPath": "C:\\ProgramData\\Particular\\ServiceControl\\localhost-33333",
+  "TransportCustomizationType": "ServiceControl.Transports.Learning.LearningTransportCustomization, ServiceControl.Transports.Learning",
+  "DbPath": "C:\\DB",
   "ErrorLogQueue": "error.log",
   "ErrorQueue": "error",
   "ForwardErrorMessages": false,
@@ -46,13 +46,6 @@
   "ProcessRetryBatchesFrequency": "00:00:30",
   "MaximumConcurrencyLevel": 10,
   "RetryHistoryDepth": 10,
-  "RemoteInstances": [
-    {
-      "ApiUri": "http://instance1"
-    },
-    {
-      "ApiUri": "http://instance2"
-    }
-  ],
+  "RemoteInstances": [],
   "DataSpaceRemainingThreshold": 20
 }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -47,7 +47,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public const string Disabled = "!disable";
         public Settings(string serviceName = null) { }
         public string ApiUrl { get; }
-        public System.TimeSpan AuditRetentionPeriod { get; }
+        public System.Nullable<System.TimeSpan> AuditRetentionPeriod { get; }
         public int DatabaseMaintenancePort { get; set; }
         public string DatabaseMaintenanceUrl { get; }
         public int DataSpaceRemainingThreshold { get; set; }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.RootPathValue.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.RootPathValue.approved.txt
@@ -1,5 +1,5 @@
 {
-  "description": "testDescription",
+  "description": "The management backend for the Particular Service Platform",
   "endpointsErrorUrl": "http://localhost/endpoints/{name}/errors/{?page,per_page,direction,sort}",
   "knownEndpointsUrl": "/endpoints/known",
   "endpointsMessageSearchUrl": "http://localhost/endpoints/{name}/messages/search/{keyword}/{?page,per_page,direction,sort}",
@@ -10,6 +10,6 @@
   "messageSearchUrl": "http://localhost/messages/search/{keyword}/{?page,per_page,direction,sort}",
   "licenseStatus": "valid",
   "licenseDetails": "http://localhost/license",
-  "name": "testName",
+  "name": "ServiceControl",
   "sagasUrl": "http://localhost/sagas"
 }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.RootPathValue.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.RootPathValue.approved.txt
@@ -1,5 +1,5 @@
 {
-  "description": "The management backend for the Particular Service Platform",
+  "description": "testDescription",
   "endpointsErrorUrl": "http://localhost/endpoints/{name}/errors/{?page,per_page,direction,sort}",
   "knownEndpointsUrl": "/endpoints/known",
   "endpointsMessageSearchUrl": "http://localhost/endpoints/{name}/messages/search/{keyword}/{?page,per_page,direction,sort}",
@@ -10,6 +10,6 @@
   "messageSearchUrl": "http://localhost/messages/search/{keyword}/{?page,per_page,direction,sort}",
   "licenseStatus": "valid",
   "licenseDetails": "http://localhost/license",
-  "name": "ServiceControl",
+  "name": "testName",
   "sagasUrl": "http://localhost/sagas"
 }

--- a/src/ServiceControl.UnitTests/Infrastructure/Settings/SettingsTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/Settings/SettingsTests.cs
@@ -17,7 +17,6 @@
             config.AppSettings.Settings.Add("ServiceControl/RemoteInstances", "[{'api_uri':'http://instance1'},{'api_uri':'http://instance2'}]'");
             // Various mandatory settings
             config.AppSettings.Settings.Add("ServiceControl/ForwardErrorMessages", "false");
-            config.AppSettings.Settings.Add("ServiceControl/AuditRetentionPeriod", 1.ToString());
             config.AppSettings.Settings.Add("ServiceControl/ErrorRetentionPeriod", 10.ToString());
             config.Save(ConfigurationSaveMode.Modified);
             ConfigurationManager.RefreshSection("appSettings");

--- a/src/ServiceControl.UnitTests/RouteApi/RetryMessage_RoutesApiTest.cs
+++ b/src/ServiceControl.UnitTests/RouteApi/RetryMessage_RoutesApiTest.cs
@@ -22,10 +22,7 @@
         [SetUp]
         public void SetUp()
         {
-            //TODO: Fix
-            ConfigurationManager.AppSettings["ServiceControl/ForwardAuditMessages"] = bool.FalseString;
             ConfigurationManager.AppSettings["ServiceControl/ForwardErrorMessages"] = bool.FalseString;
-            ConfigurationManager.AppSettings["ServiceControl/AuditRetentionPeriod"] = TimeSpan.FromHours(10).ToString();
             ConfigurationManager.AppSettings["ServiceControl/ErrorRetentionPeriod"] = TimeSpan.FromDays(10).ToString();
 
             testApi = new TestApi

--- a/src/ServiceControl.UnitTests/app.config
+++ b/src/ServiceControl.UnitTests/app.config
@@ -16,7 +16,6 @@
     <add key="ServiceControl/ForwardErrorMessages" value="false" />
     <add key="Raven/Esent/MaxVerPages" value="4096" />
     <add key="ServiceControl/ErrorRetentionPeriod" value="10.00:00:00" />
-    <add key="ServiceControl/AuditRetentionPeriod" value="10.00:00:00" />
     <add key="ServiceControl/ExposeRavenDB" value="false" />
   </appSettings>
 </configuration>

--- a/src/ServiceControl/App.config
+++ b/src/ServiceControl/App.config
@@ -9,7 +9,6 @@ These settings are only here so that we can debug ServiceControl while developin
     <add key="ServiceControl/ForwardErrorMessages" value="false" />
     <add key="Raven/Esent/MaxVerPages" value="4096" />
     <add key="ServiceControl/ErrorRetentionPeriod" value="10.00:00:00" />
-    <add key="ServiceControl/AuditRetentionPeriod" value="10.00:00:00" />
     <add key="ServiceControl/RemoteInstances" value="[{'api_uri':'http://localhost:44444/api'}]'"/>
   </appSettings>
   <runtime>

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -164,7 +164,7 @@ namespace Particular.ServiceControl
             var startupMessage = $@"
 -------------------------------------------------------------
 ServiceControl Version:             {version}
-Audit Retention Period (optional):             {settings.AuditRetentionPeriod}
+Audit Retention Period (optional):  {settings.AuditRetentionPeriod}
 Error Retention Period:             {settings.ErrorRetentionPeriod}
 Ingest Error Messages:              {settings.IngestErrorMessages}
 Forwarding Error Messages:          {settings.ForwardErrorMessages}

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -164,7 +164,7 @@ namespace Particular.ServiceControl
             var startupMessage = $@"
 -------------------------------------------------------------
 ServiceControl Version:             {version}
-Audit Retention Period:             {settings.AuditRetentionPeriod}
+Audit Retention Period (optional):             {settings.AuditRetentionPeriod}
 Error Retention Period:             {settings.ErrorRetentionPeriod}
 Ingest Error Messages:              {settings.IngestErrorMessages}
 Forwarding Error Messages:          {settings.ForwardErrorMessages}

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
@@ -12,13 +12,7 @@
     {
         public static Task<TimerJobExecutionResult> RunCleanup(int deletionBatchSize, DocumentDatabase database, Settings settings, CancellationToken token)
         {
-            var threshold = SystemTime.UtcNow.Add(-settings.AuditRetentionPeriod);
-
-            logger.Debug("Trying to find expired ProcessedMessage and SagaHistory documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
-            AuditMessageCleaner.Clean(deletionBatchSize, database, threshold, token);
-            SagaHistoryCleaner.Clean(deletionBatchSize, database, threshold, token);
-
-            threshold = SystemTime.UtcNow.Add(-settings.ErrorRetentionPeriod);
+            var threshold = SystemTime.UtcNow.Add(-settings.ErrorRetentionPeriod);
 
             logger.Debug("Trying to find expired FailedMessage documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
             ErrorMessageCleaner.Clean(deletionBatchSize, database, threshold, token);
@@ -27,6 +21,15 @@
 
             logger.Debug("Trying to find expired EventLogItem documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
             EventLogItemsCleaner.Clean(deletionBatchSize, database, threshold, token);
+
+            if (settings.AuditRetentionPeriod.HasValue)
+            {
+                threshold = SystemTime.UtcNow.Add(-settings.AuditRetentionPeriod.Value);
+
+                logger.Debug("Trying to find expired ProcessedMessage and SagaHistory documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+                AuditMessageCleaner.Clean(deletionBatchSize, database, threshold, token);
+                SagaHistoryCleaner.Clean(deletionBatchSize, database, threshold, token);
+            }
 
             return Task.FromResult(TimerJobExecutionResult.ScheduleNextExecution);
         }

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
@@ -51,8 +51,14 @@
 
             logger.Info("Running deletion of expired documents every {0} seconds", deleteFrequencyInSeconds);
             logger.Info("Deletion batch size set to {0}", deletionBatchSize);
-            logger.Info("Retention period for audits and saga history is {0}", RavenBootstrapper.Settings.AuditRetentionPeriod);
             logger.Info("Retention period for errors is {0}", RavenBootstrapper.Settings.ErrorRetentionPeriod);
+
+            var auditRetention = RavenBootstrapper.Settings.AuditRetentionPeriod;
+
+            if (auditRetention.HasValue)
+            {
+                logger.Info("Retention period for audits and saga history is {0}", RavenBootstrapper.Settings.AuditRetentionPeriod);
+            }
 
             timer = new AsyncTimer(
                 token => ExpiredDocumentsCleaner.RunCleanup(deletionBatchSize, database, RavenBootstrapper.Settings, token), due, due, e =>

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -141,7 +141,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
             }
         }
 
-        public TimeSpan AuditRetentionPeriod { get; }
+        public TimeSpan? AuditRetentionPeriod { get; }
 
         public TimeSpan ErrorRetentionPeriod { get; }
 
@@ -390,15 +390,13 @@ namespace ServiceBus.Management.Infrastructure.Settings
             return result;
         }
 
-        TimeSpan GetAuditRetentionPeriod()
+        TimeSpan? GetAuditRetentionPeriod()
         {
             string message;
             var valueRead = SettingsReader<string>.Read("AuditRetentionPeriod");
             if (valueRead == null)
             {
-                message = "AuditRetentionPeriod settings is missing, please make sure it is included.";
-                logger.Fatal(message);
-                throw new Exception(message);
+                return null;
             }
 
             if (TimeSpan.TryParse(valueRead, out var result))


### PR DESCRIPTION
Myself and @mikeminutillo thought that it would be best to make audit expiry optional in SC so that the SCMU can omit it when installing new instances