### PR TITLE
Properly call the task that checks for process exit

### DIFF
--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -6,9 +6,9 @@
     using System.Linq;
     using System.ServiceProcess;
     using System.Threading;
-    using System.Threading.Tasks;
     using FileSystem;
     using Services;
+    using Engine;
     using TimeoutException = System.ServiceProcess.TimeoutException;
 
     public abstract class BaseService : IServiceInstance
@@ -62,15 +62,13 @@
             {
                 Service.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(60));
 
-                var t = new Task(() =>
+                var t = TaskHelpers.Run(() =>
                 {
                     while (!HasUnderlyingProcessExited())
                     {
                         Thread.Sleep(250);
                     }
                 });
-
-                t.Start();
 
                 return t.Wait(TimeSpan.FromSeconds(5));
             }

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -61,15 +61,18 @@
             try
             {
                 Service.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(60));
+
                 var t = new Task(() =>
                 {
                     while (!HasUnderlyingProcessExited())
                     {
-                        Thread.Sleep(100);
+                        Thread.Sleep(250);
                     }
                 });
 
-                return t.Wait(5000);
+                t.Start();
+
+                return t.Wait(TimeSpan.FromSeconds(5));
             }
             catch (TimeoutException)
             {
@@ -111,7 +114,7 @@
             }
             catch
             {
-                //Service isn't accessible 
+                //Service isn't accessible
             }
 
             return true;

--- a/src/ServiceControlInstaller.Engine/TaskHelpers.cs
+++ b/src/ServiceControlInstaller.Engine/TaskHelpers.cs
@@ -1,0 +1,14 @@
+﻿namespace ServiceControlInstaller.Engine
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public static class TaskHelpers
+    {
+        public static Task Run(Action action)
+        {
+            return Task.Factory.StartNew(_ => action(), null, default(CancellationToken), TaskCreationOptions.None, TaskScheduler.Default);
+        }
+    }
+}


### PR DESCRIPTION
It turned out that we didn't actually start the task that makes sure that the service process have exited correctly and since we fixed the bug where the return value is ignored the SCMU always reported a failing stop. This is now fixed

Side note: I previous versions we unnecessary waited for 5s on every service shutdown