### PR TITLE
Bring the rudimentary metrics support from the Raven 5 branch

### DIFF
--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -23,6 +23,7 @@
   "Port": 8888,
   "DatabaseMaintenancePort": 44445,
   "ExposeRavenDB": false,
+  "PrintMetrics": false,
   "Hostname": "localhost",
   "VirtualDirectory": "",
   "TransportCustomizationType": "ServiceControl.Transports.Learning.LearningTransportCustomization, ServiceControl.Transports.Learning",

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -186,6 +186,7 @@ namespace ServiceControl.Audit.Infrastructure.Settings
         public int MaximumConcurrencyLevel { get; set; }
         public System.Func<string, System.Collections.Generic.Dictionary<string, string>, byte[], System.Func<System.Threading.Tasks.Task>, System.Threading.Tasks.Task> OnMessage { get; set; }
         public int Port { get; set; }
+        public bool PrintMetrics { get; }
         public string RootUrl { get; }
         public bool RunCleanupBundle { get; set; }
         public bool RunInMemory { get; set; }

--- a/src/ServiceControl.Audit/Auditing/AuditIngestionComponent.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestionComponent.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Channels;
     using System.Threading.Tasks;
@@ -12,10 +13,12 @@
     using NServiceBus.Logging;
     using NServiceBus.Transport;
     using Raven.Client;
