### PR TITLE
Update to latest RavenDB 3.5

### DIFF
--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -72,13 +72,13 @@
                         RecordKnownEndpoints(receivingEndpoint, knownEndpoints, processedMessage);
                     }
 
-                    bulkInsert.Store(processedMessage);
+                    await bulkInsert.StoreAsync(processedMessage).ConfigureAwait(false);
                     storedContexts.Add(context);
                 }
 
                 foreach (var endpoint in knownEndpoints.Values)
                 {
-                    bulkInsert.Store(endpoint);
+                    await bulkInsert.StoreAsync(endpoint).ConfigureAwait(false);
                 }
 
                 await bulkInsert.DisposeAsync().ConfigureAwait(false);

--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
     <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
-    <PackageReference Include="RavenDB.Database" Version="3.5.10-patch-35294" />
+    <PackageReference Include="RavenDB.Database" Version="3.5.10-patch-35302" />
     <PackageReference Include="NServiceBus" Version="7.4.3" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.1.0" />
     <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />
     <PackageReference Include="PublicApiGenerator" Version="9.3.0" />
-    <PackageReference Include="RavenDB.Tests.Helpers" Version="3.5.10-patch-35294" />
+    <PackageReference Include="RavenDB.Tests.Helpers" Version="3.5.10-patch-35302" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
     <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />
-    <PackageReference Include="RavenDB.Database" Version="3.5.10-patch-35294" />
+    <PackageReference Include="RavenDB.Database" Version="3.5.10-patch-35302" />
     <PackageReference Include="NServiceBus" Version="7.4.3" />
     <PackageReference Include="NServiceBus.Autofac" Version="7.1.0" />
     <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />


### PR DESCRIPTION
3.5.10-patch-35302 - 2020/09/21
Client

    [BulkInsert] Added StoreAsync method
    [BulkInsert] Fixed potential deadlock by providing TaskCreationOptions.RunContinuationsAsynchronously flag to TCS instance

3.5.10-patch-35301 - 2020/08/27
Client

    Apply the fix for losing type information when using ToArray with group by only for .NET Core