### PR TITLE
Make license management consistent between ServiceControl runtime and SCMU

### DIFF
--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
-    <DefineConstants>$(DefineConstants);REGISTRYLICENSESOURCE</DefineConstants>
     <ApplicationIcon>Operations.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/src/ServiceControl.Monitoring/Licensing/LicenseManager.cs
+++ b/src/ServiceControl.Monitoring/Licensing/LicenseManager.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.Monitoring.Licensing
 {
     using System;
-    using System.IO;
     using NServiceBus.Logging;
     using Particular.Licensing;
 
@@ -13,10 +12,11 @@
         public void Refresh()
         {
             Logger.Debug("Checking License Status");
-            var sources = LicenseSource.GetStandardLicenseSources();
-            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "License", "License.xml")));
-            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ParticularPlatformLicense.xml")));
-            var result = ActiveLicense.Find("ServiceControl", sources.ToArray());
+            var sources = new LicenseSource[]
+            {
+                new LicenseSourceFilePath(LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData))
+            };
+            var result = ActiveLicense.Find("ServiceControl", sources);
 
             if (result.License.HasExpired())
             {

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
-    <DefineConstants>$(DefineConstants);REGISTRYLICENSESOURCE</DefineConstants>
     <ApplicationIcon>Operations.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/src/ServiceControl/Licensing/ActiveLicense.cs
+++ b/src/ServiceControl/Licensing/ActiveLicense.cs
@@ -1,7 +1,6 @@
 ﻿namespace Particular.ServiceControl.Licensing
 {
     using System;
-    using System.IO;
     using NServiceBus.Logging;
     using Particular.Licensing;
 
@@ -19,10 +18,12 @@
         public void Refresh()
         {
             Logger.Debug("Refreshing ActiveLicense");
-            var sources = LicenseSource.GetStandardLicenseSources();
-            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "License", "License.xml")));
-            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ParticularPlatformLicense.xml")));
-            var result = Particular.Licensing.ActiveLicense.Find("ServiceControl", sources.ToArray());
+            var sources = new LicenseSource[]
+            {
+                new LicenseSourceFilePath(LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData))
+            };
+
+            var result = Particular.Licensing.ActiveLicense.Find("ServiceControl", sources);
 
             IsValid = !result.License.HasExpired();
 

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
-    <DefineConstants>$(DefineConstants);REGISTRYLICENSESOURCE</DefineConstants>
     <ApplicationIcon>Operations.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/src/ServiceControlInstaller.Engine/LicenseMgmt/LicenseManager.cs
+++ b/src/ServiceControlInstaller.Engine/LicenseMgmt/LicenseManager.cs
@@ -7,7 +7,11 @@
     {
         public static DetectedLicense FindLicense()
         {
-            var sources = LicenseSource.GetStandardLicenseSources().ToArray();
+            var sources = new LicenseSource[]
+            {
+                new LicenseSourceFilePath(LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData))
+            };
+
             var result = ActiveLicense.Find("ServiceControl", sources);
 
             var detectedLicense = new DetectedLicense(result.Location, LicenseDetails.FromLicense(result.License));

--- a/src/ServiceControlInstaller.Engine/LicenseMgmt/LicenseManager.cs
+++ b/src/ServiceControlInstaller.Engine/LicenseMgmt/LicenseManager.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControlInstaller.Engine.LicenseMgmt
 {
     using System;
-    using Microsoft.Win32;
     using Particular.Licensing;
 
     public class LicenseManager
@@ -43,16 +42,6 @@
             if(license.HasExpired())
             {
                 errorMessage = "Failed to import because the license has expired";
-                return false;
-            }
-
-            try
-            {
-                new RegistryLicenseStore(Registry.LocalMachine).StoreLicense(licenseText);
-            }
-            catch (Exception)
-            {
-                errorMessage = "Failed to import license into the registry";
                 return false;
             }
 

--- a/src/ServiceControlInstaller.Engine/LicenseMgmt/LicenseManager.cs
+++ b/src/ServiceControlInstaller.Engine/LicenseMgmt/LicenseManager.cs
@@ -9,7 +9,7 @@
         {
             var sources = new LicenseSource[]
             {
-                new LicenseSourceFilePath(LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData))
+                new LicenseSourceFilePath(GetMachineLevelLicenseLocation())
             };
 
             var result = ActiveLicense.Find("ServiceControl", sources);
@@ -51,9 +51,7 @@
 
             try
             {
-                var machineLevelLicenseLocation = LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData);
-
-                new FilePathLicenseStore().StoreLicense(machineLevelLicenseLocation, licenseText);
+                new FilePathLicenseStore().StoreLicense(GetMachineLevelLicenseLocation(), licenseText);
             }
             catch (Exception)
             {
@@ -63,6 +61,11 @@
 
             errorMessage = null;
             return true;
+        }
+
+        static string GetMachineLevelLicenseLocation()
+        {
+            return LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData);
         }
 
         static bool TryDeserializeLicense(string licenseText, out License license)

--- a/src/ServiceControlInstaller.Engine/LicenseMgmt/LicenseManager.cs
+++ b/src/ServiceControlInstaller.Engine/LicenseMgmt/LicenseManager.cs
@@ -10,7 +10,7 @@
             var sources = LicenseSource.GetStandardLicenseSources().ToArray();
             var result = ActiveLicense.Find("ServiceControl", sources);
 
-            var detectedLicense = new DetectedLicense("HKEY_LOCAL_MACHINE", LicenseDetails.FromLicense(result.License));
+            var detectedLicense = new DetectedLicense(result.Location, LicenseDetails.FromLicense(result.License));
 
             detectedLicense.IsEvaluationLicense = string.Equals(result.Location, "Trial License", StringComparison.OrdinalIgnoreCase);
 

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net40</TargetFramework>
-    <DefineConstants>$(DefineConstants);REGISTRYLICENSESOURCE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reduces the number of places that ServiceControl instances and ServiceControl Management look for and write license files to. This reduces the chances that there is a mismatch between where ServiceControl Management and any particular ServiceControl instance find their valid license files.

Technically this is a breaking change. It is possible that this could cause ServiceControl to lose it's license during an upgrade. If that happens, re-importing the license using ServiceControl Management will fix it. 

Risk Mitigations
- ServiceControl Management has been writing the license file to the registry and the common app data folder for some time (since November 2017 and 1.43.0). It is likely that the existing license is in the common app data folder anyway.
- ServiceControl Management will not allow you to upgrade any instances if it cannot find it's license file, so a user will have to re-import their license before upgrading any instances to this version.

Checklist
- [x] ServiceControl Management only looks for licenses on disk
- [x] ServiceControl Management only writes licenses to disk
- [x] ServiceControl only looks for licenses on disk
- [x] ServiceControl Audit only looks for licenses on disk
- [x] ServiceControl Monitoring only looks for licenses on disk

License location is machine-wide Common App Data folder.
