### PR TITLE
Allow maintenance mode to be run in portable mode

### DIFF
--- a/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
@@ -21,7 +21,10 @@
         [Test]
         public void PublicClr()
         {
-            var publicApi = ApiGenerator.GeneratePublicApi(typeof(Bootstrapper).Assembly);
+            var publicApi = typeof(Bootstrapper).Assembly.GeneratePublicApi(new ApiGeneratorOptions
+            {
+                ExcludeAttributes = new[] { "System.Reflection.AssemblyMetadataAttribute" }
+            });
             Approver.Verify(publicApi);
         }
 

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -1,9 +1,8 @@
-[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ServiceControl.Audit.AcceptanceTests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ServiceControl.Audit.UnitTests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ServiceControl.Loadtests.Reporter")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("ServiceControl.MultiInstance.AcceptanceTests")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.7.2", FrameworkDisplayName=".NET Framework 4.7.2")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ServiceControl.Audit.AcceptanceTests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ServiceControl.Audit.UnitTests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ServiceControl.Loadtests.Reporter")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ServiceControl.MultiInstance.AcceptanceTests")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7.2", FrameworkDisplayName=".NET Framework 4.7.2")]
 namespace ServiceControl.Audit.Auditing
 {
     public class DefaultEnrichers : NServiceBus.Features.Feature
@@ -43,34 +42,34 @@ namespace ServiceControl.Audit.Auditing.MessagesView
 {
     public class GetMessagesController : System.Web.Http.ApiController
     {
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("messages/{*catchAll}")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("messages/{*catchAll}")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> CatchAll(string catchAll) { }
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("messages/{id}/body")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("messages/{id}/body")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Get(string id) { }
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("messages")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("messages")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetAllMessages() { }
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("endpoints/{endpoint}/messages")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("endpoints/{endpoint}/messages")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetEndpointMessages(string endpoint) { }
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("messages/search")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("messages/search")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Search(string q) { }
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("endpoints/{endpoint}/messages/search")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("endpoints/{endpoint}/messages/search")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Search(string endpoint, string q) { }
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("messages/search/{keyword}")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("messages/search/{keyword}")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SearchByKeyWord(string keyword) { }
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("endpoints/{endpoint}/messages/search/{keyword}")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("endpoints/{endpoint}/messages/search/{keyword}")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SearchByKeyword(string endpoint, string keyword) { }
     }
     public class MessagesConversationController : System.Web.Http.ApiController
     {
-        [System.Web.Http.RouteAttribute("conversations/{conversationid}")]
+        [System.Web.Http.Route("conversations/{conversationid}")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Get(string conversationid) { }
     }
     public class MessagesView
@@ -95,7 +94,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         public ServiceControl.Audit.Monitoring.EndpointDetails ReceivingEndpoint { get; set; }
         public ServiceControl.Audit.Monitoring.EndpointDetails SendingEndpoint { get; set; }
         public ServiceControl.Audit.Monitoring.MessageStatus Status { get; set; }
-        public System.Nullable<System.DateTime> TimeSent { get; set; }
+        public System.DateTime? TimeSent { get; set; }
     }
     public class MessagesViewIndex : Raven.Client.Indexes.AbstractIndexCreationTask<ServiceControl.Audit.Auditing.ProcessedMessage, ServiceControl.Audit.Auditing.MessagesView.MessagesViewIndex.SortAndFilterOptions>
     {
@@ -104,13 +103,13 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         {
             public SortAndFilterOptions() { }
             public string ConversationId { get; set; }
-            public System.Nullable<System.TimeSpan> CriticalTime { get; set; }
-            public System.Nullable<System.TimeSpan> DeliveryTime { get; set; }
+            public System.TimeSpan? CriticalTime { get; set; }
+            public System.TimeSpan? DeliveryTime { get; set; }
             public bool IsSystemMessage { get; set; }
             public string MessageId { get; set; }
             public string MessageType { get; set; }
             public System.DateTime ProcessedAt { get; set; }
-            public System.Nullable<System.TimeSpan> ProcessingTime { get; set; }
+            public System.TimeSpan? ProcessingTime { get; set; }
             public string[] Query { get; set; }
             public string ReceivingEndpointName { get; set; }
             public ServiceControl.Audit.Monitoring.MessageStatus Status { get; set; }
@@ -142,8 +141,8 @@ namespace ServiceControl.Audit.Infrastructure.Installers
 }
 namespace ServiceControl.Audit.Infrastructure.RavenDB.Expiration
 {
-    [System.ComponentModel.Composition.ExportMetadataAttribute("Bundle", "customDocumentExpiration")]
-    [System.ComponentModel.Composition.InheritedExportAttribute(typeof(Raven.Database.Plugins.IStartupTask))]
+    [System.ComponentModel.Composition.ExportMetadata("Bundle", "customDocumentExpiration")]
+    [System.ComponentModel.Composition.InheritedExport(typeof(Raven.Database.Plugins.IStartupTask))]
     public class ExpiredDocumentsCleanerBundle : Raven.Database.Plugins.IStartupTask, System.IDisposable
     {
         public ExpiredDocumentsCleanerBundle() { }
@@ -206,12 +205,12 @@ namespace ServiceControl.Audit.Infrastructure.WebApi
 {
     public class RootController : System.Web.Http.ApiController
     {
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("configuration")]
-        [System.Web.Http.RouteAttribute("instance-info")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("configuration")]
+        [System.Web.Http.Route("instance-info")]
         public System.Web.Http.Results.OkNegotiatedContentResult<object> Config() { }
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("")]
         public System.Web.Http.Results.OkNegotiatedContentResult<ServiceControl.Audit.Infrastructure.WebApi.RootController.RootUrls> Urls() { }
         public class RootUrls
         {
@@ -247,8 +246,8 @@ namespace ServiceControl.Audit.Monitoring
     }
     public class KnownEndpointsController : System.Web.Http.ApiController
     {
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("endpoints/known")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("endpoints/known")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetAll() { }
     }
     public class KnownEndpointsView
@@ -277,8 +276,8 @@ namespace ServiceControl.Audit.SagaAudit
 {
     public class SagasController : System.Web.Http.ApiController
     {
-        [System.Web.Http.HttpGetAttribute()]
-        [System.Web.Http.RouteAttribute("sagas/{id}")]
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("sagas/{id}")]
         public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Sagas(System.Guid id) { }
     }
 }

--- a/src/ServiceControl.Audit.UnitTests/ServiceControl.Audit.UnitTests.csproj
+++ b/src/ServiceControl.Audit.UnitTests/ServiceControl.Audit.UnitTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />
-    <PackageReference Include="PublicApiGenerator" Version="9.3.0" />
+    <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
@@ -44,6 +44,11 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
                         };
                         executionMode = ExecutionMode.Maintenance;
                     }
+                },
+                {
+                    "p|portable",
+                    @"Internal use - runs as a console app, even non-interactively",
+                    s => { Portable = true; }
                 }
             };
 

