### PR TITLE
Add product version header for Monitoring Instances

### DIFF
--- a/src/ServiceControl.Monitoring/Http/RootController.cs
+++ b/src/ServiceControl.Monitoring/Http/RootController.cs
@@ -1,5 +1,7 @@
 ﻿namespace ServiceControl.Monitoring.Http
 {
+    using System.Net;
+    using System.Net.Http;
     using System.Web.Http;
     using System.Web.Http.Results;
 
@@ -15,6 +17,23 @@
             };
 
             return Ok(model);
+        }
+
+        [Route("")]
+        [HttpOptions]
+        public HttpResponseMessage GetSupportedOperations()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.NoContent)
+            {
+                Content = new ByteArrayContent(new byte[] { }) //need to force empty content to avoid null reference when adding headers below :(
+            };
+
+            response.Content.Headers.Allow.Add("GET");
+            response.Content.Headers.Allow.Add("DELETE");
+            response.Content.Headers.Allow.Add("PATCH");
+            response.Content.Headers.Add("Access-Control-Expose-Headers", "Allow");
+
+            return response;
         }
 
         public class MonitoringInstanceModel

--- a/src/ServiceControl.Monitoring/Infrastructure/OWIN/Startup.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/OWIN/Startup.cs
@@ -28,6 +28,7 @@
             config.Formatters.Remove(config.Formatters.XmlFormatter);
             config.DependencyResolver = new AutofacWebApiDependencyResolver(container);
 
+            config.MessageHandlers.Add(new XParticularVersionHttpHandler());
             config.MessageHandlers.Add(new CachingHttpHandler());
             app.UseWebApi(config);
         }

--- a/src/ServiceControl.Monitoring/Infrastructure/WebApi/Cors.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/WebApi/Cors.cs
@@ -46,7 +46,8 @@
 
             return policy;
         }
-
+        
+        public static CorsOptions MonitoringCorsOptions = GetDefaultCorsOptions();
         static Task<CorsPolicy> defaultPolicy;
     }
 }

--- a/src/ServiceControl.Monitoring/Infrastructure/WebApi/XParticularVersionHttpHandler.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/WebApi/XParticularVersionHttpHandler.cs
@@ -1,0 +1,40 @@
+﻿namespace ServiceControl.Monitoring.Infrastructure.WebApi
+{
+    using System.Net.Http;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class XParticularVersionHttpHandler : DelegatingHandler
+    {
+        static XParticularVersionHttpHandler()
+        {
+            FileVersion = GetFileVersion();
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            response.Headers.Add("X-Particular-Version", FileVersion);
+
+            return response;
+        }
+
+        static string GetFileVersion()
+        {
+            var customAttributes = typeof(XParticularVersionHttpHandler).Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
+
+            if (customAttributes.Length >= 1)
+            {
+                var fileVersionAttribute = (AssemblyInformationalVersionAttribute)customAttributes[0];
+                var informationalVersion = fileVersionAttribute.InformationalVersion;
+                return informationalVersion.Split('+')[0];
+            }
+
+            return typeof(XParticularVersionHttpHandler).Assembly.GetName().Version.ToString(4);
+        }
+
+        static readonly string FileVersion;
+    }
+}


### PR DESCRIPTION
Adds the product version to SCMonitoring instance.

Required for https://github.com/Particular/DeveloperExperience/issues/252.