### PR TITLE
Remove OWIN metrics since it was never used since 1.x

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/OWIN/Startup.cs
+++ b/src/ServiceControl.Audit/Infrastructure/OWIN/Startup.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceControl.Audit.Infrastructure.OWIN
 {
-    using System;
     using System.Collections.Generic;
     using System.Net.Http.Headers;
     using System.Reflection;
@@ -8,9 +7,7 @@
     using System.Web.Http.Dispatcher;
     using Autofac;
     using Autofac.Integration.WebApi;
-    using Metrics;
     using Owin;
-    using Owin.Metrics;
     using WebApi;
 
     class Startup
@@ -44,14 +41,6 @@
                 config.MessageHandlers.Add(new NotModifiedStatusHttpHandler());
 
                 map.UseWebApi(config);
-            });
-
-            appBuilder.Map("/metrics", b =>
-            {
-                Metric.Config
-                    .WithOwin(middleware => appBuilder.Use(middleware), owinConfig => owinConfig
-                        .WithMetricsEndpoint(c => {}, string.Empty))
-                    .WithAllCounters();
             });
         }
 

--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -32,7 +32,6 @@
     <PackageReference Include="Lucene.Net" Version="3.0.3" />
     <PackageReference Include="Rx-Linq" Version="2.2.5" />
     <PackageReference Include="Microsoft.Owin.Cors" Version="4.1.0" />
-    <PackageReference Include="Owin.Metrics" Version="0.5.5" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ServiceControl/Infrastructure/OWIN/Startup.cs
+++ b/src/ServiceControl/Infrastructure/OWIN/Startup.cs
@@ -8,12 +8,10 @@
     using System.Web.Http.Dispatcher;
     using Autofac;
     using Autofac.Integration.WebApi;
-    using Metrics;
     using Microsoft.AspNet.SignalR;
     using Microsoft.Owin.Cors;
     using Newtonsoft.Json;
     using Owin;
-    using Owin.Metrics;
     using ServiceControl.Infrastructure.OWIN;
     using ServiceControl.Infrastructure.SignalR;
     using ServiceControl.Infrastructure.WebApi;
@@ -27,14 +25,6 @@
 
         public void Configuration(IAppBuilder app, Assembly additionalAssembly = null)
         {
-            app.Map("/metrics", b =>
-            {
-                Metric.Config
-                    .WithOwin(middleware => b.Use(middleware), config => config
-                        .WithMetricsEndpoint(c => {}, string.Empty))
-                    .WithAllCounters();
-            });
-
             app.Map("/api", b =>
             {
                 b.Use<BodyUrlRouteFix>();

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Microsoft.AspNet.SignalR.Owin" Version="1.2.2" />
     <PackageReference Include="Microsoft.AspNet.Cors" Version="5.2.7" />
     <PackageReference Include="Microsoft.Owin.Cors" Version="4.1.0" />
-    <PackageReference Include="Owin.Metrics" Version="0.5.5" />
     <PackageReference Include="StackTraceParser.Source" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Licensing.Sources" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />


### PR DESCRIPTION
I did some digging on the metrics endpoint never worked all back to 1.x. Nobody complaint, it is not documented so how about we remove it?

I tested `localhost:port/metrics`