### PR TITLE
Allow for the request of archived groups

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_archived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_archived.cs
@@ -63,6 +63,59 @@
         }
 
         [Test]
+        public async Task All_archived_messages_should_be_grouped()
+        {
+            await Define<MyContext>()
+                .WithEndpoint<Receiver>(b => b.When(async bus =>
+                {
+                    await bus.SendLocal<MyMessage>(m => m.MessageNumber = 1)
+                        .ConfigureAwait(false);
+                    await bus.SendLocal<MyMessage>(m => m.MessageNumber = 2)
+                        .ConfigureAwait(false);
+                }).DoNotFailOnErrorMessages())
+                .Do("WaitUntilGrouped", async ctx =>
+                {
+                    if (ctx.FirstMessageId == null || ctx.SecondMessageId == null)
+                    {
+                        return false;
+                    }
+
+                    // Don't retry until the message has been added to a group
+                    var groups = await this.TryGetMany<FailedMessage.FailureGroup>("/api/recoverability/groups/");
+                    if (!groups)
+                    {
+                        return false;
+                    }
+
+                    ctx.GroupId = groups.Items[0].Id;
+                    return true;
+                })
+                .Do("WaitUntilGroupContainsBothMessages", async ctx =>
+                {
+                    var failedMessages = await this.TryGetMany<FailedMessage>($"/api/recoverability/groups/{ctx.GroupId}/errors").ConfigureAwait(false);
+                    return failedMessages && failedMessages.Items.Count == 2;
+                })
+                .Do("Archive", async ctx => { await this.Post<object>($"/api/recoverability/groups/{ctx.GroupId}/errors/archive"); })
+                .Do("EnsureFirstArchived", async ctx =>
+                {
+                    return await this.TryGet<FailedMessage>($"/api/errors/{ctx.FirstMessageId}",
+                        e => e.Status == FailedMessageStatus.Archived);
+                })
+                .Do("EnsureSecondArchived", async ctx =>
+                {
+                    return await this.TryGet<FailedMessage>($"/api/errors/{ctx.SecondMessageId}",
+                        e => e.Status == FailedMessageStatus.Archived);
+                })
+                .Do("WaitUntilArchiveGroupContainsBothMessages", async ctx =>
+                {
+                    var failedMessages = await this.TryGetMany<ServiceControl.Recoverability.FailureGroupView>($"/api/errors/groups/").ConfigureAwait(false);
+                    return failedMessages && failedMessages.Items.Count == 1 && failedMessages.Items[0].Count == 2;
+                })
+                .Done(ctx => true) //Done when sequence is finished
+                .Run();
+        }
+
+        [Test]
         public async Task Only_unresolved_issues_should_be_archived()
         {
             await Define<MyContext>()

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_archived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_archived.cs
@@ -116,6 +116,59 @@
         }
 
         [Test]
