### PR TITLE
Log the product version instead of the assembly version

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.Audit.Infrastructure
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -167,7 +168,7 @@ namespace ServiceControl.Audit.Infrastructure
 
         private void RecordStartup(LoggingSettings loggingSettings, EndpointConfiguration endpointConfiguration)
         {
-            var version = typeof(Bootstrapper).Assembly.GetName().Version;
+            var version = FileVersionInfo.GetVersionInfo(typeof(Bootstrapper).Assembly.Location).ProductVersion;
             var startupMessage = $@"
 -------------------------------------------------------------
 ServiceControl Audit Version:       {version}

--- a/src/ServiceControl.Monitoring/MonitorLogs.cs
+++ b/src/ServiceControl.Monitoring/MonitorLogs.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Monitoring
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using NLog;
@@ -22,7 +23,7 @@
                 return;
             }
 
-            var version = typeof(Host).Assembly.GetName().Version;
+            var version = FileVersionInfo.GetVersionInfo(typeof(Host).Assembly.Location).ProductVersion;
             var nlogConfig = new LoggingConfiguration();
             var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}");
             var header = $@"-------------------------------------------------------------

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -2,6 +2,7 @@ namespace Particular.ServiceControl
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -182,7 +183,7 @@ namespace Particular.ServiceControl
 
         private void RecordStartup(LoggingSettings loggingSettings, EndpointConfiguration endpointConfiguration)
         {
-            var version = typeof(Bootstrapper).Assembly.GetName().Version;
+            var version = FileVersionInfo.GetVersionInfo(typeof(Bootstrapper).Assembly.Location).ProductVersion;
             var startupMessage = $@"
 -------------------------------------------------------------
 ServiceControl Version:             {version}


### PR DESCRIPTION
Previously te assembly version was logged which currently is `4.0.0.0` which is not very useful. Now the product version is logged which would in the next release be `4.9.0` but is you locally build be `4.9.0-my-branch-name-bla-bla`.