### PR TITLE
Add a reference to Particular.Licensing to make so that ServiceControl.Audit gets a ReleaseDate attribute

### DIFF
--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Rx-Linq" Version="2.2.5" />
     <PackageReference Include="Microsoft.Owin.Cors" Version="4.1.1" />
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="3.4.0" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR adds a package reference to the Particular.Licensing package in ServiceControl.Audit project. If the reference is missing the generated exe is not stamped with the ReleaseDateAttribute. The attribute causes the ReleadeDateReader used by unattended installations (e.g. PowerShell) to fail.

Fix https://github.com/Particular/ServiceControl/issues/2381