### PR TITLE
Powershell unittest project

### DIFF
--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -96,6 +96,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Config.Tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.LicenseManagement", "ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj", "{FD1B9998-4B0C-4109-A3BC-0748F829F852}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{1F0F3D74-034D-4C26-A740-179EC9C951BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControlInstaller.PowerShell.UnitTests", "ServiceControlInstaller.PowerShell.UnitTests\ServiceControlInstaller.PowerShell.UnitTests.csproj", "{DEF1FC5C-041E-41AC-8871-88A17CBC4A59}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -254,6 +258,10 @@ Global
 		{FD1B9998-4B0C-4109-A3BC-0748F829F852}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD1B9998-4B0C-4109-A3BC-0748F829F852}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD1B9998-4B0C-4109-A3BC-0748F829F852}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEF1FC5C-041E-41AC-8871-88A17CBC4A59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEF1FC5C-041E-41AC-8871-88A17CBC4A59}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEF1FC5C-041E-41AC-8871-88A17CBC4A59}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEF1FC5C-041E-41AC-8871-88A17CBC4A59}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -282,6 +290,7 @@ Global
 		{BA42A516-AC01-4B4E-9177-B62AB2CFC367} = {55C388DD-2B39-4C2F-AEBD-AFD3444815F1}
 		{45AC011D-6837-47E2-A428-E156A421E4C2} = {A21A1A89-0B07-4E87-8E3C-41D9C280DCB8}
 		{9CA13A10-1F6F-495A-9623-AC62201FC0BD} = {55C388DD-2B39-4C2F-AEBD-AFD3444815F1}
+		{DEF1FC5C-041E-41AC-8871-88A17CBC4A59} = {55C388DD-2B39-4C2F-AEBD-AFD3444815F1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3B9E5B72-F580-465A-A22C-2D2148AF4EB4}

--- a/src/ServiceControlInstaller.PowerShell.UnitTests/Class1.cs
+++ b/src/ServiceControlInstaller.PowerShell.UnitTests/Class1.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace ServiceControlInstaller.PowerShell.UnitTests
 {
@@ -96,6 +97,29 @@ namespace ServiceControlInstaller.PowerShell.UnitTests
             {
                 Debug.WriteLine(result);
             }
+        }
+
+        [Test]
+        public void XXXX()
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                {"Name", "Test"},
+                {"Transport", "MSMQ"},
+                {"InstallPath", @"c:\install"},
+                {"DBPath", @"c:\db"},
+                {"LogPath", @"c:\logs"},
+                {"Port", "12"},
+                //{"AuditRetentionPeriod", "15.0:0:0"},
+                //{"ForwardAuditMessages", true},
+                {"ErrorRetentionPeriod", "15.0:0:0"},
+                {"DatabaseMaintenancePort", "2"},
+            };
+            
+            var results = new PsCmdletAssert().Invoke(typeof(NewServiceControlInstance), parameters);
+            Assert.IsNotNull(results);
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual("expected", results[0]);
         }
     }
 }

