### PR TITLE
Fix audit instances to start under Local Service account

### DIFF
--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -124,7 +124,6 @@ namespace ServiceControl.AcceptanceTests.TestSupport
             setSettings(settings);
             Settings = settings;
             var configuration = new EndpointConfiguration(instanceName);
-            configuration.EnableInstallers();
 
             configuration.GetSettings().Set("SC.ScenarioContext", context);
             configuration.GetSettings().Set(context);
@@ -176,6 +175,12 @@ namespace ServiceControl.AcceptanceTests.TestSupport
                 var httpClient = new HttpClient(Handler);
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 HttpClient = httpClient;
+            }
+
+            using (new DiagnosticTimer($"Creating infrastructure for {instanceName}"))
+            {
+                var setupBootstrapper = new SetupBootstrapper(settings, excludeAssemblies: new []{ typeof(IComponentBehavior).Assembly.GetName().Name });
+                await setupBootstrapper.Run(null);
             }
 
             using (new DiagnosticTimer($"Creating and starting Bus for {instanceName}"))

--- a/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -181,9 +181,9 @@ namespace ServiceControl.Audit.AcceptanceTests.TestSupport
                 HttpClient = httpClient;
             }
 
-            using (new DiagnosticTimer($"Creating queues for {instanceName}"))
+            using (new DiagnosticTimer($"Creating infrastructure for {instanceName}"))
             {
-                var setupBootstrapper = new SetupBootstrapper(settings);
+                var setupBootstrapper = new SetupBootstrapper(settings, excludeAssemblies: new []{ typeof(IComponentBehavior).Assembly.GetName().Name });
                 await setupBootstrapper.Run(null);
             }
 

--- a/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
@@ -9,6 +9,7 @@ namespace ServiceControl.Audit.Infrastructure
     using Contracts.MessageFailures;
     using NServiceBus;
     using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.Features;
     using Raven.Client.Embedded;
     using Settings;
     using Transports;
@@ -43,6 +44,9 @@ namespace ServiceControl.Audit.Infrastructure
 
             configuration.GetSettings().Set(loggingSettings);
             configuration.SetDiagnosticsPath(loggingSettings.LogPath);
+
+            // sagas are not auto-disabled for send-only endpoints
+            configuration.DisableFeature<Sagas>();
 
             configuration.UseSerialization<NewtonsoftSerializer>();
 

--- a/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
@@ -2,14 +2,20 @@ namespace ServiceControl.Audit.Infrastructure
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Autofac;
+    using NServiceBus;
     using NServiceBus.Logging;
     using NServiceBus.Raw;
+    using Raven.Client;
+    using Raven.Client.Embedded;
+    using Settings;
     using Transports;
 
     class SetupBootstrapper
     {
-        public SetupBootstrapper(Settings.Settings settings)
+        public SetupBootstrapper(Settings.Settings settings, string[] excludeAssemblies = null)
         {
+            this.excludeAssemblies = excludeAssemblies;
             this.settings = settings;
         }
 
@@ -40,6 +46,39 @@ namespace ServiceControl.Audit.Infrastructure
 
             //No need to start the raw endpoint to create queues
             await RawEndpoint.Create(config).ConfigureAwait(false);
+
+            var configuration = new EndpointConfiguration(settings.ServiceName);
+            var assemblyScanner = configuration.AssemblyScanner();
+            assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
+            if (excludeAssemblies != null)
+            {
+                assemblyScanner.ExcludeAssemblies(excludeAssemblies);
+            }
+
+            configuration.EnableInstallers(username);
+
+            if (settings.SkipQueueCreation)
+            {
+                log.Info("Skipping queue creation");
+                configuration.DoNotCreateQueues();
+            }
+
+            var containerBuilder = new ContainerBuilder();
+
+            containerBuilder.RegisterInstance(transportSettings).SingleInstance();
+
+            var loggingSettings = new LoggingSettings(settings.ServiceName);
+            containerBuilder.RegisterInstance(loggingSettings).SingleInstance();
+            var documentStore = new EmbeddableDocumentStore();
+            containerBuilder.RegisterInstance(documentStore).As<IDocumentStore>().ExternallyOwned();
+            containerBuilder.RegisterInstance(settings).SingleInstance();
+
+            using (documentStore)
+            using (var container = containerBuilder.Build())
+            {
+                await NServiceBusFactory.Create(settings, transportCustomization, transportSettings, loggingSettings, container, ctx => { },documentStore, configuration, false)
+                    .ConfigureAwait(false);
+            }
         }
 
         static TransportSettings MapSettings(Settings.Settings settings)
