### PR TITLE
Remove FailedMessageRetry when message is successfully retried

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/FailedMessageRetriesController.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/FailedMessageRetriesController.cs
@@ -1,13 +1,10 @@
 ﻿namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
 {
-    using System;
     using System.Net;
     using System.Net.Http;
-    using System.Threading;
     using System.Threading.Tasks;
     using System.Web.Http;
     using Infrastructure.WebApi;
-    using Operations;
     using Raven.Client;
     using ServiceControl.Recoverability;
 
@@ -25,20 +22,18 @@
 
         [Route("failedmessageretries/count")]
         [HttpGet]
-        public async Task<HttpResponseMessage> GetFailedMessageRetriesCount()
+        public Task<HttpResponseMessage> GetFailedMessageRetriesCount()
         {
             using (var session = store.OpenAsyncSession())
             {
                 var query =
                     session.Query<FailedMessageRetry>().Statistics(out var stats);
 
-                var count = await query.CountAsync();
-
-                return Request.CreateResponse(HttpStatusCode.OK, new FailedMessageRetriesCountReponse
+                return Task.FromResult(Request.CreateResponse(HttpStatusCode.OK, new FailedMessageRetriesCountReponse
                 {
-                    Count = count
+                    Count = stats.TotalResults
                 })
-                .WithEtag(stats);
+                .WithEtag(stats));
             }
         }
 

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/FailedMessageRetriesController.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/FailedMessageRetriesController.cs
@@ -1,0 +1,47 @@
+﻿namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Web.Http;
+    using Infrastructure.WebApi;
+    using Operations;
+    using Raven.Client;
+    using ServiceControl.Recoverability;
+
+    public class FailedMessageRetriesCountReponse
+    {
+        public int Count { get; set; }
+    }
+
+    public class FailedMessageRetriesController : ApiController
+    {
+        internal FailedMessageRetriesController(IDocumentStore store)
+        {
+            this.store = store;
+        }
+
+        [Route("failedmessageretries/count")]
+        [HttpGet]
+        public async Task<HttpResponseMessage> GetFailedMessageRetriesCount()
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var query =
+                    session.Query<FailedMessageRetry>().Statistics(out var stats);
+
+                var count = await query.CountAsync();
+
+                return Request.CreateResponse(HttpStatusCode.OK, new FailedMessageRetriesCountReponse
+                {
+                    Count = count
+                })
+                .WithEtag(stats);
+            }
+        }
+
+        readonly IDocumentStore store;
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
@@ -64,7 +64,7 @@
                 })
                 .Run();
 
-            Assert.AreEqual(failedMessageRetries.Count, 0, "FaileMessageRetries not removed");
+            Assert.AreEqual(failedMessageRetries.Count, 0, "FailedMessageRetries not removed");
         }
 
         [Test]

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
@@ -118,7 +118,7 @@
                     c.ReportSuccessfulRetriesToServiceControl();
 
                     var recoverability = c.Recoverability();
-                    recoverability.Immediate(s => s.NumberOfRetries(1));
+                    recoverability.Immediate(s => s.NumberOfRetries(0));
                     recoverability.Delayed(s => s.NumberOfRetries(0));
                 });
             }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
