### PR TITLE
Fix run as service introduced by  and logging initialization vs configuration order

### DIFF
--- a/src/ServiceControl.Audit.UnitTests/Infrastructure/LoggingConfiguratorTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/Infrastructure/LoggingConfiguratorTests.cs
@@ -14,6 +14,7 @@
         public void ResetLogConfiguration()
         {
             NLog.LogManager.Configuration = new LoggingConfiguration();
+            LoggingConfigurator.Settings = null;
         }
 
         [Test]

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
@@ -22,8 +22,7 @@
 
             using (var tokenSource = new CancellationTokenSource())
             {
-                var loggingSettings = new LoggingSettings(settings.ServiceName, false, LogLevel.Info, LogLevel.Info);
-                var bootstrapper = new Bootstrapper(ctx => { tokenSource.Cancel(); }, settings, busConfiguration, loggingSettings);
+                var bootstrapper = new Bootstrapper(ctx => { tokenSource.Cancel(); }, settings, busConfiguration, LoggingConfigurator.Settings);
                 var busInstance = await bootstrapper.Start().ConfigureAwait(false);
                 var importer = busInstance.ImportFailedAudits;
 

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/RunCommand.cs
@@ -23,7 +23,7 @@
 
         static void RunAsService(HostArguments args)
         {
-            using (var service = new Host(logToConsole: false) { ServiceName = args.ServiceName })
+            using (var service = new Host() { ServiceName = args.ServiceName })
             {
                 service.RunAsService();
             }
@@ -31,7 +31,7 @@
 
         static async Task RunAsConsole(HostArguments args)
         {
-            using (var service = new Host(logToConsole: true) { ServiceName = args.ServiceName })
+            using (var service = new Host() { ServiceName = args.ServiceName })
             {
                 var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 service.OnStopping = () =>

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Host.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Host.cs
@@ -12,26 +12,14 @@
             this.logToConsole = logToConsole;
         }
 
-        public void Run()
-        {
-            if (logToConsole)
-            {
-                RunInteractive();
-            }
-            else
-            {
-                RunAsService();
-            }
-        }
-
-        void RunInteractive()
+        public void RunAsConsole()
         {
             OnStart(null);
         }
 
-        void RunAsService()
+        public void RunAsService()
         {
-            Run(this);
+            ServiceBase.Run(this);
         }
 
         protected override void OnStart(string[] args)

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Host.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Host.cs
@@ -7,11 +7,6 @@
 
     class Host : ServiceBase
     {
-        public Host(bool logToConsole)
-        {
-            this.logToConsole = logToConsole;
-        }
-
         public void RunAsConsole()
         {
             OnStart(null);
@@ -28,15 +23,13 @@
             var assemblyScanner = busConfiguration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
 
-            var loggingSettings = new LoggingSettings(ServiceName, logToConsole);
-
             var settings = new Settings(ServiceName)
             {
                 RunCleanupBundle = true
             };
             bootstrapper = new Bootstrapper(
                 ctx => { }, //Do nothing. The transports in NSB 7 are designed to handle broker outages. Audit ingestion will be paused when broker is unavailable.
-                settings, busConfiguration, loggingSettings);
+                settings, busConfiguration, LoggingConfigurator.Settings);
             bootstrapper.Start().GetAwaiter().GetResult();
         }
 
@@ -54,7 +47,6 @@
 
         internal Action OnStopping = () => { };
 
-        bool logToConsole;
         Bootstrapper bootstrapper;
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.Infrastructure
 {
+    using System;
     using System.IO;
     using System.Linq;
     using NLog.Config;
@@ -12,8 +13,13 @@ namespace ServiceControl.Audit.Infrastructure
 
     static class LoggingConfigurator
     {
+        public static LoggingSettings Settings { get; internal set; }
+
         public static void ConfigureLogging(LoggingSettings loggingSettings)
         {
+            if(Settings!=null) throw new InvalidOperationException("Logging already initialized");
+            Settings = loggingSettings;
+
             LogManager.Use<NLogFactory>();
 
             const long megaByte = 1024 * 1024;

--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -23,7 +23,8 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName, false);
+            var logToConsole = Environment.UserInteractive || arguments.Portable;
+            var loggingSettings = new LoggingSettings(arguments.ServiceName, logToConsole);
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             await new CommandRunner(arguments.Commands).Execute(arguments)

--- a/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
@@ -14,13 +14,14 @@
   "SkipQueueCreation": false,
   "RootUrl": "http://localhost:9999/",
   "MaximumConcurrencyLevel": 10,
+  "Portable": false,
   "OnMessage": {
     "Method": {
-      "Name": "<.ctor>b__69_0",
+      "Name": "<.ctor>b__73_0",
       "AssemblyName": "ServiceControl.Monitoring, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null",
       "ClassName": "ServiceControl.Monitoring.Settings+<>c",
-      "Signature": "System.Threading.Tasks.Task <.ctor>b__69_0(System.String, System.Collections.Generic.Dictionary`2[System.String,System.String], Byte[], System.Func`1[System.Threading.Tasks.Task])",
-      "Signature2": "System.Threading.Tasks.Task <.ctor>b__69_0(System.String, System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], System.Byte[], System.Func`1[[System.Threading.Tasks.Task, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]])",
+      "Signature": "System.Threading.Tasks.Task <.ctor>b__73_0(System.String, System.Collections.Generic.Dictionary`2[System.String,System.String], Byte[], System.Func`1[System.Threading.Tasks.Task])",
+      "Signature2": "System.Threading.Tasks.Task <.ctor>b__73_0(System.String, System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], System.Byte[], System.Func`1[[System.Threading.Tasks.Task, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]])",
       "MemberType": 8,
       "GenericArguments": null
     },

--- a/src/ServiceControl.Monitoring/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/RunCommand.cs
@@ -22,7 +22,7 @@ namespace ServiceControl.Monitoring
 
         Task RunAsService(Settings settings)
         {
-            using (var service = new Host(logToConsole: false)
+            using (var service = new Host()
             {
                 Settings = settings,
                 ServiceName = settings.ServiceName
@@ -36,7 +36,7 @@ namespace ServiceControl.Monitoring
 
         async Task RunAsConsole(Settings settings)
         {
-            using (var service = new Host(logToConsole: true)
+            using (var service = new Host()
             {
                 Settings = settings,
                 ServiceName = settings.ServiceName,

--- a/src/ServiceControl.Monitoring/Hosting/Host.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Host.cs
@@ -15,24 +15,12 @@
 
         public Settings Settings { get; set; }
 
-        public void Run()
-        {
-            if (logToConsole)
-            {
-                RunInteractive();
-            }
-            else
-            {
-                RunAsService();
-            }
-        }
-
-        void RunInteractive()
+        public void RunAsConsole()
         {
             OnStart(null);
         }
 
-        void RunAsService()
+        public void RunAsService()
         {
             Run(this);
         }

--- a/src/ServiceControl.Monitoring/Hosting/Host.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Host.cs
@@ -8,11 +8,6 @@
     [DesignerCategory("Code")]
     class Host : ServiceBase
     {
-        public Host(bool logToConsole)
-        {
-            this.logToConsole = logToConsole;
-        }
-
         public Settings Settings { get; set; }
 
         public void RunAsConsole()
@@ -49,7 +44,6 @@
             OnStop();
         }
 
-        bool logToConsole;
         internal Action OnStopping = () => { };
         Bootstrapper bootstrapper;
     }

--- a/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
@@ -30,6 +30,11 @@
                     "skip-queue-creation",
                     "Skip queue creation during install/update",
                     s => overrides.Add(settings => settings.SkipQueueCreation = true)
+                },
+                {
+                    "p|portable",
+                    "Runs as a console app, even non-interactively.",
+                    s=> overrides.Add(settings => settings.Portable = true)
                 }
             };
 

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -18,7 +18,8 @@ namespace ServiceControl.Monitoring
 
                 var settings = LoadSettings(ConfigurationManager.AppSettings, arguments);
 
-                MonitorLogs.Configure(settings, false);
+                var logToConsole = Environment.UserInteractive || settings.Portable;
+                MonitorLogs.Configure(settings, logToConsole);
 
                 var runner = new CommandRunner(arguments.Commands);
 

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -32,6 +32,7 @@ namespace ServiceControl.Monitoring
         public bool SkipQueueCreation { get; set; }
         public string RootUrl => $"http://{HttpHostName}:{HttpPort}/";
         public int MaximumConcurrencyLevel { get; set; }
+        public bool Portable { get; set; }
 
         internal static Settings Load(SettingsReader reader)
         {

--- a/src/ServiceControl.UnitTests/Infrastructure/LoggingConfiguratorTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/LoggingConfiguratorTests.cs
@@ -14,11 +14,13 @@
         public void ResetLogConfiguration()
         {
             NLog.LogManager.Configuration = new LoggingConfiguration();
+            LoggingConfigurator.Settings = null;
         }
 
         [Test]
         public void Should_remove_Console_targets_if_not_printing_to_console()
         {
+            LoggingConfigurator.Settings = null;
             var loggingSettings = new LoggingSettings("Test", false);
 
             LoggingConfigurator.ConfigureLogging(loggingSettings);
@@ -31,6 +33,7 @@
         [Test]
         public void Should_contain_Console_targets_if_printing_to_console()
         {
+            LoggingConfigurator.Settings = null;
             var loggingSettings = new LoggingSettings("Test", true);
 
             LoggingConfigurator.ConfigureLogging(loggingSettings);

--- a/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
@@ -25,8 +25,7 @@
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
             var tokenSource = new CancellationTokenSource();
 
-            var loggingSettings = new LoggingSettings(settings.ServiceName, false, defaultLevel: LogLevel.Info, defaultRavenDBLevel: LogLevel.Info);
-            var bootstrapper = new Bootstrapper(settings, busConfiguration, loggingSettings);
+            var bootstrapper = new Bootstrapper(settings, busConfiguration, LoggingConfigurator.Settings);
             var instance = await bootstrapper.Start().ConfigureAwait(false);
             var errorIngestion = instance.ErrorIngestion;
 

--- a/src/ServiceControl/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/RunCommand.cs
@@ -3,12 +3,14 @@
     using System;
     using System.Threading.Tasks;
     using Hosting;
+    using ServiceBus.Management.Infrastructure.Settings;
 
     class RunCommand : AbstractCommand
     {
         public override async Task Execute(HostArguments args)
         {
             var consoleSession = args.Portable || Environment.UserInteractive;
+
             if (consoleSession)
             {
                 // Regular console (interactive) & Docker (non-interactive)
@@ -23,7 +25,7 @@
 
         static void RunAsService(HostArguments args)
         {
-            using (var service = new Host(logToConsole: false) { ServiceName = args.ServiceName })
+            using (var service = new Host() { ServiceName = args.ServiceName })
             {
                 service.RunAsService();
             }
@@ -31,7 +33,7 @@
 
         static async Task RunAsConsole(HostArguments args)
         {
-            using (var service = new Host(logToConsole: true) { ServiceName = args.ServiceName })
+            using (var service = new Host() { ServiceName = args.ServiceName })
             {
                 var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 service.OnStopping = () =>

--- a/src/ServiceControl/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/RunCommand.cs
@@ -8,26 +8,30 @@
     {
         public override async Task Execute(HostArguments args)
         {
-            if (!args.Portable && !Environment.UserInteractive) // Windows Service
+            var consoleSession = args.Portable || Environment.UserInteractive;
+            if (consoleSession)
             {
-                RunNonBlocking(args);
+                // Regular console (interactive) & Docker (non-interactive)
+                await RunAsConsole(args).ConfigureAwait(false);
             }
-
-            // Interactive or non-interactive portable (e.g. docker)
-            await RunAndWait(args).ConfigureAwait(false);
-        }
-
-        static void RunNonBlocking(HostArguments args)
-        {
-            using (var service = new Host(false) { ServiceName = args.ServiceName })
+            else
             {
-                service.Run();
+                // Windows Service
+                RunAsService(args);
             }
         }
 
-        static async Task RunAndWait(HostArguments args)
+        static void RunAsService(HostArguments args)
         {
-            using (var service = new Host(true) { ServiceName = args.ServiceName })
+            using (var service = new Host(logToConsole: false) { ServiceName = args.ServiceName })
+            {
+                service.RunAsService();
+            }
+        }
+
+        static async Task RunAsConsole(HostArguments args)
+        {
+            using (var service = new Host(logToConsole: true) { ServiceName = args.ServiceName })
             {
                 var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 service.OnStopping = () =>
@@ -36,7 +40,7 @@
                     completionSource.TrySetResult(true);
                 };
 
-                service.Run();
+                service.RunAsConsole();
 
                 var r = new CancelWrapper(completionSource, service);
                 Console.CancelKeyPress += r.ConsoleOnCancelKeyPress;

--- a/src/ServiceControl/Hosting/Host.cs
+++ b/src/ServiceControl/Hosting/Host.cs
@@ -7,11 +7,6 @@
 
     class Host : ServiceBase
     {
-        public Host(bool logToConsole)
-        {
-            this.logToConsole = logToConsole;
-        }
-
         public void RunAsConsole()
         {
             OnStart(null);
@@ -28,13 +23,11 @@
             var assemblyScanner = busConfiguration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
 
-            var loggingSettings = new LoggingSettings(ServiceName, logToConsole);
-
             var settings = new Settings(ServiceName)
             {
                 RunCleanupBundle = true
             };
-            bootstrapper = new Bootstrapper(settings, busConfiguration, loggingSettings);
+            bootstrapper = new Bootstrapper(settings, busConfiguration, LoggingConfigurator.Settings);
             bootstrapper.Start().GetAwaiter().GetResult();
         }
 
@@ -52,7 +45,6 @@
 
         internal Action OnStopping = () => { };
 
-        bool logToConsole;
         Bootstrapper bootstrapper;
     }
 }

--- a/src/ServiceControl/Hosting/Host.cs
+++ b/src/ServiceControl/Hosting/Host.cs
@@ -12,26 +12,14 @@
             this.logToConsole = logToConsole;
         }
 
-        public void Run()
-        {
-            if (logToConsole)
-            {
-                RunInteractive();
-            }
-            else
-            {
-                RunAsService();
-            }
-        }
-
-        void RunInteractive()
+        public void RunAsConsole()
         {
             OnStart(null);
         }
 
-        void RunAsService()
+        public void RunAsService()
         {
-            Run(this);
+            ServiceBase.Run(this); 
         }
 
         protected override void OnStart(string[] args)

--- a/src/ServiceControl/LoggingConfigurator.cs
+++ b/src/ServiceControl/LoggingConfigurator.cs
@@ -1,5 +1,6 @@
 namespace Particular.ServiceControl
 {
+    using System;
     using System.IO;
     using System.Linq;
     using NLog.Config;
@@ -12,8 +13,13 @@ namespace Particular.ServiceControl
 
     static class LoggingConfigurator
     {
+        public static LoggingSettings Settings { get; internal set; }
+
         public static void ConfigureLogging(LoggingSettings loggingSettings)
         {
+            if (Settings != null) new InvalidOperationException("Logging already initialized");
+            Settings = loggingSettings;
+
             LogManager.Use<NLogFactory>();
 
             const long megaByte = 1024 * 1024;

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -22,7 +22,9 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName, false);
+            var logToConsole = Environment.UserInteractive || arguments.Portable;
+
+            var loggingSettings = new LoggingSettings(arguments.ServiceName, logToConsole);
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             await new CommandRunner(arguments.Commands).Execute(arguments)

--- a/src/ServiceControl/SetupBootstrapper.cs
+++ b/src/ServiceControl/SetupBootstrapper.cs
@@ -40,8 +40,7 @@ namespace Particular.ServiceControl
             var transportSettings = MapSettings(settings);
             containerBuilder.RegisterInstance(transportSettings).SingleInstance();
 
-            var loggingSettings = new LoggingSettings(settings.ServiceName, false);
-            containerBuilder.RegisterInstance(loggingSettings).SingleInstance();
+            containerBuilder.RegisterInstance(LoggingConfigurator.Settings).SingleInstance();
             var documentStore = new EmbeddableDocumentStore();
             containerBuilder.RegisterInstance(documentStore).As<IDocumentStore>().ExternallyOwned();
             containerBuilder.RegisterInstance(settings).SingleInstance();
@@ -49,7 +48,7 @@ namespace Particular.ServiceControl
             using (documentStore)
             using (var container = containerBuilder.Build())
             {
-                await NServiceBusFactory.Create(settings, settings.LoadTransportCustomization(), transportSettings, loggingSettings, container, documentStore, configuration, false)
+                await NServiceBusFactory.Create(settings, settings.LoadTransportCustomization(), transportSettings, LoggingConfigurator.Settings, container, documentStore, configuration, false)
                     .ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
Fixes #2031
Fixes #2002
Fixes #2017

User reported in #2031 that windows service control manager behaved strangely. Testing this indicated it was not run as a service resulting in this strange behavior. While fixing this I noticed that logging was initialized early while 'the print to console' setting was set after logging was already initialized.
