### PR TITLE
Rename archive to delete in log messages to reflect SP changes in October release

### DIFF
--- a/src/ServiceControl/EventLog/Definitions/FailedMessageArchivedDefinition.cs
+++ b/src/ServiceControl/EventLog/Definitions/FailedMessageArchivedDefinition.cs
@@ -6,7 +6,7 @@
     {
         public FailedMessageArchivedDefinition()
         {
-            Description(m => "Failed message archived.");
+            Description(m => "Failed message deleted.");
 
             RelatesToMessage(m => m.FailedMessageId);
         }

--- a/src/ServiceControl/EventLog/Definitions/FailedMessageGroupArchivedDefinition.cs
+++ b/src/ServiceControl/EventLog/Definitions/FailedMessageGroupArchivedDefinition.cs
@@ -6,7 +6,7 @@
     {
         public FailedMessageGroupArchivedDefinition()
         {
-            Description(m => $"Deleted {m.MessagesCount} messages from group: {m.GroupName}");
+            Description(m => $"Deleted {m.MessagesCount} message(s) from group: {m.GroupName}");
             RelatesToGroup(m => m.GroupId);
         }
     }

--- a/src/ServiceControl/EventLog/Definitions/FailedMessageGroupArchivedDefinition.cs
+++ b/src/ServiceControl/EventLog/Definitions/FailedMessageGroupArchivedDefinition.cs
@@ -6,7 +6,7 @@
     {
         public FailedMessageGroupArchivedDefinition()
         {
-            Description(m => $"Archived {m.MessagesCount} messages from group: {m.GroupName}");
+            Description(m => $"Deleted {m.MessagesCount} messages from group: {m.GroupName}");
             RelatesToGroup(m => m.GroupId);
         }
     }

--- a/src/ServiceControl/EventLog/Definitions/FailedMessageGroupArchivedDefinition.cs
+++ b/src/ServiceControl/EventLog/Definitions/FailedMessageGroupArchivedDefinition.cs
@@ -1,4 +1,4 @@
-﻿namespace ServiceControl.EventLog.Definitions
+namespace ServiceControl.EventLog.Definitions
 {
     using Recoverability;
 

--- a/src/ServiceControl/EventLog/Definitions/FailedMessageUnArchivedDefinition.cs
+++ b/src/ServiceControl/EventLog/Definitions/FailedMessageUnArchivedDefinition.cs
@@ -6,7 +6,7 @@ namespace ServiceControl.EventLog.Definitions
     {
         public FailedMessageUnArchivedDefinition()
         {
-            Description(m => $"{m.MessagesCount} failed message(s) unarchived");
+            Description(m => $"{m.MessagesCount} failed message(s) Restored");
         }
     }
 }

--- a/src/ServiceControl/EventLog/Definitions/FailedMessageUnArchivedDefinition.cs
+++ b/src/ServiceControl/EventLog/Definitions/FailedMessageUnArchivedDefinition.cs
@@ -6,7 +6,7 @@ namespace ServiceControl.EventLog.Definitions
     {
         public FailedMessageUnArchivedDefinition()
         {
-            Description(m => $"{m.MessagesCount} failed message(s) Restored");
+            Description(m => $"{m.MessagesCount} failed message(s) restored");
         }
     }
 }


### PR DESCRIPTION
Change the log messages to match the terms 'archive' - 'unarchive' to 'delete' and 'restore' in SP October release