### PR TITLE
Error message body is dropped if bigger than 100KB

### DIFF
--- a/src/ServiceControl.Audit.UnitTests/BodyStorage/BodyStorageEnricherTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/BodyStorage/BodyStorageEnricherTests.cs
@@ -1,0 +1,68 @@
+namespace ServiceControl.UnitTests.BodyStorage
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Audit.Auditing.BodyStorage;
+    using Audit.Infrastructure.Settings;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class BodyStorageEnricherTests
+    {
+        [Test]
+        public async Task Should_remove_body_when_above_threshold()
+        {
+            var fakeStorage = new FakeBodyStorage();
+            var maxBodySizeToStore = 20000;
+            var settings = new Settings
+            {
+                MaxBodySizeToStore = maxBodySizeToStore
+            };
+
+            var enricher = new BodyStorageFeature.BodyStorageEnricher(fakeStorage, settings);
+            var body = Encoding.UTF8.GetBytes(new string('a', maxBodySizeToStore + 1));
+
+            await enricher.StoreAuditMessageBody(body, new Dictionary<string, string>(), new Dictionary<string, object>());
+
+            Assert.AreEqual(0, fakeStorage.StoredBodySize, "Body should be removed if above threshold");
+        }
+
+        [Test]
+        public async Task Should_store_body_when_below_threshold()
+        {
+            var fakeStorage = new FakeBodyStorage();
+            var maxBodySizeToStore = 20000;
+            var settings = new Settings
+            {
+                MaxBodySizeToStore = maxBodySizeToStore
+            };
+
+            var enricher = new BodyStorageFeature.BodyStorageEnricher(fakeStorage, settings);
+            var expectedBodySize = maxBodySizeToStore - 1;
+            var body = Encoding.UTF8.GetBytes(new string('a', expectedBodySize));
+
+            await enricher.StoreAuditMessageBody(body, new Dictionary<string, string>(), new Dictionary<string, object>());
+
+            Assert.AreEqual(expectedBodySize, fakeStorage.StoredBodySize, "Body should be stored if below threshold");
+        }
+
+        class FakeBodyStorage : IBodyStorage
+        {
+            public int StoredBodySize { get; set; }
+
+            public Task<string> Store(string bodyId, string contentType, int bodySize, Stream bodyStream)
+            {
+                StoredBodySize = bodySize;
+                return Task.FromResult(default(string));
+            }
+
+            public Task<StreamResult> TryFetch(string bodyId)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -40,7 +40,6 @@
   "ErrorRetentionPeriod": "10.00:00:00",
   "EventsRetentionPeriod": "14.00:00:00",
   "ExpirationProcessBatchSize": 65512,
-  "MaxBodySizeToStore": 102400,
   "ServiceName": "Particular.ServiceControl",
   "HttpDefaultConnectionLimit": 100,
   "TransportConnectionString": null,

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -69,7 +69,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public string Hostname { get; }
         public int HttpDefaultConnectionLimit { get; set; }
         public bool IngestErrorMessages { get; set; }
-        public int MaxBodySizeToStore { get; set; }
         public int MaximumConcurrencyLevel { get; set; }
         public System.Func<string, System.Collections.Generic.Dictionary<string, string>, byte[], System.Func<System.Threading.Tasks.Task>, System.Threading.Tasks.Task> OnMessage { get; set; }
         public int Port { get; set; }

--- a/src/ServiceControl.UnitTests/BodyStorage/BodyStorageEnricherTests.cs
+++ b/src/ServiceControl.UnitTests/BodyStorage/BodyStorageEnricherTests.cs
@@ -1,0 +1,45 @@
+namespace ServiceControl.UnitTests.BodyStorage
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using ServiceControl.Operations.BodyStorage;
+
+    [TestFixture]
+    public class BodyStorageEnricherTests
+    {
+        [Test]
+        public async Task Should_store_body_regardless_of_the_body_size()
+        {
+            var fakeStorage = new FakeBodyStorage();
+            // previously the max body storage default was larger than 100 KB
+
+            var enricher = new BodyStorageFeature.BodyStorageEnricher(fakeStorage);
+            const int ExpectedBodySize = 150000;
+            var body = Encoding.UTF8.GetBytes(new string('a', ExpectedBodySize));
+
+            await enricher.StoreErrorMessageBody(body, new Dictionary<string, string>(), new Dictionary<string, object>());
+
+            Assert.AreEqual(ExpectedBodySize, fakeStorage.StoredBodySize, "Body should never be dropped for error messages");
+        }
+
+        class FakeBodyStorage : IBodyStorage
+        {
+            public int StoredBodySize { get; set; }
+
+            public Task<string> Store(string bodyId, string contentType, int bodySize, Stream bodyStream)
+            {
+                StoredBodySize = bodySize;
+                return Task.FromResult(default(string));
+            }
+
+            public Task<StreamResult> TryFetch(string bodyId)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/BodyStorage/RavenAttachmentsBodyStorageTests.cs
+++ b/src/ServiceControl.UnitTests/BodyStorage/RavenAttachmentsBodyStorageTests.cs
@@ -6,7 +6,7 @@
     using ServiceControl.Operations.BodyStorage.RavenAttachments;
 
     [TestFixture]
-    public class BodyStorageTests
+    public class RavenAttachmentsBodyStorageTests
     {
         [Test]
         public async Task Attachments_with_ids_that_contain_backslash_should_be_readable()

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -205,7 +205,6 @@ Selected Transport Customization:   {settings.TransportCustomizationType}
                     settings.ForwardErrorMessages,
                     settings.HttpDefaultConnectionLimit,
                     settings.IngestErrorMessages,
-                    settings.MaxBodySizeToStore,
                     settings.MaximumConcurrencyLevel,
                     settings.Port,
                     settings.ProcessRetryBatchesFrequency,

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -170,21 +170,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
             }
         }
 
-        public int MaxBodySizeToStore
-        {
-            get
-            {
-                if (maxBodySizeToStore <= 0)
-                {
-                    logger.Error($"MaxBodySizeToStore settings is invalid, {1} is the minimum value. Defaulting to {MaxBodySizeToStoreDefault}");
-                    return MaxBodySizeToStoreDefault;
-                }
-
-                return maxBodySizeToStore;
-            }
-            set { maxBodySizeToStore = value; }
-        }
-
         public string ServiceName { get; }
 
         public int HttpDefaultConnectionLimit { get; set; }
@@ -482,14 +467,12 @@ namespace ServiceBus.Management.Infrastructure.Settings
         ILog logger = LogManager.GetLogger(typeof(Settings));
         int expirationProcessBatchSize = SettingsReader<int>.Read("ExpirationProcessBatchSize", ExpirationProcessBatchSizeDefault);
         int expirationProcessTimerInSeconds = SettingsReader<int>.Read("ExpirationProcessTimerInSeconds", ExpirationProcessTimerInSecondsDefault);
-        int maxBodySizeToStore = SettingsReader<int>.Read("MaxBodySizeToStore", MaxBodySizeToStoreDefault);
         public const string DEFAULT_SERVICE_NAME = "Particular.ServiceControl";
         public const string Disabled = "!disable";
 
         const int ExpirationProcessTimerInSecondsDefault = 600;
         const int ExpirationProcessBatchSizeDefault = 65512;
         const int ExpirationProcessBatchSizeMinimum = 10240;
-        const int MaxBodySizeToStoreDefault = 102400; //100 kb
         const int DataSpaceRemainingThresholdDefault = 20;
     }
 }

--- a/src/ServiceControl/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/RootController.cs
@@ -69,7 +69,6 @@
                 },
                 PerformanceTunning = new
                 {
-                    settings.MaxBodySizeToStore,
                     settings.HttpDefaultConnectionLimit,
                     settings.ExternalIntegrationsDispatchingBatchSize,
                     settings.ExpirationProcessBatchSize,


### PR DESCRIPTION
## Who's affected

All ServiceControl 4.0 to 4.3.3 users are affected.

ServiceControl Audit is not affected.

## Symptoms

When error messages with body size greater than 100 KB are ingested, ServiceControl will not store the message body. As a result, these messages can no longer be retried.

## Workaround

If you are not able to upgrade the following workaround should be applied immediately to avoid message loss:

1. Shutdown ServiceControl (ServiceControl Audit doesn't have to be shut down),
1. Add `<add key="ServiceControl/MaxBodySizeToStore" value="2147483647" />` to `ServiceControl.exe.config`,
1. Restart ServiceControl.

