### PR TITLE
Fixes Dockerfiles to retrieve data from the net472 folder which got broken in 4.15

### DIFF
--- a/src/docker/backup/servicecontrol.asb.endpoint
+++ b/src/docker/backup/servicecontrol.asb.endpoint
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.endpoint
+++ b/src/docker/backup/servicecontrol.asb.endpoint
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.endpoint.audit
+++ b/src/docker/backup/servicecontrol.asb.endpoint.audit
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.endpoint.audit
+++ b/src/docker/backup/servicecontrol.asb.endpoint.audit
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.endpoint.audit.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.audit.init
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.endpoint.audit.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.audit.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.endpoint.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.init
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.endpoint.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.endpoint.monitoring
+++ b/src/docker/backup/servicecontrol.asb.endpoint.monitoring
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.endpoint.monitoring
+++ b/src/docker/backup/servicecontrol.asb.endpoint.monitoring
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/backup/servicecontrol.asb.endpoint.monitoring.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.monitoring.init
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.endpoint.monitoring.init
+++ b/src/docker/backup/servicecontrol.asb.endpoint.monitoring.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding
+++ b/src/docker/backup/servicecontrol.asb.forwarding
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.forwarding
+++ b/src/docker/backup/servicecontrol.asb.forwarding
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding.audit
+++ b/src/docker/backup/servicecontrol.asb.forwarding.audit
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.forwarding.audit
+++ b/src/docker/backup/servicecontrol.asb.forwarding.audit
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding.audit.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.audit.init
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.forwarding.audit.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.audit.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.init
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.forwarding.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding.monitoring
+++ b/src/docker/backup/servicecontrol.asb.forwarding.monitoring
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.forwarding.monitoring
+++ b/src/docker/backup/servicecontrol.asb.forwarding.monitoring
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/backup/servicecontrol.asb.forwarding.monitoring.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.monitoring.init
@@ -1,5 +1,21 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.ASB/bin/Release/net472 .

--- a/src/docker/backup/servicecontrol.asb.forwarding.monitoring.init
+++ b/src/docker/backup/servicecontrol.asb.forwarding.monitoring.init
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASB/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASB/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.amazonsqs-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.SQS/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azureservicebus-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASBS/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.ASQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.sqlserver-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.audit
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl.Audit/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl.Audit/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.audit
 
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
 ADD /ServiceControl.Audit/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl.Audit/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl.Audit/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "ServiceControl/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "ServiceControl/Hostname"="*"

--- a/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
@@ -1,11 +1,25 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
+# Taken from https://github.com/microsoft/dotnet-framework-docker/blob/master/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile
+RUN \
+    # Install .NET 4.7.2
+    powershell -Command \
+        $ProgressPreference = 'SilentlyContinue'; \
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+        Invoke-WebRequest \
+            -UseBasicParsing \
+            -Uri "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe" \
+            -OutFile dotnet-framework-installer.exe \
+    && start /w .\dotnet-framework-installer.exe /q \
+    && del .\dotnet-framework-installer.exe \
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
+
 WORKDIR /servicecontrol.monitoring
 
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
 ADD /ServiceControl.Monitoring/bin/Release/net472 .
-
-ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 
 ENV "Monitoring/TransportType"="ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"
 ENV "Monitoring/HttpHostName"="*"

--- a/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 WORKDIR /servicecontrol.monitoring
 
-ADD /ServiceControl.Transports.SqlServer/bin/Release/net462 .
-ADD /ServiceControl.Monitoring/bin/Release/net462 .
+ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
+ADD /ServiceControl.Monitoring/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 


### PR DESCRIPTION
Docker was broken in #2301 due to bumping the framework to net472. This fixes the dockerfiles to ADD the artifacts from the correct folder.