### PR TITLE
Refactoring validation

### DIFF
--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -1,13 +1,10 @@
 ﻿namespace ServiceControl.Config.Commands
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.ServiceProcess;
     using System.Threading.Tasks;
     using Caliburn.Micro;
     using Events;
-    using Extensions;
     using FluentValidation;
     using Framework;
     using Framework.Commands;

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -2,12 +2,12 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Linq;
     using System.ServiceProcess;
     using System.Threading.Tasks;
     using Caliburn.Micro;
     using Events;
+    using Extensions;
     using FluentValidation;
     using Framework;
     using Framework.Commands;
@@ -21,6 +21,7 @@
     using UI.Upgrades;
     using Validation;
     using Xaml.Controls;
+    using Validations = Extensions.Validations;
 
     class UpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<InstanceDetailsViewModel>
     {
@@ -349,41 +350,12 @@
         {
             public PortValidator()
             {
-                ServiceControlInstances = InstanceFinder.ServiceControlInstances();
-                ServiceControlAuditInstances = InstanceFinder.ServiceControlAuditInstances();
-
                 RuleFor(x => x.Value)
                     .NotEmpty()
                     .ValidPort()
-                    .MustNotBeIn(x => UsedPorts())
-                    .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports");
+                    .MustNotBeIn(x => Validations.UsedPorts())
+                    .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Ports");
             }
-
-            List<string> UsedPorts()
-            {
-                var serviceControlPorts = ServiceControlInstances
-                    .SelectMany(p => new[]
-                    {
-                        p.Port.ToString(),
-                        p.DatabaseMaintenancePort.ToString()
-                    })
-                    .ToList();
-
-                var auditPorts = ServiceControlAuditInstances
-                    .SelectMany(p => new[]
-                    {
-                        p.Port.ToString(),
-                        p.DatabaseMaintenancePort.ToString()
-                    })
-                    .ToList();
-
-                return auditPorts.Union(serviceControlPorts)
-                    .Distinct()
-                    .ToList();
-            }
-
-            ReadOnlyCollection<ServiceControlInstance> ServiceControlInstances;
-            ReadOnlyCollection<ServiceControlAuditInstance> ServiceControlAuditInstances;
         }
     }
 }

--- a/src/ServiceControl.Config/Extensions/Validations.cs
+++ b/src/ServiceControl.Config/Extensions/Validations.cs
@@ -2,45 +2,52 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Linq;
     using ServiceControlInstaller.Engine.Instances;
 
-    public static class ServiceControlValidationExtension
+    public static class Validations
     {
-        // We need this to ignore the instance that represents the edit screen
-        public static List<string> UsedPaths(this ReadOnlyCollection<ServiceControlInstance> ServiceControlInstances, string instanceName = null)
+        public static List<string> UsedPaths(string instanceName = null)
         {
-            return ServiceControlInstances
+            var monitoringInstances = InstanceFinder.MonitoringInstances();
+            var serviceControlAuditInstances = InstanceFinder.ServiceControlAuditInstances();
+            var serviceControlInstances = InstanceFinder.ServiceControlInstances();
+            var result = new List<string>();
+
+            result.AddRange(monitoringInstances
                 .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
                 .SelectMany(p => new[]
                 {
-                    p.DBPath,
                     p.LogPath,
                     p.InstallPath
-                })
-                .Distinct()
-                .ToList();
-        }
+                }));
 
-        public static List<string> UsedPaths(this ReadOnlyCollection<ServiceControlAuditInstance> ServiceControlAuditInstances, string instanceName = null)
-        {
-            return ServiceControlAuditInstances
+            result.AddRange(serviceControlAuditInstances
                 .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
                 .SelectMany(p => new[]
                 {
-                    p.DBPath,
                     p.LogPath,
+                    p.DBPath,
                     p.InstallPath
-                })
-                .Distinct()
-                .ToList();
+                }));
+
+            result.AddRange(serviceControlInstances
+                .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
+                .SelectMany(p => new[]
+                {
+                    p.LogPath,
+                    p.DBPath,
+                    p.InstallPath
+                }));
+
+            return result.Distinct().ToList();
         }
 
         // We need this to ignore the instance that represents the edit screen
