### PR TITLE
Large object heap starts above 85000 bytes and not above 85 KB

### DIFF
--- a/src/ServiceControl.Audit/Auditing/BodyStorage/BodyStorageFeature.cs
+++ b/src/ServiceControl.Audit/Auditing/BodyStorage/BodyStorageFeature.cs
@@ -73,7 +73,7 @@
                 var isBinary = contentType.Contains("binary");
                 var isBelowMaxSize = bodySize <= settings.MaxBodySizeToStore;
                 var avoidsLargeObjectHeap = bodySize < LargeObjectHeapThreshold;
-                
+
                 if (isBelowMaxSize && avoidsLargeObjectHeap && !isBinary)
                 {
                     metadata.Add("Body", Encoding.UTF8.GetString(body));
@@ -102,7 +102,8 @@
             IBodyStorage bodyStorage;
             Settings settings;
 
-            internal const int LargeObjectHeapThreshold = 85 * 1024;
+            // large object heap starts above 85000 bytes and not above 85 KB!
+            internal const int LargeObjectHeapThreshold = 85 * 1000;
         }
     }
 }

--- a/src/ServiceControl/Operations/BodyStorage/BodyStorageFeature.cs
+++ b/src/ServiceControl/Operations/BodyStorage/BodyStorageFeature.cs
@@ -86,7 +86,8 @@
             }
 
             IBodyStorage bodyStorage;
-            static int LargeObjectHeapThreshold = 85 * 1024;
+            // large object heap starts above 85000 bytes and not above 85 KB!
+            internal const int LargeObjectHeapThreshold = 85 * 1000;
         }
     }
 }


### PR DESCRIPTION
> If an object is greater than or equal to 85,000 bytes in size, it’s considered a large object. This number was determined by performance tuning. When an object allocation request is for 85,000 or more bytes, the runtime allocates it on the large object heap.

https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/large-object-heap#how-an-object-ends-up-on-the-loh