### PR TITLE
Maintenance mode using CTRL+C / SIGINT instead waiting for keyboard input.

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/MaintCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/MaintCommand.cs
@@ -7,8 +7,7 @@
         public override Task Execute(HostArguments args)
         {
             var bootstrapper = new MaintenanceBootstrapper();
-            bootstrapper.Run(args);
-            return Task.CompletedTask;
+            return bootstrapper.Run(args);
         }
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/MaintCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/MaintCommand.cs
@@ -4,10 +4,6 @@
 
     class MaintCommand : AbstractCommand
     {
-        public override Task Execute(HostArguments args)
-        {
-            var bootstrapper = new MaintenanceBootstrapper();
-            return bootstrapper.Run(args);
-        }
+        public override Task Execute(HostArguments args) => MaintenanceBootstrapper.Run(args);
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/MaintenanceHost.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/MaintenanceHost.cs
@@ -1,36 +1,12 @@
 ﻿namespace ServiceControl.Audit.Infrastructure.Hosting
 {
     using System.ServiceProcess;
-    using Raven.Client.Embedded;
     using Settings;
 
     class MaintenanceHost : ServiceBase
     {
-        public MaintenanceHost(Settings settings, EmbeddableDocumentStore documentStore)
-        {
-            this.documentStore = documentStore;
-            ServiceName = settings.ServiceName;
-        }
+        public MaintenanceHost(Settings settings) => ServiceName = settings.ServiceName;
 
-        public void Run()
-        {
-            Run(this);
-        }
-
-        protected override void OnStart(string[] args)
-        {
-        }
-
-        protected override void OnStop()
-        {
-            documentStore?.Dispose();
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            OnStop();
-        }
-
-        readonly EmbeddableDocumentStore documentStore;
+        public void Run() => Run(this);
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/MaintenanceBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/MaintenanceBootstrapper.cs
@@ -1,45 +1,48 @@
 namespace ServiceControl.Audit.Infrastructure
 {
     using System;
-    using System.Threading;
     using System.Threading.Tasks;
     using Hosting;
     using Raven.Client.Embedded;
     using RavenDB;
 
-    class MaintenanceBootstrapper
+    static class MaintenanceBootstrapper
     {
-        public async Task Run(HostArguments args)
+        public static async Task Run(HostArguments args)
         {
             var settings = new Settings.Settings(args.ServiceName);
-            var documentStore = new EmbeddableDocumentStore();
-
-            new RavenBootstrapper().StartRaven(documentStore, settings, true);
-
-            if (args.RunAsWindowsService)
+            using (var documentStore = new EmbeddableDocumentStore())
             {
-                using (var service = new MaintenanceHost(settings, documentStore))
+                new RavenBootstrapper().StartRaven(documentStore, settings, true);
+
+                if (args.RunAsWindowsService)
                 {
-                    service.Run();
+                    using (var service = new MaintenanceHost(settings))
+                    {
+                        service.Run();
+                    }
                 }
-            }
-            else
-            {
-                await Console.Out.WriteLineAsync($"RavenDB is now accepting requests on {settings.StorageUrl}").ConfigureAwait(false);
-                await Console.Out.WriteLineAsync("RavenDB Maintenance Mode - Press CTRL+C to exit").ConfigureAwait(false);
-
-                var closing = new AutoResetEvent(false);
-
-                Console.CancelKeyPress += (sender, eventArgs) =>
+                else
                 {
-                    eventArgs.Cancel = true;
-                    closing.Set();
-                };
+                    await Console.Out.WriteLineAsync($"RavenDB is now accepting requests on {settings.StorageUrl}")
+                        .ConfigureAwait(false);
+                    await Console.Out.WriteLineAsync("RavenDB Maintenance Mode - Press CTRL+C to exit")
+                        .ConfigureAwait(false);
 
-                closing.WaitOne();
+                    var taskCompletionSource =
+                        new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                await Console.Out.WriteLineAsync("Disposing RavenDB document store (this might take a while)...").ConfigureAwait(false);
-                documentStore.Dispose();
+                    Console.CancelKeyPress += (sender, eventArgs) =>
+                    {
+                        eventArgs.Cancel = true;
+                        taskCompletionSource.TrySetResult(true);
+                    };
+
+                    await taskCompletionSource.Task.ConfigureAwait(false);
+
+                    await Console.Out.WriteLineAsync("Disposing RavenDB document store (this might take a while)...")
+                        .ConfigureAwait(false);
+                }
                 await Console.Out.WriteLineAsync("Done!").ConfigureAwait(false);
             }
         }

--- a/src/ServiceControl/Hosting/Commands/MaintCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/MaintCommand.cs
@@ -7,10 +7,6 @@
 
     class MaintCommand : AbstractCommand
     {
-        public override Task Execute(HostArguments args)
-        {
-            var bootstrapper = new MaintenanceBootstrapper();
-            return bootstrapper.Run(args);
-        }
+        public override Task Execute(HostArguments args) => MaintenanceBootstrapper.Run(args);
     }
 }

--- a/src/ServiceControl/Hosting/Commands/MaintCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/MaintCommand.cs
@@ -10,8 +10,7 @@
         public override Task Execute(HostArguments args)
         {
             var bootstrapper = new MaintenanceBootstrapper();
-            bootstrapper.Run(args);
-            return Task.CompletedTask;
+            return bootstrapper.Run(args);
         }
     }
 }

--- a/src/ServiceControl/Hosting/MaintenanceHost.cs
+++ b/src/ServiceControl/Hosting/MaintenanceHost.cs
@@ -1,36 +1,12 @@
 ﻿namespace Particular.ServiceControl.Hosting
 {
     using System.ServiceProcess;
-    using Raven.Client.Embedded;
     using ServiceBus.Management.Infrastructure.Settings;
 
     class MaintenanceHost : ServiceBase
     {
-        public MaintenanceHost(Settings settings, EmbeddableDocumentStore documentStore)
-        {
-            this.documentStore = documentStore;
-            ServiceName = settings.ServiceName;
-        }
+        public MaintenanceHost(Settings settings) => ServiceName = settings.ServiceName;
 
-        public void Run()
-        {
-            Run(this);
-        }
-
-        protected override void OnStart(string[] args)
-        {
-        }
-
-        protected override void OnStop()
-        {
-            documentStore?.Dispose();
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            OnStop();
-        }
-
-        readonly EmbeddableDocumentStore documentStore;
+        public void Run() => Run(this);
     }
 }

--- a/src/ServiceControl/MaintenanceBootstrapper.cs
+++ b/src/ServiceControl/MaintenanceBootstrapper.cs
@@ -9,41 +9,44 @@ namespace Particular.ServiceControl
     using Raven.Client.Embedded;
     using ServiceBus.Management.Infrastructure.Settings;
 
-    class MaintenanceBootstrapper
+    static class MaintenanceBootstrapper
     {
-        public async Task Run(HostArguments args)
+        public static async Task Run(HostArguments args)
         {
             var settings = new Settings(args.ServiceName);
-            var documentStore = new EmbeddableDocumentStore();
-
-            new RavenBootstrapper().StartRaven(documentStore, settings, true);
-
-            if (args.RunAsWindowsService)
+            using (var documentStore = new EmbeddableDocumentStore())
             {
-                using (var service = new MaintenanceHost(settings, documentStore))
+                new RavenBootstrapper().StartRaven(documentStore, settings, true);
+
+                if (args.RunAsWindowsService)
                 {
-                    service.Run();
+                    using (var service = new MaintenanceHost(settings))
+                    {
+                        service.Run();
+                    }
+                }
+                else
+                {
+                    await Console.Out.WriteLineAsync($"RavenDB is now accepting requests on {settings.StorageUrl}").ConfigureAwait(false);
+                    await Console.Out.WriteLineAsync("RavenDB Maintenance Mode - Press CTRL+C to exit").ConfigureAwait(false);
+
+                    var taskCompletionSource =
+                        new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                    Console.CancelKeyPress += (sender, eventArgs) =>
+                    {
+                        eventArgs.Cancel = true;
+                        taskCompletionSource.TrySetResult(true);
+                    };
+
+                    await taskCompletionSource.Task.ConfigureAwait(false);
+
+                    await Console.Out.WriteLineAsync("Disposing RavenDB document store (this might take a while)...").ConfigureAwait(false);
+
                 }
             }
-            else
-            {
-                await Console.Out.WriteLineAsync($"RavenDB is now accepting requests on {settings.StorageUrl}").ConfigureAwait(false);
-                await Console.Out.WriteLineAsync("RavenDB Maintenance Mode - Press CTRL+C to exit").ConfigureAwait(false);
 
-                var closing = new AutoResetEvent(false);
-
-                Console.CancelKeyPress += (sender, eventArgs) =>
-                {
-                    eventArgs.Cancel = true;
-                    closing.Set();
-                };
-
-                closing.WaitOne();
-
-                await Console.Out.WriteLineAsync("Disposing RavenDB document store (this might take a while)...").ConfigureAwait(false);
-                documentStore.Dispose();
-                await Console.Out.WriteLineAsync("Done!").ConfigureAwait(false);
-            }
+            await Console.Out.WriteLineAsync("Done!").ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
When running maintenance mode in Docker this failed because maintenance mode used `Console.ReadKey` while docker runs non-interactive. Now using CTRL+C / SIGINT instead to prevent failure.

![image](https://user-images.githubusercontent.com/152998/113902887-ab6d7080-97d0-11eb-9a6e-493510af590c.png)
