### PR TITLE
Expand environment variables in the learning transport connection string

### DIFF
--- a/src/ServiceControl.Transports.Learning/LearningTransportCustomization.cs
+++ b/src/ServiceControl.Transports.Learning/LearningTransportCustomization.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Transports.Learning
 {
+    using System;
     using LearningTransport;
     using NServiceBus;
     using NServiceBus.Raw;
@@ -49,14 +50,14 @@
         static void CustomizeEndpoint(EndpointConfiguration endpointConfig, TransportSettings transportSettings, TransportTransactionMode transportTransactionMode)
         {
             var transport = endpointConfig.UseTransport<LearningTransport>();
-            transport.StorageDirectory(transportSettings.ConnectionString);
+            transport.StorageDirectory(Environment.ExpandEnvironmentVariables(transportSettings.ConnectionString));
             transport.Transactions(transportTransactionMode);
         }
 
         static void CustomizeRawEndpoint(RawEndpointConfiguration endpointConfig, TransportSettings transportSettings, TransportTransactionMode transportTransactionMode)
         {
             var transport = endpointConfig.UseTransport<LearningTransport>();
-            transport.StorageDirectory(transportSettings.ConnectionString);
+            transport.StorageDirectory(Environment.ExpandEnvironmentVariables(transportSettings.ConnectionString));
             transport.Transactions(transportTransactionMode);
         }
     }

--- a/src/ServiceControl.Transports.Learning/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.Learning/QueueLengthProvider.cs
@@ -13,7 +13,7 @@
     {
         public void Initialize(string connectionString, Action<QueueLengthEntry[], EndpointToQueueMapping> store)
         {
-            rootFolder = connectionString;
+            rootFolder = Environment.ExpandEnvironmentVariables(connectionString);
             this.store = store;
         }
 


### PR DESCRIPTION
This make it possible to do for example `%TEMP%\.learningTransport`