### PR TITLE
Remove attachment locks since the underlying put static has significantly changed and should no longer need it

### DIFF
--- a/src/ServiceControl.Audit/Auditing/BodyStorage/RavenAttachments/RavenAttachmentsBodyStorage.cs
+++ b/src/ServiceControl.Audit/Auditing/BodyStorage/RavenAttachments/RavenAttachmentsBodyStorage.cs
@@ -1,50 +1,26 @@
 ﻿namespace ServiceControl.Audit.Auditing.BodyStorage.RavenAttachments
 {
-    using System;
     using System.IO;
-    using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
     using Raven.Client;
     using Raven.Json.Linq;
 
     class RavenAttachmentsBodyStorage : IBodyStorage
     {
-        public RavenAttachmentsBodyStorage()
-        {
-            locks = Enumerable.Range(0, 42).Select(i => new SemaphoreSlim(1)).ToArray(); //because 42 is the answer
-        }
-
         public IDocumentStore DocumentStore { get; set; }
 
         public async Task<string> Store(string bodyId, string contentType, int bodySize, Stream bodyStream)
         {
-            /*
-             * The locking here is a workaround for RavenDB bug DocumentDatabase.PutStatic that allows multiple threads to enter a critical section.
-             */
-            var idHash = Math.Abs(bodyId.GetHashCode());
-            var lockIndex = idHash % locks.Length; //I think using bit manipulation is not worth the effort
-
-            var semaphore = locks[lockIndex];
-            try
-            {
-                await semaphore.WaitAsync().ConfigureAwait(false);
-
-                //We want to continue using attachments for now
+            //We want to continue using attachments for now
 #pragma warning disable 618
-                await DocumentStore.AsyncDatabaseCommands.PutAttachmentAsync($"messagebodies/{bodyId}", null, bodyStream, new RavenJObject
+            await DocumentStore.AsyncDatabaseCommands.PutAttachmentAsync($"messagebodies/{bodyId}", null, bodyStream, new RavenJObject
 #pragma warning restore 618
-                {
-                    {"ContentType", contentType},
-                    {"ContentLength", bodySize}
-                }).ConfigureAwait(false);
-
-                return $"/messages/{bodyId}/body";
-            }
-            finally
             {
-                semaphore.Release();
-            }
+                {"ContentType", contentType},
+                {"ContentLength", bodySize}
+            }).ConfigureAwait(false);
+
+            return $"/messages/{bodyId}/body";
         }
 
         public async Task<StreamResult> TryFetch(string bodyId)
@@ -69,7 +45,5 @@
                     Etag = attachment.Etag
                 };
         }
-
-        SemaphoreSlim[] locks;
     }
 }

--- a/src/ServiceControl/Operations/BodyStorage/RavenAttachments/RavenAttachmentsBodyStorage.cs
+++ b/src/ServiceControl/Operations/BodyStorage/RavenAttachments/RavenAttachmentsBodyStorage.cs
@@ -10,41 +10,20 @@
 
     class RavenAttachmentsBodyStorage : IBodyStorage
     {
-        public RavenAttachmentsBodyStorage()
-        {
-            locks = Enumerable.Range(0, 42).Select(i => new SemaphoreSlim(1)).ToArray(); //because 42 is the answer
-        }
-
         public IDocumentStore DocumentStore { get; set; }
 
         public async Task<string> Store(string bodyId, string contentType, int bodySize, Stream bodyStream)
         {
-            /*
-             * The locking here is a workaround for RavenDB bug DocumentDatabase.PutStatic that allows multiple threads to enter a critical section.
-             */
-            var idHash = Math.Abs(bodyId.GetHashCode());
-            var lockIndex = idHash % locks.Length; //I think using bit manipulation is not worth the effort
-
-            var semaphore = locks[lockIndex];
-            try
-            {
-                await semaphore.WaitAsync().ConfigureAwait(false);
-
-                //We want to continue using attachments for now
+            //We want to continue using attachments for now
 #pragma warning disable 618
-                await DocumentStore.AsyncDatabaseCommands.PutAttachmentAsync($"messagebodies/{bodyId}", null, bodyStream, new RavenJObject
+            await DocumentStore.AsyncDatabaseCommands.PutAttachmentAsync($"messagebodies/{bodyId}", null, bodyStream, new RavenJObject
 #pragma warning restore 618
-                {
-                    {"ContentType", contentType},
-                    {"ContentLength", bodySize}
-                }).ConfigureAwait(false);
-
-                return $"/messages/{bodyId}/body";
-            }
-            finally
             {
-                semaphore.Release();
-            }
+                {"ContentType", contentType},
+                {"ContentLength", bodySize}
+            }).ConfigureAwait(false);
+
+            return $"/messages/{bodyId}/body";
         }
 
         public async Task<StreamResult> TryFetch(string bodyId)
@@ -69,7 +48,5 @@
                     Etag = attachment.Etag
                 };
         }
-
-        SemaphoreSlim[] locks;
     }
 }


### PR DESCRIPTION
Introduced in https://github.com/Particular/ServiceControl/pull/1046

It seems put static should no longer need this. At least on my local tests with RabbitMQ this worked perfectly fine

https://github.com/ravendb/ravendb/blob/v3.5/Raven.Database/Actions/AttachmentActions.cs#L90-L163

Seems to have a per body lock in place already on the DB side