@@ -1,0 +1,125 @@
+﻿namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Infrastructure;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Features;
+    using NServiceBus.Settings;
+    using NUnit.Framework;
+    using ServiceControl.MessageFailures;
+    using TestSupport.EndpointTemplates;
+
+    class When_a_failed_message_is_retried : AcceptanceTest
+    {
+        [Test]
+        public async Task Should_remove_failedmessageretries_for_the_retry()
+        {
+            FailedMessageRetriesCountReponse failedMessageRetries = null;
+
+            await Define<Context>()
+                .WithEndpoint<FailingEndpoint>(b => b.When(async ctx =>
+                {
+                    if (ctx.UniqueMessageId == null)
+                    {
+                        return false;
+                    }
+
+                    return await this.TryGet<FailedMessage>($"/api/errors/{ctx.UniqueMessageId}");
+                }, async (bus, ctx) =>
+                {
+                    ctx.AboutToSendRetry = true;
+                    await this.Post<object>($"/api/errors/{ctx.UniqueMessageId}/retry");
+                }).DoNotFailOnErrorMessages())
+                .Done(async ctx =>
+                {
+                    if (ctx.Retried)
+                    {
+                        failedMessageRetries = await this.TryGet<FailedMessageRetriesCountReponse>("/api/failedmessageretries/count");
+                        return true;
+                    }
+
+                    return false;
+                })
+                .Run();
+
+            Assert.AreEqual(failedMessageRetries.Count, 0, "FaileMessageRetries not removed");
+        }
+
+        public class FailingEndpoint : EndpointConfigurationBuilder
+        {
+            public FailingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.EnableFeature<Outbox>();
+
+                    var recoverability = c.Recoverability();
+                    recoverability.Immediate(s => s.NumberOfRetries(1));
+                    recoverability.Delayed(s => s.NumberOfRetries(0));
+                });
+            }
+
+            class StartFeature : Feature
+            {
+                public StartFeature()
+                {
+                    EnableByDefault();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    context.RegisterStartupTask(new SendMessageAtStart());
+                }
+
+                class SendMessageAtStart : FeatureStartupTask
+                {
+                    protected override Task OnStart(IMessageSession session)
+                    {
+                        return session.SendLocal(new MyMessage());
+                    }
+
+                    protected override Task OnStop(IMessageSession session)
+                    {
+                        return Task.FromResult(0);
+                    }
+                }
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+                public ReadOnlySettings Settings { get; set; }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    Console.WriteLine("Message Handled");
+                    if (Context.AboutToSendRetry)
+                    {
+                        Context.Retried = true;
+                    }
+                    else
+                    {
+                        Context.UniqueMessageId = DeterministicGuid.MakeId(context.MessageId, Settings.EndpointName()).ToString();
+                        throw new Exception("Simulated Exception");
+                    }
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string UniqueMessageId { get; set; }
+            public bool Retried { get; set; }
+            public bool AboutToSendRetry { get; set; }
+        }
+
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -12,6 +12,7 @@ namespace ServiceControl.AcceptanceTests.TestSupport
     using System.Security.AccessControl;
     using System.Security.Principal;
     using System.Threading.Tasks;
+    using System.Web.Http;
     using AcceptanceTesting;
     using Autofac;
     using Infrastructure.WebApi;
@@ -155,9 +156,10 @@ namespace ServiceControl.AcceptanceTests.TestSupport
                 var loggingSettings = new LoggingSettings(settings.ServiceName, logPath: logPath);
                 bootstrapper = new Bootstrapper(settings, configuration, loggingSettings, builder =>
                 {
-                    builder.RegisterType<FailedErrorsController>().FindConstructorsWith(t => t.GetTypeInfo().DeclaredConstructors.ToArray());
-                    builder.RegisterType<FailedMessageRetriesController>().FindConstructorsWith(t => t.GetTypeInfo().DeclaredConstructors.ToArray());
-                    builder.RegisterType<CriticalErrorTriggerController>().FindConstructorsWith(t => t.GetTypeInfo().DeclaredConstructors.ToArray());
+                    builder.RegisterAssemblyTypes(typeof(FailedErrorsController).Assembly)
+                      .AssignableTo<ApiController>()
+                      .FindConstructorsWith(t => t.GetTypeInfo().DeclaredConstructors.ToArray())
+                      .AsSelf();
                 });
                 bootstrapper.HttpClientFactory = HttpClientFactory;
             }

--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -156,6 +156,7 @@ namespace ServiceControl.AcceptanceTests.TestSupport
                 bootstrapper = new Bootstrapper(settings, configuration, loggingSettings, builder =>
                 {
                     builder.RegisterType<FailedErrorsController>().FindConstructorsWith(t => t.GetTypeInfo().DeclaredConstructors.ToArray());
+                    builder.RegisterType<FailedMessageRetriesController>().FindConstructorsWith(t => t.GetTypeInfo().DeclaredConstructors.ToArray());
                     builder.RegisterType<CriticalErrorTriggerController>().FindConstructorsWith(t => t.GetTypeInfo().DeclaredConstructors.ToArray());
                 });
                 bootstrapper.HttpClientFactory = HttpClientFactory;


### PR DESCRIPTION
A partial fix for #2019 

The FailedMessageRetry document collection is used for the Pending Retries screen, but it seems that the entries here are only cleared when a messages is a repeated failure. When a message is successfully re-processed and ServiceControl receives and audit message confirming it, it should remove the corresponding entry so that the collection does not end up being unbounded in size.