### PR TITLE
Stop retry history from growing constantly

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
@@ -12,6 +12,7 @@
     using NServiceBus.Settings;
     using NUnit.Framework;
     using ServiceControl.MessageFailures;
+    using ServiceControl.Recoverability;
     using TestSupport;
     using TestSupport.EndpointTemplates;
 

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -98,6 +99,47 @@
                 .Run();
 
             Assert.AreEqual(failedMessageRetries.Count, 0, "FaileMessageRetries not removed");
+        }
+
+        [Test]
+        public async Task Should_remove_UnacknowledgedOperation_when_retrying_individual_messages()
+        {
+            RetryHistory retryHistory = null;
+
+            await Define<Context>()
+                .WithEndpoint<FailingEndpoint>(b => b.When(async ctx =>
+                {
+                    if (ctx.UniqueMessageId == null)
+                    {
+                        return false;
+                    }
+
+                    FailedMessage failedMessage = await this.TryGet<FailedMessage>($"/api/errors/{ctx.UniqueMessageId}");
+                    if (failedMessage == null)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }, async (bus, ctx) =>
+                {
+                    ctx.AboutToSendRetry = true;
+                    await this.Post<object>("/api/errors/retry", new List<string> { ctx.UniqueMessageId });
+                }).DoNotFailOnErrorMessages())
+                .Done(async ctx =>
+                {
+                    if (ctx.Retried)
+                    {
+                        retryHistory = await this.TryGet<RetryHistory>("/api/recoverability/history");
+
+                        return !retryHistory.UnacknowledgedOperations.Any() && retryHistory.HistoricOperations.Any();
+                    }
+
+                    return false;
+                })
+                .Run();
+
+            Assert.IsEmpty(retryHistory.UnacknowledgedOperations, "Unucknowledged retry operation not removed");
         }
 
         [Test]

--- a/src/ServiceControl/Recoverability/Retrying/History/RetryHistory.cs
+++ b/src/ServiceControl/Recoverability/Retrying/History/RetryHistory.cs
@@ -33,6 +33,10 @@
                 .OrderByDescending(retry => retry.CompletionTime)
                 .Take(historyDepth)
                 .ToList();
+
+            UnacknowledgedOperations = UnacknowledgedOperations
+                .Where(operation => operation.RetryType != RetryType.MultipleMessages && operation.RetryType != RetryType.SingleMessage)
+                .ToList();
         }
 
         public string GetHistoryOperationsUniqueIdentifier()

--- a/src/ServiceControl/Recoverability/Retrying/History/RetryHistory.cs
+++ b/src/ServiceControl/Recoverability/Retrying/History/RetryHistory.cs
@@ -33,10 +33,6 @@
                 .OrderByDescending(retry => retry.CompletionTime)
                 .Take(historyDepth)
                 .ToList();
-
-            UnacknowledgedOperations = UnacknowledgedOperations
-                .Where(operation => operation.RetryType != RetryType.MultipleMessages && operation.RetryType != RetryType.SingleMessage)
-                .ToList();
         }
 
         public string GetHistoryOperationsUniqueIdentifier()
@@ -46,10 +42,12 @@
 
         public void AddToUnacknowledged(UnacknowledgedRetryOperation unacknowledgedRetryOperation)
         {
-            if (unacknowledgedRetryOperation.RetryType != RetryType.MultipleMessages && unacknowledgedRetryOperation.RetryType != RetryType.SingleMessage)
-            {
-                UnacknowledgedOperations.Add(unacknowledgedRetryOperation);
-            }
+            UnacknowledgedOperations.Add(unacknowledgedRetryOperation);
+
+            UnacknowledgedOperations = UnacknowledgedOperations
+                // All other retry types already have an explicit way to dismiss them on the UI
+                .Where(operation => operation.RetryType != RetryType.MultipleMessages && operation.RetryType != RetryType.SingleMessage)
+                .ToList();
         }
 
         public UnacknowledgedRetryOperation[] GetUnacknowledgedByClassifier(string classifier)

--- a/src/ServiceControl/Recoverability/Retrying/History/RetryHistory.cs
+++ b/src/ServiceControl/Recoverability/Retrying/History/RetryHistory.cs
@@ -46,7 +46,10 @@
 
         public void AddToUnacknowledged(UnacknowledgedRetryOperation unacknowledgedRetryOperation)
         {
-            UnacknowledgedOperations.Add(unacknowledgedRetryOperation);
+            if (unacknowledgedRetryOperation.RetryType != RetryType.MultipleMessages && unacknowledgedRetryOperation.RetryType != RetryType.SingleMessage)
+            {
+                UnacknowledgedOperations.Add(unacknowledgedRetryOperation);
+            }
         }
 
         public UnacknowledgedRetryOperation[] GetUnacknowledgedByClassifier(string classifier)

