### PR TITLE
Scatter gather endpoints

### DIFF
--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.NancyModulePaths.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.NancyModulePaths.approved.txt
@@ -19,5 +19,8 @@
     "GET: /",
     "GET: /configuration",
     "GET: /instance-info"
+  ],
+  "ServiceControl.Audit.Monitoring.WebApi": [
+    "GET: /endpoints/known"
   ]
 }

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -177,6 +177,13 @@ namespace ServiceControl.Audit.Monitoring
         public System.Guid HostId { get; set; }
         public string Name { get; set; }
     }
+    public class KnownEndpointsView
+    {
+        public KnownEndpointsView() { }
+        public ServiceControl.Audit.Monitoring.EndpointDetails EndpointDetails { get; set; }
+        public string HostDisplayName { get; set; }
+        public System.Guid Id { get; set; }
+    }
     public enum MessageStatus
     {
         Successful = 3,

--- a/src/ServiceControl.Audit/Monitoring/KnownEndpoints/EndpointsIndex.cs
+++ b/src/ServiceControl.Audit/Monitoring/KnownEndpoints/EndpointsIndex.cs
@@ -1,0 +1,35 @@
+namespace ServiceControl.Audit.Monitoring
+{
+    using System.Linq;
+    using Auditing;
+    using Raven.Client.Indexes;
+
+    class EndpointsIndex : AbstractIndexCreationTask<ProcessedMessage, EndpointDetails>
+    {
+        public EndpointsIndex()
+        {
+            Map = messages => from message in messages
+                let sending = (EndpointDetails)message.MessageMetadata["SendingEndpoint"]
+                let receiving = (EndpointDetails)message.MessageMetadata["ReceivingEndpoint"]
+                from endpoint in new[] { sending, receiving }
+                where endpoint != null
+                select new EndpointDetails
+                {
+                    Host = endpoint.Host,
+                    HostId = endpoint.HostId,
+                    Name = endpoint.Name
+                };
+
+            Reduce = results => from result in results
+                group result by new {result.Name, result.HostId}
+                into grouped
+                let first = grouped.First()
+                select new EndpointDetails
+                {
+                    Host = first.Host,
+                    HostId = first.HostId,
+                    Name = first.Name
+                };
+        }
+    }
+}

--- a/src/ServiceControl.Audit/Monitoring/KnownEndpoints/GetKnownEndpointsApi.cs
+++ b/src/ServiceControl.Audit/Monitoring/KnownEndpoints/GetKnownEndpointsApi.cs
@@ -1,0 +1,35 @@
+namespace ServiceControl.Audit.Monitoring
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Auditing.MessagesView;
+    using Infrastructure;
+    using Infrastructure.Extensions;
+    using Nancy;
+    using Raven.Client;
+
+    class GetKnownEndpointsApi : ApiBase<NoInput, KnownEndpointsView[]>
+    {
+        public override async Task<QueryResult<KnownEndpointsView[]>> Query(Request request, NoInput input)
+        {
+            using (var session = Store.OpenAsyncSession())
+            {
+                var endpoints = await session.Query<EndpointDetails, EndpointsIndex>()
+                    .Statistics(out var stats)
+                    .ToListAsync()
+                    .ConfigureAwait(false);
+
+                var knownEndpoints = endpoints
+                    .Select(x => new KnownEndpointsView
+                    {
+                        Id = DeterministicGuid.MakeId(x.Name, x.HostId.ToString()),
+                        EndpointDetails = x,
+                        HostDisplayName = x.Host
+                    })
+                    .ToArray();
+
+                return new QueryResult<KnownEndpointsView[]>(knownEndpoints, stats.ToQueryStatsInfo());
+            }
+        }
+    }
+}

--- a/src/ServiceControl.Audit/Monitoring/KnownEndpoints/GetKnownEndpointsApi.cs
+++ b/src/ServiceControl.Audit/Monitoring/KnownEndpoints/GetKnownEndpointsApi.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.Monitoring
 {
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using Auditing.MessagesView;
@@ -8,9 +9,9 @@ namespace ServiceControl.Audit.Monitoring
     using Nancy;
     using Raven.Client;
 
-    class GetKnownEndpointsApi : ApiBase<NoInput, KnownEndpointsView[]>
+    class GetKnownEndpointsApi : ApiBase<NoInput, IList<KnownEndpointsView>>
     {
-        public override async Task<QueryResult<KnownEndpointsView[]>> Query(Request request, NoInput input)
+        public override async Task<QueryResult<IList<KnownEndpointsView>>> Query(Request request, NoInput input)
         {
             using (var session = Store.OpenAsyncSession())
             {
@@ -26,9 +27,9 @@ namespace ServiceControl.Audit.Monitoring
                         EndpointDetails = x,
                         HostDisplayName = x.Host
                     })
-                    .ToArray();
+                    .ToList();
 
-                return new QueryResult<KnownEndpointsView[]>(knownEndpoints, stats.ToQueryStatsInfo());
+                return new QueryResult<IList<KnownEndpointsView>>(knownEndpoints, stats.ToQueryStatsInfo());
             }
         }
     }

