### PR TITLE
Turn-off console logging only when running as Windows Service

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
@@ -1,6 +1,5 @@
 namespace ServiceControl.Audit.Infrastructure
 {
-    using System;
     using System.IO;
     using System.Linq;
     using NLog.Config;
@@ -82,7 +81,7 @@ namespace ServiceControl.Audit.Infrastructure
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel < LogLevel.Info ? loggingSettings.LoggingLevel : LogLevel.Info, consoleTarget));
 
             // Remove Console Logging when running as a service
-            if (!Environment.UserInteractive)
+            if (!loggingSettings.LogToConsole)
             {
                 foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
                 {

--- a/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
@@ -7,11 +7,12 @@ namespace ServiceControl.Audit.Infrastructure.Settings
 
     class LoggingSettings
     {
-        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null)
+        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null, bool logToConsole = true)
         {
             LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
             RavenDBLogLevel = InitializeLevel("RavenDBLogLevel", defaultRavenDBLevel ?? LogLevel.Warn);
             LogPath = Environment.ExpandEnvironmentVariables(ConfigFileSettingsReader<string>.Read("LogPath", logPath ?? DefaultLogPathForInstance(serviceName)));
+            LogToConsole = logToConsole;
         }
 
         public LogLevel LoggingLevel { get; }
@@ -19,6 +20,8 @@ namespace ServiceControl.Audit.Infrastructure.Settings
         public LogLevel RavenDBLogLevel { get; }
 
         public string LogPath { get; }
+
+        public bool LogToConsole { get; }
 
         LogLevel InitializeLevel(string key, LogLevel defaultLevel)
         {

--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -23,7 +23,7 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName);
+            var loggingSettings = new LoggingSettings(arguments.ServiceName, logToConsole: !arguments.RunAsWindowsService);
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             await new CommandRunner(arguments.Commands).Execute(arguments)

--- a/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
@@ -14,13 +14,14 @@
   "SkipQueueCreation": false,
   "RootUrl": "http://localhost:9999/",
   "MaximumConcurrencyLevel": 10,
+  "RunAsWindowsService": false,
   "OnMessage": {
     "Method": {
-      "Name": "<.ctor>b__69_0",
+      "Name": "<.ctor>b__71_0",
       "AssemblyName": "ServiceControl.Monitoring, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null",
       "ClassName": "ServiceControl.Monitoring.Settings+<>c",
-      "Signature": "System.Threading.Tasks.Task <.ctor>b__69_0(System.String, System.Collections.Generic.Dictionary`2[System.String,System.String], Byte[], System.Func`1[System.Threading.Tasks.Task])",
-      "Signature2": "System.Threading.Tasks.Task <.ctor>b__69_0(System.String, System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], System.Byte[], System.Func`1[[System.Threading.Tasks.Task, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]])",
+      "Signature": "System.Threading.Tasks.Task <.ctor>b__71_0(System.String, System.Collections.Generic.Dictionary`2[System.String,System.String], Byte[], System.Func`1[System.Threading.Tasks.Task])",
+      "Signature2": "System.Threading.Tasks.Task <.ctor>b__71_0(System.String, System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], System.Byte[], System.Func`1[[System.Threading.Tasks.Task, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]])",
       "MemberType": 8,
       "GenericArguments": null
     },

--- a/src/ServiceControl.Monitoring/MonitorLogs.cs
+++ b/src/ServiceControl.Monitoring/MonitorLogs.cs
@@ -70,7 +70,7 @@ Selected Transport:					{settings.TransportType}
             nlogConfig.LoggingRules.Add(new LoggingRule("*", settings.LogLevel < LogLevel.Info ? settings.LogLevel : LogLevel.Info, consoleTarget));
 
             // Remove Console Logging when running as a service
-            if (!Environment.UserInteractive)
+            if (settings.RunAsWindowsService)
             {
                 foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
                 {

--- a/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
@@ -7,11 +7,12 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
     class LoggingSettings
     {
-        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null)
+        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null, bool logToConsole = true)
         {
             LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
             RavenDBLogLevel = InitializeLevel("RavenDBLogLevel", defaultRavenDBLevel ?? LogLevel.Warn);
             LogPath = Environment.ExpandEnvironmentVariables(ConfigFileSettingsReader<string>.Read("LogPath", logPath ?? DefaultLogPathForInstance(serviceName)));
+            LogToConsole = logToConsole;
         }
 
         public LogLevel LoggingLevel { get; }
@@ -19,6 +20,8 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public LogLevel RavenDBLogLevel { get; }
 
         public string LogPath { get; }
+
+        public bool LogToConsole { get; }
 
         LogLevel InitializeLevel(string key, LogLevel defaultLevel)
         {

--- a/src/ServiceControl/LoggingConfigurator.cs
+++ b/src/ServiceControl/LoggingConfigurator.cs
@@ -1,6 +1,5 @@
 namespace Particular.ServiceControl
 {
-    using System;
     using System.IO;
     using System.Linq;
     using NLog.Config;
@@ -81,8 +80,7 @@ namespace Particular.ServiceControl
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel, fileTarget));
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel < LogLevel.Info ? loggingSettings.LoggingLevel : LogLevel.Info, consoleTarget));
 
-            // Remove Console Logging when running as a service
-            if (!Environment.UserInteractive)
+            if (!loggingSettings.LogToConsole)
             {
                 foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
                 {

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -22,7 +22,7 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName);
+            var loggingSettings = new LoggingSettings(arguments.ServiceName, logToConsole: !arguments.RunAsWindowsService);
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             await new CommandRunner(arguments.Commands).Execute(arguments)


### PR DESCRIPTION
Fixes #2175 

These changes turn-off console logging only when Service Console figures out that it's running as a Windows Service. Service Control assumes it's running as a Windows Service if `Environment.UserInteractive` is set to `true` and there has been no `--portable` argument passed-in.