### PR TITLE
Use Mono.Cecil to read release date

### DIFF
--- a/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
+++ b/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="Moq" Version="4.15.1" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />

--- a/src/ServiceControl.Transports.SqlServer/ServiceControl.Transports.SqlServer.csproj
+++ b/src/ServiceControl.Transports.SqlServer/ServiceControl.Transports.SqlServer.csproj
@@ -9,6 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.SNI" Version="2.1.1" />
     <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.2.0" />
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="Moq" Version="4.15.1" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />

--- a/src/ServiceControlInstaller.Engine/FileSystem/ReleaseDateReader.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/ReleaseDateReader.cs
@@ -9,66 +9,27 @@
     {
         public static bool TryReadReleaseDateAttribute(string exe, out DateTime releaseDate)
         {
-            releaseDate = DateTime.MinValue;
-            var tempDomain = AppDomain.CreateDomain("TemporaryAppDomain");
             try
             {
-                var loaderType = typeof(AssemblyReleaseDateReader);
-                var loader = (AssemblyReleaseDateReader)tempDomain.CreateInstanceFrom(Assembly.GetExecutingAssembly().Location, loaderType.FullName).Unwrap();
-                releaseDate = loader.GetReleaseDate(exe);
-                return true;
+                using (var assemblyDefinition = Mono.Cecil.AssemblyDefinition.ReadAssembly(exe))
+                {
+                    var customAttribute = assemblyDefinition.CustomAttributes.SingleOrDefault(ca => ca.AttributeType.Name == "ReleaseDateAttribute");
+                    var constructorArgument = customAttribute?.ConstructorArguments[0];
+                    var dateString = (string)constructorArgument?.Value;
+                    if (!string.IsNullOrWhiteSpace(dateString))
+                    {
+                        releaseDate = DateTime.ParseExact(dateString, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+                        return true;
+                    }
+                }
             }
             catch
             {
-                try
-                {
-                    return TryReadReleaseDateAttributeUsingMonoCecil(exe, out releaseDate);
-                }
-                catch
-                {
-                    return false;
-                }
-            }
-            finally
-            {
-                AppDomain.Unload(tempDomain);
-            }
-        }
-
-        static bool TryReadReleaseDateAttributeUsingMonoCecil(string exe, out DateTime releaseDate)
-        {
-            using (var assemblyDefinition = Mono.Cecil.AssemblyDefinition.ReadAssembly(exe))
-            {
-                var customAttribute = assemblyDefinition.CustomAttributes.SingleOrDefault(ca => ca.AttributeType.Name == "ReleaseDateAttribute");
-                var constructorArgument = customAttribute?.ConstructorArguments[0];
-                var dateString = (string)constructorArgument?.Value;
-                if (!string.IsNullOrWhiteSpace(dateString))
-                {
-                    releaseDate = DateTime.ParseExact(dateString, "yyyy-MM-dd", CultureInfo.InvariantCulture);
-                    return true;
-                }
+                //NOP
             }
 
             releaseDate = DateTime.MinValue;
             return false;
-        }
-
-        class AssemblyReleaseDateReader : MarshalByRefObject
-        {
-            internal DateTime GetReleaseDate(string assemblyPath)
-            {
-                try
-                {
-                    var assembly = Assembly.ReflectionOnlyLoadFrom(assemblyPath);
-                    var releaseDateAttribute = assembly.GetCustomAttributesData().FirstOrDefault(p => p.Constructor?.ReflectedType?.Name == "ReleaseDateAttribute");
-                    var x = (string)releaseDateAttribute?.ConstructorArguments[0].Value;
-                    return DateTime.ParseExact(x, "yyyy-MM-dd", CultureInfo.InvariantCulture);
-                }
-                catch (Exception)
-                {
-                    return DateTime.MinValue;
-                }
-            }
         }
     }
 }

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetZip" Version="1.14.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.3" />
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/src/Setup/ServiceControl.aip
+++ b/src/Setup/ServiceControl.aip
@@ -39,10 +39,14 @@
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiDirsComponent">
     <ROW Directory="APPDIR" Directory_Parent="TARGETDIR" DefaultDir="APPDIR:." IsPseudoRoot="1" DirectoryOptions="3"/>
