### PR TITLE
Guard trim with check for /api path

### DIFF
--- a/src/ServiceControl.UnitTests/Infrastructure/Extensions/NegotiatorExtensionsTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/Extensions/NegotiatorExtensionsTests.cs
@@ -10,9 +10,20 @@
     public class NegotiatorExtensionsTests
     {
         [Test]
-        public void WithPagingLinks_ReturnsLinksWithRelativeUriButWithoutApiPrefix()
+        public void WithPagingLinks_ReturnsLinksWithRelativeUri()
         {
             var pagingHeaders = GetLinks(totalResults: 200, currentPage: 3, path: "test1/test2");
+
+            Assert.Contains("<test1/test2?page=4>; rel=\"next\"", pagingHeaders);
+            Assert.Contains("<test1/test2?page=4>; rel=\"last\"", pagingHeaders);
+            Assert.Contains("<test1/test2?page=2>; rel=\"prev\"", pagingHeaders);
+            Assert.Contains("<test1/test2?page=1>; rel=\"first\"", pagingHeaders);
+        }
+
+        [Test]
+        public void WithPagingLinks_ReturnsLinksWithRelativeUriButWithoutApiPrefix()
+        {
+            var pagingHeaders = GetLinks(totalResults: 200, currentPage: 3, path: "api/test1/test2");
 
             Assert.Contains("<test1/test2?page=4>; rel=\"next\"", pagingHeaders);
             Assert.Contains("<test1/test2?page=4>; rel=\"last\"", pagingHeaders);
@@ -125,7 +136,7 @@
             }
 
             queryString += queryParams;
-            var request = new HttpRequestMessage(new HttpMethod("GET"), $"http://name.tld:99/api/{path ?? string.Empty}{queryString.TrimEnd('&')}");
+            var request = new HttpRequestMessage(new HttpMethod("GET"), $"http://name.tld:99/{path ?? string.Empty}{queryString.TrimEnd('&')}");
 
             var response = request.CreateResponse().WithPagingLinks(totalResults, highestTotalCountOfAllInstances ?? totalResults, request);
 

--- a/src/ServiceControl/Infrastructure/WebApi/Negotiator.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/Negotiator.cs
@@ -105,7 +105,9 @@ namespace ServiceControl.Infrastructure.WebApi
                 return response;
             }
 
-            var path = request.RequestUri.AbsolutePath.Substring(5); // NOTE: Strips off the /api/ for backwards compat
+            var path = request.RequestUri.AbsolutePath.StartsWith("/api/", StringComparison.OrdinalIgnoreCase) 
+                ? request.RequestUri.AbsolutePath.Substring(5) // NOTE: Strips off the /api/ for backwards compat
+                : request.RequestUri.AbsolutePath.TrimStart('/'); 
             var query = new StringBuilder();
 
             query.Append("?");


### PR DESCRIPTION
Helps to prevent potential bugs in case the /api/ prefix will ever be changed or dropped.

This might be unnecessary if we assume /api/ will always be there I guess but on the other hand I didn't see any tests regarding this assumption nor do I have a good idea how we could tests this instead.

Thoughts @mikeminutillo ?