--- a/src/ServiceControl.Audit/Infrastructure/MaintenanceBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/MaintenanceBootstrapper.cs
@@ -14,24 +14,20 @@ namespace ServiceControl.Audit.Infrastructure
 
             new RavenBootstrapper().StartRaven(documentStore, settings, true);
 
-            if (args.Portable)
+            if (!args.RunAsWindowsService)
             {
                 Console.Out.WriteLine("RavenDB is now accepting requests on {0}", settings.StorageUrl);
-                Console.Out.WriteLine("RavenDB Maintenance Mode - Press Enter to exit");
-                while (Console.ReadKey().Key != ConsoleKey.Enter)
-                {
-                }
+                Console.Out.WriteLine("RavenDB Maintenance Mode - Press any key to exit");
+                Console.Read();
 
                 documentStore.Dispose();
 
                 return;
             }
-            else
+
+            using (var service = new MaintenanceHost(settings, documentStore))
             {
-                using (var service = new MaintenanceHost(settings, documentStore))
-                {
-                    service.Run();
-                }
+                service.Run();
             }
         }
     }

--- a/src/ServiceControl.Audit/Infrastructure/MaintenanceBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/MaintenanceBootstrapper.cs
@@ -14,7 +14,7 @@ namespace ServiceControl.Audit.Infrastructure
 
             new RavenBootstrapper().StartRaven(documentStore, settings, true);
 
-            if (Environment.UserInteractive)
+            if (args.Portable)
             {
                 Console.Out.WriteLine("RavenDB is now accepting requests on {0}", settings.StorageUrl);
                 Console.Out.WriteLine("RavenDB Maintenance Mode - Press Enter to exit");
@@ -26,10 +26,12 @@ namespace ServiceControl.Audit.Infrastructure
 
                 return;
             }
-
-            using (var service = new MaintenanceHost(settings, documentStore))
+            else
             {
-                service.Run();
+                using (var service = new MaintenanceHost(settings, documentStore))
+                {
+                    service.Run();
+                }
             }
         }
     }

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -45,6 +45,11 @@ namespace Particular.ServiceControl.Hosting
                         };
                         executionMode = ExecutionMode.Maintenance;
                     }
+                },
+                {
+                    "p|portable",
+                    @"Internal use - runs as a console app, even non-interactively",
+                    s => { Portable = true; }
                 }
             };
 

--- a/src/ServiceControl/MaintenanceBootstrapper.cs
+++ b/src/ServiceControl/MaintenanceBootstrapper.cs
@@ -15,24 +15,20 @@ namespace Particular.ServiceControl
 
             new RavenBootstrapper().StartRaven(documentStore, settings, true);
 
-            if (args.Portable)
+            if (!args.RunAsWindowsService)
             {
                 Console.Out.WriteLine("RavenDB is now accepting requests on {0}", settings.StorageUrl);
-                Console.Out.WriteLine("RavenDB Maintenance Mode - Press Enter to exit");
-                while (Console.ReadKey().Key != ConsoleKey.Enter)
-                {
-                }
+                Console.Out.WriteLine("RavenDB Maintenance Mode - Press any key to exit");
+                Console.Read();
 
                 documentStore.Dispose();
 
                 return;
             }
-            else
+
+            using (var service = new MaintenanceHost(settings, documentStore))
             {
-                using (var service = new MaintenanceHost(settings, documentStore))
-                {
-                    service.Run();
-                }
+                service.Run();
             }
         }
     }

--- a/src/ServiceControl/MaintenanceBootstrapper.cs
+++ b/src/ServiceControl/MaintenanceBootstrapper.cs
@@ -15,7 +15,7 @@ namespace Particular.ServiceControl
 
             new RavenBootstrapper().StartRaven(documentStore, settings, true);
 
-            if (Environment.UserInteractive)
+            if (args.Portable)
             {
                 Console.Out.WriteLine("RavenDB is now accepting requests on {0}", settings.StorageUrl);
                 Console.Out.WriteLine("RavenDB Maintenance Mode - Press Enter to exit");
@@ -27,10 +27,12 @@ namespace Particular.ServiceControl
 
                 return;
             }
-
-            using (var service = new MaintenanceHost(settings, documentStore))
+            else
             {
-                service.Run();
+                using (var service = new MaintenanceHost(settings, documentStore))
+                {
+                    service.Run();
+                }
             }
         }
     }


### PR DESCRIPTION
The `--portable` argument is ignored when running in maintenance mode. This PR adds support for it so that maintenance mode an be run outside of a windows service like when running in a Docker container.