### PR TITLE
Lower MaximumConcurrencyLevel default to 2

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -36,7 +36,7 @@
             AuditRetentionPeriod = GetAuditRetentionPeriod();
             Port = SettingsReader<int>.Read("Port", 44444);
             DatabaseMaintenancePort = SettingsReader<int>.Read("DatabaseMaintenancePort", 44445);
-            MaximumConcurrencyLevel = SettingsReader<int>.Read("MaximumConcurrencyLevel", 32);
+            MaximumConcurrencyLevel = SettingsReader<int>.Read("MaximumConcurrencyLevel", 2);
             HttpDefaultConnectionLimit = SettingsReader<int>.Read("HttpDefaultConnectionLimit", 100);
             DisableRavenDBPerformanceCounters = SettingsReader<bool>.Read("DisableRavenDBPerformanceCounters", true);
             DbPath = GetDbPath();

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -41,7 +41,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
             Port = SettingsReader<int>.Read("Port", 33333);
             DatabaseMaintenancePort = SettingsReader<int>.Read("DatabaseMaintenancePort", 33334);
             ProcessRetryBatchesFrequency = TimeSpan.FromSeconds(30);
-            MaximumConcurrencyLevel = SettingsReader<int>.Read("MaximumConcurrencyLevel", 10);
+            MaximumConcurrencyLevel = SettingsReader<int>.Read("MaximumConcurrencyLevel", 2);
             RetryHistoryDepth = SettingsReader<int>.Read("RetryHistoryDepth", 10);
             HttpDefaultConnectionLimit = SettingsReader<int>.Read("HttpDefaultConnectionLimit", 100);
             DisableRavenDBPerformanceCounters = SettingsReader<bool>.Read("DisableRavenDBPerformanceCounters", true);


### PR DESCRIPTION
MaximumConcurrencyLevel default to 2 to prevent indexes become too stale under load.

During load testing it was observed that ingestion rate can be high (hundreds of message per second) but that indexes become too stale. Some never achieve to 'keep up' with the ingestion rate. 

This behavior was more evident the faster the storage becomes as this resulted in the CPU to max out. Likely due to indexing which results in indexing operation to be too slow.

Taking 2 as the default should result in async indexes to "keep up". During load testing a continuous ingestion rate of more than 50 messages per second was still possible.