### PR TITLE
Provide default port for Docker monitoring instances

### DIFF
--- a/src/docker/backup/servicecontrol.asb.endpoint.monitoring
+++ b/src/docker/backup/servicecontrol.asb.endpoint.monitoring
@@ -7,6 +7,7 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 EXPOSE 33633
 

--- a/src/docker/backup/servicecontrol.asb.endpoint.monitoring.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.monitoring.init
@@ -7,5 +7,6 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/backup/servicecontrol.asb.forwarding.monitoring
+++ b/src/docker/backup/servicecontrol.asb.forwarding.monitoring
@@ -7,6 +7,7 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 EXPOSE 33633
 

--- a/src/docker/backup/servicecontrol.asb.forwarding.monitoring.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.monitoring.init
@@ -7,5 +7,6 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
@@ -7,6 +7,7 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 EXPOSE 33633
 

--- a/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
@@ -7,5 +7,6 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
@@ -7,6 +7,7 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 EXPOSE 33633
 

--- a/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
@@ -7,5 +7,6 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
@@ -7,6 +7,7 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 EXPOSE 33633
 

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
@@ -7,5 +7,6 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
@@ -7,6 +7,7 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 EXPOSE 33633
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
@@ -7,5 +7,6 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
@@ -7,6 +7,7 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 EXPOSE 33633
 

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
@@ -7,5 +7,6 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
@@ -7,6 +7,7 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 EXPOSE 33633
 

--- a/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
@@ -7,5 +7,6 @@ ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "Monitoring/HttpHostName"="*"
+ENV "Monitoring/HttpPort"="33633"
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]


### PR DESCRIPTION
Without this setting users have to specify the httpport as an environment variable. This makes sure the default is at least provided so that it doesn't can be used.