### PR TITLE
Adjusted log level for cleanup/purge operations to be less verbose for expected results

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
@@ -129,11 +129,17 @@
 
             if (deletedAttachments + deletedAuditDocuments == 0)
             {
-                logger.Info("No expired audit documents found");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug("No expired audit documents found");
+                }
             }
             else
             {
-                logger.Info($"Deleted {deletedAuditDocuments} expired audit documents and {deletedAttachments} message body attachments. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Deleted {deletedAuditDocuments} expired audit documents and {deletedAttachments} message body attachments. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                }
             }
         }
 

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/KnownEndpointsCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/KnownEndpointsCleaner.cs
@@ -94,11 +94,17 @@
 
             if (deleteKnownEndpointDocuments == 0)
             {
-                logger.Info("No expired known endpoints documents found");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug("No expired known endpoints documents found");
+                }
             }
             else
             {
-                logger.Info($"Deleted {deleteKnownEndpointDocuments} expired known endpoint documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Deleted {deleteKnownEndpointDocuments} expired known endpoint documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                }
             }
         }
 

--- a/src/ServiceControl.SagaAudit/SagaHistoryCleaner.cs
+++ b/src/ServiceControl.SagaAudit/SagaHistoryCleaner.cs
@@ -93,11 +93,17 @@
 
             if (deletionCount == 0)
             {
-                logger.Info("No expired saga history documents found");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug("No expired saga history documents found");
+                }
             }
             else
             {
-                logger.Info($"Deleted {deletionCount} expired saga history documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Deleted {deletionCount} expired saga history documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                }
             }
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
@@ -129,11 +129,17 @@
 
             if (deletedAttachments + deletedAuditDocuments == 0)
             {
-                logger.Info("No expired audit documents found");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug("No expired audit documents found");
+                }
             }
             else
             {
-                logger.Info($"Deleted {deletedAuditDocuments} expired audit documents and {deletedAttachments} message body attachments. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Deleted {deletedAuditDocuments} expired audit documents and {deletedAttachments} message body attachments. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                }
             }
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ErrorMessageCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ErrorMessageCleaner.cs
@@ -155,11 +155,17 @@
 
             if (deletedFailedMessage + deletedAttachments + deletedFailedMessageRetry == 0)
             {
-                logger.Info("No expired error documents found");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug("No expired error documents found");
+                }
             }
             else
             {
-                logger.Info($"Deleted {deletedFailedMessage} expired error documents and {deletedAttachments} message body attachments. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Deleted {deletedFailedMessage} expired error documents and {deletedAttachments} message body attachments. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                }
             }
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/EventLogItemsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/EventLogItemsCleaner.cs
@@ -93,11 +93,17 @@
 
             if (deletionCount == 0)
             {
-                logger.Info("No expired event log documents found");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug("No expired event log documents found");
+                }
             }
             else
             {
-                logger.Info($"Deleted {deletionCount} expired event log documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Deleted {deletionCount} expired event log documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                }
             }
         }
 


### PR DESCRIPTION
During a support case I noticed some of these excessively logged not and providing any info indicating the log level is set incorrect.