+        public async Task Archived_messages_group_info_should_be_accessible()
+        {
+            await Define<MyContext>()
+                .WithEndpoint<Receiver>(b => b.When(async bus =>
+                {
+                    await bus.SendLocal<MyMessage>(m => m.MessageNumber = 1)
+                        .ConfigureAwait(false);
+                    await bus.SendLocal<MyMessage>(m => m.MessageNumber = 2)
+                        .ConfigureAwait(false);
+                }).DoNotFailOnErrorMessages())
+                .Do("WaitUntilGrouped", async ctx =>
+                {
+                    if (ctx.FirstMessageId == null || ctx.SecondMessageId == null)
+                    {
+                        return false;
+                    }
+
+                    // Don't retry until the message has been added to a group
+                    var groups = await this.TryGetMany<FailedMessage.FailureGroup>("/api/recoverability/groups/");
+                    if (!groups)
+                    {
+                        return false;
+                    }
+
+                    ctx.GroupId = groups.Items[0].Id;
+                    return true;
+                })
+                .Do("WaitUntilGroupContainsBothMessages", async ctx =>
+                {
+                    var failedMessages = await this.TryGetMany<FailedMessage>($"/api/recoverability/groups/{ctx.GroupId}/errors").ConfigureAwait(false);
+                    return failedMessages && failedMessages.Items.Count == 2;
+                })
+                .Do("Archive", async ctx => { await this.Post<object>($"/api/recoverability/groups/{ctx.GroupId}/errors/archive"); })
+                .Do("EnsureFirstArchived", async ctx =>
+                {
+                    return await this.TryGet<FailedMessage>($"/api/errors/{ctx.FirstMessageId}",
+                        e => e.Status == FailedMessageStatus.Archived);
+                })
+                .Do("EnsureSecondArchived", async ctx =>
+                {
+                    return await this.TryGet<FailedMessage>($"/api/errors/{ctx.SecondMessageId}",
+                        e => e.Status == FailedMessageStatus.Archived);
+                })
+                .Do("WaitUntilArchiveGroupContainsBothMessages", async ctx =>
+                {
+                    var failedMessages = await this.TryGet<ServiceControl.Recoverability.FailureGroupView>($"/api/archive/groups/id/{ctx.GroupId}").ConfigureAwait(false);
+                    return failedMessages && failedMessages.Item.Count == 2;
+                })
+                .Done(ctx => true) //Done when sequence is finished
+                .Run();
+        }
+
+        [Test]
         public async Task Only_unresolved_issues_should_be_archived()
         {
             await Define<MyContext>()

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -618,6 +618,7 @@ namespace ServiceControl.Infrastructure.WebApi
             public string EndpointsUrl { get; set; }
             public string ErrorsUrl { get; set; }
             public string EventLogItems { get; set; }
+            public string GetArchiveGroup { get; set; }
             public string KnownEndpointsUrl { get; set; }
             public string LicenseDetails { get; set; }
             public string LicenseStatus { get; set; }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -609,6 +609,7 @@ namespace ServiceControl.Infrastructure.WebApi
         public class RootUrls
         {
             public RootUrls() { }
+            public string ArchivedGroupsUrl { get; set; }
             public string Configuration { get; set; }
             public string Description { get; set; }
             public string EndpointsErrorUrl { get; set; }
@@ -665,7 +666,7 @@ namespace ServiceControl.MessageFailures.Api
 {
     public class ArchiveMessagesController : System.Web.Http.ApiController
     {
-        public ArchiveMessagesController(NServiceBus.IMessageSession session) { }
+        public ArchiveMessagesController(NServiceBus.IMessageSession session, Raven.Client.IDocumentStore store) { }
         [System.Web.Http.HttpPatchAttribute()]
         [System.Web.Http.HttpPostAttribute()]
         [System.Web.Http.RouteAttribute("errors/{messageid}/archive")]
@@ -674,6 +675,12 @@ namespace ServiceControl.MessageFailures.Api
         [System.Web.Http.HttpPostAttribute()]
         [System.Web.Http.RouteAttribute("errors/archive")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> ArchiveBatch(System.Collections.Generic.List<string> messageIds) { }
+        [System.Web.Http.HttpGetAttribute()]
+        [System.Web.Http.RouteAttribute("errors/groups/{classifier?}")]
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetArchiveMessageGroups([System.Web.Http.FromUriAttribute()] string classifierFilter = null, string classifier = "Exception Type and Stack Trace") { }
+        [System.Web.Http.HttpGetAttribute()]
+        [System.Web.Http.RouteAttribute("archive/groups/id/{groupId}")]
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetGroup(string groupId) { }
     }
     public class EditConfigurationModel
     {
@@ -1139,6 +1146,10 @@ namespace ServiceControl.Recoverability
         AllForEndpoint = 4,
         All = 5,
         ByQueueAddress = 6,
+    }
+    public class ArchivedGroupsViewIndex : Raven.Client.Indexes.AbstractIndexCreationTask<ServiceControl.MessageFailures.FailedMessage, ServiceControl.Recoverability.FailureGroupView>
+    {
+        public ArchivedGroupsViewIndex() { }
     }
     public struct ClassifiableMessageDetails
     {

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.RootPathValue.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.RootPathValue.approved.txt
@@ -13,5 +13,6 @@
   "Name": "testName",
   "SagasUrl": "http://localhost/sagas",
   "EventLogItems": "http://localhost/eventlogitems",
-  "ArchivedGroupsUrl": "http://localhost/errors/groups/{classifier?}"
+  "ArchivedGroupsUrl": "http://localhost/errors/groups/{classifier?}",
+  "GetArchiveGroup": "http://localhost/archive/groups/id/{groupId}"
 }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.RootPathValue.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.RootPathValue.approved.txt
@@ -12,5 +12,6 @@
   "LicenseDetails": "http://localhost/license",
   "Name": "testName",
   "SagasUrl": "http://localhost/sagas",
-  "EventLogItems": "http://localhost/eventlogitems"
+  "EventLogItems": "http://localhost/eventlogitems",
+  "ArchivedGroupsUrl": "http://localhost/errors/groups/{classifier?}"
 }

--- a/src/ServiceControl/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/RootController.cs
@@ -40,7 +40,8 @@
                 LicenseDetails = baseUrl + "license",
                 Configuration = baseUrl + "configuration",
                 EventLogItems = baseUrl + "eventlogitems",
-                ArchivedGroupsUrl = baseUrl + "errors/groups/{classifier?}"
+                ArchivedGroupsUrl = baseUrl + "errors/groups/{classifier?}",
+                GetArchiveGroup = baseUrl + "archive/groups/id/{groupId}",
             };
 
             return Ok(model);
@@ -114,6 +115,7 @@
             public string SagasUrl { get; set; }
             public string EventLogItems { get; set; }
             public string ArchivedGroupsUrl { get; set; }
+            public string GetArchiveGroup { get; set; }
         }
     }
 }

