### PR TITLE
Allow for the removal of stale endpoints

### DIFF
--- a/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiController.cs
+++ b/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiController.cs
@@ -173,29 +173,11 @@
             return Ok(data);
         }
 
-        [Route("monitored-instance/{instanceId}")]
+        [Route("monitored-instance/{endpointName}/{instanceId}")]
         [HttpDelete]
-        public IHttpActionResult DeleteEndpointInstance(string instanceId)
+        public IHttpActionResult DeleteEndpointInstance(string endpointName, string instanceId)
         {
-            var asd = breakdownProviders.Where(provider =>
-            {
-                if (provider is EndpointInstanceId)
-                {
-                    return ((EndpointInstanceId)provider).InstanceId == instanceId;
-                }
-
-                return false;
-            }).ToList();
-
-            breakdownProviders.RemoveAll(provider =>
-            {
-                if (provider is EndpointInstanceId)
-                {
-                    return ((EndpointInstanceId)provider).InstanceId == instanceId;
-                }
-
-                return false;
-            });
+            endpointRegistry.RemoveEndpointInstance(endpointName, instanceId);
 
             return Ok();
         }

--- a/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiController.cs
+++ b/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiController.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Web.Http;
     using Infrastructure;
@@ -175,11 +176,16 @@
 
         [Route("monitored-instance/{endpointName}/{instanceId}")]
         [HttpDelete]
-        public IHttpActionResult DeleteEndpointInstance(string endpointName, string instanceId)
+        public HttpResponseMessage DeleteEndpointInstance(string endpointName, string instanceId)
         {
             endpointRegistry.RemoveEndpointInstance(endpointName, instanceId);
 
-            return Ok();
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { }) //need to force empty content to avoid null reference when adding headers below :(
+            };
+
+            return response;
         }
 
         static DateTime[] GetTimeAxisValues<T>(IEnumerable<IntervalsStore<T>.IntervalsBreakdown> intervals)

--- a/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiController.cs
+++ b/src/ServiceControl.Monitoring/Http/Diagrams/DiagramApiController.cs
@@ -13,7 +13,7 @@
     {
         public DiagramApiController(IProvideBreakdown[] breakdownProviders, EndpointRegistry endpointRegistry, EndpointInstanceActivityTracker activityTracker, MessageTypeRegistry messageTypeRegistry)
         {
-            this.breakdownProviders = breakdownProviders;
+            this.breakdownProviders = new List<IProvideBreakdown>(breakdownProviders);
             this.endpointRegistry = endpointRegistry;
             this.activityTracker = activityTracker;
             this.messageTypeRegistry = messageTypeRegistry;
@@ -173,6 +173,33 @@
             return Ok(data);
         }
 
+        [Route("monitored-instance/{instanceId}")]
+        [HttpDelete]
+        public IHttpActionResult DeleteEndpointInstance(string instanceId)
+        {
+            var asd = breakdownProviders.Where(provider =>
+            {
+                if (provider is EndpointInstanceId)
+                {
+                    return ((EndpointInstanceId)provider).InstanceId == instanceId;
+                }
+
+                return false;
+            }).ToList();
+
+            breakdownProviders.RemoveAll(provider =>
+            {
+                if (provider is EndpointInstanceId)
+                {
+                    return ((EndpointInstanceId)provider).InstanceId == instanceId;
+                }
+
+                return false;
+            });
+
+            return Ok();
+        }
+
         static DateTime[] GetTimeAxisValues<T>(IEnumerable<IntervalsStore<T>.IntervalsBreakdown> intervals)
         {
             return intervals
@@ -229,7 +256,7 @@
                 .ToArray();
         }
 
-        readonly IProvideBreakdown[] breakdownProviders;
+        readonly List<IProvideBreakdown> breakdownProviders;
         readonly EndpointRegistry endpointRegistry;
         readonly EndpointInstanceActivityTracker activityTracker;
         readonly MessageTypeRegistry messageTypeRegistry;

--- a/src/ServiceControl.Monitoring/Infrastructure/BreakdownRegistry.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/BreakdownRegistry.cs
@@ -51,6 +51,11 @@ namespace ServiceControl.Monitoring.Infrastructure
             return emptyResult;
         }
 
+        public void RemoveBreakdown(BreakdownT breakdown)
+        {
+            breakdowns.Remove(breakdown);
+        }
+
         Dictionary<BreakdownT, BreakdownT> breakdowns = new Dictionary<BreakdownT, BreakdownT>();
         volatile Dictionary<string, IEnumerable<BreakdownT>> lookup = new Dictionary<string, IEnumerable<BreakdownT>>();
         object @lock = new object();

--- a/src/ServiceControl.Monitoring/Infrastructure/BreakdownRegistry.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/BreakdownRegistry.cs
@@ -53,7 +53,12 @@ namespace ServiceControl.Monitoring.Infrastructure
 
         public void RemoveBreakdown(BreakdownT breakdown)
         {
-            breakdowns.Remove(breakdown);
+            if (breakdowns.Remove(breakdown))
+            {
+                lookup = breakdowns.Values.ToArray()
+                        .GroupBy(b => endpointNameExtractor(b))
+                        .ToDictionary(g => g.Key, g => (IEnumerable<BreakdownT>)g.Select(i => i).ToArray());
+            }
         }
 
         Dictionary<BreakdownT, BreakdownT> breakdowns = new Dictionary<BreakdownT, BreakdownT>();

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointRegistry.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointRegistry.cs
@@ -1,6 +1,9 @@
 ﻿namespace ServiceControl.Monitoring.Infrastructure
 {
+    using ServiceControl.Monitoring.Infrastructure.Extensions;
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     public class EndpointRegistry : BreakdownRegistry<EndpointInstanceId>
     {
@@ -20,6 +23,15 @@
             existingBreakdowns.Add(newEndpointId, newEndpointId);
 
             return true;
+        }
+
+        public void RemoveEndpointInstance(string endpointName, string endpointInstance)
+        {
+            var instances = GetForEndpointName(endpointName).Where(breakdown => string.Equals(breakdown.InstanceId, endpointInstance, StringComparison.OrdinalIgnoreCase));
+            instances.ForEach(instance =>
+            {
+                RemoveBreakdown(instance);
+            });
         }
     }
 }


### PR DESCRIPTION
Adds an endpoint that can be DELETE'd to which will remove the specified endpoint instance from the registry.

* If the endpoint instance starts up again and begins sending metrics again, it will reappear in the monitoring UI
* If the endpoint instance never sends metrics again, it does not show up in the monitoring UI
* If all instances for an endpoint are removed, the endpoint no longer shows in the monitoring UI