### PR TITLE
Use Key Vault certificate for installer

### DIFF
--- a/src/Setup/ServiceControl.aip
+++ b/src/Setup/ServiceControl.aip
@@ -158,7 +158,7 @@
     <ROW Path="&lt;AI_DICTS&gt;ui_en.ail"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.DigCertStoreComponent">
-    <ROW TimeStampUrl="http://timestamp.digicert.com/?alg=sha256" SignerDescription="[|ProductName]" SignOptions="7" SignTool="0" Thumbprint="11b319724eaacd57d9df429926f77fc47e544e2b Subject: NServiceBus Ltd&#10;Issuer: DigiCert SHA2 Assured ID Code Signing CA&#10;Valid from 11/05/2020 to 01/30/2024"/>
+    <ROW TimeStampUrl="http://timestamp.digicert.com/?alg=sha256" SignerDescription="[|ProductName]" SignOptions="7" SignTool="5" UseSha256="1" CustomToolPath="C:\Users\Administrator\.dotnet\tools\azuresigntool.exe" CustomToolCmdLine="sign -d ServiceControl -kvu https://particularcodesigning.vault.azure.net -kvi %AZURE_KEY_VAULT_CLIENT_ID% -kvs %AZURE_KEY_VAULT_CLIENT_SECRET% -kvc %AZURE_KEY_VAULT_CERTIFICATE_NAME% -tr http://timestamp.digicert.com -v " KVTenantId="replace-tenant-id" KVAppId="replace-app-id" KVName="particularcodesigning" KVCertName="replace-cert-name"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.FragmentComponent">
     <ROW Fragment="CommonUI.aip" Path="&lt;AI_FRAGS&gt;CommonUI.aip"/>

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -17,6 +17,7 @@
       <AdvancedInstallerPath>$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Caphyon\Advanced Installer@Advanced Installer Path)</AdvancedInstallerPath>
       <AdvancedInstallerExe>"$(AdvancedInstallerPath)bin\x86\AdvancedInstaller.com"</AdvancedInstallerExe>
       <AIPFile>ServiceControl.aip</AIPFile>
+      <CommandFile>commands.aic</CommandFile>
     </PropertyGroup>
     <ItemGroup>
       <ResourceFiles Include="Res\**\*.*" />
@@ -32,6 +33,7 @@
     </ItemGroup>
     <Delete Files="@(ExistingExes)" />
     <Copy SourceFiles="$(AIPFile)" DestinationFolder="$(IntermediateOutputPath)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(CommandFile)" DestinationFolder="$(IntermediateOutputPath)" />
     <Copy SourceFiles="@(ResourceFiles)" DestinationFolder="$(IntermediateOutputPath)Res\%(RecursiveDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(Prerequisites)" DestinationFolder="$(IntermediateOutputPath)Prerequisites\%(RecursiveDir)" SkipUnchangedFiles="true" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name PROJECT_PATH -value $(SolutionDir)Setup -valuetype Folder" />
@@ -40,7 +42,7 @@
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name CUSTOMACTIONS_PATH -value $(SolutionDir)ServiceControlInstaller.CustomActions\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /SetVersion $(GitVersion_MajorMinorPatch)" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /SetPackageName $(SetupExeOutputFolder)$(SetupExeName) -buildname DefaultBuild" />
-    <Exec Command="$(AdvancedInstallerExe) /rebuild $(IntermediateOutputPath)$(AIPFile)" />
+    <Exec Command="$(AdvancedInstallerExe) /execute $(IntermediateOutputPath)$(AIPFile) $(IntermediateOutputPath)$(CommandFile)" />
   </Target>
 
 </Project>

--- a/src/Setup/commands.aic
+++ b/src/Setup/commands.aic
@@ -1,0 +1,2 @@
+﻿;aic
+Rebuild


### PR DESCRIPTION
This converts the installer to use a certificate stored in Key Vault instead of a local certificate on the build agents. This is required for the EV code signing certificate we are using now.

This includes some changes that aren't required while we're still using TeamCity, but will be needed when we move this repo to GitHub Actions.