### PR TITLE
Fix stopping error and audit ingestion when poison message is received

### DIFF
--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/FailedAuditsController.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/FailedAuditsController.cs
@@ -12,10 +12,10 @@
 
     public class FailedAuditsController : ApiController
     {
-        internal FailedAuditsController(IDocumentStore store, Lazy<ImportFailedAudits> importFailedAudits)
+        internal FailedAuditsController(IDocumentStore store, AuditIngestionComponent auditIngestion)
         {
             this.store = store;
-            this.importFailedAudits = importFailedAudits;
+            this.auditIngestion = auditIngestion;
         }
 
         [Route("failedaudits/count")]
@@ -42,12 +42,12 @@
         public async Task<HttpResponseMessage> ImportFailedAudits(CancellationToken token)
         {
             var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
-            await importFailedAudits.Value.Run(tokenSource.Token);
+            await auditIngestion.ImportFailedAudits(tokenSource.Token);
             return Request.CreateResponse(HttpStatusCode.OK);
         }
 
         readonly IDocumentStore store;
-        readonly Lazy<ImportFailedAudits> importFailedAudits;
+        readonly AuditIngestionComponent auditIngestion;
     }
 
     public class FailedAuditsCountReponse

--- a/src/ServiceControl.Audit/Auditing/AuditIngestionComponent.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestionComponent.cs
@@ -119,7 +119,7 @@
             // will fall out here when writer is completed
         }
 
-        public Task ImportFailedErrors(CancellationToken cancellationToken)
+        public Task ImportFailedAudits(CancellationToken cancellationToken)
         {
             return failedImporter.Run(cancellationToken);
         }

--- a/src/ServiceControl.Audit/Auditing/AuditIngestionFaultPolicy.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestionFaultPolicy.cs
@@ -38,8 +38,6 @@
 
             await StoreFailedMessageDocument(handlingContext.Error)
                 .ConfigureAwait(false);
-            await handlingContext.MoveToErrorQueue(handlingContext.FailedQueue, false)
-                .ConfigureAwait(false);
             return ErrorHandleResult.Handled;
         }
 

--- a/src/ServiceControl.Audit/Auditing/AuditIngestionFaultPolicy.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestionFaultPolicy.cs
@@ -64,7 +64,7 @@
             }
             finally
             {
-                await failureCircuitBreaker.Increment(exception).ConfigureAwait(false);
+                failureCircuitBreaker.Increment(exception);
             }
         }
 

--- a/src/ServiceControl.Audit/Auditing/ImportFailureCircuitBreaker.cs
+++ b/src/ServiceControl.Audit/Auditing/ImportFailureCircuitBreaker.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Infrastructure;
 
     class ImportFailureCircuitBreaker : IDisposable
     {
@@ -23,12 +24,12 @@
             Interlocked.Exchange(ref failureCount, 0);
         }
 
-        public async Task Increment(Exception lastException)
+        public void Increment(Exception lastException)
         {
             var result = Interlocked.Increment(ref failureCount);
             if (result > 50)
             {
-                await onCriticalError("Failed to import too many times", lastException).ConfigureAwait(false);
+                Task.Run(() => onCriticalError("Failed to import too many times", lastException)).Ignore();
             }
         }
 

--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -11,6 +11,7 @@ namespace ServiceControl.Audit.Infrastructure
     using System.Reflection;
     using System.Threading.Tasks;
     using System.Web.Http.Controllers;
+    using Auditing;
     using Auditing.MessagesView;
     using Autofac;
     using Autofac.Core.Activators.Reflection;
@@ -87,6 +88,7 @@ namespace ServiceControl.Audit.Infrastructure
             containerBuilder.Register(c => HttpClientFactory);
             containerBuilder.RegisterModule<ApisModule>();
             containerBuilder.RegisterType<EndpointInstanceMonitoring>().SingleInstance();
+            containerBuilder.RegisterType<AuditIngestionComponent>().SingleInstance();
 
             RegisterInternalWebApiControllers(containerBuilder);
 

