### PR TITLE
Show warning in log file if disk space is running low

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/CheckFreeDiskSpace.cs
+++ b/src/ServiceControl.Audit/Infrastructure/CheckFreeDiskSpace.cs
@@ -35,9 +35,15 @@
                 Logger.Debug($"Free space: {availableFreeSpace} | Total: {totalSpace} | Percent remaining {percentRemaining:P0}");
             }
 
-            return percentRemaining > percentageThreshold
-                ? CheckResult.Pass
-                : CheckResult.Failed($"{percentRemaining:P0} disk space remaining on data drive '{dataDriveInfo.VolumeLabel} ({dataDriveInfo.RootDirectory})' on '{Environment.MachineName}'.");
+            if (percentRemaining > percentageThreshold)
+            {
+                return CheckResult.Pass;
+            }
+
+            var message = $"{percentRemaining:P0} disk space remaining on data drive '{dataDriveInfo.VolumeLabel} ({dataDriveInfo.RootDirectory})' on '{Environment.MachineName}'.";
+
+            Logger.Warn(message);
+            return CheckResult.Failed(message);
         }
 
         readonly string dataPath;


### PR DESCRIPTION
The custom check sends a warning, but that isn't in log files so customers have to monitor ServicePulse. Showing it in the log file means customers can use log monitors with filters to notify them proactively.