### PR TITLE
Allow config keys to use `_` as well as `/`

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
@@ -21,8 +21,15 @@ namespace ServiceControl.Audit.Infrastructure.Settings
 
         public static bool TryRead(string root, string name, out T value)
         {
-            var fullKey = $"{root}/{name}";
+            if (TryReadVariable(out value, $"{root}/{name}")) return true;
+            if (TryReadVariable(out value, $"{root}_{name}")) return true;
 
+            value = default;
+            return false;
+        }
+
+        private static bool TryReadVariable(out T value, string fullKey)
+        {
             var environmentValue = Environment.GetEnvironmentVariable(fullKey);
 
             if (environmentValue != null)
@@ -34,5 +41,6 @@ namespace ServiceControl.Audit.Infrastructure.Settings
             value = default;
             return false;
         }
+
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
@@ -22,7 +22,8 @@ namespace ServiceControl.Audit.Infrastructure.Settings
         public static bool TryRead(string root, string name, out T value)
         {
             if (TryReadVariable(out value, $"{root}/{name}")) return true;
-            if (TryReadVariable(out value, $"{root}_{name}")) return true;
+            // Azure container instance compatibility:
+            if (TryReadVariable(out value, $"{root}_{name}".Replace('.', '_'))) return true;
 
             value = default;
             return false;

--- a/src/ServiceControl.Monitoring/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
@@ -22,7 +22,8 @@ namespace ServiceControl.Monitoring.Infrastructure.Settings
         public static bool TryRead(string root, string name, out T value)
         {
             if (TryReadVariable(out value, $"{root}/{name}")) return true;
-            if (TryReadVariable(out value, $"{root}_{name}")) return true;
+            // Azure container instance compatibility:
+            if (TryReadVariable(out value, $"{root}_{name}".Replace('.', '_'))) return true;
 
             value = default;
             return false;

--- a/src/ServiceControl.Monitoring/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
@@ -21,8 +21,15 @@ namespace ServiceControl.Monitoring.Infrastructure.Settings
 
         public static bool TryRead(string root, string name, out T value)
         {
-            var fullKey = $"{root}/{name}";
+            if (TryReadVariable(out value, $"{root}/{name}")) return true;
+            if (TryReadVariable(out value, $"{root}_{name}")) return true;
 
+            value = default;
+            return false;
+        }
+
+        private static bool TryReadVariable(out T value, string fullKey)
+        {
             var environmentValue = Environment.GetEnvironmentVariable(fullKey);
 
             if (environmentValue != null)
@@ -34,5 +41,6 @@ namespace ServiceControl.Monitoring.Infrastructure.Settings
             value = default;
             return false;
         }
+
     }
 }

--- a/src/ServiceControl/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
+++ b/src/ServiceControl/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
@@ -21,8 +21,15 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
         public static bool TryRead(string root, string name, out T value)
         {
-            var fullKey = $"{root}/{name}";
+            if (TryReadVariable(out value, $"{root}/{name}")) return true;
+            if (TryReadVariable(out value, $"{root}_{name}")) return true;
 
+            value = default;
+            return false;
+        }
+
+        private static bool TryReadVariable(out T value, string fullKey)
+        {
             var environmentValue = Environment.GetEnvironmentVariable(fullKey);
 
             if (environmentValue != null)

--- a/src/ServiceControl/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
+++ b/src/ServiceControl/Infrastructure/Settings/EnvironmentVariableSettingsReader.cs
@@ -22,7 +22,8 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public static bool TryRead(string root, string name, out T value)
         {
             if (TryReadVariable(out value, $"{root}/{name}")) return true;
-            if (TryReadVariable(out value, $"{root}_{name}")) return true;
+            // Azure container instance compatibility:
+            if (TryReadVariable(out value, $"{root}_{name}".Replace('.', '_'))) return true;
 
             value = default;
             return false;


### PR DESCRIPTION
_Connected to https://github.com/Particular/DeveloperExperience/issues/1168_

`Azure Container Instance` doesn't allow the usage of `root/value` environment variables, only underscores.