### PR TITLE
Fix audit instances to start under Local System account

### DIFF
--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -124,7 +124,6 @@ namespace ServiceControl.AcceptanceTests.TestSupport
             setSettings(settings);
             Settings = settings;
             var configuration = new EndpointConfiguration(instanceName);
-            configuration.EnableInstallers();
 
             configuration.GetSettings().Set("SC.ScenarioContext", context);
             configuration.GetSettings().Set(context);
@@ -176,6 +175,12 @@ namespace ServiceControl.AcceptanceTests.TestSupport
                 var httpClient = new HttpClient(Handler);
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 HttpClient = httpClient;
+            }
+
+            using (new DiagnosticTimer($"Creating infrastructure for {instanceName}"))
+            {
+                var setupBootstrapper = new SetupBootstrapper(settings, excludeAssemblies: new []{ typeof(IComponentBehavior).Assembly.GetName().Name });
+                await setupBootstrapper.Run(null);
             }
 
             using (new DiagnosticTimer($"Creating and starting Bus for {instanceName}"))

--- a/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -181,9 +181,9 @@ namespace ServiceControl.Audit.AcceptanceTests.TestSupport
                 HttpClient = httpClient;
             }
 
-            using (new DiagnosticTimer($"Creating queues for {instanceName}"))
+            using (new DiagnosticTimer($"Creating infrastructure for {instanceName}"))
             {
-                var setupBootstrapper = new SetupBootstrapper(settings);
+                var setupBootstrapper = new SetupBootstrapper(settings, excludeAssemblies: new []{ typeof(IComponentBehavior).Assembly.GetName().Name });
                 await setupBootstrapper.Run(null);
             }
 

--- a/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
@@ -9,6 +9,7 @@ namespace ServiceControl.Audit.Infrastructure
     using Contracts.MessageFailures;
     using NServiceBus;
     using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.Features;
     using Raven.Client.Embedded;
     using Settings;
     using Transports;
@@ -43,6 +44,9 @@ namespace ServiceControl.Audit.Infrastructure
 
             configuration.GetSettings().Set(loggingSettings);
             configuration.SetDiagnosticsPath(loggingSettings.LogPath);
+
+            // sagas are not auto-disabled for send-only endpoints
+            configuration.DisableFeature<Sagas>();
 
             configuration.UseSerialization<NewtonsoftSerializer>();
 

--- a/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
@@ -71,7 +71,7 @@ namespace ServiceControl.Audit.Infrastructure
             using (documentStore)
             using (var container = containerBuilder.Build())
             {
-                await NServiceBusFactory.Create(settings, settings.LoadTransportCustomization(), transportSettings, loggingSettings, container, ctx => { },documentStore, configuration, false)
+                await NServiceBusFactory.Create(settings, transportCustomization, transportSettings, loggingSettings, container, ctx => { },documentStore, configuration, false)
                     .ConfigureAwait(false);
             }
         }

--- a/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
@@ -13,8 +13,9 @@ namespace ServiceControl.Audit.Infrastructure
 
     class SetupBootstrapper
     {
-        public SetupBootstrapper(Settings.Settings settings)
+        public SetupBootstrapper(Settings.Settings settings, string[] excludeAssemblies = null)
         {
+            this.excludeAssemblies = excludeAssemblies;
             this.settings = settings;
         }
 
@@ -49,6 +50,10 @@ namespace ServiceControl.Audit.Infrastructure
             var configuration = new EndpointConfiguration(settings.ServiceName);
             var assemblyScanner = configuration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
+            if (excludeAssemblies != null)
+            {
+                assemblyScanner.ExcludeAssemblies(excludeAssemblies);
+            }
 
             configuration.EnableInstallers(username);
 
@@ -90,5 +95,6 @@ namespace ServiceControl.Audit.Infrastructure
         private readonly Settings.Settings settings;
 
         private static ILog log = LogManager.GetLogger<SetupBootstrapper>();
+        string[] excludeAssemblies;
     }
 }

--- a/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
@@ -40,6 +40,7 @@ namespace ServiceBus.Management.Infrastructure
             configuration.DisableFeature<AutoSubscribe>();
             configuration.DisableFeature<TimeoutManager>();
             configuration.DisableFeature<Outbox>();
+            configuration.DisableFeature<Sagas>();
 
             var recoverability = configuration.Recoverability();
             recoverability.Immediate(c => c.NumberOfRetries(3));

--- a/src/ServiceControl/SetupBootstrapper.cs
+++ b/src/ServiceControl/SetupBootstrapper.cs
@@ -13,8 +13,9 @@ namespace Particular.ServiceControl
 
     class SetupBootstrapper
     {
-        public SetupBootstrapper(Settings settings)
+        public SetupBootstrapper(Settings settings, string[] excludeAssemblies = null)
         {
+            this.excludeAssemblies = excludeAssemblies;
             this.settings = settings;
         }
 
@@ -23,6 +24,10 @@ namespace Particular.ServiceControl
             var configuration = new EndpointConfiguration(settings.ServiceName);
             var assemblyScanner = configuration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
+            if (excludeAssemblies != null)
+            {
+                assemblyScanner.ExcludeAssemblies(excludeAssemblies);
+            }
 
             configuration.EnableInstallers(username);
 
@@ -53,7 +58,7 @@ namespace Particular.ServiceControl
                     .ConfigureAwait(false);
             }
         }
-        
+
         static TransportSettings MapSettings(Settings settings)
         {
             var transportSettings = new TransportSettings
@@ -68,5 +73,6 @@ namespace Particular.ServiceControl
         private readonly Settings settings;
 
         private static ILog log = LogManager.GetLogger<SetupBootstrapper>();
+        string[] excludeAssemblies;
     }
 }


### PR DESCRIPTION
Fixes #2047

Reintroduces running the send-only endpoint of ServiceControl.Audit with installers enabled in the `SetupBootstrapper` to make sure all required infrastructure is created including `RavenBoostrapper` which relies on `INeedInitialization`. Ideally ServiceControl.Audit Host should be in charge of creating and orchestrating the startup process and not NServiceBus. For historic reasons NServiceBus was in charge and still is so we went for still relying on `INeedInitialization`. Embarking a journey of refactoring the startup of ServiceControl is not a risk we were willing to take.

This PR also aligns the acceptance test components to rely on the setup bootstrappers to create the necessary infrastructure. In order to make sure assembly scanning doesn't discover additional assemblies that can cause undesired side effects the setup bootstrapper can be configured with additional optional exclusions