### PR TITLE
Make sure NotModifiedStatusHttpHandler returns no content for NotModified

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/WebApi/NotModifiedStatusHttpHandler.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/NotModifiedStatusHttpHandler.cs
@@ -26,7 +26,7 @@
 
             if (ifNoneMatch || ifNotModifiedSince)
             {
-                return Get304ResponseMessage(responseHeaders, response.Content.Headers.LastModified, request);
+                return Get304ResponseMessage(responseHeaders, response.Content?.Headers?.LastModified, request);
             }
 
             return response;
@@ -47,19 +47,15 @@
             return lastModified <= ifModifiedSince;
         }
 
-
+        // currently lastModified is not supported without returning a content which would violate the HTTP spec
+        // it can be resurrected once ASP.NET Core is in place.
         static HttpResponseMessage Get304ResponseMessage(HttpResponseHeaders responseHeaders, DateTimeOffset? lastModified, HttpRequestMessage request)
         {
-            var response = request.CreateResponse(HttpStatusCode.NotModified, "");
+            var response = request.CreateResponse(HttpStatusCode.NotModified);
 
             if (responseHeaders.ETag.Tag != null)
             {
                 response.Headers.ETag = responseHeaders.ETag;
-            }
-
-            if (lastModified != null)
-            {
-                response.Content.Headers.LastModified = lastModified;
             }
 
             return response;

--- a/src/ServiceControl/Infrastructure/WebApi/NotModifiedStatusHttpHandler.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/NotModifiedStatusHttpHandler.cs
@@ -26,13 +26,7 @@
 
             if (ifNoneMatch || ifNotModifiedSince)
             {
-                DateTimeOffset? lastModified = null;
-                if (response.Content?.Headers?.LastModified != null)
-                {
-                    lastModified = response.Content.Headers.LastModified;
-                }
-
-                return Get304ResponseMessage(responseHeaders, lastModified, request);
+                return Get304ResponseMessage(responseHeaders, response.Content?.Headers?.LastModified, request);
             }
 
             return response;
@@ -53,19 +47,15 @@
             return lastModified <= ifModifiedSince;
         }
 
-
+        // currently lastModified is not supported without returning a content which would violate the HTTP spec
+        // it can be resurrected once ASP.NET Core is in place.
         static HttpResponseMessage Get304ResponseMessage(HttpResponseHeaders responseHeaders, DateTimeOffset? lastModified, HttpRequestMessage request)
         {
-            var response = request.CreateResponse(HttpStatusCode.NotModified, "");
+            var response = request.CreateResponse(HttpStatusCode.NotModified);
 
             if (responseHeaders.ETag.Tag != null)
             {
                 response.Headers.ETag = responseHeaders.ETag;
-            }
-
-            if (lastModified != null)
-            {
-                response.Content.Headers.LastModified = lastModified;
             }
 
             return response;


### PR DESCRIPTION
Fixes #2233 

I had no idea how to test this other than manually checking if it works with curl.

## Before

```powershell
curl --head -XGET --header 'If-None-Match: "5CD7BD88-AF7D-DDB4-8621-A1E7A82F958C"' http://localhost:33333/api/recoverability/groups/Endpoint%20Name?classifierFilter=undefined
HTTP/1.1 304 Not Modified
Cache-Control: max-age=0, private
Content-Length: 2
Content-Type: application/json; charset=utf-8
ETag: "5CD7BD88-AF7D-DDB4-8621-A1E7A82F958C"
Vary: Accept
Server: Microsoft-HTTPAPI/2.0
X-Particular-Version: 4.14.0-alpha.76
Date: Tue, 27 Oct 2020 07:25:38 GMT
```

## After

```powershell
curl --head -XGET --header 'If-None-Match: "5CD7BD88-AF7D-DDB4-8621-A1E7A82F958C"' http://localhost:33333/api/recoverability/groups/Endpoint%20Name?classifierFilter=undefined
HTTP/1.1 304 Not Modified
Cache-Control: max-age=0, private
Content-Length: 0
ETag: "5CD7BD88-AF7D-DDB4-8621-A1E7A82F958C"
Vary: Accept
Server: Microsoft-HTTPAPI/2.0
X-Particular-Version: 4.14.0-not-modified.1
Date: Tue, 27 Oct 2020 07:23:40 GMT
```