### PR TITLE
Only purge endpoints when not in maintenance mode

### DIFF
--- a/src/ServiceControl/Infrastructure/RavenDB/RavenBootstrapper.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/RavenBootstrapper.cs
@@ -105,7 +105,11 @@
             IndexCreation.CreateIndexes(typeof(RavenBootstrapper).Assembly, documentStore);
             IndexCreation.CreateIndexes(typeof(SagaAudit.SagaSnapshot).Assembly, documentStore);
 
-            PurgeKnownEndpointsWithTemporaryIdsThatAreDuplicate(documentStore);
+            if (!maintenanceMode)
+            {
+                // Only purge endpoints when not in maintenance mode
+                PurgeKnownEndpointsWithTemporaryIdsThatAreDuplicate(documentStore);
+            }
         }
 
         static void PurgeKnownEndpointsWithTemporaryIdsThatAreDuplicate(IDocumentStore documentStore)


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceControl/issues/2242

This results in ServiceControl only accessing the `KnownEndpointIndex` index when not in maintenance mode. If the `KnownEndpointIndex` is disabled due to previously running out of disk space, it would be impossible to re-enable that index in maintenance mode as maintenance mode would fail to start.