### PR TITLE
Use the app.manifest file in the config app

### DIFF
--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>ServiceControlConfig</AssemblyName>
     <ApplicationIcon>App.ico</ApplicationIcon>
     <UseWpf>true</UseWpf>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes a problem introduced in #1942.

The previous MSBuild.Sdk.Extras SDK automatically added a reference to the app.manifest file, but the Microsoft.NET.Sdk.WindowsDesktop SDK doesn't.

Without the manifest being referenced properly, the management app won't require a UAC elevation.