### PR TITLE
Fix missing assembly attributes

### DIFF
--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -7,7 +7,14 @@
     <ApplicationIcon>App.ico</ApplicationIcon>
     <UseWpf>true</UseWpf>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Wpf workaround: GitVersion and .NET SDK < v5.0.200 -->
+    <!-- See https://github.com/GitTools/GitVersion/blob/main/docs/input/docs/usage/msbuild.md#wpf-specific-concerns -->
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
WPF generates the same assembly attributes that GitVersion does, causing a compile error. We originally got rid of this by preventing WPF from generating anything but that leaves some attributes out that GitVersion does not include.

This change prevents WPF from generating only those attributes that GitVersion also creates. This avoids the conflict and allows the build to proceed.

Missing attributes:
- AssemblyCompany
- AssemblyConfiguration
- AssemblyCopyright
-  AssemblyDescription
- AssemblyProduct
- AssemblyTitle
- AssemblyMetadata

Before this change

![image](https://user-images.githubusercontent.com/124014/139406850-91de0643-6e47-4cd9-ad23-86476a2a6b98.png)

After this change

![image](https://user-images.githubusercontent.com/124014/139407186-7c986715-0257-464b-b617-1851d8511d78.png)


