### PR TITLE
Fix logging in non-user-interactive environments (e.g. docker) where logs were not sent to STDOUT

### DIFF
--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -153,7 +153,7 @@ namespace ServiceControl.AcceptanceTests.TestSupport
                 var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 Directory.CreateDirectory(logPath);
 
-                var loggingSettings = new LoggingSettings(settings.ServiceName, logPath: logPath);
+                var loggingSettings = new LoggingSettings(settings.ServiceName, false, logPath: logPath);
                 bootstrapper = new Bootstrapper(settings, configuration, loggingSettings, builder =>
                 {
                     builder.RegisterType<FailedErrorsController>().FindConstructorsWith(t => t.GetTypeInfo().DeclaredConstructors.ToArray());

--- a/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -149,7 +149,7 @@ namespace ServiceControl.Audit.AcceptanceTests.TestSupport
                 var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 Directory.CreateDirectory(logPath);
 
-                var loggingSettings = new LoggingSettings(settings.ServiceName, logPath: logPath);
+                var loggingSettings = new LoggingSettings(settings.ServiceName, false, logPath: logPath);
                 bootstrapper = new Bootstrapper(ctx =>
                 {
                     var logitem = new ScenarioContext.LogItem

--- a/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
@@ -31,7 +31,7 @@
             var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost");
             request.Properties.Add(HttpPropertyKeys.RequestContextKey, new HttpRequestContext {VirtualPathRoot = "/"});
 
-            var controller = new RootController(new LoggingSettings("testEndpoint"), new Settings())
+            var controller = new RootController(new LoggingSettings("testEndpoint", false), new Settings())
             {
                 Url = new UrlHelper(request)
             };

--- a/src/ServiceControl.Audit.UnitTests/Infrastructure/LoggingConfiguratorTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/Infrastructure/LoggingConfiguratorTests.cs
@@ -1,0 +1,43 @@
+﻿namespace ServiceControl.Audit.UnitTests.Infrastructure
+{
+    using System.Linq;
+    using NLog.Config;
+    using NLog.Targets;
+    using NUnit.Framework;
+    using ServiceControl.Audit.Infrastructure;
+    using ServiceControl.Audit.Infrastructure.Settings;
+
+    [TestFixture]
+    public class LoggingConfiguratorTests
+    {
+        [TearDown]
+        public void ResetLogConfiguration()
+        {
+            NLog.LogManager.Configuration = new LoggingConfiguration();
+        }
+
+        [Test]
+        public void Should_remove_Console_targets_if_not_printing_to_console()
+        {
+            var loggingSettings = new LoggingSettings("Test", false);
+
+            LoggingConfigurator.ConfigureLogging(loggingSettings);
+
+            var logConfiguration = NLog.LogManager.Configuration;
+
+            Assert.IsEmpty(logConfiguration.LoggingRules.Where(rule => rule.Targets.Any(target => target is ColoredConsoleTarget)));
+        }
+
+        [Test]
+        public void Should_contain_Console_targets_if_printing_to_console()
+        {
+            var loggingSettings = new LoggingSettings("Test", true);
+
+            LoggingConfigurator.ConfigureLogging(loggingSettings);
+
+            var logConfiguration = NLog.LogManager.Configuration;
+
+            Assert.IsNotEmpty(logConfiguration.LoggingRules.Where(rule => rule.Targets.Any(target => target is ColoredConsoleTarget)));
+        }
+    }
+}

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
@@ -22,7 +22,7 @@
 
             using (var tokenSource = new CancellationTokenSource())
             {
-                var loggingSettings = new LoggingSettings(settings.ServiceName, LogLevel.Info, LogLevel.Info);
+                var loggingSettings = new LoggingSettings(settings.ServiceName, false, LogLevel.Info, LogLevel.Info);
                 var bootstrapper = new Bootstrapper(ctx => { tokenSource.Cancel(); }, settings, busConfiguration, loggingSettings);
                 var busInstance = await bootstrapper.Start().ConfigureAwait(false);
                 var importer = busInstance.ImportFailedAudits;

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/RunCommand.cs
@@ -7,25 +7,26 @@
     {
         public override async Task Execute(HostArguments args)
         {
-            if (!args.Portable && !Environment.UserInteractive)
+            if (!args.Portable && !Environment.UserInteractive) // Windows Service
             {
                 RunNonBlocking(args);
             }
 
+            // Interactive or non-interactive portable (e.g. docker)
             await RunAndWait(args).ConfigureAwait(false);
         }
 
         static void RunNonBlocking(HostArguments args)
         {
-            using (var service = new Host {ServiceName = args.ServiceName})
+            using (var service = new Host(false) { ServiceName = args.ServiceName })
             {
-                service.Run(false);
+                service.Run();
             }
         }
 
         static async Task RunAndWait(HostArguments args)
         {
-            using (var service = new Host {ServiceName = args.ServiceName})
+            using (var service = new Host(true) { ServiceName = args.ServiceName })
             {
                 var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 service.OnStopping = () =>
@@ -34,7 +35,7 @@
                     completionSource.TrySetResult(true);
                 };
 
-                service.Run(args.Portable || Environment.UserInteractive);
+                service.Run();
 
                 var r = new CancelWrapper(completionSource, service);
                 Console.CancelKeyPress += r.ConsoleOnCancelKeyPress;

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Host.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Host.cs
@@ -7,9 +7,14 @@
 
     class Host : ServiceBase
     {
-        public void Run(bool interactive)
+        public Host(bool logToConsole)
         {
-            if (interactive)
+            this.logToConsole = logToConsole;
+        }
+
+        public void Run()
+        {
+            if (logToConsole)
             {
                 RunInteractive();
             }
@@ -35,7 +40,7 @@
             var assemblyScanner = busConfiguration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
 
-            var loggingSettings = new LoggingSettings(ServiceName);
+            var loggingSettings = new LoggingSettings(ServiceName, logToConsole);
 
             var settings = new Settings(ServiceName)
             {
@@ -61,6 +66,7 @@
 
         internal Action OnStopping = () => { };
 
+        bool logToConsole;
         Bootstrapper bootstrapper;
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
@@ -1,6 +1,5 @@
 namespace ServiceControl.Audit.Infrastructure
 {
-    using System;
     using System.IO;
     using System.Linq;
     using NLog.Config;
@@ -81,8 +80,8 @@ namespace ServiceControl.Audit.Infrastructure
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel, fileTarget));
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel < LogLevel.Info ? loggingSettings.LoggingLevel : LogLevel.Info, consoleTarget));
 
-            // Remove Console Logging when running as a service
-            if (!Environment.UserInteractive)
+            // Remove Console Logging if not needed
+            if (!loggingSettings.PrintToConsole)
             {
                 foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
                 {

--- a/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
@@ -7,8 +7,9 @@ namespace ServiceControl.Audit.Infrastructure.Settings
 
     class LoggingSettings
     {
-        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null)
+        public LoggingSettings(string serviceName, bool printToConsole, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null)
         {
+            PrintToConsole = printToConsole;
             LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
             RavenDBLogLevel = InitializeLevel("RavenDBLogLevel", defaultRavenDBLevel ?? LogLevel.Warn);
             LogPath = Environment.ExpandEnvironmentVariables(ConfigFileSettingsReader<string>.Read("LogPath", logPath ?? DefaultLogPathForInstance(serviceName)));
@@ -19,6 +20,8 @@ namespace ServiceControl.Audit.Infrastructure.Settings
         public LogLevel RavenDBLogLevel { get; }
 
         public string LogPath { get; }
+
+        public bool PrintToConsole { get; }
 
         LogLevel InitializeLevel(string key, LogLevel defaultLevel)
         {

--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -23,7 +23,7 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName);
+            var loggingSettings = new LoggingSettings(arguments.ServiceName, false);
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             await new CommandRunner(arguments.Commands).Execute(arguments)

--- a/src/ServiceControl.Monitoring.UnitTests/Infrastructure/LoggingConfiguratorTests.cs
+++ b/src/ServiceControl.Monitoring.UnitTests/Infrastructure/LoggingConfiguratorTests.cs
@@ -1,0 +1,50 @@
+﻿namespace ServiceControl.Monitoring.UnitTests.Infrastructure
+{
+    using System.Linq;
+    using NLog;
+    using NLog.Config;
+    using NLog.Targets;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class LoggingConfiguratorTests
+    {
+        [TearDown]
+        public void ResetLogConfiguration()
+        {
+            NLog.LogManager.Configuration = new LoggingConfiguration();
+        }
+
+        [Test]
+        public void Should_remove_Console_targets_if_not_printing_to_console()
+        {
+            var settings = new Settings
+            {
+                LogLevel = LogLevel.Info,
+                LogPath = "TestLogPath"
+            };
+
+            MonitorLogs.Configure(settings, false);
+
+            var logConfiguration = NLog.LogManager.Configuration;
+
+            Assert.IsEmpty(logConfiguration.LoggingRules.Where(rule => rule.Targets.Any(target => target is ColoredConsoleTarget)));
+        }
+
+        [Test]
+        public void Should_contain_Console_targets_if_printing_to_console()
+        {
+            var settings = new Settings
+            {
+                LogLevel = LogLevel.Info,
+                LogPath = "TestLogPath"
+            };
+
+            MonitorLogs.Configure(settings, true);
+
+            var logConfiguration = NLog.LogManager.Configuration;
+
+            Assert.IsNotEmpty(logConfiguration.LoggingRules.Where(rule => rule.Targets.Any(target => target is ColoredConsoleTarget)));
+        }
+    }
+}

--- a/src/ServiceControl.Monitoring/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/RunCommand.cs
@@ -7,23 +7,24 @@ namespace ServiceControl.Monitoring
     {
         public override Task Execute(Settings settings)
         {
-            if (Environment.UserInteractive)
+            if (Environment.UserInteractive) // Interactive or non-interactive portable (e.g. docker)
             {
                 return RunAndWait(settings);
             }
 
+            // Windows Service
             return RunNonBlocking(settings);
         }
 
         Task RunNonBlocking(Settings settings)
         {
-            using (var service = new Host
+            using (var service = new Host(false)
             {
                 Settings = settings,
                 ServiceName = settings.ServiceName
             })
             {
-                service.Run(false);
+                service.Run();
             }
 
             return Task.FromResult(0);
@@ -31,10 +32,10 @@ namespace ServiceControl.Monitoring
 
         async Task RunAndWait(Settings settings)
         {
-            using (var service = new Host
+            using (var service = new Host(true)
             {
                 Settings = settings,
-                ServiceName = settings.ServiceName
+                ServiceName = settings.ServiceName,
             })
             {
                 var tcs = new TaskCompletionSource<bool>();
@@ -49,7 +50,7 @@ namespace ServiceControl.Monitoring
 
                 OnConsoleCancel.Run(done);
 
-                service.Run(true);
+                service.Run();
 
                 Console.WriteLine("Press Ctrl+C to exit");
 

--- a/src/ServiceControl.Monitoring/Hosting/Host.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Host.cs
@@ -8,11 +8,16 @@
     [DesignerCategory("Code")]
     class Host : ServiceBase
     {
+        public Host(bool logToConsole)
+        {
+            this.logToConsole = logToConsole;
+        }
+
         public Settings Settings { get; set; }
 
-        public void Run(bool interactive)
+        public void Run()
         {
-            if (interactive)
+            if (logToConsole)
             {
                 RunInteractive();
             }
@@ -56,6 +61,7 @@
             OnStop();
         }
 
+        bool logToConsole;
         internal Action OnStopping = () => { };
         Bootstrapper bootstrapper;
     }

--- a/src/ServiceControl.Monitoring/MonitorLogs.cs
+++ b/src/ServiceControl.Monitoring/MonitorLogs.cs
@@ -14,7 +14,7 @@
 
     static class MonitorLogs
     {
-        public static void Configure(Settings settings)
+        public static void Configure(Settings settings, bool printToConsole)
         {
             LogManager.Use<NLogFactory>();
 
@@ -69,8 +69,8 @@ Selected Transport:					{settings.TransportType}
             nlogConfig.LoggingRules.Add(new LoggingRule("*", settings.LogLevel, fileTarget));
             nlogConfig.LoggingRules.Add(new LoggingRule("*", settings.LogLevel < LogLevel.Info ? settings.LogLevel : LogLevel.Info, consoleTarget));
 
-            // Remove Console Logging when running as a service
-            if (!Environment.UserInteractive)
+            // Remove Console Logging if not needed
+            if (!printToConsole)
             {
                 foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
                 {

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -18,7 +18,7 @@ namespace ServiceControl.Monitoring
 
                 var settings = LoadSettings(ConfigurationManager.AppSettings, arguments);
 
-                MonitorLogs.Configure(settings);
+                MonitorLogs.Configure(settings, false);
 
                 var runner = new CommandRunner(arguments.Commands);
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -170,7 +170,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.TestSupport
                 var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 Directory.CreateDirectory(logPath);
 
-                var loggingSettings = new LoggingSettings(settings.ServiceName, logPath: logPath);
+                var loggingSettings = new LoggingSettings(settings.ServiceName, false, logPath: logPath);
                 bootstrapper = new Bootstrapper(settings, configuration, loggingSettings, builder => { });
                 bootstrappers[instanceName] = bootstrapper;
                 bootstrapper.HttpClientFactory = HttpClientFactory;
@@ -290,7 +290,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.TestSupport
                 var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 Directory.CreateDirectory(logPath);
 
-                var loggingSettings = new ServiceControl.Audit.Infrastructure.Settings.LoggingSettings(settings.ServiceName, logPath: logPath);
+                var loggingSettings = new ServiceControl.Audit.Infrastructure.Settings.LoggingSettings(settings.ServiceName, false, logPath: logPath);
                 bootstrapper = new ServiceControl.Audit.Infrastructure.Bootstrapper(ctx =>
                 {
                     var logitem = new ScenarioContext.LogItem

--- a/src/ServiceControl.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.UnitTests/API/APIApprovals.cs
@@ -41,7 +41,7 @@
             var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost");
             request.Properties.Add(HttpPropertyKeys.RequestContextKey, new HttpRequestContext {VirtualPathRoot = "/"});
 
-            var controller = new RootController(new ActiveLicense {IsValid = true}, new LoggingSettings("testEndpoint"), new Settings())
+            var controller = new RootController(new ActiveLicense {IsValid = true}, new LoggingSettings("testEndpoint", false), new Settings())
             {
                 Url = new UrlHelper(request)
             };

--- a/src/ServiceControl.UnitTests/Infrastructure/LoggingConfiguratorTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/LoggingConfiguratorTests.cs
@@ -1,0 +1,43 @@
+﻿namespace ServiceControl.UnitTests.Infrastructure
+{
+    using System.Linq;
+    using NLog.Config;
+    using NLog.Targets;
+    using NUnit.Framework;
+    using Particular.ServiceControl;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    [TestFixture]
+    public class LoggingConfiguratorTests
+    {
+        [TearDown]
+        public void ResetLogConfiguration()
+        {
+            NLog.LogManager.Configuration = new LoggingConfiguration();
+        }
+
+        [Test]
+        public void Should_remove_Console_targets_if_not_printing_to_console()
+        {
+            var loggingSettings = new LoggingSettings("Test", false);
+
+            LoggingConfigurator.ConfigureLogging(loggingSettings);
+
+            var logConfiguration = NLog.LogManager.Configuration;
+
+            Assert.IsEmpty(logConfiguration.LoggingRules.Where(rule => rule.Targets.Any(target => target is ColoredConsoleTarget)));
+        }
+
+        [Test]
+        public void Should_contain_Console_targets_if_printing_to_console()
+        {
+            var loggingSettings = new LoggingSettings("Test", true);
+
+            LoggingConfigurator.ConfigureLogging(loggingSettings);
+
+            var logConfiguration = NLog.LogManager.Configuration;
+
+            Assert.IsNotEmpty(logConfiguration.LoggingRules.Where(rule => rule.Targets.Any(target => target is ColoredConsoleTarget)));
+        }
+    }
+}

--- a/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
@@ -25,7 +25,7 @@
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
             var tokenSource = new CancellationTokenSource();
 
-            var loggingSettings = new LoggingSettings(settings.ServiceName, LogLevel.Info, LogLevel.Info);
+            var loggingSettings = new LoggingSettings(settings.ServiceName, false, defaultLevel: LogLevel.Info, defaultRavenDBLevel: LogLevel.Info);
             var bootstrapper = new Bootstrapper(settings, busConfiguration, loggingSettings);
             var instance = await bootstrapper.Start().ConfigureAwait(false);
             var errorIngestion = instance.ErrorIngestion;

--- a/src/ServiceControl/Hosting/Host.cs
+++ b/src/ServiceControl/Hosting/Host.cs
@@ -7,9 +7,14 @@
 
     class Host : ServiceBase
     {
-        public void Run(bool interactive)
+        public Host(bool logToConsole)
         {
-            if (interactive)
+            this.logToConsole = logToConsole;
+        }
+
+        public void Run()
+        {
+            if (logToConsole)
             {
                 RunInteractive();
             }
@@ -35,7 +40,7 @@
             var assemblyScanner = busConfiguration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
 
-            var loggingSettings = new LoggingSettings(ServiceName);
+            var loggingSettings = new LoggingSettings(ServiceName, logToConsole);
 
             var settings = new Settings(ServiceName)
             {
@@ -59,6 +64,7 @@
 
         internal Action OnStopping = () => { };
 
+        bool logToConsole;
         Bootstrapper bootstrapper;
     }
 }

--- a/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
@@ -7,8 +7,9 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
     class LoggingSettings
     {
-        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null)
+        public LoggingSettings(string serviceName, bool printToConsole, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null)
         {
+            PrintToConsole = printToConsole;
             LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
             RavenDBLogLevel = InitializeLevel("RavenDBLogLevel", defaultRavenDBLevel ?? LogLevel.Warn);
             LogPath = Environment.ExpandEnvironmentVariables(ConfigFileSettingsReader<string>.Read("LogPath", logPath ?? DefaultLogPathForInstance(serviceName)));
@@ -19,6 +20,8 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public LogLevel RavenDBLogLevel { get; }
 
         public string LogPath { get; }
+
+        public bool PrintToConsole { get; }
 
         LogLevel InitializeLevel(string key, LogLevel defaultLevel)
         {

--- a/src/ServiceControl/LoggingConfigurator.cs
+++ b/src/ServiceControl/LoggingConfigurator.cs
@@ -1,6 +1,5 @@
 namespace Particular.ServiceControl
 {
-    using System;
     using System.IO;
     using System.Linq;
     using NLog.Config;
@@ -81,8 +80,8 @@ namespace Particular.ServiceControl
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel, fileTarget));
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel < LogLevel.Info ? loggingSettings.LoggingLevel : LogLevel.Info, consoleTarget));
 
-            // Remove Console Logging when running as a service
-            if (!Environment.UserInteractive)
+            // Remove Console Logging if not needed
+            if (!loggingSettings.PrintToConsole)
             {
                 foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
                 {

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -22,7 +22,7 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName);
+            var loggingSettings = new LoggingSettings(arguments.ServiceName, false);
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             await new CommandRunner(arguments.Commands).Execute(arguments)

--- a/src/ServiceControl/SetupBootstrapper.cs
+++ b/src/ServiceControl/SetupBootstrapper.cs
@@ -40,7 +40,7 @@ namespace Particular.ServiceControl
             var transportSettings = MapSettings(settings);
             containerBuilder.RegisterInstance(transportSettings).SingleInstance();
 
-            var loggingSettings = new LoggingSettings(settings.ServiceName);
+            var loggingSettings = new LoggingSettings(settings.ServiceName, false);
             containerBuilder.RegisterInstance(loggingSettings).SingleInstance();
             var documentStore = new EmbeddableDocumentStore();
             containerBuilder.RegisterInstance(documentStore).As<IDocumentStore>().ExternallyOwned();


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceControl/issues/1622

Adds a flag so that STDOUT can be used when running with docker containers.