### PR TITLE
Auto-migrate ASB Forwarding Topology transport seam to the new ASB seam

### DIFF
--- a/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
@@ -114,6 +114,8 @@ namespace ServiceControl.Config.Framework.Modules
                 };
             }
 
+            instance.UpgradeTransportSeam();
+
             progress.Report(currentStep++, totalSteps, "Backing up app.config...");
             var backupFile = instance.BackupAppConfig();
             try
@@ -334,6 +336,8 @@ namespace ServiceControl.Config.Framework.Modules
                     Status = Status.Failed
                 };
             }
+
+            instance.UpgradeTransportSeam();
 
             progress.Report(1, 5, "Backing up app.config...");
             var backupFile = instance.BackupAppConfig();

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModel.cs
@@ -17,7 +17,7 @@
     {
         public ServiceControlEditorViewModel()
         {
-            Transports = ServiceControlCoreTransports.All;
+            Transports = ServiceControlCoreTransports.All.Where(t => t.AvailableInSCMU);
             ServiceControl = new ServiceControlInformation();
             ServiceControlAudit = new ServiceControlAuditInformation();
         }

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
@@ -336,7 +336,7 @@
 
         void UpdateServiceProperties()
         {
-            ServiceInstance.RefreshServiceProperties();
+            ServiceInstance.Reload();
 
             NotifyOfPropertyChange("Status");
             NotifyOfPropertyChange("AllowStop");

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMonitoringEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMonitoringEditorViewModel.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Windows.Input;
     using Framework.Rx;
     using PropertyChanged;
@@ -12,7 +13,7 @@
     {
         public SharedMonitoringEditorViewModel()
         {
-            Transports = ServiceControlCoreTransports.All;
+            Transports = ServiceControlCoreTransports.All.Where(t => t.AvailableInSCMU);
         }
 
         [DoNotNotify]

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/AppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/AppConfig.cs
@@ -60,6 +60,13 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
             Config.Save();
         }
 
+        public override void SetTransportType(string transportTypeName)
+        {
+            var settings = Config.AppSettings.Settings;
+            var version = details.Version;
+            settings.Set(ServiceControlSettings.TransportType, transportTypeName, version);
+        }
+
         public override IEnumerable<string> RavenDataPaths()
         {
             string[] keys =
@@ -160,6 +167,13 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
             }
         }
 
+        public override void SetTransportType(string transportTypeName)
+        {
+            var settings = Config.AppSettings.Settings;
+            var version = details.Version;
+            settings.Set(AuditInstanceSettingsList.TransportType, transportTypeName, version);
+        }
+
         IServiceControlAuditInstance details;
     }
 
@@ -185,6 +199,7 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
 
         public abstract IEnumerable<string> RavenDataPaths();
 
+        public abstract void SetTransportType(string transportTypeName);
 
         void UpdateRuntimeSection()
         {

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -137,9 +137,6 @@
             return destinationFile;
         }
 
-        public virtual void RefreshServiceProperties()
-        {
-            Service.Refresh();
-        }
+        public abstract void Reload();
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -290,5 +290,17 @@
                 ReportCard.Errors.Add(ex.Message);
             }
         }
+
+        public void UpgradeTransportSeam()
+        {
+            //Legacy ASB Forwarding Topology should be migrated to the ASBS transport seam
+            if (TransportPackage.Name == TransportNames.AzureServiceBusForwardingTopologyDeprecated)
+            {
+                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.AzureServiceBus);
+
+                var config = new AppConfig(this);
+                config.Save();
+            }
+        }
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -295,14 +295,10 @@
 
         public void UpgradeTransportSeam()
         {
-            //Legacy ASB Forwarding Topology should be migrated to the ASBS transport seam
-            if (TransportPackage.Name == TransportNames.AzureServiceBusForwardingTopologyDeprecated)
-            {
-                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.AzureServiceBus);
+            TransportPackage = ServiceControlCoreTransports.UpgradedTransportSeam(TransportPackage);
 
-                var config = new AppConfig(this);
-                config.Save();
-            }
+            var config = new AppConfig(this);
+            config.Save();
         }
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -60,9 +60,11 @@
             }
         }
 