-    <ROW Directory="POWERSHELLDIR" Directory_Parent="APPDIR" DefaultDir=".:PowerS~1|PowerShellModule" DirectoryOptions="3"/>
+    <ROW Directory="Modules_Dir" Directory_Parent="WindowsPowerShell_Dir" DefaultDir="Modules"/>
+    <ROW Directory="POWERSHELLDIR" Directory_Parent="ServiceControlMgmt_Dir" DefaultDir=".:PowerS~1|PowerShellModule" DirectoryOptions="3"/>
+    <ROW Directory="ProgramFilesFolder" Directory_Parent="TARGETDIR" DefaultDir="PROGRA~2|ProgramFilesFolder" IsPseudoRoot="1"/>
     <ROW Directory="ProgramMenuFolder" Directory_Parent="TARGETDIR" DefaultDir="Progra~1|ProgramMenuFolder" IsPseudoRoot="1"/>
     <ROW Directory="SHORTCUTDIR" Directory_Parent="TARGETDIR" DefaultDir="SHORTC~1|SHORTCUTDIR" IsPseudoRoot="1"/>
+    <ROW Directory="ServiceControlMgmt_Dir" Directory_Parent="Modules_Dir" DefaultDir="SERVIC~1|ServiceControlMgmt"/>
     <ROW Directory="TARGETDIR" DefaultDir="SourceDir"/>
+    <ROW Directory="WindowsPowerShell_Dir" Directory_Parent="ProgramFilesFolder" DefaultDir="WINDOW~1|WindowsPowerShell"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiCompsComponent">
     <ROW Component="AI_CustomARPName" ComponentId="{86B714D7-9C86-41C8-9C3F-D3988F63F047}" Directory_="APPDIR" Attributes="260" KeyPath="DisplayName" Options="1"/>
@@ -142,7 +146,7 @@
     <ROW Name="CUSTOMACTIONS_PATH" Path="..\ServiceControlInstaller.CustomActions\bin\Release\net40" Type="2" Content="0"/>
     <ROW Name="POSH_PATH" Path="..\ServiceControlInstaller.PowerShell\bin\Release\net40" Type="2" Content="0"/>
     <ROW Name="PROJECT_PATH" Path="." Type="2" Content="0"/>
-    <ROW Name="WPF_PATH" Path="..\ServiceControl.Config\bin\Release\net461" Type="2" Content="0"/>
+    <ROW Name="WPF_PATH" Path="..\ServiceControl.Config\bin\Release\net462" Type="2" Content="0"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.BootstrOptComponent">
     <ROW BootstrOptKey="GlobalOptions" GeneralOptions="hq" DownloadFolder="[AppDataFolder][|Manufacturer]\[|ProductName]\prerequisites"/>


### PR DESCRIPTION
Fix https://github.com/Particular/ServiceControl/issues/2123

This PR adds support for `PowerShell Core`. When managing ServiceControl instances using PowerShell Core a .NET Core based infrastructure (PowerShell) needs to load reflection information for a .NET Framework assembly (ServiceControl) and it blows up.

## Background

The installation process checks if the license is valid at installation time, and to do so it needs to extract the release date from the assembly it's trying to install.

The release date is stored in assemblies by the Licensing package. The Licensing package at build time, using an MSBuild task, [writes a `ReleaseDate` attribute](https://github.com/Particular/Operations.Licensing/blob/13608e31ab7ce46e357fd777380b9bc57051ab1b/src/Particular.Licensing/Particular.Licensing.Sources.targets#L16-L18) to the compiled assembly storing the GitVersion `$(GitVersion_CommitDate)`.

Finally, `ServiceControlInstaller.Packaging` project [zips all assemblies](https://github.com/Particular/ServiceControl/blob/a56860be685270d06490342e90007e84480bf00e/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj#L38) at build time using an MSBuild task.

At installation time the release date is read by the engine using reflection from the ServiceControl executable: https://github.com/Particular/ServiceControl/blob/a56860be685270d06490342e90007e84480bf00e/src/ServiceControlInstaller.Engine/FileSystem/ReleaseDateReader.cs#L33-L46

One option is to use `Mono.Cecil`, as proposed by this PR, to read the assembly definition.