### PR TITLE
Notify ServicePulse UI when a Redirect is Created

### DIFF
--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -356,7 +356,7 @@ namespace ServiceControl.Contracts.MessageRedirects
         public string PreviousToPhysicalAddress { get; set; }
         public string ToPhysicalAddress { get; set; }
     }
-    public class MessageRedirectCreated
+    public class MessageRedirectCreated : ServiceControl.Infrastructure.SignalR.IUserInterfaceEvent
     {
         public MessageRedirectCreated() { }
         public string FromPhysicalAddress { get; set; }

--- a/src/ServiceControl/Contracts/MessageRedirects/MessageRedirectCreated.cs
+++ b/src/ServiceControl/Contracts/MessageRedirects/MessageRedirectCreated.cs
@@ -2,8 +2,9 @@
 {
     using System;
     using Infrastructure.DomainEvents;
+    using Infrastructure.SignalR;
 
-    public class MessageRedirectCreated : IDomainEvent
+    public class MessageRedirectCreated : IDomainEvent, IUserInterfaceEvent
     {
         public Guid MessageRedirectId { get; set; }
         public string FromPhysicalAddress { get; set; }


### PR DESCRIPTION
Fixes https://github.com/Particular/ServicePulse/issues/706

ServicePulse has code wired up to capture this event and use it to update the UI. Unfortunately we don't send them the event as it's not marked as a UI event.