### PR TITLE
Responses returned from Audit instances are not decompressed resulting in corrupt visualization in ServiceInsight due to malformed aggregation response

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -49,7 +49,11 @@ namespace ServiceControl.Audit.Infrastructure
         {
             if (httpClient == null)
             {
-                httpClient = new HttpClient();
+                var handler = new HttpClientHandler
+                {
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                };
+                httpClient = new HttpClient(handler);
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             }
 

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -54,7 +54,11 @@ namespace Particular.ServiceControl
         {
             if (httpClient == null)
             {
-                httpClient = new HttpClient();
+                var handler = new HttpClientHandler
+                {
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                };
+                httpClient = new HttpClient(handler);
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             }
 

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
@@ -113,6 +113,7 @@ namespace ServiceControl.CompositeViews.Messages
             var httpClient = HttpClientFactory();
             try
             {
+                // Assuming SendAsync returns uncompressed response and the AutomaticDecompression is enabled on the http client.
                 var rawResponse = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, instanceUri)).ConfigureAwait(false);
                 // special case - queried by conversation ID and nothing was found
                 if (rawResponse.StatusCode == HttpStatusCode.NotFound)


### PR DESCRIPTION
Resolved the issue in `ScatterGatherApi` where its `FetchAndParse` does not consider the body to be compressed.