### PR TITLE
`FailedMessage` patch with failure de-duplication by AttemptedAt

### DIFF
--- a/src/ServiceControl/Operations/ErrorPersister.cs
+++ b/src/ServiceControl/Operations/ErrorPersister.cs
@@ -90,6 +90,9 @@
             var failureGroupsField = nameof(FailedMessage.FailureGroups);
             var uniqueMessageIdField = nameof(FailedMessage.UniqueMessageId);
 
+            var serializedGroups = RavenJToken.FromObject(groups);
+            var serializedAttempt = RavenJToken.FromObject(processingAttempt, Serializer);
+
             await store.AsyncDatabaseCommands.PatchAsync(documentId,
                 new ScriptedPatchRequest
                 {
@@ -106,8 +109,8 @@
                     Values = new Dictionary<string, object>
                     {
                         { "status", (int)FailedMessageStatus.Unresolved },
-                        { "failureGroups", RavenJToken.FromObject(groups) },
-                        { "attempt", RavenJToken.FromObject(processingAttempt, Serializer)}
+                        { "failureGroups", serializedGroups },
+                        { "attempt", serializedAttempt}
                     }
                 }, 
                 new ScriptedPatchRequest
@@ -120,8 +123,8 @@
                     Values = new Dictionary<string, object>
                     {
                         { "status", (int)FailedMessageStatus.Unresolved },
-                        { "failureGroups", RavenJToken.FromObject(groups) },
-                        { "attempt", RavenJToken.FromObject(processingAttempt, Serializer)},
+                        { "failureGroups", serializedGroups },
+                        { "attempt", serializedAttempt},
                         { "uniqueMessageId", uniqueMessageId }
                     }
                 },

--- a/src/ServiceControl/Operations/ErrorPersister.cs
+++ b/src/ServiceControl/Operations/ErrorPersister.cs
@@ -80,7 +80,7 @@
             return failureDetails;
         }
 
-        async Task SaveToDb(string uniqueMessageId, FailedMessage.ProcessingAttempt processingAttempt, List<FailedMessage.FailureGroup> groups)
+        Task SaveToDb(string uniqueMessageId, FailedMessage.ProcessingAttempt processingAttempt, List<FailedMessage.FailureGroup> groups)
         {
             var documentId = FailedMessage.MakeDocumentId(uniqueMessageId);
 
@@ -93,7 +93,7 @@
             var serializedGroups = RavenJToken.FromObject(groups);
             var serializedAttempt = RavenJToken.FromObject(processingAttempt, Serializer);
 
-            await store.AsyncDatabaseCommands.PatchAsync(documentId,
+            return store.AsyncDatabaseCommands.PatchAsync(documentId,
                 new ScriptedPatchRequest
                 {
                     Script = $@"this.{statusField} = status;
@@ -128,7 +128,7 @@
                         { "uniqueMessageId", uniqueMessageId }
                     }
                 },
-                JObjectMetadata).ConfigureAwait(false);
+                JObjectMetadata);
         }
 
         IEnrichImportedErrorMessages[] enrichers;


### PR DESCRIPTION
This does de-duplication of the `ProcessingAttempts` based on `TimeOfFailure` value. This is stored to the microsecond so a chance that we will have two failures for the same message happening at the same time (to the microsecond) is slim.

That said there are are two (a least) additional angles to this change:
  * de-duplication based on `TimeOfFailure` is a hack. I think we should introduce a proper `ProcessingAttemptId`
  * I'm not an expert in Raven but my hunch is that Javascript patch might be significantly slower than non-Javascript patch. I propose to do some testing around that

Thoughts?