### PR TITLE
Revert trial license installation feedback experience

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -43,7 +43,6 @@
             DataSpaceRemainingThreshold = GetDataSpaceRemainingThreshold();
             ServiceControlQueueAddress = SettingsReader<string>.Read("ServiceControlQueueAddress");
             TimeToRestartAuditIngestionAfterFailure = GetTimeToRestartAuditIngestionAfterFailure();
-            IsRunningInDocker = SettingsReader<bool>.Read("IsDocker", false);
         }
 
         public Func<string, Dictionary<string, string>, byte[], Func<Task>, Task> OnMessage { get; set; } = (messageId, headers, body, next) => next();
@@ -170,8 +169,6 @@
         public string ServiceControlQueueAddress { get; set; }
 
         public TimeSpan TimeToRestartAuditIngestionAfterFailure { get; set; }
-
-        public bool IsRunningInDocker { get; set; }
 
         public TransportCustomization LoadTransportCustomization()
         {

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -43,6 +43,7 @@
             DataSpaceRemainingThreshold = GetDataSpaceRemainingThreshold();
             ServiceControlQueueAddress = SettingsReader<string>.Read("ServiceControlQueueAddress");
             TimeToRestartAuditIngestionAfterFailure = GetTimeToRestartAuditIngestionAfterFailure();
+            IsRunningInDocker = SettingsReader<bool>.Read("IsDocker", false);
         }
 
         public Func<string, Dictionary<string, string>, byte[], Func<Task>, Task> OnMessage { get; set; } = (messageId, headers, body, next) => next();
@@ -169,6 +170,8 @@
         public string ServiceControlQueueAddress { get; set; }
 
         public TimeSpan TimeToRestartAuditIngestionAfterFailure { get; set; }
+
+        public bool IsRunningInDocker { get; set; }
 
         public TransportCustomization LoadTransportCustomization()
         {

--- a/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
@@ -112,13 +112,14 @@ namespace ServiceControl.Audit.Infrastructure
                     return false;
                 }
             }
-
-            // Validate license:
-            var license = LicenseManager.FindLicense();
-            if (!LicenseManager.IsLicenseValidForServiceControlInit(license, out var errorMessageForFoundLicense))
+            else
             {
-                log.Error(errorMessageForFoundLicense);
-                return false;
+                var license = LicenseManager.FindLicense();
+                if (!LicenseManager.IsLicenseValidForServiceControlInit(license, out var errorMessageForFoundLicense))
+                {
+                    log.Error(errorMessageForFoundLicense);
+                    return false;
+                }
             }
 
             return true;

--- a/src/ServiceControl.LicenseManagement/LicenseManager.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseManager.cs
@@ -35,8 +35,8 @@
                 return false;
             }
 
-            // E.g. when within a docker container
-            if (MustBeNonTrialLicenseForSetup() && license.IsEvaluationLicense)
+            // E.g. Cannot set up a new instance of ServiceControl on a trial license when running in a docker container
+            if (IsRunningInDocker && license.IsEvaluationLicense)
             {
                 errorMessage = "Cannot run ServiceControl in a container with a trial license";
                 return false;
@@ -108,12 +108,7 @@
             return LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData);
         }
 
-        static bool MustBeNonTrialLicenseForSetup()
-        {
-            var isDockerEnvironmentVariable = Environment.GetEnvironmentVariable("SERVICECONTROL_NO_TRIAL");
-
-            return string.Equals("true", isDockerEnvironmentVariable, StringComparison.InvariantCultureIgnoreCase);
-        }
+        static bool IsRunningInDocker => bool.TryParse(Environment.GetEnvironmentVariable("SERVICECONTROL_RUNNING_IN_DOCKER"), out bool isDocker) && isDocker;
 
         static bool TryDeserializeLicense(string licenseText, out License license)
         {

--- a/src/ServiceControl.LicenseManagement/LicenseManager.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseManager.cs
@@ -35,8 +35,8 @@
                 return false;
             }
 
-            // Not allowed to run setup within a docker container
-            if (IsDockerEnvironmentVariableSet() && license.IsEvaluationLicense)
+            // E.g. when within a docker container
+            if (MustBeNonTrialLicenseForSetup() && license.IsEvaluationLicense)
             {
                 errorMessage = "Cannot run ServiceControl in a container with a trial license";
                 return false;
@@ -108,9 +108,9 @@
             return LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData);
         }
 
