### PR TITLE
Use standard license sources

### DIFF
--- a/src/ServiceControl.LicenseManagement/LicenseManager.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseManager.cs
@@ -7,12 +7,8 @@
     {
         public static DetectedLicense FindLicense()
         {
-            var sources = new LicenseSource[]
-            {
-                new LicenseSourceFilePath(GetMachineLevelLicenseLocation())
-            };
-
-            var result = ActiveLicense.Find("ServiceControl", sources);
+            var sources = LicenseSource.GetStandardLicenseSources();
+            var result = ActiveLicense.Find("ServiceControl", sources.ToArray());
 
             var detectedLicense = new DetectedLicense(result.Location, LicenseDetails.FromLicense(result.License))
             {

--- a/src/ServiceControl.Monitoring/Licensing/LicenseManager.cs
+++ b/src/ServiceControl.Monitoring/Licensing/LicenseManager.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceControl.Monitoring.Licensing
 {
-    using System;
     using NServiceBus.Logging;
     using Particular.Licensing;
 
@@ -12,11 +11,9 @@
         public void Refresh()
         {
             Logger.Debug("Checking License Status");
-            var sources = new LicenseSource[]
-            {
-                new LicenseSourceFilePath(LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData))
-            };
-            var result = ActiveLicense.Find("ServiceControl", sources);
+
+            var sources = LicenseSource.GetStandardLicenseSources();
+            var result = ActiveLicense.Find("ServiceControl", sources.ToArray());
 
             if (result.License.HasExpired())
             {

--- a/src/ServiceControl/Licensing/ActiveLicense.cs
+++ b/src/ServiceControl/Licensing/ActiveLicense.cs
@@ -1,6 +1,5 @@
 ﻿namespace Particular.ServiceControl.Licensing
 {
-    using System;
     using NServiceBus.Logging;
     using Particular.Licensing;
 
@@ -18,12 +17,9 @@
         public void Refresh()
         {
             Logger.Debug("Refreshing ActiveLicense");
-            var sources = new LicenseSource[]
-            {
-                new LicenseSourceFilePath(LicenseFileLocationResolver.GetPathFor(Environment.SpecialFolder.CommonApplicationData))
-            };
 
-            var result = Particular.Licensing.ActiveLicense.Find("ServiceControl", sources);
+            var sources = LicenseSource.GetStandardLicenseSources();
+            var result = Particular.Licensing.ActiveLicense.Find("ServiceControl", sources.ToArray());
 
             IsValid = !result.License.HasExpired();
 


### PR DESCRIPTION
This restores ServiceControl's ability to find licenses in the "standard" sources, which was removed as part of #2155.

As of this PR, that means ServiceControl will once again start looking for a license in the following additional locations:

- The application's folder
- LocalApplicationData\ParticularSoftware

It also means that when we we add new standard sources, ServiceControl will stay in sync with those changes.