### PR TITLE
SagaAudit enricher removed from the error ingestion

### DIFF
--- a/src/ServiceControl.Audit.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/SagaAudit/SagaRelationshipsEnricherTests.cs
@@ -1,8 +1,10 @@
-﻿namespace ServiceControl.UnitTests.SagaAudit
+﻿namespace ServiceControl.Audit.UnitTests.SagaAudit
 {
     using System.Collections.Generic;
+    using Audit.Auditing;
+    using Audit.SagaAudit;
+    using NServiceBus;
     using NUnit.Framework;
-    using ServiceControl.Operations;
     using ServiceControl.SagaAudit;
 
     [TestFixture]
@@ -11,7 +13,7 @@
         [Test]
         public void New_overrides_Updated_state()
         {
-            var enricher = new SagaAuditComponent.SagaRelationshipsEnricher();
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
 
             var headers = new Dictionary<string, string>
             {
@@ -20,8 +22,9 @@
             };
 
             var metadata = new Dictionary<string, object>();
+            var commandsToEmit = new List<ICommand>();
 
-            enricher.Enrich(new ErrorEnricherContext(headers, metadata));
+            enricher.Enrich(new AuditEnricherContext(headers, commandsToEmit, metadata));
 
             var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
 
@@ -32,7 +35,7 @@
         [Test]
         public void Updated_does_not_override_new()
         {
-            var enricher = new SagaAuditComponent.SagaRelationshipsEnricher();
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
 
             var headers = new Dictionary<string, string>
             {
@@ -41,8 +44,9 @@
             };
 
             var metadata = new Dictionary<string, object>();
+            var commandsToEmit = new List<ICommand>();
 
-            enricher.Enrich(new ErrorEnricherContext(headers, metadata));
+            enricher.Enrich(new AuditEnricherContext(headers, commandsToEmit, metadata));
 
             var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
 
@@ -53,7 +57,7 @@
         [Test]
         public void Updated_does_not_override_completed()
         {
-            var enricher = new SagaAuditComponent.SagaRelationshipsEnricher();
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
 
             var headers = new Dictionary<string, string>
             {
@@ -62,8 +66,9 @@
             };
 
             var metadata = new Dictionary<string, object>();
+            var commandsToEmit = new List<ICommand>();
 
-            enricher.Enrich(new ErrorEnricherContext(headers, metadata));
+            enricher.Enrich(new AuditEnricherContext(headers, commandsToEmit, metadata));
 
             var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
 
@@ -74,7 +79,7 @@
         [Test]
         public void Completed_overrides_new()
         {
-            var enricher = new SagaAuditComponent.SagaRelationshipsEnricher();
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
 
             var headers = new Dictionary<string, string>
             {
@@ -83,8 +88,9 @@
             };
 
             var metadata = new Dictionary<string, object>();
+            var commandsToEmit = new List<ICommand>();
 
-            enricher.Enrich(new ErrorEnricherContext(headers, metadata));
+            enricher.Enrich(new AuditEnricherContext(headers, commandsToEmit, metadata));
 
             var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
 
@@ -95,7 +101,7 @@
         [Test]
         public void New_does_not_override_completed()
         {
-            var enricher = new SagaAuditComponent.SagaRelationshipsEnricher();
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
 
             var headers = new Dictionary<string, string>
             {
@@ -104,8 +110,9 @@
             };
 
             var metadata = new Dictionary<string, object>();
+            var commandsToEmit = new List<ICommand>();
 
-            enricher.Enrich(new ErrorEnricherContext(headers, metadata));
+            enricher.Enrich(new AuditEnricherContext(headers, commandsToEmit, metadata));
 
             var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
 
@@ -116,7 +123,7 @@
         [Test]
         public void It_can_parse_malformed_headers_of_three_sagas()
         {
-            var enricher = new SagaAuditComponent.SagaRelationshipsEnricher();
+            var enricher = new SagaAuditing.SagaRelationshipsEnricher();
 
             var headers = new Dictionary<string, string>
             {
@@ -125,8 +132,9 @@
             };
 
             var metadata = new Dictionary<string, object>();
+            var commandsToEmit = new List<ICommand>();
 
-            enricher.Enrich(new ErrorEnricherContext(headers, metadata));
+            enricher.Enrich(new AuditEnricherContext(headers, commandsToEmit, metadata));
 
             var sagaData = (List<SagaInfo>)metadata["InvokedSagas"];
 

--- a/src/ServiceControl.Audit/SagaAudit/SagaAuditing.cs
+++ b/src/ServiceControl.Audit/SagaAudit/SagaAuditing.cs
@@ -17,7 +17,7 @@
             context.Container.ConfigureComponent<SagaRelationshipsEnricher>(DependencyLifecycle.SingleInstance);
         }
 
-        class SagaRelationshipsEnricher : IEnrichImportedAuditMessages
+        internal class SagaRelationshipsEnricher : IEnrichImportedAuditMessages
         {
             public void Enrich(AuditEnricherContext context)
             {

--- a/src/ServiceControl/Operations/IEnrichImportedMessages.cs
+++ b/src/ServiceControl/Operations/IEnrichImportedMessages.cs
@@ -1,7 +1,5 @@
 namespace ServiceControl.Operations
 {
-    using System.Threading.Tasks;
-
     interface IEnrichImportedErrorMessages
     {
         void Enrich(ErrorEnricherContext context);

--- a/src/ServiceControl/SagaAudit/SagaAuditComponent.cs
+++ b/src/ServiceControl/SagaAudit/SagaAuditComponent.cs
@@ -1,8 +1,6 @@
 ﻿namespace ServiceControl.SagaAudit
 {
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
-    using Operations;
     using Particular.ServiceControl;
     using ServiceBus.Management.Infrastructure.Settings;
 
@@ -10,20 +8,11 @@
     {
         public override void Configure(Settings settings, IHostBuilder hostBuilder)
         {
-            hostBuilder.ConfigureServices(collection =>
-            {
-                collection.AddSingleton<IEnrichImportedErrorMessages, SagaRelationshipsEnricher>();
-            });
         }
 
         public override void Setup(Settings settings, IComponentSetupContext context)
         {
             context.AddIndexAssembly(typeof(SagaSnapshot).Assembly);
-        }
-
-        internal class SagaRelationshipsEnricher : IEnrichImportedErrorMessages
-        {
-            public void Enrich(ErrorEnricherContext context) => InvokedSagasParser.Parse(context.Headers, context.Metadata);
         }
     }
 }


### PR DESCRIPTION
SagaAudit enricher for error messages has been in ServiceControl at least since [2015](https://github.com/Particular/ServiceControl/commit/20cd88323b3babb2ccd725a5899456675b5daa0c#diff-1776ca4a1f88dd295fcbefcd1ab9bea5542e4e0cdfc8489ab218260605646e27R23). That said it looks there is no scenario possible in version 5, 6 or 7 of Core that would result in failing message having `InvokedSagas` header added either by Core or the SagaAudit plugin.
One [old bug report issue](https://github.com/Particular/ServiceControl/issues/977) seems to indicate that this is possible but after closer examination, the stack trace points to audit ingestor and not error ingestor.