### PR TITLE
Make sure when indexes are disabled due to low disk space the cleanup logic doesn't churn CPU and floods the log

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
@@ -70,7 +70,7 @@
             }
             catch (IndexDisabledException ex)
             {
-                logger.Warn($"Unable to cleanup audit messages. The index ${indexName} was disabled.", ex);
+                logger.Error($"Unable to cleanup audit messages. The index ${indexName} was disabled.", ex);
                 return;
             }
             catch (OperationCanceledException)

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/KnownEndpointsCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/KnownEndpointsCleaner.cs
@@ -61,7 +61,7 @@
             }
             catch (IndexDisabledException ex)
             {
-                logger.Warn($"Unable to cleanup known endpoints. The index ${indexName} was disabled.", ex);
+                logger.Error($"Unable to cleanup known endpoints. The index ${indexName} was disabled.", ex);
                 return;
             }
             catch (OperationCanceledException)

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/KnownEndpointsCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/KnownEndpointsCleaner.cs
@@ -9,6 +9,7 @@
     using Raven.Abstractions;
     using Raven.Abstractions.Commands;
     using Raven.Abstractions.Data;
+    using Raven.Abstractions.Exceptions;
     using Raven.Database;
     using ServiceControl.Infrastructure.RavenDB;
 
@@ -18,6 +19,7 @@
         {
             var stopwatch = Stopwatch.StartNew();
             var items = new List<ICommandData>(deletionBatchSize);
+            var indexName = new ExpiryKnownEndpointsIndex().IndexName;
 
             try
             {
@@ -42,7 +44,6 @@
                     }
                 };
 
-                var indexName = new ExpiryKnownEndpointsIndex().IndexName;
                 database.Query(indexName, query, token,
                     (doc, state) =>
                     {
@@ -57,6 +58,11 @@
                             Key = id
                         });
                     }, items);
+            }
+            catch (IndexDisabledException ex)
+            {
+                logger.Warn($"Unable to cleanup known endpoints. The index ${indexName} was disabled.", ex);
+                return;
             }
             catch (OperationCanceledException)
             {

--- a/src/ServiceControl.SagaAudit/SagaHistoryCleaner.cs
+++ b/src/ServiceControl.SagaAudit/SagaHistoryCleaner.cs
@@ -61,7 +61,7 @@
             }
             catch (IndexDisabledException ex)
             {
-                logger.Warn($"Unable to cleanup saga history. The index ${indexName} was disabled.", ex);
+                logger.Error($"Unable to cleanup saga history. The index ${indexName} was disabled.", ex);
                 return;
             }
             catch (OperationCanceledException)

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
@@ -9,6 +9,7 @@
     using Raven.Abstractions;
     using Raven.Abstractions.Commands;
     using Raven.Abstractions.Data;
+    using Raven.Abstractions.Exceptions;
     using Raven.Database;
     using Raven.Json.Linq;
 
@@ -20,6 +21,7 @@
             var items = new List<ICommandData>(deletionBatchSize);
             var attachments = new List<string>(deletionBatchSize);
             var itemsAndAttachements = Tuple.Create(items, attachments);
+            var indexName = new ExpiryProcessedMessageIndex().IndexName;
 
             try
             {
@@ -45,7 +47,7 @@
                         }
                     }
                 };
-                var indexName = new ExpiryProcessedMessageIndex().IndexName;
+
                 database.Query(indexName, query, token,
                     (doc, state) =>
                     {
@@ -66,6 +68,11 @@
                         }
                     }, itemsAndAttachements);
             }