-        public static List<string> UsedQueueNames(this ReadOnlyCollection<ServiceControlInstance> ServiceControlInstances, TransportInfo transportInfo = null, string instanceName = null, string connectionString = null)
+        public static List<string> UsedErrorQueueNames(TransportInfo transportInfo = null, string instanceName = null, string connectionString = null)
         {
-            var instancesByTransport = ServiceControlInstances.Where(p => p.TransportPackage.Equals(transportInfo) &&
+            var serviceControlInstances = InstanceFinder.ServiceControlInstances();
+            var instancesByTransport = serviceControlInstances.Where(p => p.TransportPackage.Equals(transportInfo) &&
                                                                           string.Equals(p.ConnectionString, connectionString, StringComparison.OrdinalIgnoreCase)).ToList();
 
             return instancesByTransport
@@ -55,9 +62,10 @@
                 .ToList();
         }
 
-        public static List<string> UsedQueueNames(this ReadOnlyCollection<ServiceControlAuditInstance> ServiceControlInstances, TransportInfo transportInfo = null, string instanceName = null, string connectionString = null)
+        public static List<string> UsedAuditQueueNames(TransportInfo transportInfo = null, string instanceName = null, string connectionString = null)
         {
-            var instancesByTransport = ServiceControlInstances.Where(p => p.TransportPackage.Equals(transportInfo) &&
+            var serviceControlInstances = InstanceFinder.ServiceControlInstances();
+            var instancesByTransport = serviceControlInstances.Where(p => p.TransportPackage.Equals(transportInfo) &&
                                                                           string.Equals(p.ConnectionString, connectionString, StringComparison.OrdinalIgnoreCase)).ToList();
 
             return instancesByTransport
@@ -72,31 +80,34 @@
                 .ToList();
         }
 
-        // We need this to ignore the instance that represents the edit screen
-        public static List<string> UsedPorts(this ReadOnlyCollection<ServiceControlInstance> ServiceControlInstances, string instanceName = null)
+        public static List<string> UsedPorts(string instanceName = null)
         {
-            return ServiceControlInstances
-                .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
-                .SelectMany(p => new[]
-                {
-                    p.Port.ToString(),
-                    p.DatabaseMaintenancePort.ToString()
-                })
-                .Distinct()
-                .ToList();
-        }
+            var monitoringInstances = InstanceFinder.MonitoringInstances();
+            var serviceControlAuditInstances = InstanceFinder.ServiceControlAuditInstances();
+            var serviceControlInstances = InstanceFinder.ServiceControlInstances();
+            var result = new List<string>();
 
-        public static List<string> UsedPorts(this ReadOnlyCollection<ServiceControlAuditInstance> ServiceControlInstances, string instanceName = null)
-        {
-            return ServiceControlInstances
+            result.AddRange(monitoringInstances
+                .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
+                .Select(p => p.Port.ToString()));
+
+            result.AddRange(serviceControlInstances
                 .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
                 .SelectMany(p => new[]
                 {
                     p.Port.ToString(),
                     p.DatabaseMaintenancePort.ToString()
-                })
-                .Distinct()
-                .ToList();
+                }));
+
+            result.AddRange(serviceControlAuditInstances
+                .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
+                .SelectMany(p => new[]
+                {
+                    p.Port.ToString(),
+                    p.DatabaseMaintenancePort.ToString()
+                }));
+
+            return result.Distinct().ToList();
         }
     }
 }

--- a/src/ServiceControl.Config/Extensions/Validations.cs
+++ b/src/ServiceControl.Config/Extensions/Validations.cs
@@ -64,7 +64,7 @@
 
         public static List<string> UsedAuditQueueNames(TransportInfo transportInfo = null, string instanceName = null, string connectionString = null)
         {
-            var serviceControlInstances = InstanceFinder.ServiceControlInstances();
+            var serviceControlInstances = InstanceFinder.ServiceControlAuditInstances();
             var instancesByTransport = serviceControlInstances.Where(p => p.TransportPackage.Equals(transportInfo) &&
                                                                           string.Equals(p.ConnectionString, connectionString, StringComparison.OrdinalIgnoreCase)).ToList();
 

--- a/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddViewModelValidator.cs
@@ -1,6 +1,5 @@
 namespace ServiceControl.Config.UI.InstanceAdd
 {
-    using Extensions;
     using FluentValidation;
     using Validation;
     using Validations = Extensions.Validations;

--- a/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddViewModelValidator.cs
@@ -1,7 +1,9 @@
 namespace ServiceControl.Config.UI.InstanceAdd
 {
+    using Extensions;
     using FluentValidation;
     using Validation;
+    using Validations = Extensions.Validations;
 
     public class MonitoringAddViewModelValidator : SharedMonitoringEditorViewModelValidator<MonitoringAddViewModel>
     {
@@ -18,22 +20,22 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 .NotEmpty()
                 .ValidPort()
                 .PortAvailable()
-                .MustNotBeIn(x => UsedPorts(x.InstanceName))
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Monitoring Port")
+                .MustNotBeIn(x => Validations.UsedPorts(x.InstanceName))
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Monitoring Port")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.DestinationPath)
                 .NotEmpty()
                 .ValidPath()
-                .MustNotBeIn(x => UsedPaths(x.InstanceName))
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Destination Path")
+                .MustNotBeIn(x => Validations.UsedPaths(x.InstanceName))
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Destination Path")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ErrorQueueName)
                 .NotEmpty();
 
             RuleFor(x => x.ConnectionString)
-                .NotEmpty().WithMessage(Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
+                .NotEmpty().WithMessage(Validation.Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
                 .When(x => !string.IsNullOrWhiteSpace(x.SelectedTransport?.SampleConnectionString) && x.SubmitAttempted);
         }
     }

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
@@ -1,6 +1,5 @@
 namespace ServiceControl.Config.UI.InstanceAdd
 {
-    using Extensions;
     using FluentValidation;
     using Validation;
     using Validations = Extensions.Validations;

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
@@ -2,16 +2,13 @@ namespace ServiceControl.Config.UI.InstanceAdd
 {
     using Extensions;
     using FluentValidation;
-    using ServiceControlInstaller.Engine.Instances;
     using Validation;
+    using Validations = Extensions.Validations;
 
     public class ServiceControlAddViewModelValidator : AbstractValidator<ServiceControlEditorViewModel>
     {
         public ServiceControlAddViewModelValidator()
         {
-            var serviceControlInstances = InstanceFinder.ServiceControlInstances();
-            var serviceControlAuditInstances = InstanceFinder.ServiceControlAuditInstances();
-
             RuleFor(x => x.SelectedTransport)
                 .NotEmpty();
 
@@ -27,127 +24,118 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 .NotEmpty()
                 .ValidPort()
                 .PortAvailable()
-                .MustNotBeIn(x => serviceControlInstances.UsedPorts(x.ServiceControl.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPorts(x.ServiceControl.InstanceName))
+                .MustNotBeIn(x => Validations.UsedPorts(x.ServiceControl.InstanceName))
                 .NotEqual(x => x.ServiceControl.DatabaseMaintenancePortNumber)
                 .NotEqual(x => x.ServiceControlAudit.PortNumber)
                 .NotEqual(x => x.ServiceControlAudit.DatabaseMaintenancePortNumber)
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "ServiceControl Ports")
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "ServiceControl Ports")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.PortNumber)
                 .NotEmpty()
                 .ValidPort()
                 .PortAvailable()
-                .MustNotBeIn(x => serviceControlInstances.UsedPorts(x.ServiceControlAudit.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPorts(x.ServiceControlAudit.InstanceName))
+                .MustNotBeIn(x => Validations.UsedPorts(x.ServiceControlAudit.InstanceName))
                 .NotEqual(x => x.ServiceControlAudit.DatabaseMaintenancePortNumber)
                 .NotEqual(x => x.ServiceControl.PortNumber)
                 .NotEqual(x => x.ServiceControl.DatabaseMaintenancePortNumber)
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "ServiceControl Audit Instance Ports")
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "ServiceControl Audit Instance Ports")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControl.DatabaseMaintenancePortNumber)
                 .NotEmpty()
                 .ValidPort()
                 .PortAvailable()
-                .MustNotBeIn(x => serviceControlInstances.UsedPorts(x.ServiceControl.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPorts(x.ServiceControl.InstanceName))
+                .MustNotBeIn(x => Validations.UsedPorts(x.ServiceControl.InstanceName))
                 .NotEqual(x => x.ServiceControl.PortNumber)
                 .NotEqual(x => x.ServiceControlAudit.PortNumber)
                 .NotEqual(x => x.ServiceControlAudit.DatabaseMaintenancePortNumber)
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "ServiceControl Database Maintenance Ports")
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "ServiceControl Database Maintenance Ports")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.DatabaseMaintenancePortNumber)
                 .NotEmpty()
                 .ValidPort()
                 .PortAvailable()
-                .MustNotBeIn(x => serviceControlInstances.UsedPorts(x.ServiceControlAudit.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPorts(x.ServiceControlAudit.InstanceName))
+                .MustNotBeIn(x => Validations.UsedPorts(x.ServiceControlAudit.InstanceName))
                 .NotEqual(x => x.ServiceControlAudit.PortNumber)
                 .NotEqual(x => x.ServiceControl.PortNumber)
                 .NotEqual(x => x.ServiceControl.DatabaseMaintenancePortNumber)
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "ServiceControl Audit Instance Ports")
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "ServiceControl Audit Instance Ports")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControl.DestinationPath)
                 .NotEmpty()
                 .ValidPath()
