### PR TITLE
ServiceName must be set before Run is called

### DIFF
--- a/src/ServiceControl.Monitoring/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/RunCommand.cs
@@ -17,7 +17,11 @@ namespace ServiceControl.Monitoring
 
         Task RunNonBlocking(Settings settings)
         {
-            using (var service = new Host {Settings = settings})
+            using (var service = new Host
+            {
+                Settings = settings,
+                ServiceName = settings.ServiceName
+            })
             {
                 service.Run(false);
             }
@@ -27,7 +31,11 @@ namespace ServiceControl.Monitoring
 
         async Task RunAndWait(Settings settings)
         {
-            using (var service = new Host {Settings = settings})
+            using (var service = new Host
+            {
+                Settings = settings,
+                ServiceName = settings.ServiceName
+            })
             {
                 var tcs = new TaskCompletionSource<bool>();
 

--- a/src/ServiceControl.Monitoring/Hosting/Host.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Host.cs
@@ -33,8 +33,6 @@
 
         protected override void OnStart(string[] args)
         {
-            ServiceName = Settings.ServiceName;
-
             bootstrapper = new Bootstrapper(Settings);
             bootstrapper.Start().GetAwaiter().GetResult();
         }


### PR DESCRIPTION
The allows monitoring to start properly when running as a Windows Service. The problem was likely introduced in the WebAPI conversion so no users are affected. I have verified that 4.3.3 is ok