+    using ServiceControl.Infrastructure.Metrics;
 
     class AuditIngestionComponent
     {
         static ILog log = LogManager.GetLogger<AuditIngestionComponent>();
+        static readonly long FrequencyInMilliseconds = Stopwatch.Frequency / 1000;
 
         ImportFailedAudits failedImporter;
         Watchdog watchdog;
@@ -24,8 +27,12 @@
         AuditIngestor ingestor;
         Task ingestionWorker;
         Settings settings;
+        Counter receivedMeter;
+        Meter batchSizeMeter;
+        Meter batchDurationMeter;
 
         public AuditIngestionComponent(
+            Metrics metrics,
             Settings settings,
             IDocumentStore documentStore,
             RawEndpointFactory rawEndpointFactory,
@@ -35,9 +42,18 @@
             AuditIngestionCustomCheck.State ingestionState
         )
         {
+            receivedMeter = metrics.GetCounter("Audit ingestion - received");
+            batchSizeMeter = metrics.GetMeter("Audit ingestion - batch size");
+            var ingestedAuditMeter = metrics.GetCounter("Audit ingestion - ingested audit");
+            var ingestedSagaAuditMeter = metrics.GetCounter("Audit ingestion - ingested saga audit");
+            var auditBulkInsertDurationMeter = metrics.GetMeter("Audit ingestion - audit bulk insert duration", FrequencyInMilliseconds);
+            var sagaAuditBulkInsertDurationMeter = metrics.GetMeter("Audit ingestion - saga audit bulk insert duration", FrequencyInMilliseconds);
+            var bulkInsertCommitDurationMeter = metrics.GetMeter("Audit ingestion - bulk insert commit duration", FrequencyInMilliseconds);
+            batchDurationMeter = metrics.GetMeter("Audit ingestion - batch processing duration", FrequencyInMilliseconds);
+
             this.settings = settings;
             var errorHandlingPolicy = new AuditIngestionFaultPolicy(documentStore, loggingSettings, FailedMessageFactory, OnCriticalError);
-            auditPersister = new AuditPersister(documentStore, bodyStorageEnricher, enrichers);
+            auditPersister = new AuditPersister(documentStore, bodyStorageEnricher, enrichers, ingestedAuditMeter, ingestedSagaAuditMeter, auditBulkInsertDurationMeter, sagaAuditBulkInsertDurationMeter, bulkInsertCommitDurationMeter);
             ingestor = new AuditIngestor(auditPersister, settings);
 
             var ingestion = new AuditIngestion(
@@ -45,6 +61,8 @@
                 {
                     var taskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     messageContext.SetTaskCompletionSource(taskCompletionSource);
+
+                    receivedMeter.Mark();
 
                     await channel.Writer.WriteAsync(messageContext).ConfigureAwait(false);
                     await taskCompletionSource.Task.ConfigureAwait(false);
@@ -110,7 +128,11 @@
                         contexts.Add(context);
                     }
 
-                    await ingestor.Ingest(contexts).ConfigureAwait(false);
+                    batchSizeMeter.Mark(contexts.Count);
+                    using (batchDurationMeter.Measure())
+                    {
+                        await ingestor.Ingest(contexts).ConfigureAwait(false);
+                    }
                 }
                 catch (Exception e) // show must go on
                 {

--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -142,7 +142,10 @@ namespace ServiceControl.Audit.Infrastructure
             }
 
             logger.InfoFormat("Api is now accepting requests on {0}", settings.ApiUrl);
-            reporter.Start();
+            if (settings.PrintMetrics)
+            {
+                reporter.Start();
+            }
             return bus;
         }
 

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -82,6 +82,7 @@
         public int DatabaseMaintenancePort { get; set; }
 
         public bool ExposeRavenDB => SettingsReader<bool>.Read("ExposeRavenDB");
+        public bool PrintMetrics => SettingsReader<bool>.Read("PrintMetrics");
         public string Hostname => SettingsReader<string>.Read("Hostname", "localhost");
         public string VirtualDirectory => SettingsReader<string>.Read("VirtualDirectory", string.Empty);
 

--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.Infrastructure.Metrics\ServiceControl.Infrastructure.Metrics.csproj" />
     <ProjectReference Include="..\ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj" />
     <ProjectReference Include="..\ServiceControl.SagaAudit\ServiceControl.SagaAudit.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />

--- a/src/ServiceControl.Infrastructure.Metrics/Counter.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/Counter.cs
@@ -1,0 +1,113 @@
+﻿namespace ServiceControl.Infrastructure.Metrics
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+
+    public class Counter
+    {
+        readonly string name;
+        readonly int[] eventsPerSecond;
+        readonly int[] movingAverage;
+        readonly long[] movingAverageEpochs;
+        long epoch;
+
+        public Counter(string name)
+        {
+            this.name = name;
+            eventsPerSecond = new int[2];
+            movingAverage = new int[300];
+            movingAverageEpochs = new long[300];
+            epoch = DateTime.Now.Minute;
+        }
+
+        public void Mark()
+        {
+            var ticks = Stopwatch.GetTimestamp();
+            var currentEpoch = ticks / Stopwatch.Frequency;
+            var bucketTierIndex = currentEpoch % 2;
+
+
+            if (InterlockedExchangeIfGreaterThan(ref epoch, currentEpoch, currentEpoch, out var previousEpoch))
+            {
+                var previousBucketTierIndex = previousEpoch % 2;
+
+                var previousEpochTotal = eventsPerSecond[previousBucketTierIndex];
+
+                eventsPerSecond[previousBucketTierIndex] = 0;
+
+                Interlocked.Increment(ref eventsPerSecond[bucketTierIndex]);
+
+                AddMovingAverageValue(previousEpochTotal, previousEpoch);
+            }
+            else
+            {
+                Interlocked.Increment(ref eventsPerSecond[bucketTierIndex]);
+            }
+        }
+
+        public MeterValues GetValues()
+        {
+            var ticks = Stopwatch.GetTimestamp();
+            var currentEpoch = ticks / Stopwatch.Frequency;
+
+            var currentValueIndex = Array.IndexOf(movingAverageEpochs, currentEpoch - 1);
+            var currentValue = currentValueIndex != -1 ? movingAverage[currentValueIndex] : 0;
+
+            var threshold15 = currentEpoch - 15;
+            var threshold60 = currentEpoch - 60;
+            var threshold300 = currentEpoch - 300;
+
+            var count15 = 0;
+            var count60 = 0;
+            var count300 = 0;
+
+            for (var i = 0; i < movingAverage.Length; i++)
+            {
+                if (movingAverageEpochs[i] > threshold300)
+                {
+                    var v = movingAverage[i];
+                    count300 += v;
+
+                    if (movingAverageEpochs[i] > threshold60)
+                    {
+                        count60 += v;
+
+                        if (movingAverageEpochs[i] > threshold15)
+                        {
+                            count15 += v;
+                        }
+                    }
+                }
+
+            }
+
+            return new MeterValues(name, currentValue, count15 / 15f, count60 / 60f, count300 / 300f);
+        }
+
+        void AddMovingAverageValue(int previousEpochTotal, long previousEpoch)
+        {
+            var bucket = previousEpoch % 300;
+
+            movingAverage[bucket] = previousEpochTotal;
+            movingAverageEpochs[bucket] = previousEpoch;
+        }
+
+        public static bool InterlockedExchangeIfGreaterThan(ref long location, long comparison, long newValue, out long previous)
+        {
+            long initialValue;
+            do
+            {
+                initialValue = location;
+                if (initialValue >= comparison)
+                {
+                    previous = -1;
+                    return false;
+                }
+            }
+            while (Interlocked.CompareExchange(ref location, newValue, initialValue) != initialValue);
+            previous = initialValue;
+            return true;
+        }
+    }
+}

