### PR TITLE
Docker images have shared data path for both Logs and Database for easier volume mapping

### DIFF
--- a/src/docker/backup/servicecontrol.asb.endpoint
+++ b/src/docker/backup/servicecontrol.asb.endpoint
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 EXPOSE 33333
 EXPOSE 33334

--- a/src/docker/backup/servicecontrol.asb.endpoint.audit
+++ b/src/docker/backup/servicecontrol.asb.endpoint.audit
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 EXPOSE 44444
 EXPOSE 44445

--- a/src/docker/backup/servicecontrol.asb.endpoint.audit.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.audit.init
@@ -8,7 +8,7 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable", "--setup"]

--- a/src/docker/backup/servicecontrol.asb.endpoint.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.init
@@ -8,7 +8,7 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 ENTRYPOINT ["ServiceControl.exe", "--portable", "--setup"]

--- a/src/docker/backup/servicecontrol.asb.forwarding
+++ b/src/docker/backup/servicecontrol.asb.forwarding
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 EXPOSE 33333
 EXPOSE 33334

--- a/src/docker/backup/servicecontrol.asb.forwarding.audit
+++ b/src/docker/backup/servicecontrol.asb.forwarding.audit
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 EXPOSE 44444
 EXPOSE 44445

--- a/src/docker/backup/servicecontrol.asb.forwarding.audit.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.audit.init
@@ -8,7 +8,7 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable", "--setup"]

--- a/src/docker/backup/servicecontrol.asb.forwarding.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.init
@@ -8,7 +8,7 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 ENTRYPOINT ["ServiceControl.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.amazonsqs-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.azureservicebus-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.sqlserver-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"

--- a/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl.Audit/bin/Release/net462 .
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl.Audit/Hostname"="*"
 
-ENV "ServiceControl.Audit/DBPath"="C:\\Data\\"
-ENV "ServiceControl.Audit/LogPath"="C:\\Logs\\"
+ENV "ServiceControl.Audit/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"

--- a/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
@@ -8,8 +8,8 @@ ADD /ServiceControl/bin/Release/net462 .
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl/Hostname"="*"
 
-ENV "ServiceControl/DBPath"="C:\\Data\\"
-ENV "ServiceControl/LogPath"="C:\\Logs\\"
+ENV "ServiceControl/DBPath"="C:\\Data\\DB\\"
+ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 
 # Defaults
 ENV "ServiceControl/ForwardErrorMessages"="False"


### PR DESCRIPTION
This way `C:\Data` can be mapped to a volume so that both logs and database data are mounted via a single mapping.