-                .MustNotBeIn(x => serviceControlInstances.UsedPaths(x.ServiceControl.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPaths(x.ServiceControl.InstanceName))
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Destination Paths")
+                .MustNotBeIn(x => Validations.UsedPaths(x.ServiceControl.InstanceName))
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Destination Paths")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.DestinationPath)
                 .NotEmpty()
                 .ValidPath()
-                .MustNotBeIn(x => serviceControlInstances.UsedPaths(x.ServiceControlAudit.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPaths(x.ServiceControlAudit.InstanceName))
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Destination Paths")
+                .MustNotBeIn(x => Validations.UsedPaths(x.ServiceControlAudit.InstanceName))
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Destination Paths")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControl.DatabasePath)
                 .NotEmpty()
                 .ValidPath()
-                .MustNotBeIn(x => serviceControlInstances.UsedPaths(x.ServiceControl.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPaths(x.ServiceControl.InstanceName))
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Database Paths")
+                .MustNotBeIn(x => Validations.UsedPaths(x.ServiceControl.InstanceName))
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Database Paths")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.DatabasePath)
                 .NotEmpty()
                 .ValidPath()
-                .MustNotBeIn(x => serviceControlInstances.UsedPaths(x.ServiceControlAudit.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPaths(x.ServiceControlAudit.InstanceName))
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Database Paths")
+                .MustNotBeIn(x => Validations.UsedPaths(x.ServiceControlAudit.InstanceName))
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Database Paths")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.AuditForwarding)
-                .NotNull().WithMessage(Validations.MSG_SELECTAUDITFORWARDING);
+                .NotNull().WithMessage(Validation.Validations.MSG_SELECTAUDITFORWARDING);
 
             RuleFor(x => x.ServiceControl.ErrorForwarding)
-                .NotNull().WithMessage(Validations.MSG_SELECTERRORFORWARDING);
+                .NotNull().WithMessage(Validation.Validations.MSG_SELECTERRORFORWARDING);
 
 
             RuleFor(x => x.ServiceControl.ErrorQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.ServiceControl.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
-                .NotEqual(x => x.ServiceControlAudit.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
-                .NotEqual(x => x.ServiceControlAudit.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
-                .MustNotBeIn(x => serviceControlInstances.UsedQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .NotEqual(x => x.ServiceControl.ErrorForwardingQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
+                .NotEqual(x => x.ServiceControlAudit.AuditQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .NotEqual(x => x.ServiceControlAudit.AuditForwardingQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
+                .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .MustNotBeIn(x => Validations.UsedAuditQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
                 .When(x => x.SubmitAttempted && x.ServiceControl.ErrorQueueName != "!disable");
 
             RuleFor(x => x.ServiceControl.ErrorForwardingQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.ServiceControl.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
-                .NotEqual(x => x.ServiceControlAudit.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
-                .NotEqual(x => x.ServiceControlAudit.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
-                .MustNotBeIn(x => serviceControlInstances.UsedQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .NotEqual(x => x.ServiceControl.ErrorQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Error")
+                .NotEqual(x => x.ServiceControlAudit.AuditQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .NotEqual(x => x.ServiceControlAudit.AuditForwardingQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
+                .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .MustNotBeIn(x => Validations.UsedAuditQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
                 .When(x => x.SubmitAttempted && x.ServiceControl.ErrorForwarding.Value);
 
             RuleFor(x => x.ServiceControlAudit.AuditQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.ServiceControl.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
-                .NotEqual(x => x.ServiceControl.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
-                .NotEqual(x => x.ServiceControlAudit.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
-                .MustNotBeIn(x => serviceControlInstances.UsedQueueNames(x.SelectedTransport, x.ServiceControlAudit.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedQueueNames(x.SelectedTransport, x.ServiceControlAudit.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .NotEqual(x => x.ServiceControl.ErrorQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Error")
+                .NotEqual(x => x.ServiceControl.ErrorForwardingQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
+                .NotEqual(x => x.ServiceControlAudit.AuditForwardingQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
+                .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.ServiceControlAudit.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
                 .When(x => x.SubmitAttempted && x.ServiceControlAudit.AuditQueueName != "!disable");
 
             RuleFor(x => x.ServiceControlAudit.AuditForwardingQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.ServiceControl.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
-                .NotEqual(x => x.ServiceControlAudit.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
-                .NotEqual(x => x.ServiceControl.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
-                .MustNotBeIn(x => serviceControlInstances.UsedQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .NotEqual(x => x.ServiceControl.ErrorQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Error")
+                .NotEqual(x => x.ServiceControlAudit.AuditQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .NotEqual(x => x.ServiceControl.ErrorForwardingQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
+                .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .MustNotBeIn(x => Validations.UsedAuditQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
                 .When(x => x.SubmitAttempted && (x.ServiceControlAudit.AuditForwarding?.Value ?? false));
 
             RuleFor(x => x.ConnectionString)
-                .NotEmpty().WithMessage(Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
+                .NotEmpty().WithMessage(Validation.Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
                 .When(x => !string.IsNullOrWhiteSpace(x.SelectedTransport?.SampleConnectionString) && x.SubmitAttempted);
         }
     }

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlAuditEditViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlAuditEditViewModelValidator.cs
@@ -1,6 +1,5 @@
 namespace ServiceControl.Config.UI.InstanceEdit
 {
-    using Extensions;
     using FluentValidation;
     using Validation;
     using Validations = Extensions.Validations;

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlAuditEditViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlAuditEditViewModelValidator.cs
@@ -2,15 +2,13 @@ namespace ServiceControl.Config.UI.InstanceEdit
 {
     using Extensions;
     using FluentValidation;
-    using ServiceControlInstaller.Engine.Instances;
     using Validation;
+    using Validations = Extensions.Validations;
 
     public class ServiceControlAuditEditViewModelValidator : AbstractValidator<ServiceControlAuditEditViewModel>
     {
         public ServiceControlAuditEditViewModelValidator()
         {
-            var instances = InstanceFinder.ServiceControlAuditInstances();
-
             RuleFor(x => x.ServiceControlAudit.ServiceAccount)
                 .NotEmpty()
                 .When(x => x.SubmitAttempted);
@@ -19,30 +17,31 @@ namespace ServiceControl.Config.UI.InstanceEdit
                 .NotEmpty();
 
             RuleFor(x => x.ServiceControlAudit.AuditForwarding)
-                .NotNull().WithMessage(Validations.MSG_SELECTAUDITFORWARDING);
+                .NotNull().WithMessage(Validation.Validations.MSG_SELECTAUDITFORWARDING);
 
             RuleFor(x => x.ServiceControlAudit.AuditQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.ServiceControlAudit.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
-                .MustNotBeIn(x => instances.UsedQueueNames(x.SelectedTransport, x.ServiceControlAudit.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .NotEqual(x => x.ServiceControlAudit.AuditForwardingQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
+                .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.ServiceControlAudit.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
                 .When(x => x.SubmitAttempted && x.ServiceControlAudit.AuditQueueName != "!disable");
 
             RuleFor(x => x.ServiceControlAudit.AuditForwardingQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.ServiceControlAudit.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
-                .MustNotBeIn(x => instances.UsedQueueNames(x.SelectedTransport, x.ServiceControlAudit.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
-                .When(x => x.SubmitAttempted && x.ServiceControlAudit.AuditForwarding?.Value == true);
+                .NotEqual(x => x.ServiceControlAudit.AuditQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .MustNotBeIn(x => Validations.UsedAuditQueueNames(x.SelectedTransport, x.ServiceControlAudit.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.ServiceControlAudit.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .When(x => x.SubmitAttempted && x.ServiceControlAudit.AuditForwarding.Value);
 
             RuleFor(x => x.ConnectionString)
-                .NotEmpty().WithMessage(Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
+                .NotEmpty().WithMessage(Validation.Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
                 .When(x => !string.IsNullOrWhiteSpace(x.SelectedTransport?.SampleConnectionString) && x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.DatabaseMaintenancePortNumber)
                 .NotEmpty()
                 .ValidPort()
-                .MustNotBeIn(x => instances.UsedPorts(x.ServiceControlAudit.InstanceName))
+                .MustNotBeIn(x => Validations.UsedPorts(x.ServiceControlAudit.InstanceName))
                 .NotEqual(x => x.ServiceControlAudit.PortNumber)
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports")
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Ports")
                 .When(x => x.SubmitAttempted);
         }
     }

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModelValidator.cs
@@ -1,6 +1,5 @@
 namespace ServiceControl.Config.UI.InstanceEdit
 {
-    using Extensions;
     using FluentValidation;
     using Validation;
     using Validations = Extensions.Validations;

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlEditViewModelValidator.cs
@@ -2,15 +2,13 @@ namespace ServiceControl.Config.UI.InstanceEdit
 {
     using Extensions;
     using FluentValidation;
-    using ServiceControlInstaller.Engine.Instances;
     using Validation;
+    using Validations = Extensions.Validations;
 
     public class ServiceControlEditViewModelValidator : AbstractValidator<ServiceControlEditViewModel>
     {
         public ServiceControlEditViewModelValidator()
         {
-            var instances = InstanceFinder.ServiceControlInstances();
-
             RuleFor(x => x.ServiceControl.ServiceAccount)
                 .NotEmpty()
                 .When(x => x.SubmitAttempted);
@@ -19,30 +17,32 @@ namespace ServiceControl.Config.UI.InstanceEdit
                 .NotEmpty();
 
             RuleFor(x => x.ServiceControl.ErrorForwarding)
-                .NotNull().WithMessage(Validations.MSG_SELECTERRORFORWARDING);
+                .NotNull().WithMessage(Validation.Validations.MSG_SELECTERRORFORWARDING);
 
             RuleFor(x => x.ServiceControl.ErrorQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.ServiceControl.ErrorForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
-                .MustNotBeIn(x => instances.UsedQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .NotEqual(x => x.ServiceControl.ErrorForwardingQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding")
+                .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .MustNotBeIn(x => Validations.UsedAuditQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
                 .When(x => x.SubmitAttempted && x.ServiceControl.ErrorQueueName != "!disable");
 
             RuleFor(x => x.ServiceControl.ErrorForwardingQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.ServiceControl.ErrorQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Error")
-                .MustNotBeIn(x => instances.UsedQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .NotEqual(x => x.ServiceControl.ErrorQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Error")
+                .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
+                .MustNotBeIn(x => Validations.UsedAuditQueueNames(x.SelectedTransport, x.ServiceControl.InstanceName, x.ConnectionString)).WithMessage(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED)
                 .When(x => x.SubmitAttempted && x.ServiceControl.ErrorForwarding.Value);
 
             RuleFor(x => x.ConnectionString)
-                .NotEmpty().WithMessage(Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
+                .NotEmpty().WithMessage(Validation.Validations.MSG_THIS_TRANSPORT_REQUIRES_A_CONNECTION_STRING)
                 .When(x => !string.IsNullOrWhiteSpace(x.SelectedTransport?.SampleConnectionString) && x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControl.DatabaseMaintenancePortNumber)
                 .NotEmpty()
                 .ValidPort()
-                .MustNotBeIn(x => instances.UsedPorts(x.ServiceControl.InstanceName))
+                .MustNotBeIn(x => Validations.UsedPorts(x.ServiceControl.InstanceName))
                 .NotEqual(x => x.ServiceControl.PortNumber)
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports")
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Ports")
                 .When(x => x.SubmitAttempted);
         }
     }

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMontioringEditorViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMontioringEditorViewModelValidator.cs
@@ -1,18 +1,13 @@
 namespace ServiceControl.Config.Validation
 {
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Linq;
+    using Extensions;
     using FluentValidation;
-    using ServiceControlInstaller.Engine.Instances;
     using UI.SharedInstanceEditor;
 
     public class SharedMonitoringEditorViewModelValidator<T> : AbstractValidator<T> where T : SharedMonitoringEditorViewModel
     {
         protected SharedMonitoringEditorViewModelValidator()
         {
-            MonitoringInstances = InstanceFinder.MonitoringInstances();
-
             RuleFor(x => x.InstanceName)
                 .NotEmpty()
                 .MustNotContainWhitespace()
@@ -25,35 +20,9 @@ namespace ServiceControl.Config.Validation
             RuleFor(x => x.LogPath)
                 .NotEmpty()
                 .ValidPath()
-                .MustNotBeIn(x => UsedPaths(x.InstanceName))
+                .MustNotBeIn(x => Extensions.Validations.UsedPaths(x.InstanceName))
                 .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Paths")
                 .When(x => x.SubmitAttempted);
         }
-
-        // We need this to ignore the instance that represents the edit screen
-        protected List<string> UsedPaths(string instanceName = null)
-        {
-            return MonitoringInstances
-                .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
-                .SelectMany(p => new[]
-                {
-                    p.LogPath,
-                    p.InstallPath
-                })
-                .Distinct()
-                .ToList();
-        }
-
-        // We need this to ignore the instance that represents the edit screen
-        protected List<string> UsedPorts(string instanceName = null)
-        {
-            return MonitoringInstances
-                .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
-                .Select(p => p.Port.ToString())
-                .Distinct()
-                .ToList();
-        }
-
-        ReadOnlyCollection<MonitoringInstance> MonitoringInstances;
     }
 }

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMontioringEditorViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMontioringEditorViewModelValidator.cs
@@ -1,6 +1,5 @@
 namespace ServiceControl.Config.Validation
 {
-    using Extensions;
     using FluentValidation;
     using UI.SharedInstanceEditor;
 

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModelValidator.cs
@@ -2,7 +2,6 @@ namespace ServiceControl.Config.Validation
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Linq;
     using FluentValidation;
     using ServiceControlInstaller.Engine.Instances;
@@ -12,8 +11,6 @@ namespace ServiceControl.Config.Validation
     {
         protected SharedServiceControlEditorViewModelValidator()
         {
-            ServiceControlInstances = InstanceFinder.ServiceControlInstances();
-
             RuleFor(x => x.InstanceName)
                 .NotEmpty()
                 .MustNotContainWhitespace()
@@ -41,7 +38,7 @@ namespace ServiceControl.Config.Validation
         // We need this to ignore the instance that represents the edit screen
         protected List<string> UsedPaths(string instanceName = null)
         {
-            return ServiceControlInstances
+            return InstanceFinder.ServiceControlInstances()
                 .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
                 .SelectMany(p => new[]
                 {
@@ -56,7 +53,7 @@ namespace ServiceControl.Config.Validation
         // We need this to ignore the instance that represents the edit screen
         protected List<string> UsedQueueNames(TransportInfo transportInfo = null, string instanceName = null, string connectionString = null)
         {
-            var instancesByTransport = ServiceControlInstances.Where(p => p.TransportPackage.Equals(transportInfo) &&
+            var instancesByTransport = InstanceFinder.ServiceControlInstances().Where(p => p.TransportPackage.Equals(transportInfo) &&
                                                                           string.Equals(p.ConnectionString, connectionString, StringComparison.OrdinalIgnoreCase)).ToList();
 
             return instancesByTransport
@@ -76,7 +73,7 @@ namespace ServiceControl.Config.Validation
         // We need this to ignore the instance that represents the edit screen
         protected List<string> UsedPorts(string instanceName = null)
         {
-            return ServiceControlInstances
+            return InstanceFinder.ServiceControlInstances()
                 .Where(p => string.IsNullOrWhiteSpace(instanceName) || p.Name != instanceName)
                 .SelectMany(p => new[]
                 {
@@ -86,7 +83,5 @@ namespace ServiceControl.Config.Validation
                 .Distinct()
                 .ToList();
         }
-
-        ReadOnlyCollection<ServiceControlInstance> ServiceControlInstances;
     }
 }

--- a/src/ServiceControl.Config/UI/Shell/ShellView.xaml.cs
+++ b/src/ServiceControl.Config/UI/Shell/ShellView.xaml.cs
@@ -11,7 +11,11 @@
         {
             InitializeComponent();
 
-            Activated += (s, e) => IoC.Get<IEventAggregator>().PublishOnUIThread(new RefreshInstances());
+            Activated += (s, e) =>
+            {
+                //IoC.Get<IEventAggregator>().PublishOnUIThread(new RefreshInstances());
+                Model?.RefreshInstances();
+            };
 
             Loaded += (sender, args) =>
             {
@@ -28,6 +32,8 @@
                 window.GotKeyboardFocus += (s, e) => IoC.Get<IEventAggregator>().PublishOnUIThread(new FocusChanged { HasFocus = true });
             };
         }
+
+        ShellViewModel Model => DataContext as ShellViewModel;
 
         void Window_SizeChanged(object sender, SizeChangedEventArgs e)
         {

--- a/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
+++ b/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
@@ -91,7 +91,7 @@
             RefreshInstances();
         }
 
-        void RefreshInstances()
+        public void RefreshInstances()
         {
             if (ActiveItem != null && !(ActiveItem == listInstances || ActiveItem == noInstances))
             {

--- a/src/ServiceControl.Config/UI/Upgrades/AddNewAuditInstanceView.xaml
+++ b/src/ServiceControl.Config/UI/Upgrades/AddNewAuditInstanceView.xaml
@@ -138,7 +138,7 @@
                             Margin="20,0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
-                            Visibility="{Binding Path=ValidationTemplate.Error,
+                            Visibility="{Binding Path=(cm:IDataErrorInfo.Error),
                                                  Converter={StaticResource nullOrEmptyToVis}}">
                 <ContentControl.Content>
                     <Grid>
@@ -165,12 +165,10 @@
                         </Grid.RowDefinitions>
                         <TextBlock Margin="0,0,0,5"
                                FontSize="14"
-                               FontWeight="Bold">
-                        Validation Errors
-                        </TextBlock>
+                               FontWeight="Bold">Validation Errors</TextBlock>
                         <TextBlock Grid.Row="1"
                                Foreground="{StaticResource ErrorBrush}"
-                               Text="{Binding Path=ValidationTemplate.Error}" />
+                               Text="{Binding Path=(cm:IDataErrorInfo.Error)}" />
                     </Grid>
                 </ContentControl.ToolTip>
             </ContentControl>

--- a/src/ServiceControl.Config/UI/Upgrades/AddNewAuditInstanceViewModel.cs
+++ b/src/ServiceControl.Config/UI/Upgrades/AddNewAuditInstanceViewModel.cs
@@ -3,8 +3,10 @@
     using System.Windows.Input;
     using Framework.Rx;
     using InstanceAdd;
+    using Validar;
     using Validation;
 
+    [InjectValidation]
     public class AddNewAuditInstanceViewModel : RxScreen
     {
         public AddNewAuditInstanceViewModel(string serviceControlName)

--- a/src/ServiceControl.Config/UI/Upgrades/AddNewAuditInstanceViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/Upgrades/AddNewAuditInstanceViewModelValidator.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.Config.UI.Upgrades
 {
     using FluentValidation;
-    using Extensions;
     using Validation;
     using Validations = Extensions.Validations;
 

--- a/src/ServiceControl.Config/UI/Upgrades/AddNewAuditInstanceViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/Upgrades/AddNewAuditInstanceViewModelValidator.cs
@@ -2,15 +2,13 @@
 {
     using FluentValidation;
     using Extensions;
-    using ServiceControlInstaller.Engine.Instances;
     using Validation;
+    using Validations = Extensions.Validations;
+
     public class AddNewAuditInstanceViewModelValidator : AbstractValidator<AddNewAuditInstanceViewModel>
     {
         public AddNewAuditInstanceViewModelValidator()
         {
-            var serviceControlInstances = InstanceFinder.ServiceControlInstances();
-            var serviceControlAuditInstances = InstanceFinder.ServiceControlAuditInstances();
-
             RuleFor(x => x.ServiceControlAudit.ServiceAccount)
                 .NotEmpty()
                 .When(x => x.SubmitAttempted);
@@ -19,49 +17,45 @@
                 .NotEmpty()
                 .ValidPort()
                 .PortAvailable()
-                .MustNotBeIn(x => serviceControlInstances.UsedPorts(x.ServiceControlAudit.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPorts(x.ServiceControlAudit.InstanceName))
+                .MustNotBeIn(x => Validations.UsedPorts(x.ServiceControlAudit.InstanceName))
                 .NotEqual(x => x.ServiceControlAudit.DatabaseMaintenancePortNumber)
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports")
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Ports")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.DatabaseMaintenancePortNumber)
                 .NotEmpty()
                 .ValidPort()
                 .PortAvailable()
-                .MustNotBeIn(x => serviceControlInstances.UsedPorts(x.ServiceControlAudit.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPorts(x.ServiceControlAudit.InstanceName))
+                .MustNotBeIn(x => Validations.UsedPorts(x.ServiceControlAudit.InstanceName))
                 .NotEqual(x => x.ServiceControlAudit.PortNumber)
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Ports")
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Ports")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.DestinationPath)
                 .NotEmpty()
                 .ValidPath()
-                .MustNotBeIn(x => serviceControlInstances.UsedPaths(x.ServiceControlAudit.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPaths(x.ServiceControlAudit.InstanceName))
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Paths")
+                .MustNotBeIn(x => Validations.UsedPaths(x.ServiceControlAudit.InstanceName))
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Paths")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.DatabasePath)
                 .NotEmpty()
                 .ValidPath()
-                .MustNotBeIn(x => serviceControlInstances.UsedPaths(x.ServiceControlAudit.InstanceName))
-                .MustNotBeIn(x => serviceControlAuditInstances.UsedPaths(x.ServiceControlAudit.InstanceName))
-                .WithMessage(Validations.MSG_MUST_BE_UNIQUE, "Paths")
+                .MustNotBeIn(x => Validations.UsedPaths(x.ServiceControlAudit.InstanceName))
+                .WithMessage(Validation.Validations.MSG_MUST_BE_UNIQUE, "Paths")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.AuditForwarding)
-                .NotNull().WithMessage(Validations.MSG_SELECTAUDITFORWARDING);
+                .NotNull().WithMessage(Validation.Validations.MSG_SELECTAUDITFORWARDING);
 
             RuleFor(x => x.ServiceControlAudit.AuditQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.ServiceControlAudit.AuditForwardingQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
+                .NotEqual(x => x.ServiceControlAudit.AuditForwardingQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding")
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.ServiceControlAudit.AuditForwardingQueueName)
                 .NotEmpty()
-                .NotEqual(x => x.ServiceControlAudit.AuditQueueName).WithMessage(Validations.MSG_UNIQUEQUEUENAME, "Audit")
+                .NotEqual(x => x.ServiceControlAudit.AuditQueueName).WithMessage(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit")
                 .When(x => x.SubmitAttempted && (x.ServiceControlAudit.AuditForwarding?.Value ?? false));
         }
     }

--- a/src/ServiceControlInstaller.Engine.UnitTests/Validation/QueueValidationTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Validation/QueueValidationTests.cs
@@ -60,7 +60,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
             var newInstance = new ServiceControlAuditNewInstance
             {
                 TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.MSMQ),
-                AuditQueue = "audit",
+                AuditQueue = "audit"
             };
 
             var validator = new QueueNameValidator(newInstance)
@@ -132,7 +132,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
             // with default names
             var defaultInstance = new ServiceControlNewInstance
             {
-                ErrorQueue = "Error",
+                ErrorQueue = "Error"
             };
 
             p = new QueueNameValidator(defaultInstance)
@@ -154,7 +154,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
                 TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.RabbitMQConventionalRoutingTopology),
                 ErrorLogQueue = "errorlog",
                 ErrorQueue = "error",
-                ForwardErrorMessages = true,
+                ForwardErrorMessages = true
             };
 
             var p = new QueueNameValidator(newInstance)
@@ -169,7 +169,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
             // with default names
             var defaultInstance = new ServiceControlNewInstance
             {
-                ErrorQueue = "Error",
+                ErrorQueue = "Error"
             };
             p = new QueueNameValidator(defaultInstance)
             {

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/AppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/AppConfig.cs
@@ -28,7 +28,7 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
             settings.Set(ServiceControlSettings.ForwardErrorMessages, details.ForwardErrorMessages.ToString(), version);
             settings.Set(ServiceControlSettings.TransportType, details.TransportPackage.TypeName, version);
             settings.Set(ServiceControlSettings.ErrorQueue, details.ErrorQueue);
-            settings.Set(ServiceControlSettings.ErrorLogQueue, details.ErrorLogQueue);
+            settings.Set(ServiceControlSettings.ErrorLogQueue, details.ForwardErrorMessages ? details.ErrorLogQueue : null);
             settings.Set(ServiceControlSettings.AuditRetentionPeriod, details.AuditRetentionPeriod.ToString(), version);
             settings.Set(ServiceControlSettings.ErrorRetentionPeriod, details.ErrorRetentionPeriod.ToString(), version);
             settings.Set(ServiceControlSettings.RemoteInstances, RemoteInstanceConverter.ToJson(details.RemoteInstances), version);
@@ -108,7 +108,7 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
             settings.Set(AuditInstanceSettingsList.ForwardAuditMessages, details.ForwardAuditMessages.ToString());
             settings.Set(AuditInstanceSettingsList.TransportType, details.TransportPackage.TypeName, version);
             settings.Set(AuditInstanceSettingsList.AuditQueue, details.AuditQueue);
-            settings.Set(AuditInstanceSettingsList.AuditLogQueue, details.AuditLogQueue);
+            settings.Set(AuditInstanceSettingsList.AuditLogQueue, details.ForwardAuditMessages ? details.AuditLogQueue : null);
             settings.Set(AuditInstanceSettingsList.AuditRetentionPeriod, details.AuditRetentionPeriod.ToString(), version);
             settings.Set(AuditInstanceSettingsList.ServiceControlQueueAddress, details.ServiceControlQueueAddress);
 

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
@@ -61,8 +61,6 @@ namespace ServiceControlInstaller.Engine.Instances
             LogPath = AppConfig.Read(AuditInstanceSettingsList.LogPath, DefaultLogPath());
             DBPath = AppConfig.Read(AuditInstanceSettingsList.DBPath, DefaultDBPath());
             AuditQueue = AppConfig.Read(AuditInstanceSettingsList.AuditQueue, "audit");
-            AuditLogQueue = AppConfig.Read(AuditInstanceSettingsList.AuditLogQueue, $"{AuditQueue}.log");
-            ForwardAuditMessages = AppConfig.Read(AuditInstanceSettingsList.ForwardAuditMessages, false);
             AuditRetentionPeriod = TimeSpan.Parse(AppConfig.Read(AuditInstanceSettingsList.AuditRetentionPeriod, "30.00:00:00"));
             InMaintenanceMode = AppConfig.Read(AuditInstanceSettingsList.MaintenanceMode, false);
             ServiceControlQueueAddress = AppConfig.Read<string>(AuditInstanceSettingsList.ServiceControlQueueAddress, null);
@@ -70,6 +68,12 @@ namespace ServiceControlInstaller.Engine.Instances
             ConnectionString = ReadConnectionString();
             Description = GetDescription();
             ServiceAccount = Service.Account;
+
+            ForwardAuditMessages = AppConfig.Read(ServiceControlSettings.ForwardAuditMessages, false);
+            if (ForwardAuditMessages)
+            {
+                AuditLogQueue = AppConfig.Read(ServiceControlSettings.AuditLogQueue, $"{AuditQueue}.log");
+            }
         }
 
         public override void RunQueueCreation()

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -101,16 +101,24 @@ namespace ServiceControlInstaller.Engine.Instances
             LogPath = AppConfig.Read(ServiceControlSettings.LogPath, DefaultLogPath());
             DBPath = AppConfig.Read(ServiceControlSettings.DBPath, DefaultDBPath());
             AuditQueue = AppConfig.Read(ServiceControlSettings.AuditQueue, (string)null);
-            AuditLogQueue = AppConfig.Read(ServiceControlSettings.AuditLogQueue, string.IsNullOrEmpty(AuditQueue) ? null : $"{AuditQueue}.log");
-            ForwardAuditMessages = AppConfig.Read(ServiceControlSettings.ForwardAuditMessages, false);
-            ForwardErrorMessages = AppConfig.Read(ServiceControlSettings.ForwardErrorMessages, false);
             InMaintenanceMode = AppConfig.Read(ServiceControlSettings.MaintenanceMode, false);
             ErrorQueue = AppConfig.Read(ServiceControlSettings.ErrorQueue, "error");
-            ErrorLogQueue = AppConfig.Read(ServiceControlSettings.ErrorLogQueue, $"{ErrorQueue}.log");
             TransportPackage = DetermineTransportPackage();
             ConnectionString = ReadConnectionString();
             Description = GetDescription();
             ServiceAccount = Service.Account;
+
+            ForwardErrorMessages = AppConfig.Read(ServiceControlSettings.ForwardErrorMessages, false);
+            if (ForwardErrorMessages)
+            {
+                ErrorLogQueue = AppConfig.Read(ServiceControlSettings.ErrorLogQueue, $"{ErrorQueue}.log");
+            }
+
+            ForwardAuditMessages = AppConfig.Read(ServiceControlSettings.ForwardAuditMessages, false);
+            if (ForwardAuditMessages)
+            {
+                AuditLogQueue = AppConfig.Read(ServiceControlSettings.AuditLogQueue, string.IsNullOrEmpty(AuditQueue) ? null : $"{AuditQueue}.log");
+            }
 
             if (TimeSpan.TryParse(AppConfig.Read(ServiceControlSettings.ErrorRetentionPeriod, (string)null), out var errorRetentionPeriod))
             {
@@ -159,7 +167,6 @@ namespace ServiceControlInstaller.Engine.Instances
             {
                 if (Compatibility.RemoteInstancesDoNotNeedQueueAddress.SupportedFrom <= Version)
                 {
-
                     foreach (var instance in RemoteInstances)
                     {
                         instance.QueueAddress = null;

--- a/src/ServiceControlInstaller.Engine/Interfaces.cs
+++ b/src/ServiceControlInstaller.Engine/Interfaces.cs
@@ -73,7 +73,16 @@ namespace ServiceControlInstaller.Engine
         int? DatabaseMaintenancePort { get; }
     }
 
-    public interface IServiceControlAuditInstance : IServiceInstance, IServiceControlPaths, IHttpInstance, IInstallable, IDatabaseMaintenanceSupport, ITransportConfig
+    public interface IServiceControlBaseInstance : IHttpInstance, 
+        IDatabaseMaintenanceSupport, 
+        IServiceInstance, 
+        IServiceControlPaths,
+        IInstallable,
+        ITransportConfig
+    {
+    }
+
+    public interface IServiceControlAuditInstance : IServiceControlBaseInstance
     {
         string AuditQueue { get; }
         string AuditLogQueue { get; }
@@ -83,7 +92,7 @@ namespace ServiceControlInstaller.Engine
         string ServiceControlQueueAddress { get; set; }
     }
 
-    public interface IServiceControlInstance : IServiceInstance, IServiceControlPaths, IHttpInstance, IURLInfo, IInstallable, IDatabaseMaintenanceSupport, ITransportConfig
+    public interface IServiceControlInstance : IServiceControlBaseInstance, IURLInfo
     {
         string ErrorQueue { get; }
         string ErrorLogQueue { get; }

--- a/src/ServiceControlInstaller.Engine/Validation/QueueNameValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/QueueNameValidator.cs
@@ -157,7 +157,7 @@ namespace ServiceControlInstaller.Engine.Validation
 
             if (duplicates.Count > 1)
             {
-                throw new EngineValidationException($"Some queue names specified are already assigned to another ServiceControl instance - Correct the values for {string.Join(", ", duplicates)}");
+                throw new EngineValidationException($"Some queue names specified are already assigned to another ServiceControl instance - Correct the values for {string.Join(", ", duplicates.OrderBy(x => x))}");
             }
         }
 


### PR DESCRIPTION
This PR has a few things:

- Using one set of validation for Ports and Paths between different instances.
- Checking all instances for used folders, ports and queues except for audit. 
- Slightly better validation messages
- Excluding Audit queue from duplication check
- Using [InjectValidation] for the upgrade view model (to make it consistent with other VMs)
- Not writing the AuditQueueLog/ErrorQueueLog if the forwarding options are not turned on.
- Fixing an issue with the auto-refresh of the instances