### PR TITLE
[POC] Host ServicePulse UI directly from ServiceControl

### DIFF
--- a/src/ServiceControl/Infrastructure/OWIN/OwinExtensions.cs
+++ b/src/ServiceControl/Infrastructure/OWIN/OwinExtensions.cs
@@ -1,0 +1,25 @@
+﻿namespace ServiceBus.Management.Infrastructure.OWIN
+{
+    using System.Net;
+    using Owin;
+
+    static class OwinExtensions
+    {
+        public static IAppBuilder RedirectRootTo(this IAppBuilder app, string destination)
+        {
+            app.Use(async (ctx, next) =>
+            {
+                if (ctx.Request.Path.Value == "/")
+                {
+                    ctx.Response.StatusCode = (int)HttpStatusCode.Redirect;
+                    ctx.Response.Headers.Set("Location", ctx.Request.Uri + destination);
+                }
+                else
+                {
+                    await next().ConfigureAwait(false);
+                }
+            });
+            return app;
+        }
+    }
+}

--- a/src/ServiceControl/Infrastructure/OWIN/Startup.cs
+++ b/src/ServiceControl/Infrastructure/OWIN/Startup.cs
@@ -11,6 +11,7 @@
     using Metrics;
     using Microsoft.AspNet.SignalR;
     using Microsoft.Owin.Cors;
+    using Microsoft.Owin.StaticFiles;
     using Newtonsoft.Json;
     using Owin;
     using Owin.Metrics;
@@ -64,6 +65,27 @@
 
                 b.UseWebApi(config);
             });
+
+            app.Map("/web", b =>
+            {
+                var uiFileSystem = new ZipFileSystem(@"C:\Code\Particular\ServicePulse-1.22.0.zip");
+
+                b.UseDefaultFiles(new DefaultFilesOptions
+                {
+                    FileSystem = uiFileSystem,
+                    DefaultFileNames = new List<string>{ "index.html" }
+                });
+
+                var options = new StaticFileOptions
+                {
+                    FileSystem = uiFileSystem,
+                    ServeUnknownFileTypes = true
+                };
+
+                b.UseStaticFiles(options);
+            });
+
+            app.RedirectRootTo("web");
         }
 
         private void ConfigureSignalR(IAppBuilder app)

--- a/src/ServiceControl/Infrastructure/OWIN/ZipFileSystem.cs
+++ b/src/ServiceControl/Infrastructure/OWIN/ZipFileSystem.cs
@@ -1,0 +1,58 @@
+﻿namespace ServiceBus.Management.Infrastructure.OWIN
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
+    using Microsoft.Owin.FileSystems;
+
+    class ZipFileSystem : IFileSystem
+    {
+        ZipArchive archive;
+
+        public ZipFileSystem(string path)
+        {
+            archive = ZipFile.OpenRead(path);
+        }
+
+        public bool TryGetFileInfo(string subpath, out IFileInfo fileInfo)
+        {
+            if (subpath.Length > 1)
+            {
+                var entry = archive.GetEntry(subpath.Substring(1));
+                if (entry != null)
+                {
+                    fileInfo = new ZipEntryFileInfo(entry);
+                    return true;
+                }
+            }
+            fileInfo = null;
+            return false;
+        }
+
+        public bool TryGetDirectoryContents(string subpath, out IEnumerable<IFileInfo> contents)
+        {
+            contents = Enumerable.Empty<IFileInfo>();
+            return true;
+        }
+
+        class ZipEntryFileInfo : IFileInfo
+        {
+            readonly ZipArchiveEntry entry;
+
+            public ZipEntryFileInfo(ZipArchiveEntry entry)
+            {
+                this.entry = entry;
+            }
+
+            public Stream CreateReadStream() => entry.Open();
+
+            public long Length => entry.Length;
+            public string PhysicalPath => null;
+            public string Name => entry.Name;
+            public DateTime LastModified => entry.LastWriteTime.DateTime;
+            public bool IsDirectory => false;
+        }
+    }
+}

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
     <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Owin.StaticFiles" Version="4.1.0" />
     <PackageReference Include="RavenDB.Database" Version="3.5.10-patch-35283" />
     <PackageReference Include="NServiceBus" Version="7.2.0" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.0.0" />


### PR DESCRIPTION
To test this, extract ServicePulse and then zip it's contents into C:\Code\Particular\ServicePulse-1.22.0.zip

At the moment the filename is hardcoded just to get it going.

All this does is serve up the js/html/css/img assets in ServicePulse directly from the ServiceControl endpoint at the /web location. No additional setup of ServicePulse is needed. 

It also sets up index.html as the default document, and redirects requests for the root (/) url to /web.

NOTE: This won't handle SC instances that aren't hosted at localhost without some additional mucking about but it's really just a Proof of Concept.