### PR TITLE
remove redundant method

### DIFF
--- a/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
@@ -8,8 +8,6 @@ namespace ServiceControl.MultiInstance.AcceptanceTests
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using System.Threading;
-    using System.Threading.Tasks;
     using AcceptanceTesting;
     using Newtonsoft.Json;
     using NServiceBus;
@@ -103,20 +101,6 @@ namespace ServiceControl.MultiInstance.AcceptanceTests
             {
                 File.Delete(transportAssembly);
             }
-        }
-
-        protected void ExecuteWhen(Func<bool> execute, Func<dynamic, Task> action, string instanceName = Settings.DEFAULT_SERVICE_NAME)
-        {
-            var timeout = TimeSpan.FromSeconds(1);
-
-            _ = Task.Run(async () =>
-            {
-                while (!SpinWait.SpinUntil(execute, timeout))
-                {
-                }
-
-                await action(Busses[instanceName].DomainEvents);
-            });
         }
 
         protected IScenarioWithEndpointBehavior<T> Define<T>() where T : ScenarioContext, new()


### PR DESCRIPTION
`ServiceControl.MultiInstance.AcceptanceTests.AcceptanceTest.ExecuteWhen`

I was completely confused as to why [this change](https://github.com/Particular/ServiceControl/pull/2325/files#diff-27a55256e4a8beae22709ff4b1e7ea29cfb97c9c88ccbe942b7d601a9e076d13R108-R112) didn't break things until I realised the method is not used. 🙂🗑️