+            catch (IndexDisabledException ex)
+            {
+                logger.Warn($"Unable to cleanup audit messages. The index ${indexName} was disabled.", ex);
+                return;
+            }
             catch (OperationCanceledException)
             {
                 logger.Info("Cleanup operation cancelled");
@@ -76,7 +83,6 @@
             {
                 return;
             }
-
 
             var deletedAuditDocuments = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
@@ -70,7 +70,7 @@
             }
             catch (IndexDisabledException ex)
             {
-                logger.Warn($"Unable to cleanup audit messages. The index ${indexName} was disabled.", ex);
+                logger.Error($"Unable to cleanup audit messages. The index ${indexName} was disabled.", ex);
                 return;
             }
             catch (OperationCanceledException)

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ErrorMessageCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ErrorMessageCleaner.cs
@@ -80,7 +80,7 @@
             }
             catch (IndexDisabledException ex)
             {
-                logger.Warn($"Unable to cleanup error messages. The index ${indexName} was disabled.", ex);
+                logger.Error($"Unable to cleanup error messages. The index ${indexName} was disabled.", ex);
                 return;
             }
             catch (OperationCanceledException)

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/EventLogItemsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/EventLogItemsCleaner.cs
@@ -60,7 +60,7 @@
             }
             catch (IndexDisabledException ex)
             {
-                logger.Warn($"Unable to cleanup event log items. The index ${indexName} was disabled.", ex);
+                logger.Error($"Unable to cleanup event log items. The index ${indexName} was disabled.", ex);
                 return;
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
## Who's affected

Customers running on low disk space or having corrupted indexes

## Symptoms

Indexes can be disabled due to multiple reasons. Some of them are:

- Low disk space
- Corrupted

when that happens the cleanup logic will throw an `IndexDisabledException` which then causes the async timer to immediately reschedule another execution. This causes the instance to continuously churn CPU and flood the log files which then contributes to eating up even more disk space.

The log files will be flooded with

```
2021-03-08 10:25:22.0739|25|Error|ServiceControl.Audit.Infrastructure.RavenDB.Expiration.ExpiredDocumentsCleanerBundle|Error when trying to find expired documents
Raven.Abstractions.Exceptions.IndexDisabledException: The index has been disabled due to errors
at Raven.Database.Indexing.Index.IndexQueryOperation.<Query>d__17.MoveNext()
at Raven.Database.Util.ActiveEnumerable`1..ctor(IEnumerable`1 enumerable)
at Raven.Database.Actions.QueryActions.DatabaseQueryOperation.Init()
at Raven.Database.Actions.QueryActions.<>c__DisplayClass2_0.<Query>b__0(IStorageActionsAccessor accessor)
at Raven.Storage.Esent.TransactionalStorage.ExecuteBatch(Action`1 action, EsentTransactionContext transactionContext)
at Raven.Storage.Esent.TransactionalStorage.Batch(Action`1 action)
at Raven.Database.Actions.QueryActions.Query(String index, IndexQuery query, CancellationToken externalCancellationToken)
at ServiceControl.Infrastructure.RavenDB.Extensions.Query[TState](DocumentDatabase db, String index, IndexQuery query, CancellationToken externalCancellationToken, Action`2 onItem, TState state) in /_/src/ServiceControl.Infrastructure.RavenDB/Extensions.cs:line 13
at ServiceControl.Audit.Infrastructure.RavenDB.Expiration.AuditMessageCleaner.Clean(Int32 deletionBatchSize, DocumentDatabase database, DateTime expiryThreshold, CancellationToken token) in /_/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs:line 20
at ServiceControl.Audit.Infrastructure.RavenDB.Expiration.ExpiredDocumentsCleaner.RunCleanup(Int32 deletionBatchSize, DocumentDatabase database, Settings settings, CancellationToken token) in /_/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs:line 20
at ServiceControl.Audit.Infrastructure.RavenDB.Expiration.ExpiredDocumentsCleanerBundle.<>c__DisplayClass1_0.<Execute>b__0(CancellationToken token) in /_/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs:line 58
at ServiceControl.Audit.Infrastructure.AsyncTimer.<>c__DisplayClass1_0.<<Start>b__0>d.MoveNext() in /_/src/ServiceControl.Audit/Infrastructure/AsyncTimer.cs:line 36
```

by catching this exception we will still notice the index has gone into error state but will only log it whenever the cleanup logic runs.

