### PR TITLE
Use MetadataLoadContext to read release date

### DIFF
--- a/src/ServiceControl.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.UnitTests/API/APIApprovals.cs
@@ -63,8 +63,11 @@
             //HINT: Those names are used in PowerShell scripts thus constitute a public api.
             //Also Particular.PlatformSamples relies on it to specify the learning transport.
             var transportNamesType = typeof(TransportNames);
-
-            var publicTransportNames = transportNamesType.Assembly.GeneratePublicApi(new ApiGeneratorOptions { IncludeTypes = new[] {transportNamesType}});
+            var publicTransportNames = transportNamesType.Assembly.GeneratePublicApi(new ApiGeneratorOptions
+            {
+                IncludeTypes = new[] {transportNamesType},
+                ExcludeAttributes = new[] { "System.Reflection.AssemblyMetadataAttribute" }
+            });
 
             Approver.Verify(publicTransportNames);
         }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
@@ -1,4 +1,5 @@
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7.2", FrameworkDisplayName=".NET Framework 4.7.2")]
+[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
 namespace ServiceControl.Transports
 {
     public class EndpointToQueueMapping

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
@@ -1,4 +1,4 @@
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7.2", FrameworkDisplayName=".NET Framework 4.7.2")]
 namespace ServiceControl.Transports
 {
     public class EndpointToQueueMapping

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
@@ -1,4 +1,3 @@
-[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "")]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
 namespace ServiceControl.Transports
 {

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.TransportNames.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.TransportNames.approved.txt
@@ -1,5 +1,5 @@
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ServiceControlInstaller.Engine.UnitTests")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ServiceControlInstaller.Engine.UnitTests")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
 namespace ServiceControlInstaller.Engine.Instances
 {
     public static class TransportNames

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.TransportNames.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.TransportNames.approved.txt
@@ -1,5 +1,6 @@
-assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ServiceControlInstaller.Engine.UnitTests")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4")]
+[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ServiceControlInstaller.Engine.UnitTests")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
 namespace ServiceControlInstaller.Engine.Instances
 {
     public static class TransportNames

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.TransportNames.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.TransportNames.approved.txt
@@ -1,4 +1,3 @@
-[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ServiceControlInstaller.Engine.UnitTests")]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4.6.2")]
 namespace ServiceControlInstaller.Engine.Instances

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.TransportNames.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.TransportNames.approved.txt
@@ -1,5 +1,5 @@
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ServiceControlInstaller.Engine.UnitTests")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.0", FrameworkDisplayName=".NET Framework 4")]
+assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ServiceControlInstaller.Engine.UnitTests")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.2", FrameworkDisplayName=".NET Framework 4")]
 namespace ServiceControlInstaller.Engine.Instances
 {
     public static class TransportNames

--- a/src/ServiceControlInstaller.CustomActions/MSILogger.cs
+++ b/src/ServiceControlInstaller.CustomActions/MSILogger.cs
@@ -7,24 +7,24 @@
     {
         public MSILogger(Session session)
         {
-            _session = session;
+            this.session = session;
         }
 
         public void Info(string message)
         {
-            _session.Log(message);
+            session.Log(message);
         }
 
         public void Warn(string message)
         {
-            _session.Log("WARN: {0}", message);
+            session.Log("WARN: {0}", message);
         }
 
         public void Error(string message)
         {
-            _session.Log("ERROR: {0}", message);
+            session.Log("ERROR: {0}", message);
         }
 
-        Session _session;
+        Session session;
     }
 }

--- a/src/ServiceControlInstaller.CustomActions/ServiceControlInstaller.CustomActions.csproj
+++ b/src/ServiceControlInstaller.CustomActions/ServiceControlInstaller.CustomActions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.CustomActions/ServiceControlInstaller.CustomActions.csproj
+++ b/src/ServiceControlInstaller.CustomActions/ServiceControlInstaller.CustomActions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.Engine/Api/LUID_AND_ATTRIBUTES.cs
+++ b/src/ServiceControlInstaller.Engine/Api/LUID_AND_ATTRIBUTES.cs
@@ -7,6 +7,6 @@
     internal struct LUID_AND_ATTRIBUTES
     {
         public LUID Luid;
-        public UInt32 Attributes;
+        public uint Attributes;
     }
 }