--- a/src/ServiceControl.Infrastructure.Metrics/Measurement.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/Measurement.cs
@@ -1,0 +1,24 @@
+﻿namespace ServiceControl.Infrastructure.Metrics
+{
+    using System;
+    using System.Diagnostics;
+
+    public readonly struct Measurement : IDisposable
+    {
+        readonly Meter meter;
+        readonly long startTimestamp;
+
+        public Measurement(Meter meter)
+        {
+            this.meter = meter;
+            startTimestamp = Stopwatch.GetTimestamp();
+        }
+
+        public void Dispose()
+        {
+            var endTimestamp = Stopwatch.GetTimestamp();
+            var duration = endTimestamp - startTimestamp;
+            meter.Mark(duration);
+        }
+    }
+}

--- a/src/ServiceControl.Infrastructure.Metrics/Meter.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/Meter.cs
@@ -1,0 +1,138 @@
+﻿namespace ServiceControl.Infrastructure.Metrics
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+
+    public class Meter
+    {
+        readonly string name;
+        readonly float scale;
+        readonly long[] eventsPerSecond;
+        readonly long[] sumPerSecond;
+        readonly long[] movingAverageSums;
+        readonly long[] movingAverageCounts;
+        readonly long[] movingAverageEpochs;
+        long epoch;
+
+        public Meter(string name, float scale = 1)
+        {
+            this.name = name;
+            this.scale = scale;
+            eventsPerSecond = new long[2];
+            sumPerSecond = new long[2];
+            movingAverageSums = new long[300];
+            movingAverageCounts = new long[300];
+            movingAverageEpochs = new long[300];
+            epoch = DateTime.Now.Minute;
+        }
+
+        public Measurement Measure()
+        {
+            return new Measurement(this);
+        }
+
+        public void Mark(long value)
+        {
+            var ticks = Stopwatch.GetTimestamp();
+            var currentEpoch = ticks / Stopwatch.Frequency;
+            var bucketTierIndex = currentEpoch % 2;
+
+
+            if (InterlockedExchangeIfGreaterThan(ref epoch, currentEpoch, currentEpoch, out var previousEpoch))
+            {
+                var previousBucketTierIndex = previousEpoch % 2;
+
+                var previousEpochTotal = sumPerSecond[previousBucketTierIndex];
+                var previousEpochCount = eventsPerSecond[previousBucketTierIndex];
+
+                eventsPerSecond[previousBucketTierIndex] = 0;
+                sumPerSecond[previousBucketTierIndex] = 0;
+
+                Interlocked.Increment(ref eventsPerSecond[bucketTierIndex]);
+                Interlocked.Add(ref sumPerSecond[bucketTierIndex], value);
+
+                AddMovingAverageValue(previousEpochTotal, previousEpochCount, previousEpoch);
+            }
+            else
+            {
+                Interlocked.Increment(ref eventsPerSecond[bucketTierIndex]);
+                Interlocked.Add(ref sumPerSecond[bucketTierIndex], value);
+            }
+        }
+
+        public MeterValues GetValues()
+        {
+            var ticks = Stopwatch.GetTimestamp();
+            var currentEpoch = ticks / Stopwatch.Frequency;
+
+            var currentValueIndex = Array.IndexOf(movingAverageEpochs, currentEpoch - 1);
+            var currentSum = currentValueIndex != -1 ? movingAverageSums[currentValueIndex] : 0;
+            var currentCount = (float)(currentValueIndex != -1 ? movingAverageCounts[currentValueIndex] : 0);
+
+            var threshold15 = currentEpoch - 15;
+            var threshold60 = currentEpoch - 60;
+            var threshold300 = currentEpoch - 300;
+
+            var count15 = 0f;
+            var sum15 = 0L;
+            var count60 = 0f;
+            var sum60 = 0L;
+            var count300 = 0f;
+            var sum300 = 0L;
+
+            for (var i = 0; i < movingAverageEpochs.Length; i++)
+            {
+                if (movingAverageEpochs[i] > threshold300)
+                {
+                    var s = movingAverageSums[i];
+                    var c = movingAverageCounts[i];
+                    count300 += c;
+                    sum300 += s;
+
+                    if (movingAverageEpochs[i] > threshold60)
+                    {
+                        count60 += c;
+                        sum60 += s;
+
+                        if (movingAverageEpochs[i] > threshold15)
+                        {
+                            count15 += c;
+                            sum15 += s;
+                        }
+                    }
+                }
+            }
+
+            var currentValue = currentCount != 0 ? currentSum / currentCount : 0;
+
+            return new MeterValues(name, currentValue / scale, sum15 / count15 / scale, sum60 / count60 / scale, sum300 / count300 / scale);
+        }
+
+        void AddMovingAverageValue(long previousEpochTotal, long previousEpochCount, long previousEpoch)
+        {
+            var bucket = previousEpoch % 300;
+
+            movingAverageCounts[bucket] = previousEpochCount;
+            movingAverageSums[bucket] = previousEpochTotal;
+            movingAverageEpochs[bucket] = previousEpoch;
+        }
+
+        public static bool InterlockedExchangeIfGreaterThan(ref long location, long comparison, long newValue, out long previous)
+        {
+            long initialValue;
+            do
+            {
+                initialValue = location;
+                if (initialValue >= comparison)
+                {
+                    previous = -1;
+                    return false;
+                }
+            }
+            while (Interlocked.CompareExchange(ref location, newValue, initialValue) != initialValue);
+            previous = initialValue;
+            return true;
+        }
+    }
+}

