### PR TITLE
Argument help for `--portable` argument.

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
@@ -77,7 +77,7 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
                 },
                 {
                     "p|portable",
-                    @"Internal use - runs as a console app, even non-interactively",
+                    @"Runs as a console app, even non-interactively",
                     s => { Portable = true; }
                 }
             };
@@ -86,7 +86,7 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
             {
                 {
                     "p|portable",
-                    @"Internal use - runs as a console app, even non-interactively",
+                    @"Runs as a console app, even non-interactively",
                     s => { Portable = true; }
                 }
             };

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -48,7 +48,7 @@ namespace Particular.ServiceControl.Hosting
                 },
                 {
                     "p|portable",
-                    @"Internal use - runs as a console app, even non-interactively",
+                    @"Runs as a console app, even non-interactively",
                     s => { Portable = true; }
                 }
             };
@@ -78,7 +78,7 @@ namespace Particular.ServiceControl.Hosting
                 },
                 {
                     "p|portable",
-                    @"Internal use - runs as a console app, even non-interactively",
+                    @"Runs as a console app, even non-interactively",
                     s => { Portable = true; }
                 }
             };
@@ -87,7 +87,7 @@ namespace Particular.ServiceControl.Hosting
             {
                 {
                     "p|portable",
-                    @"Internal use - runs as a console app, even non-interactively",
+                    @"Runs as a console app, even non-interactively",
                     s => { Portable = true; }
                 }
             };


### PR DESCRIPTION
Removed the "Internal use - " prefix which doesn't feel really applicable due to use supporting this for containerization.