### PR TITLE
Improve audit ingestion to make sure ingestion loop continues even when dispose throws

### DIFF
--- a/src/ServiceControl.Audit/Auditing/AuditIngestionComponent.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestionComponent.cs
@@ -112,6 +112,19 @@
 
                     await ingestor.Ingest(contexts).ConfigureAwait(false);
                 }
+                catch (Exception e) // ingestion must continue
+                {
+                    if (log.IsInfoEnabled)
+                    {
+                        log.Info("Ingesting messages failed", e);
+                    }
+
+                    // let's give up
+                    foreach (var context in contexts)
+                    {
+                        context.GetTaskCompletionSource().TrySetException(e);
+                    }
+                }
                 finally
                 {
                     contexts.Clear();

--- a/src/ServiceControl.Audit/Auditing/AuditIngestionComponent.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestionComponent.cs
@@ -112,14 +112,14 @@
 
                     await ingestor.Ingest(contexts).ConfigureAwait(false);
                 }
-                catch (Exception e) // ingestion must continue
+                catch (Exception e) // show must go on
                 {
                     if (log.IsInfoEnabled)
                     {
                         log.Info("Ingesting messages failed", e);
                     }
 
-                    // let's give up
+                    // signal all message handling tasks to terminate
                     foreach (var context in contexts)
                     {
                         context.GetTaskCompletionSource().TrySetException(e);

--- a/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
@@ -23,6 +23,7 @@
             {
                 log.Debug($"Ingesting {contexts.Count} message contexts");
             }
+
             var stored = await auditPersister.Persist(contexts).ConfigureAwait(false);
 
             try
@@ -50,14 +51,11 @@
             {
                 if (log.IsDebugEnabled)
                 {
-                    log.Debug($"Forwarding messages failed");
+                    log.Debug("Forwarding messages failed", e);
                 }
 
-                // in case forwarding throws
-                foreach (var context in stored)
-                {
-                    context.GetTaskCompletionSource().TrySetException(e);
-                }
+                // making sure to rethrow so that all messages get marked as failed
+                throw;
             }
         }
 


### PR DESCRIPTION
In 4.14. we moved the `DisposeAsync` into a finally block. I assumed that the bulk insertion [follows the framework design guidelines](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1065#dispose-methods) but apparently, [it doesn't](https://github.com/ravendb/ravendb/blob/v3.5/Raven.Client.Lightweight/Document/RemoteBulkInsertOperation.cs#L499). 

Therefore it broke the assumptions that `Persist` cannot throw causing the ingestion loop to halt. This rearranges the ingestion logic to make sure we continue to ingest and move the "marking all messages in the batch as failed into the component to simplify the code"