### PR TITLE
Drop docker OS to 2016

### DIFF
--- a/src/docker/dockerfile.asb.asbs
+++ b/src/docker/dockerfile.asb.asbs
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.asb.asbs.audit
+++ b/src/docker/dockerfile.asb.asbs.audit
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.asb.asbs.audit.init
+++ b/src/docker/dockerfile.asb.asbs.audit.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.asb.asbs.init
+++ b/src/docker/dockerfile.asb.asbs.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.asb.asbs.monitoring
+++ b/src/docker/dockerfile.asb.asbs.monitoring
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.asb.asbs.monitoring.init
+++ b/src/docker/dockerfile.asb.asbs.monitoring.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.asb.endpoint
+++ b/src/docker/dockerfile.asb.endpoint
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.asb.endpoint.audit
+++ b/src/docker/dockerfile.asb.endpoint.audit
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.asb.endpoint.audit.init
+++ b/src/docker/dockerfile.asb.endpoint.audit.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.asb.endpoint.init
+++ b/src/docker/dockerfile.asb.endpoint.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.asb.endpoint.monitoring
+++ b/src/docker/dockerfile.asb.endpoint.monitoring
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.asb.endpoint.monitoring.init
+++ b/src/docker/dockerfile.asb.endpoint.monitoring.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.asb.forwarding
+++ b/src/docker/dockerfile.asb.forwarding
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.asb.forwarding.audit
+++ b/src/docker/dockerfile.asb.forwarding.audit
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.asb.forwarding.audit.init
+++ b/src/docker/dockerfile.asb.forwarding.audit.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.asb.forwarding.init
+++ b/src/docker/dockerfile.asb.forwarding.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.asb.forwarding.monitoring
+++ b/src/docker/dockerfile.asb.forwarding.monitoring
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.asb.forwarding.monitoring.init
+++ b/src/docker/dockerfile.asb.forwarding.monitoring.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.asq
+++ b/src/docker/dockerfile.asq
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.asq.audit
+++ b/src/docker/dockerfile.asq.audit
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.asq.audit.init
+++ b/src/docker/dockerfile.asq.audit.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.asq.init
+++ b/src/docker/dockerfile.asq.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.asq.monitoring
+++ b/src/docker/dockerfile.asq.monitoring
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.asq.monitoring.init
+++ b/src/docker/dockerfile.asq.monitoring.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.rabbitmq.conventional
+++ b/src/docker/dockerfile.rabbitmq.conventional
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.rabbitmq.conventional.audit
+++ b/src/docker/dockerfile.rabbitmq.conventional.audit
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.rabbitmq.conventional.audit.init
+++ b/src/docker/dockerfile.rabbitmq.conventional.audit.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.rabbitmq.conventional.init
+++ b/src/docker/dockerfile.rabbitmq.conventional.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.rabbitmq.conventional.monitoring
+++ b/src/docker/dockerfile.rabbitmq.conventional.monitoring
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.rabbitmq.conventional.monitoring.init
+++ b/src/docker/dockerfile.rabbitmq.conventional.monitoring.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.rabbitmq.direct
+++ b/src/docker/dockerfile.rabbitmq.direct
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.rabbitmq.direct.audit
+++ b/src/docker/dockerfile.rabbitmq.direct.audit
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.rabbitmq.direct.audit.init
+++ b/src/docker/dockerfile.rabbitmq.direct.audit.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.rabbitmq.direct.init
+++ b/src/docker/dockerfile.rabbitmq.direct.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.rabbitmq.direct.monitoring
+++ b/src/docker/dockerfile.rabbitmq.direct.monitoring
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.rabbitmq.direct.monitoring.init
+++ b/src/docker/dockerfile.rabbitmq.direct.monitoring.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.sqlserver
+++ b/src/docker/dockerfile.sqlserver
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.sqlserver.audit
+++ b/src/docker/dockerfile.sqlserver.audit
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.sqlserver.audit.init
+++ b/src/docker/dockerfile.sqlserver.audit.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.sqlserver.init
+++ b/src/docker/dockerfile.sqlserver.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.sqlserver.monitoring
+++ b/src/docker/dockerfile.sqlserver.monitoring
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.sqlserver.monitoring.init
+++ b/src/docker/dockerfile.sqlserver.monitoring.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.sqs
+++ b/src/docker/dockerfile.sqs
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.sqs.audit
+++ b/src/docker/dockerfile.sqs.audit
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.sqs.audit.init
+++ b/src/docker/dockerfile.sqs.audit.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 

--- a/src/docker/dockerfile.sqs.init
+++ b/src/docker/dockerfile.sqs.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 

--- a/src/docker/dockerfile.sqs.monitoring
+++ b/src/docker/dockerfile.sqs.monitoring
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 

--- a/src/docker/dockerfile.sqs.monitoring.init
+++ b/src/docker/dockerfile.sqs.monitoring.init
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 


### PR DESCRIPTION
Changes the base OS version to 2016 for the docker images. This should allow for more environments to use the dockerfiles.