### PR TITLE
Prevent endpoints from reappearing after removal

### DIFF
--- a/src/ServiceControl.UnitTests/Monitoring/EndpointInstanceMonitoringTests.cs
+++ b/src/ServiceControl.UnitTests/Monitoring/EndpointInstanceMonitoringTests.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+using ServiceControl.Infrastructure.DomainEvents;
+using ServiceControl.Monitoring;
+using System;
+using System.Threading.Tasks;
+
+namespace ServiceControl.UnitTests.Monitoring
+{
+    class EndpointInstanceMonitoringTests
+    {
+        [Test]
+        public async Task When_endpoint_removed_should_stay_removed()
+        {
+            var monitor = new EndpointInstanceMonitoring(new FakeDomainEvents());
+
+            var monitoredEndpoint = new EndpointInstanceId("MonitoredEndpoint", "HostName", Guid.NewGuid());
+            var lastHeartbeat = DateTime.UtcNow;
+
+            monitor.RecordHeartbeat(monitoredEndpoint, lastHeartbeat);
+            await monitor.CheckEndpoints(lastHeartbeat);
+
+            Assert.IsTrue(monitor.HasEndpoint(monitoredEndpoint.UniqueId), "Monitored Endpoint should be recorded");
+
+            monitor.RemoveEndpoint(monitoredEndpoint.UniqueId);
+
+            Assert.IsFalse(monitor.HasEndpoint(monitoredEndpoint.UniqueId), "Monitored Endpoint should be removed");
+
+            await monitor.CheckEndpoints(lastHeartbeat);
+
+            Assert.IsFalse(monitor.HasEndpoint(monitoredEndpoint.UniqueId), "Monitored Endpoint should not be added back");
+        }
+
+        class FakeDomainEvents : IDomainEvents
+        {
+            public Task Raise<T>(T domainEvent) where T : IDomainEvent
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/ServiceControl/Monitoring/EndpointInstanceMonitoring.cs
+++ b/src/ServiceControl/Monitoring/EndpointInstanceMonitoring.cs
@@ -127,6 +127,11 @@ namespace ServiceControl.Monitoring
 
         public void RemoveEndpoint(Guid endpointId)
         {
+            var heartbeat = heartbeats.Keys.SingleOrDefault(t => t.UniqueId == endpointId);
+            if(heartbeat != null)
+            {
+                heartbeats.TryRemove(heartbeat, out var _);
+            }
             endpoints.TryRemove(endpointId, out _);
         }
 


### PR DESCRIPTION
Fixes #2026

Removes the record of heartbeats so that the endpoint doesn't get recreated on the next sweep.

Note that we will still recreate the endpoint if it is sending heartbeats. The theory is that if it is sending heartbeats then it should be monitored. There can be a delay between when the endpoint stops sending heartbeats and the last heartbeat is recorded. This is due to the fact that the heartbeats go via the transport and may be in-flight when the endpoint is removed from the list.