### PR TITLE
Report total folder size as MB, GB, or TB

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -168,6 +168,36 @@ namespace ServiceControl.Audit.Infrastructure
             }
         }
 
+        long FolderSize()
+        {
+            try
+            {
+                var dir = new DirectoryInfo(settings.DbPath);
+                var dirSize = DirSize(dir);
+                return dirSize;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        static long DirSize(DirectoryInfo d)
+        {
+            long size = 0;
+            FileInfo[] fis = d.GetFiles();
+            foreach (FileInfo fi in fis)
+            {
+                size += fi.Length;
+            }
+            DirectoryInfo[] dis = d.GetDirectories();
+            foreach (DirectoryInfo di in dis)
+            {
+                size += DirSize(di);
+            }
+            return size;
+        }
+
         void RecordStartup(LoggingSettings loggingSettings, EndpointConfiguration endpointConfiguration)
         {
             var version = FileVersionInfo.GetVersionInfo(typeof(Bootstrapper).Assembly.Location).ProductVersion;
@@ -176,7 +206,8 @@ namespace ServiceControl.Audit.Infrastructure
 ServiceControl Audit Version:       {version}
 Audit Retention Period:             {settings.AuditRetentionPeriod}
 Forwarding Audit Messages:          {settings.ForwardAuditMessages}
-Database Size:                      {DataSize()} bytes
+Database Size:                      {DataSize():n0} bytes
+Database Folder Size:               {FolderSize():n0} bytes
 ServiceControl Logging Level:       {loggingSettings.LoggingLevel}
 RavenDB Logging Level:              {loggingSettings.RavenDBLogLevel}
 Selected Transport Customization:   {settings.TransportCustomizationType}

--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -210,8 +210,8 @@ namespace ServiceControl.Audit.Infrastructure
 ServiceControl Audit Version:       {version}
 Audit Retention Period:             {settings.AuditRetentionPeriod}
 Forwarding Audit Messages:          {settings.ForwardAuditMessages}
-Database Size:                      {dataSize:n0} bytes ({ByteSize.FromBytes(dataSize).ToString("#.##", CultureInfo.InvariantCulture)})
-Database Folder Size:               {folderSize:n0} bytes ({ByteSize.FromBytes(folderSize).ToString("#.##", CultureInfo.InvariantCulture)})
+Database Size:                      {ByteSize.FromBytes(dataSize).ToString("#.##", CultureInfo.InvariantCulture)}
+Database Folder Size:               {ByteSize.FromBytes(folderSize).ToString("#.##", CultureInfo.InvariantCulture)}
 ServiceControl Logging Level:       {loggingSettings.LoggingLevel}
 RavenDB Logging Level:              {loggingSettings.RavenDBLogLevel}
 Selected Transport Customization:   {settings.TransportCustomizationType}

--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.Audit.Infrastructure
     using System;
     using System.Collections.Concurrent;
     using System.Diagnostics;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -16,6 +17,7 @@ namespace ServiceControl.Audit.Infrastructure
     using Autofac;
     using Autofac.Core.Activators.Reflection;
     using Autofac.Features.ResolveAnything;
+    using Humanizer;
     using Microsoft.Owin.Hosting;
     using Monitoring;
     using NServiceBus;
@@ -201,13 +203,15 @@ namespace ServiceControl.Audit.Infrastructure
         void RecordStartup(LoggingSettings loggingSettings, EndpointConfiguration endpointConfiguration)
         {
             var version = FileVersionInfo.GetVersionInfo(typeof(Bootstrapper).Assembly.Location).ProductVersion;
+            var dataSize = DataSize();
+            var folderSize = FolderSize();
             var startupMessage = $@"
 -------------------------------------------------------------
 ServiceControl Audit Version:       {version}
 Audit Retention Period:             {settings.AuditRetentionPeriod}
 Forwarding Audit Messages:          {settings.ForwardAuditMessages}
-Database Size:                      {DataSize():n0} bytes
-Database Folder Size:               {FolderSize():n0} bytes
+Database Size:                      {dataSize:n0} bytes ({dataSize.Bytes().ToString("#.##", CultureInfo.InvariantCulture)})
+Database Folder Size:               {folderSize:n0} bytes ({folderSize.Bytes().ToString("#.##", CultureInfo.InvariantCulture)})
 ServiceControl Logging Level:       {loggingSettings.LoggingLevel}
 RavenDB Logging Level:              {loggingSettings.RavenDBLogLevel}
 Selected Transport Customization:   {settings.TransportCustomizationType}

--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -17,7 +17,7 @@ namespace ServiceControl.Audit.Infrastructure
     using Autofac;
     using Autofac.Core.Activators.Reflection;
     using Autofac.Features.ResolveAnything;
-    using Humanizer;
+    using ByteSizeLib;
     using Microsoft.Owin.Hosting;
     using Monitoring;
     using NServiceBus;
@@ -210,8 +210,8 @@ namespace ServiceControl.Audit.Infrastructure
 ServiceControl Audit Version:       {version}
 Audit Retention Period:             {settings.AuditRetentionPeriod}
 Forwarding Audit Messages:          {settings.ForwardAuditMessages}
-Database Size:                      {dataSize:n0} bytes ({dataSize.Bytes().ToString("#.##", CultureInfo.InvariantCulture)})
-Database Folder Size:               {folderSize:n0} bytes ({folderSize.Bytes().ToString("#.##", CultureInfo.InvariantCulture)})
+Database Size:                      {dataSize:n0} bytes ({ByteSize.FromBytes(dataSize).ToString("#.##", CultureInfo.InvariantCulture)})
+Database Folder Size:               {folderSize:n0} bytes ({ByteSize.FromBytes(folderSize).ToString("#.##", CultureInfo.InvariantCulture)})
 ServiceControl Logging Level:       {loggingSettings.LoggingLevel}
 RavenDB Logging Level:              {loggingSettings.RavenDBLogLevel}
 Selected Transport Customization:   {settings.TransportCustomizationType}

--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="ByteSize" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
     <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />

--- a/src/ServiceControl.SagaAudit/ServiceControl.SagaAudit.csproj
+++ b/src/ServiceControl.SagaAudit/ServiceControl.SagaAudit.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="2.8.26" />
     <PackageReference Include="NServiceBus" Version="7.4.6" />
   </ItemGroup>
 

--- a/src/ServiceControl.SagaAudit/ServiceControl.SagaAudit.csproj
+++ b/src/ServiceControl.SagaAudit/ServiceControl.SagaAudit.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Humanizer.Core" Version="2.8.26" />
     <PackageReference Include="NServiceBus" Version="7.4.6" />
   </ItemGroup>
 

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -174,13 +174,42 @@ namespace Particular.ServiceControl
             try
             {
                 var info = new FileInfo(datafilePath);
-
                 return info.Length;
             }
-            catch (Exception)
+            catch
             {
-                return 0;
+                return -1;
             }
+        }
+
+        long FolderSize()
+        {
+            try
+            {
+                var dir = new DirectoryInfo(settings.DbPath);
+                var dirSize = DirSize(dir);
+                return dirSize;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        static long DirSize(DirectoryInfo d)
+        {
+            long size = 0;
+            FileInfo[] fis = d.GetFiles();
+            foreach (FileInfo fi in fis)
+            {
+                size += fi.Length;
+            }
+            DirectoryInfo[] dis = d.GetDirectories();
+            foreach (DirectoryInfo di in dis)
+            {
+                size += DirSize(di);
+            }
+            return size;
         }
 
         void RecordStartup(LoggingSettings loggingSettings, EndpointConfiguration endpointConfiguration)
@@ -193,7 +222,8 @@ Audit Retention Period (optional):  {settings.AuditRetentionPeriod}
 Error Retention Period:             {settings.ErrorRetentionPeriod}
 Ingest Error Messages:              {settings.IngestErrorMessages}
 Forwarding Error Messages:          {settings.ForwardErrorMessages}
-Database Size:                      {DataSize()} bytes
+Database Size:                      {DataSize():n0} bytes
+Database Folder Size:               {FolderSize():n0} bytes
 ServiceControl Logging Level:       {loggingSettings.LoggingLevel}
 RavenDB Logging Level:              {loggingSettings.RavenDBLogLevel}
 Selected Transport Customization:   {settings.TransportCustomizationType}

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -15,6 +15,7 @@ namespace Particular.ServiceControl
     using Autofac;
     using Autofac.Core.Activators.Reflection;
     using Autofac.Features.ResolveAnything;
+    using ByteSizeLib;
     using global::ServiceControl.CompositeViews.Messages;
     using global::ServiceControl.Infrastructure;
     using global::ServiceControl.Infrastructure.DomainEvents;
@@ -23,7 +24,6 @@ namespace Particular.ServiceControl
     using global::ServiceControl.Operations;
     using global::ServiceControl.Recoverability;
     using global::ServiceControl.Transports;
-    using Humanizer;
     using Microsoft.Owin.Hosting;
     using NServiceBus;
     using NServiceBus.Configuration.AdvancedExtensibility;
@@ -226,8 +226,8 @@ Audit Retention Period (optional):  {settings.AuditRetentionPeriod}
 Error Retention Period:             {settings.ErrorRetentionPeriod}
 Ingest Error Messages:              {settings.IngestErrorMessages}
 Forwarding Error Messages:          {settings.ForwardErrorMessages}
-Database Size:                      {dataSize:n0} bytes ({dataSize.Bytes().ToString("#.##", CultureInfo.InvariantCulture)})
-Database Folder Size:               {folderSize:n0} bytes ({folderSize.Bytes().ToString("#.##", CultureInfo.InvariantCulture)})
+Database Size:                      {dataSize:n0} bytes ({ByteSize.FromBytes(dataSize).ToString("#.##", CultureInfo.InvariantCulture)})
+Database Folder Size:               {folderSize:n0} bytes ({ByteSize.FromBytes(folderSize).ToString("#.##", CultureInfo.InvariantCulture)})
 ServiceControl Logging Level:       {loggingSettings.LoggingLevel}
 RavenDB Logging Level:              {loggingSettings.RavenDBLogLevel}
 Selected Transport Customization:   {settings.TransportCustomizationType}

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -3,6 +3,7 @@ namespace Particular.ServiceControl
     using System;
     using System.Collections.Concurrent;
     using System.Diagnostics;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -22,6 +23,7 @@ namespace Particular.ServiceControl
     using global::ServiceControl.Operations;
     using global::ServiceControl.Recoverability;
     using global::ServiceControl.Transports;
+    using Humanizer;
     using Microsoft.Owin.Hosting;
     using NServiceBus;
     using NServiceBus.Configuration.AdvancedExtensibility;
@@ -215,6 +217,8 @@ namespace Particular.ServiceControl
         void RecordStartup(LoggingSettings loggingSettings, EndpointConfiguration endpointConfiguration)
         {
             var version = FileVersionInfo.GetVersionInfo(typeof(Bootstrapper).Assembly.Location).ProductVersion;
+            var dataSize = DataSize();
+            var folderSize = FolderSize();
             var startupMessage = $@"
 -------------------------------------------------------------
 ServiceControl Version:             {version}
@@ -222,8 +226,8 @@ Audit Retention Period (optional):  {settings.AuditRetentionPeriod}
 Error Retention Period:             {settings.ErrorRetentionPeriod}
 Ingest Error Messages:              {settings.IngestErrorMessages}
 Forwarding Error Messages:          {settings.ForwardErrorMessages}
-Database Size:                      {DataSize():n0} bytes
-Database Folder Size:               {FolderSize():n0} bytes
+Database Size:                      {dataSize:n0} bytes ({dataSize.Bytes().ToString("#.##", CultureInfo.InvariantCulture)})
+Database Folder Size:               {folderSize:n0} bytes ({folderSize.Bytes().ToString("#.##", CultureInfo.InvariantCulture)})
 ServiceControl Logging Level:       {loggingSettings.LoggingLevel}
 RavenDB Logging Level:              {loggingSettings.RavenDBLogLevel}
 Selected Transport Customization:   {settings.TransportCustomizationType}

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -226,8 +226,8 @@ Audit Retention Period (optional):  {settings.AuditRetentionPeriod}
 Error Retention Period:             {settings.ErrorRetentionPeriod}
 Ingest Error Messages:              {settings.IngestErrorMessages}
 Forwarding Error Messages:          {settings.ForwardErrorMessages}
-Database Size:                      {dataSize:n0} bytes ({ByteSize.FromBytes(dataSize).ToString("#.##", CultureInfo.InvariantCulture)})
-Database Folder Size:               {folderSize:n0} bytes ({ByteSize.FromBytes(folderSize).ToString("#.##", CultureInfo.InvariantCulture)})
+Database Size:                      {ByteSize.FromBytes(dataSize).ToString("#.##", CultureInfo.InvariantCulture)}
+Database Folder Size:               {ByteSize.FromBytes(folderSize).ToString("#.##", CultureInfo.InvariantCulture)}
 ServiceControl Logging Level:       {loggingSettings.LoggingLevel}
 RavenDB Logging Level:              {loggingSettings.RavenDBLogLevel}
 Selected Transport Customization:   {settings.TransportCustomizationType}

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="2.8.26" />
+    <PackageReference Include="ByteSize" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
     <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Humanizer.Core" Version="2.8.26" />
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
     <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />


### PR DESCRIPTION
Alternative to #2480 to report the sizes as MB, GB, or TB.

[ByteSize 2.0.0 license is MIT](https://github.com/omar/ByteSize/blob/v2.0.0/LICENSE)

Example of startup info:

```txt
-------------------------------------------------------------
ServiceControl Version:             4.17.0-report-foldersize-humanize.1+56.Branch.report-foldersize-humanize.Sha.0a74daee389ee6283d319f77c56b69916b6534fa
Audit Retention Period (optional):
Error Retention Period:             10.00:00:00
Ingest Error Messages:              True
Forwarding Error Messages:          False
Database Size:                      1.05 MB
Database Folder Size:               119.93 MB
ServiceControl Logging Level:       Info
RavenDB Logging Level:              Warn
Selected Transport Customization:   ServiceControl.Transports.Learning.LearningTransportCustomization, ServiceControl.Transports.Learning
-------------------------------------------------------------
```
