### PR TITLE
Interactive console logging was broken by 05662e5 which is now restored

### DIFF
--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -23,7 +23,7 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName, false);
+            var loggingSettings = new LoggingSettings(arguments.ServiceName, printToConsole: Environment.UserInteractive);
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             await new CommandRunner(arguments.Commands).Execute(arguments)

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -18,7 +18,7 @@ namespace ServiceControl.Monitoring
 
                 var settings = LoadSettings(ConfigurationManager.AppSettings, arguments);
 
-                MonitorLogs.Configure(settings, false);
+                MonitorLogs.Configure(settings, printToConsole: Environment.UserInteractive);
 
                 var runner = new CommandRunner(arguments.Commands);
 

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -22,7 +22,7 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName, false);
+            var loggingSettings = new LoggingSettings(arguments.ServiceName, printToConsole: Environment.UserInteractive);
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             await new CommandRunner(arguments.Commands).Execute(arguments)


### PR DESCRIPTION
This will log to the console for interactive sessions `printToConsole: Environment.UserInteractive`. This ensures logging to console is restored when launching from VS or Rider.

Should not conflict with "environment detection" for docker vs window service. These permutations would be:

- interactive console
- non-interactive console
- windows service