--- a/src/ServiceControlInstaller.PowerShell.UnitTests/Class1.cs
+++ b/src/ServiceControlInstaller.PowerShell.UnitTests/Class1.cs
@@ -1,0 +1,101 @@
+﻿using System.IO;
+
+namespace ServiceControlInstaller.PowerShell.UnitTests
+{
+    using ServiceControlInstaller.PowerShell;
+    using System.Diagnostics;
+    using NUnit;
+    using NUnit.Framework;
+    using System.Management.Automation;
+    using System.Management.Automation.Runspaces;
+    using System.Collections.ObjectModel;
+    using System.Security;
+
+
+    [TestFixture]
+    public class NewServiceControlInstanceTests
+    {
+        readonly string tmpPath = Path.GetTempPath().TrimEnd('\\');
+        Runspace runSpace;
+        RunspaceConfiguration config;
+
+        Pipeline pipe;
+        Command command;
+
+
+        [SetUp]
+        public void PSSetup()
+        {
+            config = RunspaceConfiguration.Create();
+
+            //PSSnapInException warning;
+            //config.AddPSSnapIn("LuifITPSSnapin", out warning);
+
+            //runSpace = RunspaceFactory.CreateRunspace();
+            runSpace = RunspaceFactory.CreateRunspace(config);
+            runSpace.Open();
+            //var cmd = runSpace.CreatePipeline($"set-Location '{tmpPath}'");
+            //cmd.Invoke();
+
+
+            pipe = runSpace.CreatePipeline();
+            command = new Command("New-ServiceControlInstance");
+            pipe.Commands.Add(command);
+        }
+
+        [TearDown]
+        public void FixtureTearDown()
+        {
+            runSpace.Close();
+        }
+
+        [Test]
+        public void XX()
+        {
+            //Arrange
+            command.Parameters.Add(new CommandParameter("Person", "ME"));
+
+            //Act
+            Collection<PSObject> psObject = pipe.Invoke();
+
+            //Assert
+            Assert.AreEqual(1, psObject.Count);
+            Assert.IsTrue((bool) psObject[0].BaseObject);
+        }
+
+
+        [Test]
+        public void PSTest()
+        {
+            var cmd = runSpace.CreatePipeline("get-location");
+            var resultObject = cmd.Invoke();
+            var currDir = resultObject[0].ToString();
+            Assert.AreEqual(tmpPath, currDir);
+
+            cmd = runSpace.CreatePipeline(@".\new-securestring.ps1 password");
+            resultObject = cmd.Invoke();
+            var ss = (SecureString) resultObject[0].ImmediateBaseObject;
+            Assert.AreEqual(0, ss.Length, nameof(ss.Length));
+
+            runSpace.SessionStateProxy.SetVariable("ss", ss);
+            cmd = runSpace.CreatePipeline(@".\getfrom-securestring.ps1 $ss");
+            resultObject = cmd.Invoke();
+            var clearText = (string) resultObject[0].ImmediateBaseObject;
+            Assert.AreEqual("password", clearText, "password");
+        }
+
+        // New-ServiceControlInstance -Name Test -Transport MSMQ -InstallPath c:\install -DBPath c:\db -LogPath c:\logs -Port 12 -AuditRetentionPeriod "15.0:0:0" -ErrorRetentionPeriod "15.0:0:0" -ForwardAuditMessages -DatabaseMaintenancePort 2 -ErrorVariable MyError
+
+        [Explicit]
+        [Test]
+        public void IsMsmqInstalled()
+        {
+            var cmdlet = new NewServiceControlInstance();
+            var results = cmdlet.Invoke();
+            foreach (var result in results)
+            {
+                Debug.WriteLine(result);
+            }
+        }
+    }
+}

