### PR TITLE
Recoverability improvements

### DIFF
--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -1210,6 +1210,15 @@ namespace ServiceControl.Recoverability
     {
         public FailedMessages_ByGroup() { }
     }
+    public class FailedMessages_UniqueMessageIdAndTimeOfFailures : Raven.Client.Indexes.AbstractTransformerCreationTask<ServiceControl.MessageFailures.FailedMessage>
+    {
+        public FailedMessages_UniqueMessageIdAndTimeOfFailures() { }
+        public struct Result
+        {
+            public System.DateTime LatestTimeOfFailure { get; set; }
+            public string UniqueMessageId { get; set; }
+        }
+    }
     public class FailureGroupMessageView : ServiceControl.MessageFailures.IHaveStatus
     {
         public FailureGroupMessageView() { }

--- a/src/ServiceControl.UnitTests/Recoverability/Retry_State_Tests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/Retry_State_Tests.cs
@@ -281,7 +281,8 @@
                 await session.SaveChangesAsync();
             }
 
-            new FailedMessages_ByGroup().Execute(documentStore);
+            await new FailedMessages_ByGroup().ExecuteAsync(documentStore);
+            await new FailedMessages_UniqueMessageIdAndTimeOfFailures().ExecuteAsync(documentStore);
 
             documentStore.WaitForIndexing();
 

--- a/src/ServiceControl/Recoverability/Retrying/FailedMessageRetries.cs
+++ b/src/ServiceControl/Recoverability/Retrying/FailedMessageRetries.cs
@@ -160,7 +160,7 @@
                 using (var session = store.OpenAsyncSession())
                 {
                     var batchesProcessed = await processor.ProcessBatches(session, token).ConfigureAwait(false);
-                    await session.SaveChangesAsync().ConfigureAwait(false);
+                    await session.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
                     return batchesProcessed ? TimerJobExecutionResult.ExecuteImmediately : TimerJobExecutionResult.ScheduleNextExecution;
                 }
             }

--- a/src/ServiceControl/Recoverability/Retrying/RetryDocumentManager.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetryDocumentManager.cs
@@ -49,7 +49,7 @@ namespace ServiceControl.Recoverability
             return batchDocumentId;
         }
 
-        public ICommandData CreateFailedMessageRetryDocument(string batchDocumentId, string messageId)
+        public static ICommandData CreateFailedMessageRetryDocument(string batchDocumentId, string messageId)
         {
             return new PatchCommandData
             {

--- a/src/ServiceControl/Recoverability/Retrying/RetryStagingException.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetryStagingException.cs
@@ -4,5 +4,8 @@ namespace ServiceControl.Recoverability
 
     class RetryStagingException : Exception
     {
+        public RetryStagingException(Exception innerException) : base("Staging failed. Retry required", innerException)
+        {
+        }
     }
 }


### PR DESCRIPTION
* User server side transformer to pick failed messages

* Batch dispatch and remove concurrent access to failed message

* Deterministic request id for the same list of messages

* Stream UniqueMessageId and TimeOfFailure only

* If staging failed the first time then fall back the second time to individual dispatches