--- a/src/ServiceControl.Infrastructure.Metrics/MeterValues.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/MeterValues.cs
@@ -1,0 +1,20 @@
+﻿namespace ServiceControl.Infrastructure.Metrics
+{
+    public readonly struct MeterValues
+    {
+        public MeterValues(string name, float current, float average15, float average60, float average300)
+        {
+            Current = current;
+            Average15 = average15;
+            Average60 = average60;
+            Average300 = average300;
+            Name = name;
+        }
+
+        public string Name { get; }
+        public float Current { get; }
+        public float Average15 { get; }
+        public float Average60 { get; }
+        public float Average300 { get; }
+    }
+}

--- a/src/ServiceControl.Infrastructure.Metrics/Metrics.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/Metrics.cs
@@ -1,0 +1,40 @@
+﻿namespace ServiceControl.Infrastructure.Metrics
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class Metrics
+    {
+        readonly Dictionary<string, Counter> counters = new Dictionary<string, Counter>();
+        readonly Dictionary<string, Meter> meters = new Dictionary<string, Meter>();
+
+        public Counter GetCounter(string name)
+        {
+            if (!counters.TryGetValue(name, out var meter))
+            {
+                meter = new Counter(name);
+                counters[name] = meter;
+            }
+
+            return meter;
+        }
+
+        public Meter GetMeter(string name, float scale = 1)
+        {
+            if (!meters.TryGetValue(name, out var meter))
+            {
+                meter = new Meter(name, scale);
+                meters[name] = meter;
+            }
+
+            return meter;
+        }
+
+        public IReadOnlyCollection<MeterValues> GetMeterValues()
+        {
+            var counterValues = counters.Values.Select(x => x.GetValues());
+            var meterValues = meters.Values.Select(x => x.GetValues());
+            return counterValues.Concat(meterValues).ToArray();
+        }
+    }
+}

