### PR TITLE
Fixes dockerfiles incorrectly importing net462 folder and now imports net472 since v4.15

### DIFF
--- a/src/docker/backup/servicecontrol.asb.endpoint
+++ b/src/docker/backup/servicecontrol.asb.endpoint
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.endpoint.audit
+++ b/src/docker/backup/servicecontrol.asb.endpoint.audit
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.endpoint.audit.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.audit.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.endpoint.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.endpoint.monitoring
+++ b/src/docker/backup/servicecontrol.asb.endpoint.monitoring
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/backup/servicecontrol.asb.endpoint.monitoring.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.monitoring.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding
+++ b/src/docker/backup/servicecontrol.asb.forwarding
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding.audit
+++ b/src/docker/backup/servicecontrol.asb.forwarding.audit
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding.audit.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.audit.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding.monitoring
+++ b/src/docker/backup/servicecontrol.asb.forwarding.monitoring
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding.monitoring.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.monitoring.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.amazonsqs-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 


### PR DESCRIPTION
Trying to run the 4.15 version in docker resulted in type load exceptions. This was caused by #2301 which bumped the framework to 472. The artifacts folder is used by the docker files to `ADD` them into the images and was using `net462` and as this folder didn't exist the files were not added. It seems `ADD` does not fail if either the sources folder does not exist or is empty.