### PR TITLE
Drop audit retention question when upgrading primary instance

### DIFF
--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -119,32 +119,6 @@
                         upgradeOptions.AuditRetentionPeriod = TimeSpan.FromHours(i);
                     }
                 }
-
-                // No setting to migrate so display dialog
-                if (!upgradeOptions.AuditRetentionPeriod.HasValue)
-                {
-                    var viewModel = new SliderDialogViewModel("INPUT REQUIRED - DATABASE RETENTION",
-                        "Service Control periodically purges audit messages from the database.",
-                        "AUDIT RETENTION PERIOD",
-                        "Please specify the age at which these records should be removed",
-                        TimeSpanUnits.Hours,
-                        SettingConstants.AuditRetentionPeriodMinInHours,
-                        SettingConstants.AuditRetentionPeriodMaxInHours,
-                        1,
-                        24,
-                        SettingConstants.AuditRetentionPeriodDefaultInHoursForUI);
-
-                    if (windowManager.ShowSliderDialog(viewModel))
-                    {
-                        upgradeOptions.AuditRetentionPeriod = viewModel.Period;
-                    }
-                    else
-                    {
-                        //Dialog was cancelled
-                        await eventAggregator.PublishOnUIThreadAsync(new RefreshInstances());
-                        return;
-                    }
-                }
             }
 
             if (!instance.AppConfig.AppSettingExists(ServiceControlSettings.ErrorRetentionPeriod.Name))


### PR DESCRIPTION
Brand new ServiceControl version 4 primary instances do not have an audit retention setting (as it doesn't ingest audits). That means if you install a version 4.x primary instance and then upgrade it, you get asked to set an audit retention period.

![image](https://user-images.githubusercontent.com/124014/116493694-d3cd2400-a8d1-11eb-8436-fda48b04ac12.png)

If the audit retention period is set, then the [audit retention code needs to run](https://github.com/Particular/ServiceControl/blob/master/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs#L26-L33) so we shouldn't have a value here unless there's some audit messages to clean up.

In the worst case, already ingested audit messages will not be being cleaned up after this change. As the primary instance will not ingest any more audit message, that's at least a stable situation.

NOTE: We cannot automatically remove this setting because there _could_ be audit messages still in the database.