--- a/src/ServiceControlInstaller.Engine/Api/ProfileInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Api/ProfileInfo.cs
@@ -8,11 +8,16 @@
     {
         public int dwSize;
         public int dwFlags;
-        [MarshalAs(UnmanagedType.LPTStr)] public String lpUserName;
-        [MarshalAs(UnmanagedType.LPTStr)] public String lpProfilePath;
-        [MarshalAs(UnmanagedType.LPTStr)] public String lpDefaultPath;
-        [MarshalAs(UnmanagedType.LPTStr)] public String lpServerName;
-        [MarshalAs(UnmanagedType.LPTStr)] public String lpPolicyPath;
+        [MarshalAs(UnmanagedType.LPTStr)]
+        public string lpUserName;
+        [MarshalAs(UnmanagedType.LPTStr)]
+        public string lpProfilePath;
+        [MarshalAs(UnmanagedType.LPTStr)]
+        public string lpDefaultPath;
+        [MarshalAs(UnmanagedType.LPTStr)]
+        public string lpServerName;
+        [MarshalAs(UnmanagedType.LPTStr)]
+        public string lpPolicyPath;
         public IntPtr hProfile;
     }
 }

--- a/src/ServiceControlInstaller.Engine/Api/ServiceControlManager.cs
+++ b/src/ServiceControlInstaller.Engine/Api/ServiceControlManager.cs
@@ -6,11 +6,15 @@ namespace ServiceControlInstaller.Engine.Api
 
     struct SERVICE_FAILURE_ACTIONS
     {
-        [MarshalAs(UnmanagedType.U4)] public UInt32 dwResetPeriod;
+        [MarshalAs(UnmanagedType.U4)]
+        public uint dwResetPeriod;
 
-        [MarshalAs(UnmanagedType.LPStr)] public String lpRebootMsg;
-        [MarshalAs(UnmanagedType.LPStr)] public String lpCommand;
-        [MarshalAs(UnmanagedType.U4)] public UInt32 cActions;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string lpRebootMsg;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string lpCommand;
+        [MarshalAs(UnmanagedType.U4)]
+        public uint cActions;
         public IntPtr lpsaActions;
     }
 
@@ -57,8 +61,10 @@ namespace ServiceControlInstaller.Engine.Api
 
     struct SC_ACTION
     {
-        [MarshalAs(UnmanagedType.U4)] public SC_ACTION_TYPE Type;
-        [MarshalAs(UnmanagedType.U4)] public UInt32 Delay;
+        [MarshalAs(UnmanagedType.U4)]
+        public SC_ACTION_TYPE Type;
+        [MarshalAs(UnmanagedType.U4)]
+        public uint Delay;
     }
 
 #pragma warning restore 169

--- a/src/ServiceControlInstaller.Engine/Api/TokenPrivileges.cs
+++ b/src/ServiceControlInstaller.Engine/Api/TokenPrivileges.cs
@@ -6,7 +6,7 @@
     internal struct TokenPrivileges
     {
 #pragma warning disable 169
-        public UInt32 PrivilegeCount;
+        public uint PrivilegeCount;
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1)]
         public LUID_AND_ATTRIBUTES[] Privileges;
 #pragma warning restore 169