--- a/src/ServiceControl.Audit/Monitoring/KnownEndpoints/KnownEndpointsView.cs
+++ b/src/ServiceControl.Audit/Monitoring/KnownEndpoints/KnownEndpointsView.cs
@@ -1,0 +1,11 @@
+namespace ServiceControl.Audit.Monitoring
+{
+    using System;
+
+    public class KnownEndpointsView
+    {
+        public Guid Id { get; set; }
+        public EndpointDetails EndpointDetails { get; set; }
+        public string HostDisplayName { get; set; }
+    }
+}

--- a/src/ServiceControl.Audit/Monitoring/KnownEndpoints/WebApi.cs
+++ b/src/ServiceControl.Audit/Monitoring/KnownEndpoints/WebApi.cs
@@ -1,0 +1,15 @@
+namespace ServiceControl.Audit.Monitoring
+{
+    using Auditing.MessagesView;
+    using Infrastructure.Nancy.Modules;
+
+    class WebApi : BaseModule
+    {
+        public WebApi()
+        {
+            Get["/endpoints/known", true] = (parameters, token) => GetKnownEndpointsApi.Execute(this, NoInput.Instance);
+        }
+
+        public GetKnownEndpointsApi GetKnownEndpointsApi { get; set; }
+    }
+}

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_endpoint_known_to_audit_instance.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_endpoint_known_to_audit_instance.cs
@@ -1,0 +1,69 @@
+﻿namespace ServiceControl.MultiInstance.AcceptanceTests.Auditing
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+    using ServiceBus.Management.AcceptanceTests;
+    using ServiceBus.Management.AcceptanceTests.EndpointTemplates;
+    using ServiceControl.Monitoring;
+    using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+    class When_endpoint_known_to_audit_instance : AcceptanceTest
+    {
+        [Test]
+        public async Task Should_appear_in_list_of_known_endpoints()
+        {
+            var knownEndpoints = new List<KnownEndpointsView>();
+
+            await Define<MyContext>()
+                .WithEndpoint<Sender>(b => b.When(session => session.SendLocal(new SomeMessage())))
+                .Done(async ctx =>
+                {
+                    if (!ctx.MessageHandled)
+                    {
+                        return false;
+                    }
+
+                    var result = await this.TryGetMany<KnownEndpointsView>("/api/endpoints/known");
+                    knownEndpoints = result.Items;
+                    return result.HasResult;
+                })
+                .Run();
+            Assert.AreEqual(1, knownEndpoints.Count);
+            var knownEndpoint = knownEndpoints.FirstOrDefault(x => x.EndpointDetails.Name == Conventions.EndpointNamingConvention(typeof(Sender)));
+            Assert.IsNotNull(knownEndpoint);
+        }
+
+        class SomeMessage : IMessage
+        {
+
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServerWithAudit>();
+            }
+
+            class SomeMessageHandler : IHandleMessages<SomeMessage>
+            {
+                public MyContext Context { get; set; }
+
+                public Task Handle(SomeMessage message, IMessageHandlerContext context)
+                {
+                    Context.MessageHandled = true;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        class MyContext : ScenarioContext
+        {
+            public bool MessageHandled { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl/Monitoring/Web/ApiModule.cs
+++ b/src/ServiceControl/Monitoring/Web/ApiModule.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Monitoring
 {
     using System;
+    using CompositeViews.Messages;
     using Nancy;
     using Nancy.ModelBinding;
     using ServiceBus.Management.Infrastructure.Nancy.Modules;
@@ -18,7 +19,7 @@
 
             Get["/endpoints"] = _ => Negotiate.WithModel(Monitoring.GetEndpoints());
 
-            Get["/endpoints/known"] = _ => Negotiate.WithModel(Monitoring.GetKnownEndpoints());
+            Get["/endpoints/known", true] = (parameters, token) => GetKnownEndpointsApi.Execute(this, NoInput.Instance);
 
             Patch["/endpoints/{id}", true] = async (parameters, token) =>
             {
@@ -41,5 +42,6 @@
         }
 
         public EndpointInstanceMonitoring Monitoring { get; set; }
+        public GetKnownEndpointsApi GetKnownEndpointsApi { get; set; }
     }
 }

--- a/src/ServiceControl/Monitoring/Web/GetKnownEndpointsApi.cs
+++ b/src/ServiceControl/Monitoring/Web/GetKnownEndpointsApi.cs
@@ -20,7 +20,7 @@
         {
             return Task.FromResult(
                 new QueryResult<IList<KnownEndpointsView>>(
-                    monitoring.GetKnownEndpoints().ToList(), 
+                    monitoring.GetKnownEndpoints(), 
                     QueryStatsInfo.Zero
                 )
             );

--- a/src/ServiceControl/Monitoring/Web/GetKnownEndpointsApi.cs
+++ b/src/ServiceControl/Monitoring/Web/GetKnownEndpointsApi.cs
@@ -1,0 +1,33 @@
+﻿namespace ServiceControl.Monitoring
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using CompositeViews.Messages;
+    using Nancy;
+    using Nancy.Extensions;
+
+    class GetKnownEndpointsApi : ScatterGatherApi<NoInput, KnownEndpointsView[]>
+    {
+        EndpointInstanceMonitoring monitoring;
+
+        public GetKnownEndpointsApi(EndpointInstanceMonitoring monitoring)
+        {
+            this.monitoring = monitoring;
+        }
+
+        public override Task<QueryResult<KnownEndpointsView[]>> LocalQuery(Request request, NoInput input)
+        {
+            return Task.FromResult(
+                new QueryResult<KnownEndpointsView[]>(
+                    monitoring.GetKnownEndpoints().ToArray(), 
+                    QueryStatsInfo.Zero
+                )
+            );
+        }
+
+        protected override KnownEndpointsView[] ProcessResults(Request request, QueryResult<KnownEndpointsView[]>[] results)
+        {
+            return results.SelectMany(x => x.Results).DistinctBy(x => x.Id).ToArray();
+        }
+    }
+}

--- a/src/ServiceControl/Monitoring/Web/GetKnownEndpointsApi.cs
+++ b/src/ServiceControl/Monitoring/Web/GetKnownEndpointsApi.cs
@@ -18,17 +18,19 @@
 
         public override Task<QueryResult<IList<KnownEndpointsView>>> LocalQuery(Request request, NoInput input)
         {
+            var result = monitoring.GetKnownEndpoints();
+            
             return Task.FromResult(
                 new QueryResult<IList<KnownEndpointsView>>(
-                    monitoring.GetKnownEndpoints(), 
-                    QueryStatsInfo.Zero
+                    result, 
+                    new QueryStatsInfo(string.Empty, result.Count)
                 )
             );
         }
 
         protected override IList<KnownEndpointsView> ProcessResults(Request request, QueryResult<IList<KnownEndpointsView>>[] results)
         {
-            return results.SelectMany(x => x.Results).DistinctBy(x => x.Id).ToList();
+            return results.Where(p => p.Results != null).SelectMany(x => x.Results).DistinctBy(x => x.Id).ToList();
         }
     }
 }

--- a/src/ServiceControl/Monitoring/Web/GetKnownEndpointsApi.cs
+++ b/src/ServiceControl/Monitoring/Web/GetKnownEndpointsApi.cs
@@ -1,12 +1,13 @@
 ﻿namespace ServiceControl.Monitoring
 {
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using CompositeViews.Messages;
     using Nancy;
     using Nancy.Extensions;
 
-    class GetKnownEndpointsApi : ScatterGatherApi<NoInput, KnownEndpointsView[]>
+    class GetKnownEndpointsApi : ScatterGatherApi<NoInput, IList<KnownEndpointsView>>
     {
         EndpointInstanceMonitoring monitoring;
 
@@ -15,19 +16,19 @@
             this.monitoring = monitoring;
         }
 
-        public override Task<QueryResult<KnownEndpointsView[]>> LocalQuery(Request request, NoInput input)
+        public override Task<QueryResult<IList<KnownEndpointsView>>> LocalQuery(Request request, NoInput input)
         {
             return Task.FromResult(
-                new QueryResult<KnownEndpointsView[]>(
-                    monitoring.GetKnownEndpoints().ToArray(), 
+                new QueryResult<IList<KnownEndpointsView>>(
+                    monitoring.GetKnownEndpoints().ToList(), 
                     QueryStatsInfo.Zero
                 )
             );
         }
 
-        protected override KnownEndpointsView[] ProcessResults(Request request, QueryResult<KnownEndpointsView[]>[] results)
+        protected override IList<KnownEndpointsView> ProcessResults(Request request, QueryResult<IList<KnownEndpointsView>>[] results)
         {
-            return results.SelectMany(x => x.Results).DistinctBy(x => x.Id).ToArray();
+            return results.SelectMany(x => x.Results).DistinctBy(x => x.Id).ToList();
         }
     }
 }


### PR DESCRIPTION
In order to support [Multi-Region Deployment](https://docs.particular.net/servicecontrol/servicecontrol-instances/distributed-instances#advanced-scenarios-multi-region-deployments) we need to scatter-gather over known endpoints. 

ServiceControl instances will Scatter-Gather results over it's set of remotes

ServiceControl Audit instances index results from the ingested audits. 

This means in a multi-region deployment, the Global instance will return it's own results and the aggregated results from the primary regional instances. Each regional primary instance will return it's own results and the aggregated results from their remotes (usually audit instances). This means that each query might have 2 hops to get a full result set.