--- a/src/ServiceControl.Infrastructure.Metrics/MetricsReporter.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/MetricsReporter.cs
@@ -1,0 +1,51 @@
+﻿namespace ServiceControl.Infrastructure.Metrics
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class MetricsReporter
+    {
+        readonly Metrics metrics;
+        readonly Action<string> printLine;
+        readonly TimeSpan interval;
+        CancellationTokenSource tokenSource;
+        Task task;
+
+        public MetricsReporter(Metrics metrics, Action<string> printLine, TimeSpan interval)
+        {
+            this.metrics = metrics;
+            this.printLine = printLine;
+            this.interval = interval;
+        }
+
+        public void Start()
+        {
+            tokenSource = new CancellationTokenSource();
+            task = Task.Run(async () =>
+            {
+                while (!tokenSource.IsCancellationRequested)
+                {
+                    Print();
+                    await Task.Delay(interval).ConfigureAwait(false);
+                }
+            }, tokenSource.Token);
+        }
+
+        void Print()
+        {
+            var values = metrics.GetMeterValues();
+            foreach (var metricSet in values)
+            {
+                printLine(
+                    $"{metricSet.Name,-40};{metricSet.Current:F};{metricSet.Average15:F};{metricSet.Average60:F};{metricSet.Average300:F}");
+            }
+        }
+
+        public Task Stop()
+        {
+            tokenSource.Cancel();
+            return task;
+        }
+    }
+}

--- a/src/ServiceControl.Infrastructure.Metrics/MetricsReporter.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/MetricsReporter.cs
@@ -44,6 +44,10 @@
 
         public Task Stop()
         {
+            if (tokenSource == null)
+            {
+                return Task.CompletedTask;
+            }
             tokenSource.Cancel();
             return task;
         }

--- a/src/ServiceControl.Infrastructure.Metrics/ServiceControl.Infrastructure.Metrics.csproj
+++ b/src/ServiceControl.Infrastructure.Metrics/ServiceControl.Infrastructure.Metrics.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -94,7 +94,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Infrastructu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Config.Tests", "ServiceControl.Config.Tests\ServiceControl.Config.Tests.csproj", "{9CA13A10-1F6F-495A-9623-AC62201FC0BD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.LicenseManagement", "ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj", "{FD1B9998-4B0C-4109-A3BC-0748F829F852}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.LicenseManagement", "ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj", "{FD1B9998-4B0C-4109-A3BC-0748F829F852}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Infrastructure.Metrics", "ServiceControl.Infrastructure.Metrics\ServiceControl.Infrastructure.Metrics.csproj", "{56422C80-6A26-46B4-AF5C-84AF08BAB1D1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -254,6 +256,10 @@ Global
 		{FD1B9998-4B0C-4109-A3BC-0748F829F852}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD1B9998-4B0C-4109-A3BC-0748F829F852}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD1B9998-4B0C-4109-A3BC-0748F829F852}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56422C80-6A26-46B4-AF5C-84AF08BAB1D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56422C80-6A26-46B4-AF5C-84AF08BAB1D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56422C80-6A26-46B4-AF5C-84AF08BAB1D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56422C80-6A26-46B4-AF5C-84AF08BAB1D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I copied the code from the Raven 5 branch where we added a very simple support for metrics for the purposes of measuring increase (or decrease) in performance.