-        static bool IsDockerEnvironmentVariableSet()
+        static bool MustBeNonTrialLicenseForSetup()
         {
-            var isDockerEnvironmentVariable = Environment.GetEnvironmentVariable("IsDocker");
+            var isDockerEnvironmentVariable = Environment.GetEnvironmentVariable("SERVICECONTROL_NO_TRIAL");
 
             return string.Equals("true", isDockerEnvironmentVariable, StringComparison.InvariantCultureIgnoreCase);
         }

--- a/src/ServiceControl.LicenseManagement/LicenseManager.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseManager.cs
@@ -35,9 +35,10 @@
                 return false;
             }
 
-            if (license.IsEvaluationLicense)
+            // Not allowed to run setup within a docker container
+            if (IsDockerEnvironmentVariableSet() && license.IsEvaluationLicense)
             {
-                errorMessage = "Cannot run setup with a trial license";
+                errorMessage = "Cannot run ServiceControl in a container with a trial license";
                 return false;
             }
 
@@ -105,6 +106,13 @@
         static string GetMachineLevelLicenseLocation()
         {
             return LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData);
+        }
+
+        static bool IsDockerEnvironmentVariableSet()
+        {
+            var isDockerEnvironmentVariable = Environment.GetEnvironmentVariable("IsDocker");
+
+            return string.Equals("true", isDockerEnvironmentVariable, StringComparison.InvariantCultureIgnoreCase);
         }
 
         static bool TryDeserializeLicense(string licenseText, out License license)

--- a/src/ServiceControl.Monitoring/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/SetupCommand.cs
@@ -48,13 +48,14 @@ namespace ServiceControl.Monitoring
                     return false;
                 }
             }
-
-            // Validate license:
-            var license = LicenseManager.FindLicense();
-            if (!LicenseManager.IsLicenseValidForServiceControlInit(license, out var errorMessageForFoundLicense))
+            else
             {
-                Logger.Error(errorMessageForFoundLicense);
-                return false;
+                var license = LicenseManager.FindLicense();
+                if (!LicenseManager.IsLicenseValidForServiceControlInit(license, out var errorMessageForFoundLicense))
+                {
+                    Logger.Error(errorMessageForFoundLicense);
+                    return false;
+                }
             }
 
             return true;

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -27,6 +27,7 @@ namespace ServiceControl.Monitoring
             EndpointName = SettingsReader<string>.Read("EndpointName");
             EndpointUptimeGracePeriod = TimeSpan.Parse(SettingsReader<string>.Read("EndpointUptimeGracePeriod", "00:00:40"));
             MaximumConcurrencyLevel = SettingsReader<int>.Read("MaximumConcurrencyLevel", 32);
+            IsRunningInDocker = SettingsReader<bool>.Read("IsDocker", false);
         }
 
         public string EndpointName
@@ -51,6 +52,7 @@ namespace ServiceControl.Monitoring
         public string RootUrl => $"http://{HttpHostName}:{HttpPort}/";
         public int MaximumConcurrencyLevel { get; set; }
         public string LicenseFileText { get; set; }
+        public bool IsRunningInDocker { get; set; }
 
         // SC installer always populates LogPath in app.config on installation/change/upgrade so this will only be used when
         // debugging or if the entry is removed manually. In those circumstances default to the folder containing the exe

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -27,7 +27,6 @@ namespace ServiceControl.Monitoring
             EndpointName = SettingsReader<string>.Read("EndpointName");
             EndpointUptimeGracePeriod = TimeSpan.Parse(SettingsReader<string>.Read("EndpointUptimeGracePeriod", "00:00:40"));
             MaximumConcurrencyLevel = SettingsReader<int>.Read("MaximumConcurrencyLevel", 32);
-            IsRunningInDocker = SettingsReader<bool>.Read("IsDocker", false);
         }
 
         public string EndpointName
@@ -52,7 +51,6 @@ namespace ServiceControl.Monitoring
         public string RootUrl => $"http://{HttpHostName}:{HttpPort}/";
         public int MaximumConcurrencyLevel { get; set; }
         public string LicenseFileText { get; set; }
