### PR TITLE
Fixing upgrade for audit instance

### DIFF
--- a/src/ServiceControl.Config/Commands/StartServiceControlInMaintenanceModeCommand.cs
+++ b/src/ServiceControl.Config/Commands/StartServiceControlInMaintenanceModeCommand.cs
@@ -21,7 +21,7 @@
             model.ServiceControlInstance.Service.Refresh();
 
             var confirm = model.IsStopped ||
-                          windowManager.ShowYesNoDialog("STOP INSTANCE AND START IN MAINTENANCE MODE", $"{model.Name} needs to be stopped in order to start in Maintenance Mode.", "Do you want to proceed?", "Yes I want to proceed", "No");
+                          windowManager.ShowYesNoDialog("STOP INSTANCE AND START IN MAINTENANCE MODE", $"{model.Name} needs to be stopped in order to start in Maintenance Mode.", "Do you want to proceed?", "Yes, I want to proceed", "No");
 
             if (confirm)
             {

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -114,7 +114,7 @@
                         var serviceStarted = await model.StartService(progress);
                         if (!serviceStarted)
                         {
-                            reportCard.Errors.Add("The Service failed to start. Please consult the service control logs for this instance");
+                            reportCard.Errors.Add("The Service failed to start. Please consult the ServiceControl logs for this instance");
                             windowManager.ShowActionReport(reportCard, "UPGRADE FAILURE", "Instance reported this error after upgrade:");
                         }
                     }

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -71,7 +71,7 @@
                 !windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {serviceControlInstaller.ZipInfo.Version}",
                     $"{model.Name} needs to be stopped in order to upgrade to version {serviceControlInstaller.ZipInfo.Version}.",
                     "Do you want to proceed?",
-                    "Yes I want to proceed", "No"))
+                    "Yes, I want to proceed", "No"))
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -91,17 +91,16 @@
                 if (reportCard.HasErrors || reportCard.HasWarnings)
                 {
                     windowManager.ShowActionReport(reportCard, "ISSUES UPGRADING INSTANCE", "Could not upgrade instance because of the following errors:", "There were some warnings while upgrading the instance:");
+                    return;
                 }