@@ -56,5 +95,6 @@ namespace ServiceControl.Audit.Infrastructure
         private readonly Settings.Settings settings;
 
         private static ILog log = LogManager.GetLogger<SetupBootstrapper>();
+        string[] excludeAssemblies;
     }
 }

--- a/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
@@ -40,6 +40,7 @@ namespace ServiceBus.Management.Infrastructure
             configuration.DisableFeature<AutoSubscribe>();
             configuration.DisableFeature<TimeoutManager>();
             configuration.DisableFeature<Outbox>();
+            configuration.DisableFeature<Sagas>();
 
             var recoverability = configuration.Recoverability();
             recoverability.Immediate(c => c.NumberOfRetries(3));

--- a/src/ServiceControl/SetupBootstrapper.cs
+++ b/src/ServiceControl/SetupBootstrapper.cs
@@ -13,8 +13,9 @@ namespace Particular.ServiceControl
 
     class SetupBootstrapper
     {
-        public SetupBootstrapper(Settings settings)
+        public SetupBootstrapper(Settings settings, string[] excludeAssemblies = null)
         {
+            this.excludeAssemblies = excludeAssemblies;
             this.settings = settings;
         }
 
@@ -23,6 +24,10 @@ namespace Particular.ServiceControl
             var configuration = new EndpointConfiguration(settings.ServiceName);
             var assemblyScanner = configuration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
+            if (excludeAssemblies != null)
+            {
+                assemblyScanner.ExcludeAssemblies(excludeAssemblies);
+            }
 
             configuration.EnableInstallers(username);
 
@@ -53,7 +58,7 @@ namespace Particular.ServiceControl
                     .ConfigureAwait(false);
             }
         }
-        
+
         static TransportSettings MapSettings(Settings settings)
         {
             var transportSettings = new TransportSettings
@@ -68,5 +73,6 @@ namespace Particular.ServiceControl
         private readonly Settings settings;
 
         private static ILog log = LogManager.GetLogger<SetupBootstrapper>();
+        string[] excludeAssemblies;
     }
 }


### PR DESCRIPTION
Backport of #2043 to `release-4.10` branch
Fixes #2047

## Who's affected

Customers trying to install or upgrade to ServiceControl 4.7 and higher with the Local Service account

## Symptoms

When trying to install ServiceControl 4.7 and higher with the Local Service Account the installation or upgrade will not succeed due to ServiceControl Audit not starting. 

The event log might show

```
Application: ServiceControl.Audit.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: Microsoft.Isam.Esent.Interop.EsentTempPathInUseException
   at Microsoft.Isam.Esent.Interop.Api.JetInit(Microsoft.Isam.Esent.Interop.JET_INSTANCE ByRef)
   at Raven.Storage.Esent.TransactionalStorage.Initialize(Raven.Database.Impl.IUuidGenerator, Raven.Abstractions.MEF.OrderedPartCollection`1<Raven.Database.Plugins.AbstractDocumentCodec>, System.Action`1<System.String>, System.Action`2<System.Object,System.Exception>)
```

the detailed exception contains

```
System.InvalidOperationException
  HResult=0x80131509
  Message=Could not open transactional storage: C:\ProgramData\Particular\ServiceControl\ServiceControl.Audit\DB\Data
  Source=<Cannot evaluate the exception source>
  StackTrace:
<Cannot evaluate the exception stack trace>
Inner Exception 1:
EsentTempPathInUseException: Temp path already used by another database instance
```

