### PR TITLE
Filter out available transports by removing the ones not available in SCMU

### DIFF
--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/Transports/GetServiceControlTransportTypes.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/Transports/GetServiceControlTransportTypes.cs
@@ -9,7 +9,7 @@
     {
         protected override void ProcessRecord()
         {
-            WriteObject(ServiceControlCoreTransports.All.Select(PsTransportInfo.FromTransport), true);
+            WriteObject(ServiceControlCoreTransports.All.Where(t => t.AvailableInSCMU).Select(PsTransportInfo.FromTransport), true);
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/Particular/ServiceControl/issues/2169

Started from the same assumptions done in https://github.com/Particular/ServiceControl/pull/2165. All the migration thing seems to be handled by the installation engine. I'm not sure what else needs to be done here.