### PR TITLE
Handle saga audit messages from older version

### DIFF
--- a/src/ServiceControl.Audit.UnitTests/Infrastructure/RavenDB/MigrationTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/Infrastructure/RavenDB/MigrationTests.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+using NUnit.Framework;
+using Raven.Imports.Newtonsoft.Json;
+using ServiceControl.Audit.Infrastructure.RavenDB;
+
+[TestFixture]
+class MigrationTests
+{
+    [Test]
+    public void VerifyMigration()
+    {
+        var serializedForm = @"{
+""$type"":""ServiceControl.SagaAudit.SagaInfo, ServiceControl.Audit"",
+""ChangeStatus"":null,
+""SagaType"":null,
+""SagaId"":""00000000-0000-0000-0000-000000000000""}";
+
+        var serializer = new JsonSerializer
+        {
+            TypeNameHandling = TypeNameHandling.All,
+            Binder = new MigratedTypeAwareBinder()
+        };
+
+        serializer.Deserialize(new JsonTextReader(new StringReader(serializedForm)));
+
+        Assert.Pass("Deserialized correctly");
+    }
+}

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/MigratedTypeAwareBinder.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/MigratedTypeAwareBinder.cs
@@ -3,6 +3,7 @@
     using System;
     using Monitoring;
     using Raven.Imports.Newtonsoft.Json.Serialization;
+    using ServiceControl.SagaAudit;
 
     class MigratedTypeAwareBinder : DefaultSerializationBinder
     {
@@ -11,6 +12,11 @@
             if (typeName == "ServiceControl.Contracts.Operations.EndpointDetails" && assemblyName == "ServiceControl")
             {
                 return typeof(EndpointDetails);
+            }
+
+            if (typeName == "ServiceControl.SagaAudit.SagaInfo" && assemblyName == "ServiceControl.Audit")
+            {
+                return typeof(SagaInfo);
             }
 
             return base.BindToType(assemblyName, typeName);

--- a/src/ServiceControl.UnitTests/Infrastructure/RavenDB/MigrationTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/RavenDB/MigrationTests.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+using NUnit.Framework;
+using Raven.Imports.Newtonsoft.Json;
+using ServiceControl.Infrastructure.RavenDB;
+
+[TestFixture]
+class MigrationTests
+{
+    [Test]
+    public void VerifyMigration()
+    {
+        var serializedForm = @"{
+""$type"":""ServiceControl.SagaAudit.SagaInfo, ServiceControl"",
+""ChangeStatus"":null,
+""SagaType"":null,
+""SagaId"":""00000000-0000-0000-0000-000000000000""}";
+
+        var serializer = new JsonSerializer
+        {
+            TypeNameHandling = TypeNameHandling.All,
+            Binder = new MigratedTypeAwareBinder()
+        };
+
+        serializer.Deserialize(new JsonTextReader(new StringReader(serializedForm)));
+
+        Assert.Pass("Deserialized correctly");
+    }
+}

--- a/src/ServiceControl/Infrastructure/RavenDB/MigratedTypeAwareBinder.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/MigratedTypeAwareBinder.cs
@@ -1,0 +1,19 @@
+﻿namespace ServiceControl.Infrastructure.RavenDB
+{
+    using System;
+    using Raven.Imports.Newtonsoft.Json.Serialization;
+    using SagaAudit;
+
+    class MigratedTypeAwareBinder : DefaultSerializationBinder
+    {
+        public override Type BindToType(string assemblyName, string typeName)
+        {
+            if (typeName == "ServiceControl.SagaAudit.SagaInfo" && assemblyName == "ServiceControl")
+            {
+                return typeof(SagaInfo);
+            }
+
+            return base.BindToType(assemblyName, typeName);
+        }
+    }
+}

--- a/src/ServiceControl/Infrastructure/RavenDB/RavenBootstrapper.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/RavenBootstrapper.cs
@@ -4,6 +4,7 @@
     using System.ComponentModel.Composition.Hosting;
     using System.IO;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Audit.Monitoring;
     using Monitoring;
     using NServiceBus;
@@ -93,6 +94,7 @@
                 ? "localhost"
                 : settings.Hostname;
             documentStore.Conventions.SaveEnumsAsIntegers = true;
+            documentStore.Conventions.CustomizeJsonSerializer = serializer => serializer.Binder = MigratedTypeAwareBinder;
 
             documentStore.Configuration.Catalog.Catalogs.Add(new AssemblyCatalog(GetType().Assembly));
 
@@ -126,5 +128,7 @@
         }
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(RavenBootstrapper));
+
+        static SerializationBinder MigratedTypeAwareBinder = new MigratedTypeAwareBinder();
     }
 }


### PR DESCRIPTION
This type was moved in 4.13.0.

Fixes #2187 