-        public bool IsRunningInDocker { get; set; }
 
         // SC installer always populates LogPath in app.config on installation/change/upgrade so this will only be used when
         // debugging or if the entry is removed manually. In those circumstances default to the folder containing the exe

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -50,6 +50,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
             DataSpaceRemainingThreshold = GetDataSpaceRemainingThreshold();
             DbPath = GetDbPath();
             TimeToRestartErrorIngestionAfterFailure = GetTimeToRestartErrorIngestionAfterFailure();
+            IsRunningInDocker = SettingsReader<bool>.Read("IsDocker", false);
         }
 
         public bool AllowMessageEditing { get; set; }
@@ -188,6 +189,8 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public RemoteInstanceSetting[] RemoteInstances { get; set; }
 
         public int DataSpaceRemainingThreshold { get; set; }
+
+        public bool IsRunningInDocker { get; set; }
 
         public TransportCustomization LoadTransportCustomization()
         {

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -50,7 +50,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
             DataSpaceRemainingThreshold = GetDataSpaceRemainingThreshold();
             DbPath = GetDbPath();
             TimeToRestartErrorIngestionAfterFailure = GetTimeToRestartErrorIngestionAfterFailure();
-            IsRunningInDocker = SettingsReader<bool>.Read("IsDocker", false);
         }
 
         public bool AllowMessageEditing { get; set; }
@@ -189,8 +188,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public RemoteInstanceSetting[] RemoteInstances { get; set; }
 
         public int DataSpaceRemainingThreshold { get; set; }
-
-        public bool IsRunningInDocker { get; set; }
 
         public TransportCustomization LoadTransportCustomization()
         {

--- a/src/ServiceControl/SetupBootstrapper.cs
+++ b/src/ServiceControl/SetupBootstrapper.cs
@@ -82,13 +82,14 @@ namespace Particular.ServiceControl
                     return false;
                 }
             }
-
-            // Validate license:
-            var license = LicenseManager.FindLicense();
-            if (!LicenseManager.IsLicenseValidForServiceControlInit(license, out var errorMessageForFoundLicense))
+            else
             {
-                log.Error(errorMessageForFoundLicense);
-                return false;
+                var license = LicenseManager.FindLicense();
+                if (!LicenseManager.IsLicenseValidForServiceControlInit(license, out var errorMessageForFoundLicense))
+                {
+                    log.Error(errorMessageForFoundLicense);
+                    return false;
+                }
             }
 
             return true;

--- a/src/docker/builddockerimages.ps1
+++ b/src/docker/builddockerimages.ps1
@@ -1,4 +1,4 @@
-msbuild ../servicecontrol/ServiceControl.sln /t:Build /p:Configuration=Release
+msbuild ../ServiceControl.sln /t:Build /p:Configuration=Release
 
 docker build -f .\servicecontrol.azureservicebus-windows.dockerfile -t particular/servicecontrol/azureservicebus ./../
 docker build -f .\servicecontrol.azureservicebus.init-windows.dockerfile -t particular/servicecontrol/azureservicebus/init ./../

--- a/src/docker/servicecontrol.amazonsqs-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azureservicebus-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.azureservicebus-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.sqlserver-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.sqlserver-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl.Audit/Hostname"="*"
 

--- a/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.audit
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Audit/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl/Hostname"="*"
 

--- a/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"

--- a/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "IsDocker"="true"
+ENV "SERVICECONTROL_NO_TRIAL"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
-ENV "SERVICECONTROL_NO_TRIAL"="true"
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /servicecontrol.monitoring
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
 ADD /ServiceControl.Monitoring/bin/Release/net462 .
 
+ENV "IsDocker"="true"
+
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "Monitoring/HttpHostName"="*"
 ENV "Monitoring/HttpPort"="33633"


### PR DESCRIPTION
As part of https://github.com/Particular/ServiceControl/pull/2200 we prevented `--setup` to be executed when using trial licenses.

This was intended only to happen when running docker images, but it also propagated through to Powershell and the SCMU installer. The problem is that the feedback given to users was not that there was no valid license, and SCMU ended up copying files and leaving the instance in a weird state.

This was not the intention, so this PR tweaks that checks the license state to only block if a `IsDocker` environment variable is provided. This variable is set as part of the docker images too.