### PR TITLE
Adds support for .NET Core linux generated stack traces

### DIFF
--- a/src/ServiceControl.UnitTests/Recoverability/ExceptionTypeAndStackTraceFailureClassifierTest.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/ExceptionTypeAndStackTraceFailureClassifierTest.cs
@@ -77,6 +77,23 @@
         }
 
         [Test]
+        public void Stack_with_source_code_path_starting_with_forward_slash_should_parse_correctly()
+        {
+            const string stackTrace = @"SomeException: Some error message
+at Custom.Handlers.MyHandler.Handle(MyMessage message, IMessageHandlerContext context) in /source/Handlers/MyHandler.cs:line 32
+at NServiceBus.InvokeHandlerTerminator.Terminate(IInvokeHandlerContext context)
+at NServiceBus.SagaAudit.AuditInvokedSagaBehavior.Invoke(IInvokeHandlerContext context, Func`1 next)
+at NServiceBus.SagaPersistenceBehavior.Invoke(IInvokeHandlerContext context, Func`2 next)";
+
+            var classifier = new ExceptionTypeAndStackTraceFailureClassifier();
+            var standardStackTrace = CreateFailureDetailsWithStackTrace(stackTrace);
+
+            var classification = classifier.ClassifyFailure(standardStackTrace);
+            Assert.AreEqual(@"exceptionType: Custom.Handlers.MyHandler.Handle(MyMessage message, IMessageHandlerContext context)", classification);
+        }
+
+
+        [Test]
         public void Standard_stack_trace_format_should_group_by_exception_type_and_first_stack_frame()
         {
             const string stackTrace = @"at System.Environment.GetStackTrace(Exception e)

--- a/src/ServiceControl/App_Packages/StackTraceParser/StackTraceParser.cs
+++ b/src/ServiceControl/App_Packages/StackTraceParser/StackTraceParser.cs
@@ -43,7 +43,9 @@ namespace ServiceControl
                 ( " + Space + @"+
                     ( # Microsoft .NET stack traces
                     \w+ " + Space + @"+
-                    (?<file> [a-z] \: .+? )
+                    (?<file> ( [a-z] \: # Windows rooted path starting with a drive letter
+                             | / )      # *nix rooted path starting with a forward-slash
+                             .+? )
                     \: \w+ " + Space + @"+
                     (?<line> [0-9]+ ) \p{P}?
                     | # Mono stack traces
@@ -76,6 +78,7 @@ namespace ServiceControl
             return Parse(text, (idx, len, txt) => txt,
                                (t, m) => new { Type = t, Method = m },
                                (pt, pn) => new KeyValuePair<string, string>(pt, pn),
+                               // ReSharper disable once PossibleMultipleEnumeration
                                (pl, ps) => new { List = pl, Items = ps },
                                (fn, ln) => new { File = fn, Line = ln },
                                (f, tm, p, fl) => selector(f, tm.Type, tm.Method, p.List, p.Items, fl.File, fl.Line));


### PR DESCRIPTION
This updates the stack trace parser with the latest version from https://github.com/atifaziz/StackTraceParser/blob/master/StackTraceParser.cs to correctly support source file code paths starting with forwards slashes. These kinds of paths are generated by .NET Core on Linux.