--- a/src/ServiceControlInstaller.Engine/Configuration/Monitoring/SettingsList.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/Monitoring/SettingsList.cs
@@ -3,7 +3,6 @@ namespace ServiceControlInstaller.Engine.Configuration.Monitoring
     public static class SettingsList
     {
         //TODO : FIX UP Names
-
         public static SettingInfo Port = new SettingInfo {Name = "Monitoring/HttpPort"};
         public static SettingInfo HostName = new SettingInfo {Name = "Monitoring/HttpHostName"};
         public static SettingInfo LogPath = new SettingInfo {Name = "Monitoring/LogPath"};

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/Compatibility.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/Compatibility.cs
@@ -3,7 +3,6 @@
     using System;
 
     // For Removing and Adding Setting use SettingsList.cs
-
     public static class Compatibility
     {
         public static CompatibilityInfo ForwardingQueuesAreOptional = new CompatibilityInfo {SupportedFrom = new Version(1, 29)};

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/SettingsList.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/SettingsList.cs
@@ -3,7 +3,6 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
     using System;
 
     // See Compatibility.cs for version switching that isn't related to Settings
-
     public static class ServiceControlSettings
     {
         public static SettingInfo VirtualDirectory = new SettingInfo {Name = "ServiceControl/VirtualDirectory"};
@@ -31,7 +30,7 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
         public static SettingInfo TransportType = new SettingInfo {Name = "ServiceControl/TransportType"};
         public static SettingInfo AuditQueue = new SettingInfo
         {
-            Name = "ServiceBus/AuditQueue", 
+            Name = "ServiceBus/AuditQueue",
             RemovedFrom = new Version(4, 0, 0)
         };
         public static SettingInfo ErrorQueue = new SettingInfo {Name = "ServiceBus/ErrorQueue"};

--- a/src/ServiceControlInstaller.Engine/FileSystem/ReleaseDateReader.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/ReleaseDateReader.cs
@@ -29,9 +29,9 @@ namespace ServiceControlInstaller.Engine.FileSystem
                 using (mlc)
                 {
                     var assembly = mlc.LoadFromAssemblyPath(exe);
-                    var myAttributeData = assembly.GetCustomAttributesData().SingleOrDefault(ca => ca.AttributeType.Name == "ReleaseDateAttribute");
+                    var attributeData = assembly.GetCustomAttributesData().SingleOrDefault(ca => ca.AttributeType.Name == "ReleaseDateAttribute");
 
-                    var dateString = (string)myAttributeData?.ConstructorArguments[0].Value;
+                    var dateString = (string)attributeData?.ConstructorArguments[0].Value;
                     releaseDate = DateTime.ParseExact(dateString, "yyyy-MM-dd", CultureInfo.InvariantCulture);
 
                     return true;

--- a/src/ServiceControlInstaller.Engine/FileSystem/ReleaseDateReader.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/ReleaseDateReader.cs
@@ -29,7 +29,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
                 using (mlc)
                 {
                     var assembly = mlc.LoadFromAssemblyPath(exe);
-                    var myAttributeData = assembly.GetCustomAttributesData().SingleOrDefault(ca => ca.AttributeType.Name == "MyAttribute");
+                    var myAttributeData = assembly.GetCustomAttributesData().SingleOrDefault(ca => ca.AttributeType.Name == "ReleaseDateAttribute");
 
                     var dateString = (string)myAttributeData?.ConstructorArguments[0].Value;
                     releaseDate = DateTime.ParseExact(dateString, "yyyy-MM-dd", CultureInfo.InvariantCulture);

--- a/src/ServiceControlInstaller.Engine/ReportCard/TruncatedStringList.cs
+++ b/src/ServiceControlInstaller.Engine/ReportCard/TruncatedStringList.cs
@@ -4,7 +4,7 @@
     using System.Collections;
     using System.Collections.Generic;
 
-    class TruncatedStringList : IList<String>
+    class TruncatedStringList : IList<string>
     {
         public TruncatedStringList(int maxLengthsOfItems)
         {

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +15,7 @@
     <PackageReference Include="DotNetZip" Version="1.15.0" />
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.Engine/Services/WindowsServiceController.cs
+++ b/src/ServiceControlInstaller.Engine/Services/WindowsServiceController.cs
@@ -244,6 +244,7 @@
         {
             var imagePathRegex = new Regex("^\"{0,1}(?<PATH>.+" + Regex.Escape(exename) + ")\"{0,1}", RegexOptions.IgnoreCase);
             using (var servicesBaseKey = Registry.LocalMachine.OpenSubKey(@"System\CurrentControlSet\Services"))
+            {
                 if (servicesBaseKey != null)
                 {
                     foreach (var serviceName in servicesBaseKey.GetSubKeyNames())
@@ -288,6 +289,7 @@
                         }
                     }
                 }
+            }
         }
 
 

--- a/src/ServiceControlInstaller.Engine/UrlAcl/Api/HttpServiceConfigSslParam.cs
+++ b/src/ServiceControlInstaller.Engine/UrlAcl/Api/HttpServiceConfigSslParam.cs
@@ -20,9 +20,11 @@
 
         public int DefaultRevocationUrlRetrievalTimeout;
 
-        [MarshalAs(UnmanagedType.LPWStr)] public string DefaultSslCtlIdentifier;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string DefaultSslCtlIdentifier;
 
-        [MarshalAs(UnmanagedType.LPWStr)] public string DefaultSslCtlStoreName;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string DefaultSslCtlStoreName;
 
         public uint DefaultFlags;
     }

--- a/src/ServiceControlInstaller.Engine/UrlAcl/Api/HttpServiceConfigUrlAclKey.cs
+++ b/src/ServiceControlInstaller.Engine/UrlAcl/Api/HttpServiceConfigUrlAclKey.cs
@@ -5,7 +5,8 @@
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct HttpServiceConfigUrlAclKey
     {
-        [MarshalAs(UnmanagedType.LPWStr)] public string UrlPrefix;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string UrlPrefix;
 
         public HttpServiceConfigUrlAclKey(string urlPrefix)
         {

--- a/src/ServiceControlInstaller.Engine/UrlAcl/Api/HttpServiceConfigUrlAclParam.cs
+++ b/src/ServiceControlInstaller.Engine/UrlAcl/Api/HttpServiceConfigUrlAclParam.cs
@@ -5,7 +5,8 @@
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct HttpServiceConfigUrlAclParam
     {
-        [MarshalAs(UnmanagedType.LPWStr)] public string StringSecurityDescriptor;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string StringSecurityDescriptor;
 
         public HttpServiceConfigUrlAclParam(string securityDescriptor)
         {

--- a/src/ServiceControlInstaller.Engine/UrlAcl/UrlReservation.cs
+++ b/src/ServiceControlInstaller.Engine/UrlAcl/UrlReservation.cs
@@ -25,7 +25,7 @@
             {
                 HTTPS = matchResults.Groups["protocol"].Value.Equals("https", StringComparison.OrdinalIgnoreCase);
                 HostName = matchResults.Groups["hostname"].Value;
-                if (String.IsNullOrEmpty(matchResults.Groups["port"].Value))
+                if (string.IsNullOrEmpty(matchResults.Groups["port"].Value))
                 {
                     Port = HTTPS ? 443 : 80;
                 }
@@ -194,7 +194,7 @@
                     Marshal.SizeOf(inputConfigInfoSet),
                     IntPtr.Zero);
 
-                if (ErrorCode.AlreadyExists == retVal)
+                if (retVal == ErrorCode.AlreadyExists)
                 {
                     retVal = HttpApi.HttpDeleteServiceConfiguration(IntPtr.Zero,
                         HttpServiceConfigId.HttpServiceConfigUrlAclInfo,
@@ -202,7 +202,7 @@
                         Marshal.SizeOf(inputConfigInfoSet),
                         IntPtr.Zero);
 
-                    if (ErrorCode.Success == retVal)
+                    if (retVal == ErrorCode.Success)
                     {
                         retVal = HttpApi.HttpSetServiceConfiguration(IntPtr.Zero,
                             HttpServiceConfigId.HttpServiceConfigUrlAclInfo,
@@ -231,7 +231,7 @@
         private static void FreeURL(string networkURL, string securityDescriptor)
         {
             var retVal = HttpApi.HttpInitialize(HttpApiConstants.Version1, HttpApiConstants.InitializeConfig, IntPtr.Zero);
-            if (ErrorCode.Success == retVal)
+            if (retVal == ErrorCode.Success)
             {
                 var urlAclKey = new HttpServiceConfigUrlAclKey(networkURL);
                 var urlAclParam = new HttpServiceConfigUrlAclParam(securityDescriptor);
@@ -255,7 +255,7 @@
                 HttpApi.HttpTerminate(HttpApiConstants.InitializeConfig, IntPtr.Zero);
             }
 
-            if (ErrorCode.Success != retVal)
+            if (retVal != ErrorCode.Success)
             {
                 throw new Win32Exception(Convert.ToInt32(retVal));
             }

--- a/src/ServiceControlInstaller.Engine/Validation/PortUtils.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/PortUtils.cs
@@ -8,7 +8,7 @@
     {
         public static bool CheckAvailable(int portNumber)
         {
-            if (1 > portNumber || 49151 < portNumber)
+            if (portNumber < 1 || portNumber > 49151)
             {
                 throw new ArgumentOutOfRangeException(nameof(portNumber), "Port number is not between 1 and 49151");
             }

--- a/src/ServiceControlInstaller.Engine/Validation/QueueNameValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/QueueNameValidator.cs
@@ -58,7 +58,7 @@ namespace ServiceControlInstaller.Engine.Validation
                 }
             };
 
-            if(instance.ForwardAuditMessages)
+            if (instance.ForwardAuditMessages)
             {
                 queues.Add(new QueueInfo
                 {

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
@@ -43,7 +43,7 @@ namespace ServiceControlInstaller.PowerShell
             }
         }
 
-        [ValidateNotNullOrEmpty] 
+        [ValidateNotNullOrEmpty]
         [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, Position = 0, HelpMessage = "Specify the name of the ServiceControl Instance to update")]
         public string[] Name;
     }

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/InvokeMonitoringUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/InvokeMonitoringUpgrade.cs
@@ -43,7 +43,7 @@ namespace ServiceControlInstaller.PowerShell
             }
         }
 
-        [ValidateNotNullOrEmpty] 
+        [ValidateNotNullOrEmpty]
         [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, Position = 0, HelpMessage = "Specify the name of the ServiceControl Instance to update")]
         public string[] Name;
     }

--- a/src/Setup/ServiceControl.aip
+++ b/src/Setup/ServiceControl.aip
@@ -139,8 +139,8 @@
     <ROW AliasRowId="dialog" AliasRowOperation="2" Data="Res\dialog.jpg"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.AppPathsComponent">
-    <ROW Name="CUSTOMACTIONS_PATH" Path="..\ServiceControlInstaller.CustomActions\bin\Release\net40" Type="2" Content="0"/>
-    <ROW Name="POSH_PATH" Path="..\ServiceControlInstaller.PowerShell\bin\Release\net40" Type="2" Content="0"/>
+    <ROW Name="CUSTOMACTIONS_PATH" Path="..\ServiceControlInstaller.CustomActions\bin\Release\net472" Type="2" Content="0"/>
+    <ROW Name="POSH_PATH" Path="..\ServiceControlInstaller.PowerShell\bin\Release\net472" Type="2" Content="0"/>
     <ROW Name="PROJECT_PATH" Path="." Type="2" Content="0"/>
     <ROW Name="WPF_PATH" Path="..\ServiceControl.Config\bin\Release\net472" Type="2" Content="0"/>
   </COMPONENT>

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -37,7 +37,7 @@
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name PROJECT_PATH -value $(SolutionDir)Setup -valuetype Folder" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name WPF_PATH -value $(SolutionDir)ServiceControl.Config\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name POSH_PATH -value $(SolutionDir)ServiceControlInstaller.PowerShell\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name CUSTOMACTIONS_PATH -value $(SolutionDir)ServiceControlInstaller.CustomActions\bin\$(Configuration)\net40 -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name CUSTOMACTIONS_PATH -value $(SolutionDir)ServiceControlInstaller.CustomActions\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /SetVersion $(GitVersion_MajorMinorPatch)" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /SetPackageName $(SetupExeOutputFolder)$(SetupExeName) -buildname DefaultBuild" />
     <Exec Command="$(AdvancedInstallerExe) /rebuild $(IntermediateOutputPath)$(AIPFile)" />


### PR DESCRIPTION
An alternative to #2314 

Fix https://github.com/Particular/ServiceControl/issues/2123

This PR is a step towards support for `PowerShell Core`. When managing ServiceControl instances using PowerShell Core a .NET Core based infrastructure (PowerShell) needs to load reflection information for a .NET Framework assembly (ServiceControl) and it blows up.

## Background

The installation process checks if the license is valid at installation time, and to do so it needs to extract the release date from the assembly it's trying to install.

The release date is stored in assemblies by the Licensing package. The Licensing package at build time, using an MSBuild task, [writes a `ReleaseDate` attribute](https://github.com/Particular/Operations.Licensing/blob/13608e31ab7ce46e357fd777380b9bc57051ab1b/src/Particular.Licensing/Particular.Licensing.Sources.targets#L16-L18) to the compiled assembly storing the GitVersion `$(GitVersion_CommitDate)`.

Finally, `ServiceControlInstaller.Packaging` project [zips all assemblies](https://github.com/Particular/ServiceControl/blob/a56860be685270d06490342e90007e84480bf00e/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj#L38) at build time using an MSBuild task.

At installation time the release date is read by the engine using reflection from the ServiceControl executable: https://github.com/Particular/ServiceControl/blob/a56860be685270d06490342e90007e84480bf00e/src/ServiceControlInstaller.Engine/FileSystem/ReleaseDateReader.cs#L33-L46

One option is to use `MetadataLoadContext `, as proposed by this PR, to read the assembly definition.

There are a couple of downsides, though:

- projects need to be bumped from `net40` to `net462`, which I don't think it's a problem because ServiceControl requires `net462` anyway
- when using this approach it's not clear to me what `RuntimeEnvironment.GetRuntimeDirectory()` returns. 