### PR TITLE
Customize serializer to forward endpoint details type

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/MigratedTypeAwareBinder.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/MigratedTypeAwareBinder.cs
@@ -1,0 +1,18 @@
+﻿namespace ServiceControl.Audit.Infrastructure.RavenDB
+{
+    using System;
+    using Monitoring;
+    using Raven.Imports.Newtonsoft.Json.Serialization;
+
+    class MigratedTypeAwareBinder : DefaultSerializationBinder
+    {
+        public override Type BindToType(string assemblyName, string typeName)
+        {
+            if (typeName == "ServiceControl.Contracts.Operations.EndpointDetails" && assemblyName == "ServiceControl")
+            {
+                return typeof(EndpointDetails);
+            }
+            return base.BindToType(assemblyName, typeName);
+        }
+    }
+}

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/RavenBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/RavenBootstrapper.cs
@@ -3,6 +3,7 @@
     using System;
     using System.ComponentModel.Composition.Hosting;
     using System.IO;
+    using System.Runtime.Serialization;
     using NServiceBus;
     using NServiceBus.Configuration.AdvancedExtensibility;
     using NServiceBus.Logging;
@@ -87,6 +88,7 @@
                 ? "localhost"
                 : settings.Hostname;
             documentStore.Conventions.SaveEnumsAsIntegers = true;
+            documentStore.Conventions.CustomizeJsonSerializer = serializer => serializer.Binder = MigratedTypeAwareBinder;
 
             documentStore.Configuration.Catalog.Catalogs.Add(new AssemblyCatalog(GetType().Assembly));
 
@@ -107,5 +109,7 @@
         }
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(RavenBootstrapper));
+
+        static SerializationBinder MigratedTypeAwareBinder = new MigratedTypeAwareBinder();
     }
 }


### PR DESCRIPTION
For some migration scenarios especially multi-instance you might want to point a new audit instance at a database that exists from a previous instance that had error queue ingestion disabled. The problem is that processed messages get stored with

```
        "SendingEndpoint": {
            "$type": "ServiceControl.Contracts.Operations.EndpointDetails, ServiceControl",
            "Name": "Samples.RabbitMQ.Simple",
            "HostId": "46833858-6878-516f-b8fd-94f0e0a7156b",
            "Host": "BF108680"
        },
        "ConversationId": "17d734a9-8433-4f59-aac5-aa8000a47d77",
        "ReceivingEndpoint": {
            "$type": "ServiceControl.Contracts.Operations.EndpointDetails, ServiceControl",
            "Name": "Samples.RabbitMQ.Simple",
            "HostId": "46833858-6878-516f-b8fd-94f0e0a7156b",
            "Host": "BF108680"
        },
```

but the endpoint details type has moved to

```
"ReceivingEndpoint": {
            "$type": "ServiceControl.Audit.Monitoring.EndpointDetails, ServiceControl.Audit",
            "Name": "Samples.RabbitMQ.Simple",
            "HostId": "46833858-6878-516f-b8fd-94f0e0a7156b",
            "Host": "BF108680"
        },
        "MessageType": "MyMessage",
        "SendingEndpoint": {
            "$type": "ServiceControl.Audit.Monitoring.EndpointDetails, ServiceControl.Audit",
            "Name": "Samples.RabbitMQ.Simple",
            "HostId": "46833858-6878-516f-b8fd-94f0e0a7156b",
            "Host": "BF108680"
        }
```

which causes the following exception

```
2019-07-04 12:28:11.6805|100|Error|ServiceControl.Audit.Infrastructure.Nancy.NServiceBusContainerBootstrapper|Http call failed
Raven.Imports.Newtonsoft.Json.JsonSerializationException: Could not read value for property: SendingEndpoint ---> Raven.Imports.Newtonsoft.Json.JsonSerializationException: Error resolving type specified in JSON 'ServiceControl.Contracts.Operations.EndpointDetails, ServiceControl'. Path 'SendingEndpoint.$type'. ---> Raven.Imports.Newtonsoft.Json.JsonSerializationException: Could not load assembly 'ServiceControl'.
   at Raven.Imports.Newtonsoft.Json.Serialization.DefaultSerializationBinder.GetTypeFromTypeNameKey(TypeNameKey typeNameKey)
   at Raven.Imports.Newtonsoft.Json.Utilities.ThreadSafeStore`2.AddValue(TKey key)
   at Raven.Imports.Newtonsoft.Json.Serialization.DefaultSerializationBinder.BindToType(String assemblyName, String typeName)
   at Raven.Imports.Newtonsoft.Json.Serialization.JsonSerializerInternalReader.ResolveTypeName(JsonReader reader, Type& objectType, JsonContract& contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, String qualifiedTypeName)
   --- End of inner exception stack trace ---
   at Raven.Imports.Newtonsoft.Json.Serialization.JsonSerializerInternalReader.ResolveTypeName(JsonReader reader, Type& objectType, JsonContract& contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, String qualifiedTypeName)
   at Raven.Imports.Newtonsoft.Json.Serialization.JsonSerializerInternalReader.ReadMetadataProperties(JsonReader reader, Type& objectType, JsonContract& contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue, Object& newValue, String& id)
   at Raven.Imports.Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Raven.Imports.Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Raven.Imports.Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   --- End of inner exception stack trace ---
   at Raven.Imports.Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Raven.Imports.Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type 
```