-                else
+
+                if (restartAgain)
                 {
-                    if (restartAgain)
+                    var serviceStarted = await model.StartService(progress);
+                    if (!serviceStarted)
                     {
-                        var serviceStarted = await model.StartService(progress);
-                        if (!serviceStarted)
-                        {
-                            reportCard.Errors.Add("The Service failed to start. Please consult the ServiceControl logs for this instance");
-                            windowManager.ShowActionReport(reportCard, "UPGRADE FAILURE", "Instance reported this error after upgrade:");
-                        }
+                        reportCard.Errors.Add("The Service failed to start. Please consult the ServiceControl logs for this instance");
+                        windowManager.ShowActionReport(reportCard, "UPGRADE FAILURE", "Instance reported this error after upgrade:");
                     }
                 }
             }

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -1,0 +1,125 @@
+﻿namespace ServiceControl.Config.Commands
+{
+    using System;
+    using System.ServiceProcess;
+    using System.Threading.Tasks;
+    using Caliburn.Micro;
+    using Events;
+    using FluentValidation;
+    using Framework;
+    using Framework.Commands;
+    using Framework.Modules;
+    using ServiceControlInstaller.Engine.Configuration.ServiceControl;
+    using ServiceControlInstaller.Engine.Instances;
+    using ServiceControlInstaller.Engine.ReportCard;
+    using ServiceControlInstaller.Engine.Validation;
+    using UI.InstanceDetails;
+    using UI.MessageBox;
+    using UI.Upgrades;
+    using Validation;
+    using Xaml.Controls;
+    using Validations = Extensions.Validations;
+
+    class UpgradeAuditInstanceCommand : AwaitableAbstractCommand<InstanceDetailsViewModel>
+    {
+        readonly IEventAggregator eventAggregator;
+        readonly IWindowManagerEx windowManager;
+        readonly ServiceControlInstanceInstaller serviceControlInstaller;
+        readonly ServiceControlAuditInstanceInstaller serviceControlAuditInstaller;
+        readonly Func<string, AddNewAuditInstanceViewModel> auditUpgradeViewModelFactory;
+
+        [FeatureToggle(Feature.LicenseChecks)]
+        public bool LicenseChecks { get; set; }
+
+        public UpgradeAuditInstanceCommand(Func<InstanceDetailsViewModel, bool> canExecuteMethod = null) : base(canExecuteMethod)
+        {
+        }
+
+        public UpgradeAuditInstanceCommand(
+            IWindowManagerEx windowManager,
+            IEventAggregator eventAggregator,
+            ServiceControlInstanceInstaller serviceControlInstaller,
+            ServiceControlAuditInstanceInstaller serviceControlAuditInstaller,
+            Func<string, AddNewAuditInstanceViewModel> auditUpgradeViewModelFactory)
+        {
+            this.windowManager = windowManager;
+            this.eventAggregator = eventAggregator;
+            this.serviceControlInstaller = serviceControlInstaller;
+            this.serviceControlAuditInstaller = serviceControlAuditInstaller;
+            this.auditUpgradeViewModelFactory = auditUpgradeViewModelFactory;
+        }
+
+        public async override Task ExecuteAsync(InstanceDetailsViewModel model)
+        {
+            if (LicenseChecks)
+            {
+                var licenseCheckResult = serviceControlInstaller.CheckLicenseIsValid();
+                if (!licenseCheckResult.Valid)
+                {
+                    windowManager.ShowMessage("LICENSE ERROR", $"Upgrade could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact contact@particular.net", hideCancel: true);
+                    return;
+                }
+            }
+
+            var instance = InstanceFinder.FindInstanceByName<ServiceControlAuditInstance>(model.Name);
+            instance.Service.Refresh();
+
+            var upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(serviceControlInstaller.ZipInfo.Version, instance.Version);
+            var upgradeOptions = new ServiceControlUpgradeOptions { UpgradeInfo = upgradeInfo };
+
+            if (instance.Service.Status != ServiceControllerStatus.Stopped &&
+                !windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {serviceControlInstaller.ZipInfo.Version}",
+                    $"{model.Name} needs to be stopped in order to upgrade to version {serviceControlInstaller.ZipInfo.Version}.",
+                    "Do you want to proceed?",
+                    "Yes I want to proceed", "No"))
+            {
+                return;
+            }
+            
+            await UpgradeAuditInstance(model, instance, upgradeOptions);
+
+            eventAggregator.PublishOnUIThread(new RefreshInstances());
+        }
+
+        async Task UpgradeAuditInstance(InstanceDetailsViewModel model, ServiceControlAuditInstance instance, ServiceControlUpgradeOptions upgradeOptions)
+        {
+            using (var progress = model.GetProgressObject($"UPGRADING {model.Name}"))
+            {
+                var reportCard = new ReportCard();
+                var restartAgain = model.IsRunning;
+
+                var stopped = await model.StopService(progress);
+
+                if (!stopped)
+                {
+                    eventAggregator.PublishOnUIThread(new RefreshInstances());
+
+                    reportCard.Errors.Add("Failed to stop the service");
+                    reportCard.SetStatus();
+                    windowManager.ShowActionReport(reportCard, "ISSUES UPGRADING INSTANCE", "Could not upgrade instance because of the following errors:");
+
+                    return;
+                }
+
+                reportCard = await Task.Run(() => serviceControlAuditInstaller.Upgrade(instance, upgradeOptions, progress));
+
+                if (reportCard.HasErrors || reportCard.HasWarnings)
+                {
+                    windowManager.ShowActionReport(reportCard, "ISSUES UPGRADING INSTANCE", "Could not upgrade instance because of the following errors:", "There were some warnings while upgrading the instance:");
+                }
+                else
+                {
+                    if (restartAgain)
+                    {
+                        var serviceStarted = await model.StartService(progress);
+                        if (!serviceStarted)
+                        {
+                            reportCard.Errors.Add("The Service failed to start. Please consult the service control logs for this instance");
+                            windowManager.ShowActionReport(reportCard, "UPGRADE FAILURE", "Instance reported this error after upgrade:");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
@@ -46,7 +46,7 @@
             instance.Service.Refresh();
 
             var confirm = instance.Service.Status == ServiceControllerStatus.Stopped ||
-                          windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}", $"{model.Name} needs to be stopped in order to upgrade to version {installer.ZipInfo.Version}.", "Do you want to proceed?", "Yes I want to proceed", "No");
+                          windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}", $"{model.Name} needs to be stopped in order to upgrade to version {installer.ZipInfo.Version}.", "Do you want to proceed?", "Yes, I want to proceed", "No");
 
             if (confirm)
             {

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -324,7 +324,7 @@
                         var serviceStarted = await model.StartService(progress);
                         if (!serviceStarted)
                         {
-                            reportCard.Errors.Add("The Service failed to start. Please consult the service control logs for this instance");
+                            reportCard.Errors.Add("The Service failed to start. Please consult the ServiceControl logs for this instance");
                             windowManager.ShowActionReport(reportCard, "UPGRADE FAILURE", "Instance reported this error after upgrade:");
                         }
                     }

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -27,9 +27,9 @@
         }
 
         public UpgradeServiceControlInstanceCommand(
-            IWindowManagerEx windowManager, 
-            IEventAggregator eventAggregator, 
-            ServiceControlInstanceInstaller serviceControlInstaller, 
+            IWindowManagerEx windowManager,
+            IEventAggregator eventAggregator,
+            ServiceControlInstanceInstaller serviceControlInstaller,
             ServiceControlAuditInstanceInstaller serviceControlAuditInstaller,
             Func<string, AddNewAuditInstanceViewModel> auditUpgradeViewModelFactory)
         {
@@ -62,7 +62,7 @@
             var upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(serviceControlInstaller.ZipInfo.Version, instance.Version);
             var upgradeOptions = new ServiceControlUpgradeOptions {UpgradeInfo = upgradeInfo};
 
-            
+
             var upgradeAction = instance.GetRequiredUpgradeAction(serviceControlInstaller.ZipInfo.Version);
             var shouldInstallAudit = upgradeAction == RequiredUpgradeAction.SplitOutAudit;
 

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -209,7 +209,7 @@
                 !windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {serviceControlInstaller.ZipInfo.Version}",
                     $"{model.Name} needs to be stopped in order to upgrade to version {serviceControlInstaller.ZipInfo.Version}.",
                     "Do you want to proceed?",
-                    "Yes I want to proceed", "No"))
+                    "Yes, I want to proceed", "No"))
             {
                 return;
             }

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
@@ -24,6 +24,7 @@
             EditMonitoringInstanceCommand showEditMonitoringScreenCommand,
             UpgradeServiceControlInstanceCommand upgradeServiceControlCommand,
             UpgradeMonitoringInstanceCommand upgradeMonitoringCommand,
