### PR TITLE
Add VOLUME to docker files

### DIFF
--- a/src/docker/servicecontrol.amazonsqs-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl/ErrorRetentionPeriod"="15"
 EXPOSE 33333
 EXPOSE 33334
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable"]

--- a/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 EXPOSE 44444
 EXPOSE 44445
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable"]

--- a/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.audit.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"
 ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl/ForwardErrorMessages"="False"
 ENV "ServiceControl/ErrorRetentionPeriod"="15"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring-windows.dockerfile
@@ -15,4 +15,6 @@ ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
 EXPOSE 33633
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.monitoring.init-windows.dockerfile
@@ -13,4 +13,6 @@ ENV "Monitoring/HttpPort"="33633"
 
 ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.azureservicebus-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl/ErrorRetentionPeriod"="15"
 EXPOSE 33333
 EXPOSE 33334
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable"]

--- a/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 EXPOSE 44444
 EXPOSE 44445
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable"]

--- a/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.audit.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"
 ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl/ForwardErrorMessages"="False"
 ENV "ServiceControl/ErrorRetentionPeriod"="15"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring-windows.dockerfile
@@ -15,4 +15,6 @@ ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
 EXPOSE 33633
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.monitoring.init-windows.dockerfile
@@ -13,4 +13,6 @@ ENV "Monitoring/HttpPort"="33633"
 
 ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl/ErrorRetentionPeriod"="15"
 EXPOSE 33333
 EXPOSE 33334
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable"]

--- a/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 EXPOSE 44444
 EXPOSE 44445
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable"]

--- a/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.audit.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"
 ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl/ForwardErrorMessages"="False"
 ENV "ServiceControl/ErrorRetentionPeriod"="15"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring-windows.dockerfile
@@ -15,4 +15,6 @@ ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
 EXPOSE 33633
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.monitoring.init-windows.dockerfile
@@ -13,4 +13,6 @@ ENV "Monitoring/HttpPort"="33633"
 
 ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl/ErrorRetentionPeriod"="15"
 EXPOSE 33333
 EXPOSE 33334
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable"]

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 EXPOSE 44444
 EXPOSE 44445
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable"]

--- a/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.audit.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"
 ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--setup"]

--- a/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl/ForwardErrorMessages"="False"
 ENV "ServiceControl/ErrorRetentionPeriod"="15"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--setup"]

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring-windows.dockerfile
@@ -15,4 +15,6 @@ ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
 EXPOSE 33633
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.conventional.monitoring.init-windows.dockerfile
@@ -13,4 +13,6 @@ ENV "Monitoring/HttpPort"="33633"
 
 ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl/ErrorRetentionPeriod"="15"
 EXPOSE 33333
 EXPOSE 33334
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable"]

--- a/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 EXPOSE 44444
 EXPOSE 44445
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable"]

--- a/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.audit.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl/ForwardErrorMessages"="False"
 ENV "ServiceControl/ErrorRetentionPeriod"="15"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl/ForwardErrorMessages"="False"
 ENV "ServiceControl/ErrorRetentionPeriod"="15"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring-windows.dockerfile
@@ -15,4 +15,6 @@ ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
 EXPOSE 33633
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.direct.monitoring.init-windows.dockerfile
@@ -13,4 +13,6 @@ ENV "Monitoring/HttpPort"="33633"
 
 ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.sqlserver-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl/ErrorRetentionPeriod"="15"
 EXPOSE 33333
 EXPOSE 33334
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable"]

--- a/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit-windows.dockerfile
@@ -20,4 +20,6 @@ ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 EXPOSE 44444
 EXPOSE 44445
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable"]

--- a/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.audit.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl.Audit/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl.Audit/ForwardAuditMessages"="False"
 ENV "ServiceControl.Audit/AuditRetentionPeriod"="365"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Audit.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
@@ -17,4 +17,6 @@ ENV "ServiceControl/LogPath"="C:\\Data\\Logs\\"
 ENV "ServiceControl/ForwardErrorMessages"="False"
 ENV "ServiceControl/ErrorRetentionPeriod"="15"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.exe", "--portable", "--setup"]

--- a/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring-windows.dockerfile
@@ -15,4 +15,6 @@ ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
 EXPOSE 33633
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable"]

--- a/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.monitoring.init-windows.dockerfile
@@ -13,4 +13,6 @@ ENV "Monitoring/HttpPort"="33633"
 
 ENV "Monitoring/LogPath"="C:\\Data\\Logs\\"
 
+VOLUME [ "C:/Data" ]
+
 ENTRYPOINT ["ServiceControl.Monitoring.exe", "--portable", "--setup"]


### PR DESCRIPTION
Add `VOLUME` to docker files,

See <https://docs.docker.com/engine/reference/builder/#volume>:

> The VOLUME instruction creates a mount point with the specified name and marks it as holding externally mounted volumes from native host or other containers. 

After noticing this used by RabbitMQ docker images to designate default volumes I thought it makes sense to add these to our images too. 