### PR TITLE
lock analyzers to 0.9.0 while on NSB 7.x

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,12 +1,14 @@
 <Project>
 
   <PropertyGroup>
-    <IsPackable>false</IsPackable>	
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>	
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <!-- Remove after upgrading to NServiceBus 8.x -->
+    <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>
   </PropertyGroup>
 
-  <ItemGroup>	
-    <PackageReference Include="Particular.Packaging" Version="1.1.0" PrivateAssets="All" />	
-  </ItemGroup>	
+  <ItemGroup>
+    <PackageReference Include="Particular.Packaging" Version="1.1.0" PrivateAssets="All" />
+  </ItemGroup>
 
 </Project> 

--- a/src/ServiceControl.AcceptanceTesting/.editorconfig
+++ b/src/ServiceControl.AcceptanceTesting/.editorconfig
@@ -2,7 +2,3 @@
 
 # Justification: Usage is from test projects
 dotnet_diagnostic.CA2007.severity = none
-
-# may be enabled in future
-dotnet_diagnostic.PS0013.severity = none  # A Func used as a method parameter with a Task, ValueTask, or ValueTask<T> return type argument should have at least one CancellationToken parameter type argument unless it has a parameter type argument implementing ICancellableContext
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.AcceptanceTests/.editorconfig
+++ b/src/ServiceControl.AcceptanceTests/.editorconfig
@@ -2,10 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# may be enabled in future
-dotnet_diagnostic.PS0013.severity = none  # A Func used as a method parameter with a Task, ValueTask, or ValueTask<T> return type argument should have at least one CancellationToken parameter type argument unless it has a parameter type argument implementing ICancellableContext
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControl.Audit.AcceptanceTests/.editorconfig
+++ b/src/ServiceControl.Audit.AcceptanceTests/.editorconfig
@@ -2,9 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControl.Audit.UnitTests/.editorconfig
+++ b/src/ServiceControl.Audit.UnitTests/.editorconfig
@@ -2,9 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControl.Audit/.editorconfig
+++ b/src/ServiceControl.Audit/.editorconfig
@@ -1,5 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0013.severity = none  # A Func used as a method parameter with a Task, ValueTask, or ValueTask<T> return type argument should have at least one CancellationToken parameter type argument unless it has a parameter type argument implementing ICancellableContext
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Config.Tests/.editorconfig
+++ b/src/ServiceControl.Config.Tests/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControl.Config/.editorconfig
+++ b/src/ServiceControl.Config/.editorconfig
@@ -2,7 +2,3 @@
 
 # Justification: Application synchronization contexts don't require ConfigureAwait(false)
 dotnet_diagnostic.CA2007.severity = none
-
-# may be enabled in future
-dotnet_diagnostic.PS0013.severity = none  # A Func used as a method parameter with a Task, ValueTask, or ValueTask<T> return type argument should have at least one CancellationToken parameter type argument unless it has a parameter type argument implementing ICancellableContext
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Infrastructure.Metrics/.editorconfig
+++ b/src/ServiceControl.Infrastructure.Metrics/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.LoadTests.AuditGenerator/.editorconfig
+++ b/src/ServiceControl.LoadTests.AuditGenerator/.editorconfig
@@ -2,6 +2,3 @@
 
 # Justification: Application synchronization contexts don't require ConfigureAwait(false)
 dotnet_diagnostic.CA2007.severity = none
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Monitoring.AcceptanceTests/.editorconfig
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/.editorconfig
@@ -2,9 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControl.Monitoring.UnitTests/.editorconfig
+++ b/src/ServiceControl.Monitoring.UnitTests/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControl.Monitoring/.editorconfig
+++ b/src/ServiceControl.Monitoring/.editorconfig
@@ -2,6 +2,3 @@
 
 # Justification: Application synchronization contexts don't require ConfigureAwait(false)
 dotnet_diagnostic.CA2007.severity = none
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/.editorconfig
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/.editorconfig
@@ -2,10 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# may be enabled in future
-dotnet_diagnostic.PS0013.severity = none  # A Func used as a method parameter with a Task, ValueTask, or ValueTask<T> return type argument should have at least one CancellationToken parameter type argument unless it has a parameter type argument implementing ICancellableContext
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControl.Transports.ASB/.editorconfig
+++ b/src/ServiceControl.Transports.ASB/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Transports.ASBS/.editorconfig
+++ b/src/ServiceControl.Transports.ASBS/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Transports.ASQ/.editorconfig
+++ b/src/ServiceControl.Transports.ASQ/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Transports.Learning/.editorconfig
+++ b/src/ServiceControl.Transports.Learning/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Transports.Msmq/.editorconfig
+++ b/src/ServiceControl.Transports.Msmq/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Transports.RabbitMQ/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQ/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Transports.SQS/.editorconfig
+++ b/src/ServiceControl.Transports.SQS/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Transports.SqlServer/.editorconfig
+++ b/src/ServiceControl.Transports.SqlServer/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.Transports.UnitTests/.editorconfig
+++ b/src/ServiceControl.Transports.UnitTests/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControl.Transports/.editorconfig
+++ b/src/ServiceControl.Transports/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControl.UnitTests/.editorconfig
+++ b/src/ServiceControl.UnitTests/.editorconfig
@@ -2,9 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# may be enabled in future
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControl/.editorconfig
+++ b/src/ServiceControl/.editorconfig
@@ -1,5 +1,0 @@
-[*.cs]
-
-# may be enabled in future
-dotnet_diagnostic.PS0013.severity = none  # A Func used as a method parameter with a Task, ValueTask, or ValueTask<T> return type argument should have at least one CancellationToken parameter type argument unless it has a parameter type argument implementing ICancellableContext
-dotnet_diagnostic.PS0018.severity = none  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

--- a/src/ServiceControlInstaller.CustomActions.UnitTests/.editorconfig
+++ b/src/ServiceControlInstaller.CustomActions.UnitTests/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControlInstaller.Engine.UnitTests/.editorconfig
+++ b/src/ServiceControlInstaller.Engine.UnitTests/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/ServiceControlInstaller.Packaging.UnitTests/.editorconfig
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
-dotnet_diagnostic.NSB0002.severity = suggestion


### PR DESCRIPTION
and remove redundant NSB0002 entires, which are only relevant for NSB 8.x