### PR TITLE
Fix retrieval of bodies larger than the large object heap but below the maximum body size to store

### DIFF
--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointLearningTransport.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointLearningTransport.cs
@@ -15,6 +15,7 @@
 
             var transportConfig = configuration.UseTransport<LearningTransport>();
             transportConfig.StorageDirectory(ConnectionString);
+            transportConfig.NoPayloadSizeRestriction();
 
             return Task.FromResult(0);
         }

--- a/src/ServiceControl.Audit/Auditing/GetBodyByIdApi.cs
+++ b/src/ServiceControl.Audit/Auditing/GetBodyByIdApi.cs
@@ -46,6 +46,7 @@
                 content.Headers.ContentLength = result.BodySize;
                 response.Headers.ETag = new EntityTagHeaderValue($"\"{result.Etag}\"");
                 response.Content = content;
+                return response;
             }
 
             return request.CreateResponse(HttpStatusCode.NotFound);
@@ -70,7 +71,12 @@
                 {
                     return request.CreateResponse(HttpStatusCode.NoContent);
                 }
-                    
+
+                if (message.Body == null)
+                {
+                    return request.CreateResponse(HttpStatusCode.NotFound);
+                }
+
                 var response = request.CreateResponse(HttpStatusCode.OK);
                 var content = new StringContent(message.Body);
                 content.Headers.ContentType = MediaTypeHeaderValue.Parse(message.ContentType);


### PR DESCRIPTION
Fixes regression introduced in https://github.com/Particular/ServiceControl/pull/1843

```
            private static readonly byte[] body = Encoding.UTF8.GetBytes($@"<?xml version=""1.0""?>
<MyMessage xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema""
            xmlns=""http://tempuri.net/"">
   <MyProperty>{new string('a', 87 * 1024)}</MyProperty>
</MyMessage>");
```

## Before

![image](https://user-images.githubusercontent.com/174258/89909250-2608d080-dbef-11ea-8713-c4e9a66efda4.png)

## After

![image](https://user-images.githubusercontent.com/174258/89909881-d70f6b00-dbef-11ea-8107-fb937d5f45a4.png)

