### PR TITLE
Show DBPath for audit instances

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
@@ -116,7 +116,22 @@
 
         public string InstallPath => ((IServicePaths)ServiceInstance).InstallPath;
 
-        public string DBPath => ServiceControlInstance?.DBPath;
+        public string DBPath => GetDBPathIfAvailable();
+
+        string GetDBPathIfAvailable()
+        {
+            if (IsServiceControlInstance)
+            {
+                return ServiceControlInstance?.DBPath;
+            }
+
+            if (IsServiceControlAudit)
+            {
+                return ServiceControlAuditInstance?.DBPath;
+            }
+
+            return null;
+        }
 
         public bool HasBrowsableDBPath => !string.IsNullOrEmpty(DBPath);
 


### PR DESCRIPTION
Connected to https://github.com/Particular/ServiceControl/issues/1556 and https://github.com/Particular/ServiceControl/pull/1789.

Make sure to show the DB path for audit instances as well as regular service control instances.