--- a/src/ServiceControl.Audit/Infrastructure/BusInstance.cs
+++ b/src/ServiceControl.Audit/Infrastructure/BusInstance.cs
@@ -6,13 +6,13 @@ namespace ServiceControl.Audit.Infrastructure
 
     class BusInstance
     {
-        public BusInstance(IEndpointInstance bus, ImportFailedAudits importFailedAudits)
+        public BusInstance(IEndpointInstance bus, AuditIngestionComponent auditIngestion)
         {
-            ImportFailedAudits = importFailedAudits;
+            AuditIngestion = auditIngestion;
             this.bus = bus;
         }
 
-        public ImportFailedAudits ImportFailedAudits { get; }
+        public AuditIngestionComponent AuditIngestion { get; }
 
         public Task Stop()
         {

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
@@ -25,13 +25,13 @@
                 var loggingSettings = new LoggingSettings(settings.ServiceName, LogLevel.Info, LogLevel.Info);
                 var bootstrapper = new Bootstrapper(ctx => { tokenSource.Cancel(); }, settings, busConfiguration, loggingSettings);
                 var busInstance = await bootstrapper.Start().ConfigureAwait(false);
-                var importer = busInstance.ImportFailedAudits;
+                var importer = busInstance.AuditIngestion;
 
                 Console.CancelKeyPress += (sender, eventArgs) => { tokenSource.Cancel(); };
 
                 try
                 {
-                    await importer.Run(tokenSource.Token).ConfigureAwait(false);
+                    await importer.ImportFailedAudits(tokenSource.Token).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
@@ -88,9 +88,9 @@ namespace ServiceControl.Audit.Infrastructure
 
             builder.Update(container.ComponentRegistry);
 
-            var importFailedAudits = container.Resolve<ImportFailedAudits>();
+            var auditIngestion = container.Resolve<AuditIngestionComponent>();
 
-            return new BusInstance(endpointInstance, importFailedAudits);
+            return new BusInstance(endpointInstance, auditIngestion);
         }
 
         static bool IsExternalContract(Type t)

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -19,6 +19,7 @@ namespace Particular.ServiceControl
     using global::ServiceControl.Infrastructure.DomainEvents;
     using global::ServiceControl.Infrastructure.SignalR;
     using global::ServiceControl.Monitoring;
+    using global::ServiceControl.Operations;
     using global::ServiceControl.Recoverability;
     using global::ServiceControl.Transports;
     using Microsoft.Owin.Hosting;
@@ -98,6 +99,7 @@ namespace Particular.ServiceControl
 
             containerBuilder.RegisterType<EndpointInstanceMonitoring>().SingleInstance();
             containerBuilder.RegisterType<MonitoringDataPersister>().AsImplementedInterfaces().AsSelf().SingleInstance();
+            containerBuilder.RegisterType<ErrorIngestionComponent>().SingleInstance();
 
             RegisterInternalWebApiControllers(containerBuilder);
 

--- a/src/ServiceControl/Operations/ErrorIngestion.cs
+++ b/src/ServiceControl/Operations/ErrorIngestion.cs
@@ -37,7 +37,7 @@
 
                 rawConfiguration.Settings.Set("onCriticalErrorAction", (Func<ICriticalErrorContext, Task>)OnCriticalErrorAction);
 
-                rawConfiguration.CustomErrorHandlingPolicy(new ErrorIngestionFaultPolicy(importFailuresHandler));
+                rawConfiguration.CustomErrorHandlingPolicy(new ErrorIngestionFaultPolicy(importFailuresHandler, errorQueue));
 
                 var startableRaw = await RawEndpoint.Create(rawConfiguration).ConfigureAwait(false);
 

--- a/src/ServiceControl/Operations/ErrorIngestion.cs
+++ b/src/ServiceControl/Operations/ErrorIngestion.cs
@@ -37,7 +37,7 @@
 
                 rawConfiguration.Settings.Set("onCriticalErrorAction", (Func<ICriticalErrorContext, Task>)OnCriticalErrorAction);
 
-                rawConfiguration.CustomErrorHandlingPolicy(new ErrorIngestionFaultPolicy(importFailuresHandler, errorQueue));
+                rawConfiguration.CustomErrorHandlingPolicy(new ErrorIngestionFaultPolicy(importFailuresHandler));
 
                 var startableRaw = await RawEndpoint.Create(rawConfiguration).ConfigureAwait(false);
 

--- a/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs
+++ b/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs
@@ -6,12 +6,14 @@
 
     class ErrorIngestionFaultPolicy : IErrorHandlingPolicy
     {
-        public ErrorIngestionFaultPolicy(SatelliteImportFailuresHandler importFailuresHandler)
+        public ErrorIngestionFaultPolicy(SatelliteImportFailuresHandler importFailuresHandler, string errorQueue)
         {
             this.importFailuresHandler = importFailuresHandler;
+            this.errorQueue = errorQueue;
         }
 
         SatelliteImportFailuresHandler importFailuresHandler;
+        string errorQueue;
 
         public async Task<ErrorHandleResult> OnError(IErrorHandlingPolicyContext handlingContext, IDispatchMessages dispatcher)
         {
@@ -23,7 +25,7 @@
 
             await importFailuresHandler.Handle(handlingContext.Error)
                 .ConfigureAwait(false);
-            await handlingContext.MoveToErrorQueue(handlingContext.FailedQueue, false)
+            await handlingContext.MoveToErrorQueue(errorQueue, false)
                 .ConfigureAwait(false);
             return ErrorHandleResult.Handled;
         }

--- a/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs
+++ b/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs
@@ -6,14 +6,12 @@
 
     class ErrorIngestionFaultPolicy : IErrorHandlingPolicy
     {
-        public ErrorIngestionFaultPolicy(SatelliteImportFailuresHandler importFailuresHandler, string errorQueue)
+        public ErrorIngestionFaultPolicy(SatelliteImportFailuresHandler importFailuresHandler)
         {
             this.importFailuresHandler = importFailuresHandler;
-            this.errorQueue = errorQueue;
         }
 
         SatelliteImportFailuresHandler importFailuresHandler;
-        string errorQueue;
 
         public async Task<ErrorHandleResult> OnError(IErrorHandlingPolicyContext handlingContext, IDispatchMessages dispatcher)
         {
@@ -24,8 +22,6 @@
             }
 
             await importFailuresHandler.Handle(handlingContext.Error)
-                .ConfigureAwait(false);
-            await handlingContext.MoveToErrorQueue(errorQueue, false)
                 .ConfigureAwait(false);
             return ErrorHandleResult.Handled;
         }

--- a/src/ServiceControl/Operations/ImportFailureCircuitBreaker.cs
+++ b/src/ServiceControl/Operations/ImportFailureCircuitBreaker.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Infrastructure;
 
     class ImportFailureCircuitBreaker : IDisposable
     {
@@ -23,12 +24,12 @@
             Interlocked.Exchange(ref failureCount, 0);
         }
 
-        public async Task Increment(Exception lastException)
+        public void Increment(Exception lastException)
         {
             var result = Interlocked.Increment(ref failureCount);
             if (result > 50)
             {
-                await onCriticalError("Failed to import too many times", lastException).ConfigureAwait(false);
+                Task.Run(() => onCriticalError("Failed to import too many times", lastException)).Ignore();
             }
         }
 

--- a/src/ServiceControl/Operations/SatelliteImportFailuresHandler.cs
+++ b/src/ServiceControl/Operations/SatelliteImportFailuresHandler.cs
@@ -50,7 +50,7 @@
             }
             finally
             {
-                await failureCircuitBreaker.Increment(exception).ConfigureAwait(false);
+                failureCircuitBreaker.Increment(exception);
             }
         }
 

--- a/src/ServiceControl/Operations/Watchdog.cs
+++ b/src/ServiceControl/Operations/Watchdog.cs
@@ -38,10 +38,12 @@
         {
             watchdog = Task.Run(async () =>
             {
+                log.Debug($"Starting watching process {processName}");
                 while (!shutdownTokenSource.IsCancellationRequested)
                 {
                     try
                     {
+                        log.Debug($"Ensuring {processName} is running");
                         await ensureStarted(shutdownTokenSource.Token).ConfigureAwait(false);
                         clearFailure();
                     }
@@ -66,6 +68,7 @@
                 }
                 try
                 {
+                    log.Debug($"Stopping watching process {processName}");
                     //We don't pass the shutdown token here because it has already been cancelled and we want to ensure we stop the ingestion.
                     await ensureStopped(CancellationToken.None).ConfigureAwait(false);
                 }


### PR DESCRIPTION
 - Ensure `onCriticalError` callback is invoked on a separate thread similarly to what NServiceBus does in `CriticalError` class to prevent deadlocks when the critical error is triggered from within message processing code
 - Remove the code that tried to store the message that failed to be ingested in an error queue as this was never intended. The correct behavior of ServiceControl is to store these messages in the RavenDB database
 - Add debug-level logging in the `Watchdog` class
 - Fix command-line audit ingestion by changing the root type resolved from the container