+            UpgradeAuditInstanceCommand upgradeAuditCommand,
             AdvancedMonitoringOptionsCommand advancedOptionsMonitoringCommand,
             AdvancedServiceControlOptionsCommand advancedOptionsServiceControlCommand,
             ServiceControlInstanceInstaller serviceControlinstaller,
@@ -64,7 +65,7 @@
                 ServiceControlAuditInstance = (ServiceControlAuditInstance)instance;
                 NewVersion = serviceControlAuditInstaller.ZipInfo.Version;
                 EditCommand = showAuditEditScreenCommand;
-                UpgradeToNewVersionCommand = null;
+                UpgradeToNewVersionCommand = upgradeAuditCommand;
                 AdvancedOptionsCommand = advancedOptionsServiceControlCommand;
                 InstanceType = InstanceType.ServiceControlAudit;
                 return;


### PR DESCRIPTION
1. Added a new command called "UpgradeAuditInstanceCommand"
2. Wired the command in the InstanceDetailsViewModel.

Tested the change:
1. Installed ServiceControl 4.0.1 release
2. Created an instance of both SC and Audit. 
3. Changed the audit expiration to 1 day and 4 hours
4. Used the new version and clicked on the upgrade link
5. The version was upgraded successfully and verified that the expiration setting remained to 1 day and 4 hours. 