### PR TITLE
Remove unneeded GitVersionTask reference

### DIFF
--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.Owin.Cors" Version="3.0.1" />
     <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />
     <PackageReference Include="Autofac" Version="4.6.0" />
-    <PackageReference Include="GitVersionTask" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NLog" Version="4.5.10" />
     <PackageReference Include="NServiceBus" Version="7.2.0" />


### PR DESCRIPTION
This older version isn't needed since it is included in all projects via Directory.Build.props.