### PR TITLE
If no values are present instance must return as being stale

### DIFF
--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointInstanceActivityTracker.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointInstanceActivityTracker.cs
@@ -17,14 +17,13 @@
 
         public bool IsStale(EndpointInstanceId endpointInstance)
         {
-            DateTime lastActivityTime;
-            if (endpointsInstances.TryGetValue(endpointInstance, out lastActivityTime))
+            if (endpointsInstances.TryGetValue(endpointInstance, out var lastActivityTime))
             {
-                var timeSpan = DateTime.UtcNow - lastActivityTime;
-                return timeSpan > StalenessThreshold;
+                var age = DateTime.UtcNow - lastActivityTime;
+                return age > StalenessThreshold;
             }
 
-            return false;
+            return true;
         }
 
         internal readonly TimeSpan StalenessThreshold;


### PR DESCRIPTION
While creating a unit test to test the `GetAllEndpointsMetrics` API I stumbled upon this API. Normally this state probably is not possible chronologically but either it should return `true`,`null`, or an exception but not `false`.


Also, this potentially has a memory leak. If a large amount of instances is tracked that are shortlived this collection never releases this data. IMHO this collection should periodically cleanup.