--- a/src/ServiceControl/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/RootController.cs
@@ -39,7 +39,8 @@
                 LicenseStatus = license.IsValid ? "valid" : "invalid",
                 LicenseDetails = baseUrl + "license",
                 Configuration = baseUrl + "configuration",
-                EventLogItems = baseUrl + "eventlogitems"
+                EventLogItems = baseUrl + "eventlogitems",
+                ArchivedGroupsUrl = baseUrl + "errors/groups/{classifier?}"
             };
 
             return Ok(model);
@@ -112,6 +113,7 @@
             public string Name { get; set; }
             public string SagasUrl { get; set; }
             public string EventLogItems { get; set; }
+            public string ArchivedGroupsUrl { get; set; }
         }
     }
 }

--- a/src/ServiceControl/Recoverability/API/EtagHelper.cs
+++ b/src/ServiceControl/Recoverability/API/EtagHelper.cs
@@ -1,3 +1,5 @@
+using ServiceControl.Recoverability;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -9,6 +11,17 @@ static class EtagHelper
         foreach (var g in groups)
         {
             data.Append($"{g.Id}.{g.Count}.{g.OperationStatus}.{g.OperationProgress}.{g.OperationStartTime}.{g.OperationCompletionTime}.{g.NeedUserAcknowledgement}");
+        }
+
+        return data.ToString();
+    }
+
+    internal static string CalculateEtag(IList<FailureGroupView> results)
+    {
+        var data = new StringBuilder();
+        foreach (var g in results)
+        {
+            data.Append($"{g.Id}.{g.Count}");
         }
 
         return data.ToString();

--- a/src/ServiceControl/Recoverability/Grouping/Raven/ArchivedGroupsViewIndex.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Raven/ArchivedGroupsViewIndex.cs
@@ -1,0 +1,46 @@
+namespace ServiceControl.Recoverability
+{
+    using System.Linq;
+    using MessageFailures;
+    using Raven.Client.Indexes;
+
+    public class ArchivedGroupsViewIndex : AbstractIndexCreationTask<FailedMessage, FailureGroupView>
+    {
+        public ArchivedGroupsViewIndex()
+        {
+            Map = docs => from doc in docs
+                where doc.Status == FailedMessageStatus.Archived
+                let failureTimes = doc.ProcessingAttempts.Select(x => x.FailureDetails.TimeOfFailure)
+                from failureGroup in doc.FailureGroups
+                select new FailureGroupView
+                {
+                    Id = failureGroup.Id,
+                    Title = failureGroup.Title,
+                    Count = 1,
+                    First = failureTimes.Min(),
+                    Last = failureTimes.Max(),
+                    Type = failureGroup.Type
+                };
+
+            Reduce = results => from result in results
+                group result by new
+                {
+                    result.Id,
+                    result.Title,
+                    result.Type
+                }
+                into g
+                select new FailureGroupView
+                {
+                    Id = g.Key.Id,
+                    Title = g.Key.Title,
+                    Count = g.Sum(x => x.Count),
+                    First = g.Min(x => x.First),
+                    Last = g.Max(x => x.Last),
+                    Type = g.Key.Type
+                };
+
+            DisableInMemoryIndexing = true;
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to request the groups of archived messages.
ServicePulse uses this to display the information. If ServicePulse connects to a version of ServiceControl that does not support this then the ServicePulse behaviour does not change.