--- a/src/ServiceControlInstaller.PowerShell.UnitTests/PsCmdletAssert.cs
+++ b/src/ServiceControlInstaller.PowerShell.UnitTests/PsCmdletAssert.cs
@@ -1,0 +1,614 @@
+﻿/**
+ * Copyright 2016 d-fens GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Text;
+using System.Threading;
+
+class PsCmdletAssert
+{
+    private const string POWERSHELL_CMDLET_NAME_FORMATSTRING = "{0}-{1}";
+
+    // it really does not matter which help file name we use so we take this as a default when constructing a CmdletConfigurationEntry
+    private const string HELP_FILE_NAME = "Microsoft.Windows.Installer.PowerShell.dll-Help.xml";
+
+    private const string CMDLET_PARAMETER_FORMAT = "{0} {1}";
+    private const string SCRIPTBLOCK_DELIMITER = "; ";
+
+    private readonly IEnumerable<SessionStateVariableEntry> variableEntries;
+
+    public string ScriptDefinition { get; set; }
+
+    public PsCmdletAssert()
+        : this(new List<SessionStateVariableEntry>())
+    {
+        // N/A
+    }
+
+    public PsCmdletAssert(IDictionary<string, object> variableEntries)
+        : this(variableEntries
+            .Select(keyValuePair => new SessionStateVariableEntry(keyValuePair.Key, keyValuePair.Value, string.Empty)))
+    {
+        Contract.Requires(null != variableEntries);
+    }
+
+    public PsCmdletAssert(IEnumerable<SessionStateVariableEntry> variableEntries)
+    {
+        Contract.Requires(null != variableEntries);
+
+        this.variableEntries = variableEntries;
+    }
+
+    #region Obsolete Invoke() methods with string parameters
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type implementingType, string parameters)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(new Type[] {implementingType}, parameters, HELP_FILE_NAME, exceptionHandler: null,
+            errorHandler: null, scriptDefinition: null);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type[] implementingTypes, string parameters)
+    {
+        Contract.Requires(null != implementingTypes);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(implementingTypes, parameters, HELP_FILE_NAME, exceptionHandler: null, errorHandler: null,
+            scriptDefinition: null);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type implementingType, string parameters, string scriptDefinition)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(scriptDefinition));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(new Type[] {implementingType}, parameters, HELP_FILE_NAME, exceptionHandler: null,
+            errorHandler: null, scriptDefinition: scriptDefinition);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type[] implementingTypes, string parameters, string scriptDefinition)
+    {
+        Contract.Requires(null != implementingTypes);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(scriptDefinition));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(implementingTypes, parameters, HELP_FILE_NAME, exceptionHandler: null, errorHandler: null,
+            scriptDefinition: scriptDefinition);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type implementingType, string parameters, Func<Exception, Exception> exceptionHandler)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(new Type[] {implementingType}, parameters, HELP_FILE_NAME, exceptionHandler, errorHandler: null,
+            scriptDefinition: null);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type[] implementingTypes, string parameters,
+        Func<Exception, Exception> exceptionHandler)
+    {
+        Contract.Requires(null != implementingTypes);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(implementingTypes, parameters, HELP_FILE_NAME, exceptionHandler, errorHandler: null,
+            scriptDefinition: null);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type implementingType, string parameters, Func<Exception, Exception> exceptionHandler,
+        string scriptDefinition)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(scriptDefinition));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(new Type[] {implementingType}, parameters, HELP_FILE_NAME, exceptionHandler, errorHandler: null,
+            scriptDefinition: scriptDefinition);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type[] implementingTypes, string parameters,
+        Func<Exception, Exception> exceptionHandler, string scriptDefinition)
+    {
+        Contract.Requires(null != implementingTypes);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(scriptDefinition));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(implementingTypes, parameters, HELP_FILE_NAME, exceptionHandler, errorHandler: null,
+            scriptDefinition: scriptDefinition);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type implementingType, string parameters, Func<Exception, Exception> exceptionHandler,
+        Action<IList<ErrorRecord>> errorHandler)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(new Type[] {implementingType}, parameters, HELP_FILE_NAME, exceptionHandler, errorHandler,
+            scriptDefinition: null);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type[] implementingTypes, string parameters,
+        Func<Exception, Exception> exceptionHandler, Action<IList<ErrorRecord>> errorHandler)
+    {
+        Contract.Requires(null != implementingTypes);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(implementingTypes, parameters, HELP_FILE_NAME, exceptionHandler, errorHandler,
+            scriptDefinition: null);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type implementingType, string parameters, Func<Exception, Exception> exceptionHandler,
+        Action<IList<ErrorRecord>> errorHandler, string scriptDefinition)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(scriptDefinition));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(new Type[] {implementingType}, parameters, HELP_FILE_NAME, exceptionHandler, errorHandler,
+            scriptDefinition: scriptDefinition);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type[] implementingTypes, string parameters,
+        Func<Exception, Exception> exceptionHandler, Action<IList<ErrorRecord>> errorHandler, string scriptDefinition)
+    {
+        Contract.Requires(null != implementingTypes);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(scriptDefinition));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(implementingTypes, parameters, HELP_FILE_NAME, exceptionHandler, errorHandler,
+            scriptDefinition: scriptDefinition);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type implementingType, string parameters, Action<IList<ErrorRecord>> errorHandler)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(new Type[] {implementingType}, parameters, HELP_FILE_NAME, exceptionHandler: null,
+            errorHandler: errorHandler, scriptDefinition: null);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type[] implementingTypes, string parameters, Action<IList<ErrorRecord>> errorHandler)
+    {
+        Contract.Requires(null != implementingTypes);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(implementingTypes, parameters, HELP_FILE_NAME, exceptionHandler: null, errorHandler: errorHandler,
+            scriptDefinition: null);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type implementingType, string parameters, Action<IList<ErrorRecord>> errorHandler,
+        string scriptDefinition)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(scriptDefinition));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(new Type[] {implementingType}, parameters, HELP_FILE_NAME, exceptionHandler: null,
+            errorHandler: errorHandler, scriptDefinition: scriptDefinition);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type[] implementingTypes, string parameters, Action<IList<ErrorRecord>> errorHandler,
+        string scriptDefinition)
+    {
+        Contract.Requires(null != implementingTypes);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(scriptDefinition));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(implementingTypes, parameters, HELP_FILE_NAME, exceptionHandler: null, errorHandler: errorHandler,
+            scriptDefinition: scriptDefinition);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type implementingType, string parameters, string helpFileName,
+        Func<Exception, Exception> exceptionHandler, Action<IList<ErrorRecord>> errorHandler)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(helpFileName));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(new Type[] {implementingType}, parameters, HELP_FILE_NAME, exceptionHandler: null,
+            errorHandler: errorHandler, scriptDefinition: null);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type[] implementingTypes, string parameters, string helpFileName,
+        Func<Exception, Exception> exceptionHandler, Action<IList<ErrorRecord>> errorHandler)
+    {
+        Contract.Requires(null != implementingTypes);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(helpFileName));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(implementingTypes, parameters, HELP_FILE_NAME, exceptionHandler: null, errorHandler: errorHandler,
+            scriptDefinition: null);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type implementingType, string parameters, string helpFileName,
+        Func<Exception, Exception> exceptionHandler, Action<IList<ErrorRecord>> errorHandler, string scriptDefinition)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(helpFileName));
+        Contract.Requires(!string.IsNullOrWhiteSpace(scriptDefinition));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(new Type[] {implementingType}, parameters, HELP_FILE_NAME, exceptionHandler: exceptionHandler,
+            errorHandler: errorHandler, scriptDefinition: scriptDefinition);
+    }
+
+    [Obsolete("Use Invoke() with Dictionary<> parameters instead.")]
+    public IList<PSObject> Invoke(Type[] implementingTypes, string parameters, string helpFileName,
+        Func<Exception, Exception> exceptionHandler, Action<IList<ErrorRecord>> errorHandler, string scriptDefinition)
+    {
+        Contract.Requires(null != implementingTypes);
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameters));
+        Contract.Requires(!string.IsNullOrWhiteSpace(helpFileName));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        var cmdletNameToInvoke = "";
+
+        var initialSessionState = InitialSessionState.CreateDefault();
+        initialSessionState.Variables.Add(variableEntries);
+
+        foreach (var implementingType in implementingTypes)
+        {
+            // construct the Cmdlet name the type implements
+            var cmdletAttribute =
+                (CmdletAttribute) implementingType.GetCustomAttributes(typeof(CmdletAttribute), true).Single();
+            Contract.Assert(null != cmdletAttribute, typeof(CmdletAttribute).FullName);
+            var cmdletName = string.Format(POWERSHELL_CMDLET_NAME_FORMATSTRING, cmdletAttribute.VerbName,
+                cmdletAttribute.NounName);
+
+            if (implementingType == implementingTypes[0])
+            {
+                cmdletNameToInvoke = cmdletName;
+            }
+
+            Contract.Assert(!string.IsNullOrWhiteSpace(cmdletNameToInvoke));
+
+            var sessionStateCommandEntries = new List<SessionStateCommandEntry>
+            {
+                new SessionStateCmdletEntry(cmdletName, implementingType, helpFileName)
+            };
+            initialSessionState.Commands.Add(sessionStateCommandEntries);
+        }
+
+        using (var runspace = RunspaceFactory.CreateRunspace(initialSessionState))
+        {
+            runspace.ApartmentState = ApartmentState.STA;
+            runspace.Open();
+
+            // add scripts to cmdlet to be executed
+            var commandText = new StringBuilder();
+            commandText.Append(ScriptDefinition);
+            commandText.AppendLine(SCRIPTBLOCK_DELIMITER);
+            commandText.Append(scriptDefinition);
+            commandText.AppendLine(SCRIPTBLOCK_DELIMITER);
+            commandText.AppendFormat(CMDLET_PARAMETER_FORMAT, cmdletNameToInvoke, parameters);
+            commandText.AppendLine(SCRIPTBLOCK_DELIMITER);
+
+            using (var pipeline = runspace.CreatePipeline(commandText.ToString()))
+            {
+                try
+                {
+                    var invocationResults = pipeline.Invoke();
+
+                    if (null != errorHandler && pipeline.HadErrors)
+                    {
+                        var errorRecords = pipeline.Error.ReadToEnd().Cast<PSObject>().Select(e => e.BaseObject)
+                            .Cast<ErrorRecord>().ToList();
+                        errorHandler(errorRecords);
+                    }
+
+                    return invocationResults.ToList();
+                }
+                catch (CmdletInvocationException ex)
+                {
+                    if (null == exceptionHandler || null == ex.InnerException)
+                    {
+                        // throw original exception if no handler present
+                        throw;
+                    }
+
+                    throw exceptionHandler(ex.InnerException);
+                }
+            }
+        }
+    }
+
+    #endregion
+
+    #region Invoke with Dictionary parameter stubs
+
+    public IList<PSObject> Invoke(Type cmdletType, Dictionary<string, object> parameters)
+    {
+        Contract.Requires(null != cmdletType);
+        Contract.Requires(null != parameters);
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(cmdletType, parameters, HELP_FILE_NAME, exceptionHandler: null, errorHandler: null);
+    }
+
+    public IList<PSObject> Invoke(Type cmdletType, Dictionary<string, object> parameters,
+        Func<Exception, Exception> exceptionHandler)
+    {
+        Contract.Requires(null != cmdletType);
+        Contract.Requires(null != parameters);
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(cmdletType, parameters, HELP_FILE_NAME, exceptionHandler, errorHandler: null);
+    }
+
+    public IList<PSObject> Invoke(Type cmdletType, Dictionary<string, object> parameters,
+        Func<Exception, Exception> exceptionHandler, Action<IList<ErrorRecord>> errorHandler)
+    {
+        Contract.Requires(null != cmdletType);
+        Contract.Requires(null != parameters);
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(cmdletType, parameters, HELP_FILE_NAME, exceptionHandler, errorHandler);
+    }
+
+
+    public IList<PSObject> Invoke(Type cmdletType, Dictionary<string, object> parameters,
+        Action<IList<ErrorRecord>> errorHandler)
+    {
+        Contract.Requires(null != cmdletType);
+        Contract.Requires(null != parameters);
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        return Invoke(cmdletType, parameters, HELP_FILE_NAME, exceptionHandler: null, errorHandler: errorHandler);
+    }
+
+    #endregion
+
+    public IList<PSObject> Invoke(Type cmdletType, Dictionary<string, object> parameters, string helpFileName,
+        Func<Exception, Exception> exceptionHandler, Action<IList<ErrorRecord>> errorHandler)
+    {
+        Contract.Requires(null != cmdletType);
+        Contract.Requires(null != parameters);
+        Contract.Requires(!string.IsNullOrWhiteSpace(helpFileName));
+        Contract.Ensures(null != Contract.Result<IList<PSObject>>());
+
+        // construct the Cmdlet name the type implements
+        var cmdletAttribute = (CmdletAttribute) cmdletType.GetCustomAttributes(typeof(CmdletAttribute), true).Single();
+        Contract.Assert(null != cmdletAttribute, typeof(CmdletAttribute).FullName);
+        var cmdletName = string.Format(POWERSHELL_CMDLET_NAME_FORMATSTRING, cmdletAttribute.VerbName,
+            cmdletAttribute.NounName);
+
+        var cmdletNameToInvoke = cmdletName;
+        Contract.Assert(!string.IsNullOrWhiteSpace(cmdletNameToInvoke));
+
+        var initialSessionState = InitialSessionState.CreateDefault();
+        initialSessionState.Variables.Add(variableEntries);
+
+        var sessionStateCommandEntries = new List<SessionStateCommandEntry>
+        {
+            new SessionStateCmdletEntry(cmdletName, cmdletType, helpFileName)
+        };
+        initialSessionState.Commands.Add(sessionStateCommandEntries);
+
+        using (var runspace = RunspaceFactory.CreateRunspace(initialSessionState))
+        {
+            runspace.ApartmentState = ApartmentState.STA;
+            runspace.Open();
+
+            using (var pipeline = runspace.CreatePipeline())
+            {
+                try
+                {
+                    var command = new Command(cmdletNameToInvoke);
+                    foreach (var parameter in parameters)
+                    {
+                        command.Parameters.Add(new CommandParameter(parameter.Key, parameter.Value));
+                    }
+
+                    pipeline.Commands.Add(command);
+
+                    var invocationResults = pipeline.Invoke();
+
+                    if (null != errorHandler && pipeline.HadErrors)
+                    {
+                        var errorRecords = pipeline.Error.ReadToEnd().Cast<PSObject>().Select(e => e.BaseObject)
+                            .Cast<ErrorRecord>().ToList();
+                        errorHandler(errorRecords);
+                    }
+
+                    return invocationResults.ToList();
+                }
+                catch (CmdletInvocationException ex)
+                {
+                    if (null == exceptionHandler || null == ex.InnerException)
+                    {
+                        // throw original exception if no handler present
+                        throw;
+                    }
+
+                    throw exceptionHandler(ex.InnerException);
+                }
+            }
+        }
+    }
+
+    public void HasAlias(Type implementingType, string expectedAlias)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(expectedAlias));
+
+        HasAlias(implementingType, expectedAlias, null);
+    }
+
+    public void HasAlias(Type implementingType, string expectedAlias, string message)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(expectedAlias));
+
+        var customAttribute =
+            (AliasAttribute) implementingType.GetCustomAttributes(typeof(AliasAttribute), true).FirstOrDefault();
+        var isAttributeDefined = null != customAttribute?.AliasNames;
+        if (!isAttributeDefined)
+        {
+            var attributeNotDefinedMessage = new StringBuilder();
+            attributeNotDefinedMessage.AppendFormat(
+                "PsCmdletAssert2.IsAliasDefined FAILED. No AliasAttribute defined.");
+            if (null != message)
+            {
+                attributeNotDefinedMessage.AppendFormat(" '{0}'", message);
+            }
+
+            throw new Exception(attributeNotDefinedMessage.ToString());
+        }
+
+        var isAliasDefined = customAttribute.AliasNames.Any(expectedAlias.Equals);
+        if (isAliasDefined)
+        {
+            return;
+        }
+
+        var aliasNotDefinedMessage = new StringBuilder();
+        aliasNotDefinedMessage.AppendFormat("PsCmdletAssert2.IsAliasDefined FAILED. ExpectedAlias '{0}' not defined.",
+            expectedAlias);
+        if (null != message)
+        {
+            aliasNotDefinedMessage.AppendFormat(" '{0}'", message);
+        }
+
+        throw new Exception(aliasNotDefinedMessage.ToString());
+    }
+
+    public void HasOutputType(Type implementingType, Type expectedOutputType)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(null != expectedOutputType);
+
+        HasOutputType(implementingType, expectedOutputType.FullName, ParameterAttribute.AllParameterSets, null);
+    }
+
+    public void HasOutputType(Type implementingType, string expectedOutputTypeName)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(expectedOutputTypeName));
+
+        HasOutputType(implementingType, expectedOutputTypeName, ParameterAttribute.AllParameterSets, null);
+    }
+
+    public void HasOutputType(Type implementingType, Type expectedOutputType, string parameterSetName)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(null != expectedOutputType);
+
+        HasOutputType(implementingType, expectedOutputType.FullName, parameterSetName, null);
+    }
+
+    public void HasOutputType(Type implementingType, string expectedOutputTypeName, string parameterSetName)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(expectedOutputTypeName));
+
+        HasOutputType(implementingType, expectedOutputTypeName, parameterSetName, null);
+    }
+
+    public void HasOutputType(Type implementingType, string expectedOutputTypeName, string parameterSetName,
+        string message)
+    {
+        Contract.Requires(null != implementingType);
+        Contract.Requires(!string.IsNullOrWhiteSpace(expectedOutputTypeName));
+        Contract.Requires(!string.IsNullOrWhiteSpace(parameterSetName));
+
+        var outputTypeAttributes =
+            (OutputTypeAttribute[]) implementingType.GetCustomAttributes(typeof(OutputTypeAttribute), true);
+
+        var isValidOutputType = false;
+
+        var outputTypeAttributesForGivenParameterSetName =
+            outputTypeAttributes.Where(e => e.ParameterSetName.Contains(parameterSetName));
+        foreach (var outputTypeAttribute in outputTypeAttributesForGivenParameterSetName)
+        {
+            isValidOutputType |= outputTypeAttribute.Type.Any(e => e.Name == expectedOutputTypeName);
+        }
+
+        if (isValidOutputType)
+        {
+            return;
+        }
+
+        var outputTypeAttributesForAllParameterSets =
+            outputTypeAttributes.Where(e => e.ParameterSetName.Contains(ParameterAttribute.AllParameterSets));
+        foreach (var outputTypeAttribute in outputTypeAttributesForAllParameterSets)
+        {
+            isValidOutputType |= outputTypeAttribute.Type.Any(e => e.Name == expectedOutputTypeName);
+        }
+
+        if (isValidOutputType)
+        {
+            return;
+        }
+
+        var invalidOutputTypeMessage = new StringBuilder();
+        invalidOutputTypeMessage.AppendFormat(
+            "PsCmdletAssert2.HasOutputType FAILED. ExpectedType '{0}' not defined for ParameterSetName '{1}'.",
+            expectedOutputTypeName, parameterSetName);
+        if (null != message)
+        {
+            invalidOutputTypeMessage.AppendFormat(" '{0}'", message);
+        }
+
+        throw new Exception(invalidOutputTypeMessage.ToString());
+    }
+}

--- a/src/ServiceControlInstaller.PowerShell.UnitTests/ServiceControlInstaller.PowerShell.UnitTests.csproj
+++ b/src/ServiceControlInstaller.PowerShell.UnitTests/ServiceControlInstaller.PowerShell.UnitTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net48</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
+        <PackageReference Include="NUnit" Version="3.12.0" />
+        <!--        <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.7" />-->
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\ServiceControlInstaller.PowerShell\ServiceControlInstaller.PowerShell.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+            <HintPath>..\..\..\..\..\..\..\Windows\Microsoft.NET\assembly\GAC_MSIL\System.Management.Automation\v4.0_3.0.0.0__31bf3856ad364e35\System.Management.Automation.dll</HintPath>
+        </Reference>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Trying to setup a nunit project to set the powershell cmdlet but not successful. This WIP shows I'm using the libs according to the following blog, however, this does not work for PSCmdLet's. I've google numerous pages for help but couldn't find how to do this.

https://devblogs.microsoft.com/powershell/depending-on-the-right-powershell-nuget-package-in-your-net-project

I don't see how I could do an "Import-Module", on the other hand that seems to deep. I don't want to unit test existing powershell stuff or scripts just the CmdLet this solutions owns.

It seems the only option is to not derive from PSCmdLet but from CmdLet which does allow to be invoked immediately but likely then you do not run in a full powershell context.

There is this approach but that doesn't feel very nice too and a hack: https://stackoverflow.com/a/57874764/199551