### PR TITLE
Docker: Adding missing default for "Monitoring/LogPath"

### DIFF
--- a/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
@@ -9,6 +9,8 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustom
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 EXPOSE 33633
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
@@ -9,4 +9,6 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustom
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
@@ -9,6 +9,8 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCust
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 EXPOSE 33633
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
@@ -9,4 +9,6 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCust
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
@@ -9,6 +9,8 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustom
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 EXPOSE 33633
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
@@ -9,4 +9,6 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustom
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
@@ -9,6 +9,8 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConve
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 EXPOSE 33633
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
@@ -9,4 +9,6 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConve
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
@@ -9,6 +9,8 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirec
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 EXPOSE 33633
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
@@ -9,4 +9,6 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirec
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
@@ -9,6 +9,8 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTra
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 EXPOSE 33633
 
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
@@ -9,4 +9,6 @@ ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTra
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"
 
+ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]


### PR DESCRIPTION
Although monitoring doesn't log anything by default it can log errors.

Note: Assumes #2366 gets merged and uses `C:\Data\Logs`, and not `C:\Logs`