-        public void Reload()
+        public override void Reload()
         {
             Service.Refresh();
+
+            AppConfig = new AppConfig(this);
             HostName = AppConfig.Read(SettingsList.HostName, "localhost");
             Port = AppConfig.Read(SettingsList.Port, 1234);
             LogPath = AppConfig.Read(SettingsList.LogPath, DefaultLogPath());

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
@@ -56,6 +56,8 @@ namespace ServiceControlInstaller.Engine.Instances
         public override void Reload()
         {
             Service.Refresh();
+
+            AppConfig = CreateAppConfig();
             HostName = AppConfig.Read(AuditInstanceSettingsList.HostName, "localhost");
             Port = AppConfig.Read(AuditInstanceSettingsList.Port, 33333);
             DatabaseMaintenancePort = AppConfig.Read<int?>(AuditInstanceSettingsList.DatabaseMaintenancePort, null);

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
@@ -434,14 +434,10 @@ namespace ServiceControlInstaller.Engine.Instances
         
         public void UpgradeTransportSeam()
         {
-            //Legacy ASB Forwarding Topology should be migrated to the ASBS transport seam
-            if (TransportPackage.Name == TransportNames.AzureServiceBusForwardingTopologyDeprecated)
-            {
-                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.AzureServiceBus);
+            TransportPackage = ServiceControlCoreTransports.UpgradedTransportSeam(TransportPackage);
 
-                AppConfig.SetTransportType(TransportPackage.TypeName);
-                AppConfig.Save();
-            }
+            AppConfig.SetTransportType(TransportPackage.TypeName);
+            AppConfig.Save();
         }
 
         public AppConfig AppConfig;

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
@@ -432,6 +432,18 @@ namespace ServiceControlInstaller.Engine.Instances
 
             ValidateConnectionString();
         }
+        
+        public void UpgradeTransportSeam()
+        {
+            //Legacy ASB Forwarding Topology should be migrated to the ASBS transport seam
+            if (TransportPackage.Name == TransportNames.AzureServiceBusForwardingTopologyDeprecated)
+            {
+                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.AzureServiceBus);
+
+                AppConfig.SetTransportType(TransportPackage.TypeName);
+                AppConfig.Save();
+            }
+        }
 
         public AppConfig AppConfig;
 

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
@@ -93,7 +93,6 @@ namespace ServiceControlInstaller.Engine.Instances
         public bool SkipQueueCreation { get; set; }
 
         protected abstract string BaseServiceName { get; }