--- a/src/ServiceControl/Recoverability/Retrying/History/StoreHistoryHandler.cs
+++ b/src/ServiceControl/Recoverability/Retrying/History/StoreHistoryHandler.cs
@@ -20,6 +20,19 @@
                 var retryHistory = await session.LoadAsync<RetryHistory>(RetryHistory.MakeId()).ConfigureAwait(false) ??
                                    RetryHistory.CreateNew();
 
+                retryHistory.AddToUnacknowledged(new UnacknowledgedRetryOperation
+                {
+                    RequestId = message.RequestId,
+                    RetryType = message.RetryType,
+                    StartTime = message.StartTime,
+                    CompletionTime = message.CompletionTime,
+                    Originator = message.Originator,
+                    Classifier = message.Classifier,
+                    Failed = message.Failed,
+                    NumberOfMessagesProcessed = message.NumberOfMessagesProcessed,
+                    Last = message.Last
+                });
+
                 retryHistory.AddToHistory(new HistoricRetryOperation
                 {
                     RequestId = message.RequestId,
@@ -30,23 +43,6 @@
                     Failed = message.Failed,
                     NumberOfMessagesProcessed = message.NumberOfMessagesProcessed
                 }, settings.RetryHistoryDepth);
-
-                // No need to store these retry types as there is no UI to acknowledge them
-                if (message.RetryType != RetryType.MultipleMessages && message.RetryType != RetryType.SingleMessage)
-                {
-                    retryHistory.AddToUnacknowledged(new UnacknowledgedRetryOperation
-                    {
-                        RequestId = message.RequestId,
-                        RetryType = message.RetryType,
-                        StartTime = message.StartTime,
-                        CompletionTime = message.CompletionTime,
-                        Originator = message.Originator,
-                        Classifier = message.Classifier,
-                        Failed = message.Failed,
-                        NumberOfMessagesProcessed = message.NumberOfMessagesProcessed,
-                        Last = message.Last
-                    });
-                }
 
                 await session.StoreAsync(retryHistory)
                     .ConfigureAwait(false);

--- a/src/ServiceControl/Recoverability/Retrying/History/StoreHistoryHandler.cs
+++ b/src/ServiceControl/Recoverability/Retrying/History/StoreHistoryHandler.cs
@@ -31,18 +31,22 @@
                     NumberOfMessagesProcessed = message.NumberOfMessagesProcessed
                 }, settings.RetryHistoryDepth);
 
-                retryHistory.AddToUnacknowledged(new UnacknowledgedRetryOperation
+                // No need to store these retry types as there is no UI to acknowledge them
+                if (message.RetryType != RetryType.MultipleMessages && message.RetryType != RetryType.SingleMessage)
                 {
-                    RequestId = message.RequestId,
-                    RetryType = message.RetryType,
-                    StartTime = message.StartTime,
-                    CompletionTime = message.CompletionTime,
-                    Originator = message.Originator,
-                    Classifier = message.Classifier,
-                    Failed = message.Failed,
-                    NumberOfMessagesProcessed = message.NumberOfMessagesProcessed,
-                    Last = message.Last
-                });
+                    retryHistory.AddToUnacknowledged(new UnacknowledgedRetryOperation
+                    {
+                        RequestId = message.RequestId,
+                        RetryType = message.RetryType,
+                        StartTime = message.StartTime,
+                        CompletionTime = message.CompletionTime,
+                        Originator = message.Originator,
+                        Classifier = message.Classifier,
+                        Failed = message.Failed,
+                        NumberOfMessagesProcessed = message.NumberOfMessagesProcessed,
+                        Last = message.Last
+                    });
+                }
 
                 await session.StoreAsync(retryHistory)
                     .ConfigureAwait(false);


### PR DESCRIPTION
When individual messages or selections of messages are retried, a operation to reflect that is stored in the RetryHistory document. There is no mechanism in place to acknowledge these retries so the RetryHistory document continues to grow.

This PR addresses this by not storing the individual or selection retries as Unacknowledged retries. Another option could have been to add the UI feature withing ServicePulse to acknowledge these retries. To implement this within ServicePulse would add a lot of complexity to the UI for very little benefit. Individual retries are typically done as a canary or test before retrying entire batches. In this scenario, the entire batch would still have an acknowledgable retry while the individual messages would not. In the case where a user is retrying specific messages without a retry for a full group, the experience is exactly the same as it is now except that the performance of ServiceControl doesn't start degrading over time.