### PR TITLE
Fix ServiceControl shutdown detection logic

### DIFF
--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -68,14 +68,13 @@
                         Thread.Sleep(100);
                     }
                 });
-                t.Wait(5000);
+
+                return t.Wait(5000);
             }
             catch (TimeoutException)
             {
                 return false;
             }
-
-            return true;
         }
 
         public bool TryStartService()

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
@@ -112,6 +112,7 @@ namespace ServiceControlInstaller.Engine.Unattended
             if (!instance.TryStopService())
             {
                 logger.Error("Service failed to stop or service stop timed out");
+                return false;
             }
 
             try

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendMonitoringInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendMonitoringInstaller.cs
@@ -111,6 +111,7 @@ namespace ServiceControlInstaller.Engine.Unattended
             if (!instance.TryStopService())
             {
                 logger.Error("Service failed to stop or service stop timed out");
+                return false;
             }
 
             try

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
@@ -120,6 +120,7 @@ namespace ServiceControlInstaller.Engine.Unattended
             if (!instance.TryStopService())
             {
                 logger.Error("Service failed to stop or service stop timed out");
+                return false;
             }
 
             try


### PR DESCRIPTION
Fixes #907.

The return value from `Task.Wait(Int32)` was never used. Even if it had been used, it would always have returned `false`. The return value from `HasUnderlyingProcessExited` was never used to complete the task. (I may not be understanding the original code correctly, and in the case that I'm not, then the opposite would be true: the task always completes successfully and `Task.Wait(Int32)` would always return `true`--either way, this code does not behave as its intended.)

Second, given the above, and the fact that the method blocks to wait for the task to complete, why use a task at all?

Lastly, I happened to remember while reviewing all of this code that the only thing that happens when `instance.TryStopService()` is called in all of the `Upgrade` methods of the various installers is that a message is logged, but the `Upgrade` method continues on. So this PR changes the behavior so the message is logged and `false` is returned.