### PR TITLE
Disable InMemoryIndexing on EndpointsIndex

### DIFF
--- a/src/ServiceControl.Audit/Monitoring/KnownEndpoints/EndpointsIndex.cs
+++ b/src/ServiceControl.Audit/Monitoring/KnownEndpoints/EndpointsIndex.cs
@@ -30,6 +30,8 @@ namespace ServiceControl.Audit.Monitoring
                     HostId = first.HostId,
                     Name = first.Name
                 };
+
+            DisableInMemoryIndexing = true;
         }
     }
 }


### PR DESCRIPTION
RunInMemory means the whole index is stored in memory and is redone from scratch when the server restarts. That makes no sense for any of our indexes. Not even for the endpoint index because it would mean the endpoint index has to run through the entire processed message collection again. In addition to that it unnecessarily increases the memory pressure.