### PR TITLE
Handle migrated bodies

### DIFF
--- a/src/ServiceControl/Operations/BodyStorage/RavenAttachments/GetBodyByIdApi.cs
+++ b/src/ServiceControl/Operations/BodyStorage/RavenAttachments/GetBodyByIdApi.cs
@@ -1,4 +1,7 @@
-﻿namespace ServiceControl.Operations.BodyStorage.Api
+﻿using System;
+using System.Linq;
+
+namespace ServiceControl.Operations.BodyStorage.Api
 {
     using System.Net;
     using System.Net.Http;
@@ -22,11 +25,32 @@
                 var attachment = await session.Advanced.Attachments.GetAsync(FailedMessage.MakeDocumentId(input), "body")
                     .ConfigureAwait(false);
 
-                var response = request.CreateResponse(HttpStatusCode.OK);
+                string contentType;
+                if (attachment == null)
+                {
+                    var legacyAttachment = await session.Advanced.Attachments
+                        .GetAsync($"files/messagebodies/{input}", $"messagebodies/{input}")
+                        .ConfigureAwait(false);
+                    if (legacyAttachment != null)
+                    {
+                        attachment = legacyAttachment;
+                        contentType = "application/octet-stream";
+                    }
+                    else
+                    {
+                        throw new Exception($"Cannot find attachment by ID {input}.");
+                    }
+                }
+                else
+                {
+                    //We don't know the actual content type
+                    contentType = attachment.Details.ContentType;
+                }
 
+                var response = request.CreateResponse(HttpStatusCode.OK);
                 var content = new StreamContent(attachment.Stream);
                 await content.LoadIntoBufferAsync(attachment.Details.Size).ConfigureAwait(false);
-                content.Headers.ContentType = MediaTypeHeaderValue.Parse(attachment.Details.ContentType);
+                content.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
                 content.Headers.ContentLength = attachment.Details.Size;
                 //Message Id is in fact processing ID: a guid generated based on message ID, processing endpoint and processing time. It can safely be used as ETag.
                 response.Headers.ETag = new EntityTagHeaderValue($"\"{input}\"");

--- a/src/ServiceControl/Operations/ErrorPersister.cs
+++ b/src/ServiceControl/Operations/ErrorPersister.cs
@@ -116,7 +116,7 @@ this.{statusField} = $status;
 this.{failureGroupsField} = $failureGroups;
 this.{processingAttemptsField} = [$attempt];
 this.{uniqueMessageIdField} = $uniqueMessageId;
-this['@metadata'] = {{ '@collection': 'FailedMessages' }} 
+this['@metadata'] = {{ '@collection': 'FailedMessages', '@version': '5.0' }} 
 ",
 
                     Values = new Dictionary<string, object>
@@ -124,7 +124,7 @@ this['@metadata'] = {{ '@collection': 'FailedMessages' }}
                         ["status"] = (int)FailedMessageStatus.Unresolved,
                         ["failureGroups"] = groups,
                         ["attempt"] = processingAttempt,
-                        ["uniqueMessageId"] = uniqueMessageId
+                        ["uniqueMessageId"] = uniqueMessageId,
                     }
                 },
                 skipPatchIfChangeVectorMismatch: false)


### PR DESCRIPTION
Adds handling of migrated message bodies for purposes of viewing details of a failed message and retrying a failed message.