### PR TITLE
Invert license check for audit

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
@@ -101,7 +101,7 @@ namespace ServiceControl.Audit.Infrastructure
                     return false;
                 }
 
-                if (LicenseManager.TryImportLicenseFromText(settings.LicenseFileText, out var importErrorMessage))
+                if (!LicenseManager.TryImportLicenseFromText(settings.LicenseFileText, out var importErrorMessage))
                 {
                     log.Error(importErrorMessage);
                     return false;


### PR DESCRIPTION
The license check in the audit init containers was inverted.