### PR TITLE
Disable chunked bulk inserts

### DIFF
--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -50,7 +50,9 @@
                 // deliberately not using the using statement because we dispose async explicitly
                 bulkInsert = store.BulkInsert(options: new BulkInsertOptions
                 {
-                    OverwriteExisting = true
+                    OverwriteExisting = true,
+                    ChunkedBulkInsertOptions = null,
+                    BatchSize = contexts.Count
                 });
                 var inserts = new List<Task>(contexts.Count);
                 foreach (var context in contexts)
@@ -133,7 +135,7 @@
                         {
                             Logger.Debug("Bulk insertion dispose failed", e);
                         }
-                        
+
                         // making sure to rethrow so that all messages get marked as failed
                         throw;
                     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/174258/102213300-d573ed80-3ed6-11eb-9629-e205229b5792.png)

Given the small batch sizes we have and the complexity the chunking involves I think we should disable it explicitly and set the batch size

Chunking does the following:

It wraps a remote bullk insertion operation and sets the `MaximumDocumentsPerChunk` to four times the batch size of the bulk insertion operation. In addition to that the maximum volume of all documents is set to 8 MB. If either the `MaxChunkVolumeInBytes` or `MaximumDocumentsPerChunk` is reached it flushes the previous remote bulk insertion operation if there was any and then asynchronously disposes of the current one. After that a new remote bulk insertion operation is created. Created a new one requires to allocate another background thread that then tries to asynchronously complete over the queue it manages while the previous one is still disposing and being flushed against the server. 

A remote bulk insertion operation itself though is not limited in size at all so I think reducing the infrastructure complexity and handling inside RavenDB can only benefit us given that we ingest at max `MaxConcurrency` (default `32`) items in a single session providing the option to do junking seems overkill.