-        public abstract void Reload();
 
         public string Url
         {

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
@@ -122,6 +122,8 @@
                 ZipName = "AzureServiceBus",
                 SampleConnectionString = "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>;QueueLengthQueryDelayInterval=<IntervalInMilliseconds(Default=500ms)>",
                 AvailableInSCMU = false,
+                ////Legacy ASB Forwarding Topology should be migrated to the ASBS transport seam
+                AutoMigrateTo = TransportNames.AzureServiceBus,
                 Matches = name => name.Equals(TransportNames.AzureServiceBusForwardingTopologyDeprecated, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals(TransportNames.AzureServiceBusForwardingTopologyLegacy, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals(TransportNames.AzureServiceBusForwardingTopologyOld, StringComparison.OrdinalIgnoreCase)
@@ -136,5 +138,16 @@
         {
             return All.FirstOrDefault(p => p.Matches(name));
         }
+
+        public static TransportInfo UpgradedTransportSeam(TransportInfo transport)
+        {
+            if (!string.IsNullOrWhiteSpace(transport.AutoMigrateTo))
+            {
+                return Find(transport.AutoMigrateTo);
+            }
+
+            return transport;
+        }
+
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
@@ -19,6 +19,7 @@
                 ZipName = "AmazonSQS",
                 TypeName = "ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS",
                 SampleConnectionString = "Region=<REGION>;QueueNamePrefix=<prefix>;TopicNamePrefix=<prefix>;AccessKeyId=<ACCESSKEYID>;SecretAccessKey=<SECRETACCESSKEY>;S3BucketForLargeMessages=<BUCKETNAME>;S3KeyPrefix=<KEYPREFIX>",
+                AvailableInSCMU = true,
                 Help = "'Region' is mandatory. Specify 'AccessKeyId' and 'SecretAccessKey' values to set the AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY environment variables if not using IAM roles or EC2 metadata. Specify 'S3BucketForLargeMessages' and optionally 'S3KeyPrefix' if large message bodies are used.",
                 Matches = name => name.Equals(TransportNames.AmazonSQS, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS", StringComparison.OrdinalIgnoreCase)
@@ -31,6 +32,7 @@
                 TypeName = "ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS",
                 ZipName = "NetStandardAzureServiceBus",
                 SampleConnectionString = "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>;QueueLengthQueryDelayInterval=<IntervalInMilliseconds(Default=500ms)>;TopicName=<TopicBundleName(Default=bundle-1)>",
+                AvailableInSCMU = true,
                 Matches = name => name.Equals(TransportNames.AzureServiceBus, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS", StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("ServiceControl.Transports.AzureServiceBus.AzureServiceBusTransport, ServiceControl.Transports.AzureServiceBus", StringComparison.OrdinalIgnoreCase)
@@ -41,6 +43,7 @@
                 TypeName = "ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ",
                 ZipName = "AzureStorageQueue",
                 SampleConnectionString = "DefaultEndpointsProtocol=[http|https];AccountName=<MyAccountName>;AccountKey=<MyAccountKey>",
+                AvailableInSCMU = true,
                 Matches = name => name.Equals(TransportNames.AzureStorageQueue, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ", StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("NServiceBus.AzureStorageQueueTransport, NServiceBus.Azure.Transports.WindowsAzureStorageQueues", StringComparison.OrdinalIgnoreCase)
@@ -53,6 +56,7 @@
                 ZipName = "Msmq",
                 SampleConnectionString = string.Empty,
                 Default = true,
+                AvailableInSCMU = true,
                 Matches = name => name.Equals(TransportNames.MSMQ, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("ServiceControl.Transports.Msmq.MsmqTransportCustomization, ServiceControl.Transports.Msmq", StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("NServiceBus.MsmqTransport, NServiceBus.Core", StringComparison.OrdinalIgnoreCase)
@@ -64,6 +68,7 @@
                 TypeName = "ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ",
                 ZipName = "RabbitMQ",
                 SampleConnectionString = "host=<HOSTNAME>;username=<USERNAME>;password=<PASSWORD>;DisableRemoteCertificateValidation=<true|false(default)>;UseExternalAuthMechanism=<true|false(default)>",
+                AvailableInSCMU = true,
                 Matches = name => name.Equals(TransportNames.RabbitMQConventionalRoutingTopology, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("RabbitMQ", StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ", StringComparison.OrdinalIgnoreCase)
@@ -76,6 +81,7 @@
                 TypeName = "ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ",
                 ZipName = "RabbitMQ",
                 SampleConnectionString = "host=<HOSTNAME>;username=<USERNAME>;password=<PASSWORD>;DisableRemoteCertificateValidation=<true|false(default)>;UseExternalAuthMechanism=<true|false(default)>",
+                AvailableInSCMU = true,
                 Matches = name => name.Equals(TransportNames.RabbitMQDirectRoutingTopology, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ", StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("ServiceControl.Transports.RabbitMQ.DirectRoutingTopologyRabbitMQTransport, ServiceControl.Transports.RabbitMQ", StringComparison.OrdinalIgnoreCase)
@@ -86,6 +92,7 @@
                 TypeName = "ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer",
                 ZipName = "SqlServer",
                 SampleConnectionString = "Data Source=<SQLInstance>;Initial Catalog=nservicebus;Integrated Security=True;Queue Schema=myschema;Subscriptions Table=tablename@schema@catalog",
+                AvailableInSCMU = true,
                 Help = "Specify optional 'Queue Schema' to override the default schema. Specify optional 'Subscriptions Table' to override the default subscriptions table location. When integrated authentication is specified in the SQL connection string the the current installing user is used to create the required SQL tables structure not the service account.",
                 Matches = name => name.Equals(TransportNames.SQLServer, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals("ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer", StringComparison.OrdinalIgnoreCase)
@@ -99,6 +106,7 @@
                 TypeName = "ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB",
                 ZipName = "AzureServiceBus",
                 SampleConnectionString = "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>;QueueLengthQueryDelayInterval=<IntervalInMilliseconds(Default=500ms)>",
+                AvailableInSCMU = false,
                 Matches = name => name.Equals(TransportNames.AzureServiceBusEndpointOrientedTopologyDeprecated, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals(TransportNames.AzureServiceBusEndpointOrientedTopologyLegacy, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals(TransportNames.AzureServiceBusEndpointOrientedTopologyOld, StringComparison.OrdinalIgnoreCase)
@@ -113,6 +121,7 @@
                 TypeName = "ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB",
                 ZipName = "AzureServiceBus",
                 SampleConnectionString = "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>;QueueLengthQueryDelayInterval=<IntervalInMilliseconds(Default=500ms)>",
+                AvailableInSCMU = false,
                 Matches = name => name.Equals(TransportNames.AzureServiceBusForwardingTopologyDeprecated, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals(TransportNames.AzureServiceBusForwardingTopologyLegacy, StringComparison.OrdinalIgnoreCase)
                                   || name.Equals(TransportNames.AzureServiceBusForwardingTopologyOld, StringComparison.OrdinalIgnoreCase)

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -94,6 +94,8 @@ namespace ServiceControlInstaller.Engine.Instances
         public override void Reload()
         {
             Service.Refresh();
+
+            AppConfig = CreateAppConfig();
             HostName = AppConfig.Read(ServiceControlSettings.HostName, "localhost");
             Port = AppConfig.Read(ServiceControlSettings.Port, 33333);
             DatabaseMaintenancePort = AppConfig.Read<int?>(ServiceControlSettings.DatabaseMaintenancePort, null);

--- a/src/ServiceControlInstaller.Engine/Instances/TransportInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/TransportInfo.cs
@@ -15,7 +15,7 @@
         public string SampleConnectionString { get; set; }
         public string Help { get; set; }
         public bool Default { get; set; }
-
+        public bool AvailableInSCMU { get; set; }
         public Func<string, bool> Matches { get; set; }
 
         public override bool Equals(object obj)

--- a/src/ServiceControlInstaller.Engine/Instances/TransportInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/TransportInfo.cs
@@ -16,6 +16,7 @@
         public string Help { get; set; }
         public bool Default { get; set; }
         public bool AvailableInSCMU { get; set; }
+        public string AutoMigrateTo { get; set; }
         public Func<string, bool> Matches { get; set; }
 
         public override bool Equals(object obj)

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
@@ -117,6 +117,8 @@ namespace ServiceControlInstaller.Engine.Unattended
 
             try
             {
+                instance.UpgradeTransportSeam();
+
                 var backupFile = instance.BackupAppConfig();
                 try
                 {

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendMonitoringInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendMonitoringInstaller.cs
@@ -116,6 +116,8 @@ namespace ServiceControlInstaller.Engine.Unattended
 
             try
             {
+                instance.UpgradeTransportSeam();
+
                 var backupFile = instance.BackupAppConfig();
                 try
                 {

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
@@ -125,6 +125,8 @@ namespace ServiceControlInstaller.Engine.Unattended
 
             try
             {
+                instance.UpgradeTransportSeam();
+
                 var backupFile = instance.BackupAppConfig();
                 try
                 {


### PR DESCRIPTION
### Description

When an instance gets upgraded to the new ServiceControl version and it's using Deprecated Forwarding Topology it will be auto-migrated to the new ASB seam. Secondly, deprecated transports seams are not available in the UI anymore and new instances using deprecated transports can be created only via PowerShell module. 