### PR TITLE
install PowerShell to the global modules folder

### DIFF
--- a/src/Setup/ServiceControl.aip
+++ b/src/Setup/ServiceControl.aip
@@ -39,10 +39,14 @@
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiDirsComponent">
     <ROW Directory="APPDIR" Directory_Parent="TARGETDIR" DefaultDir="APPDIR:." IsPseudoRoot="1" DirectoryOptions="3"/>
-    <ROW Directory="POWERSHELLDIR" Directory_Parent="APPDIR" DefaultDir=".:PowerS~1|PowerShellModule" DirectoryOptions="3"/>
+    <ROW Directory="Modules_Dir" Directory_Parent="WindowsPowerShell_Dir" DefaultDir="Modules"/>
+    <ROW Directory="POWERSHELLDIR" Directory_Parent="ServiceControlMgmt_Dir" DefaultDir=".:PowerS~1|PowerShellModule" DirectoryOptions="3"/>
+    <ROW Directory="ProgramFilesFolder" Directory_Parent="TARGETDIR" DefaultDir="PROGRA~2|ProgramFilesFolder" IsPseudoRoot="1"/>
     <ROW Directory="ProgramMenuFolder" Directory_Parent="TARGETDIR" DefaultDir="Progra~1|ProgramMenuFolder" IsPseudoRoot="1"/>
     <ROW Directory="SHORTCUTDIR" Directory_Parent="TARGETDIR" DefaultDir="SHORTC~1|SHORTCUTDIR" IsPseudoRoot="1"/>
+    <ROW Directory="ServiceControlMgmt_Dir" Directory_Parent="Modules_Dir" DefaultDir="SERVIC~1|ServiceControlMgmt"/>
     <ROW Directory="TARGETDIR" DefaultDir="SourceDir"/>
+    <ROW Directory="WindowsPowerShell_Dir" Directory_Parent="ProgramFilesFolder" DefaultDir="WINDOW~1|WindowsPowerShell"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCompsComponent">
     <ROW Component="AI_CustomARPName" ComponentId="{86B714D7-9C86-41C8-9C3F-D3988F63F047}" Directory_="APPDIR" Attributes="260" KeyPath="DisplayName" Options="1"/>
@@ -142,7 +146,7 @@
     <ROW Name="CUSTOMACTIONS_PATH" Path="..\ServiceControlInstaller.CustomActions\bin\Release\net40" Type="2" Content="0"/>
     <ROW Name="POSH_PATH" Path="..\ServiceControlInstaller.PowerShell\bin\Release\net40" Type="2" Content="0"/>
     <ROW Name="PROJECT_PATH" Path="." Type="2" Content="0"/>
-    <ROW Name="WPF_PATH" Path="..\ServiceControl.Config\bin\Release\net461" Type="2" Content="0"/>
+    <ROW Name="WPF_PATH" Path="..\ServiceControl.Config\bin\Release\net462" Type="2" Content="0"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.BootstrOptComponent">
     <ROW BootstrOptKey="GlobalOptions" GeneralOptions="hq" DownloadFolder="[AppDataFolder][|Manufacturer]\[|ProductName]\prerequisites"/>


### PR DESCRIPTION
Connects to #1619

Installs the PowerShell module to Program Files modules folder so it is accessible globally without importing the module beforehand. 