### PR TITLE
Expose connection info via API

### DIFF
--- a/src/ServiceControl.AcceptanceTesting/ITransportIntegration.cs
+++ b/src/ServiceControl.AcceptanceTesting/ITransportIntegration.cs
@@ -7,5 +7,6 @@
         string Name { get; }
         string TypeName { get; }
         string ConnectionString { get; set; }
+        string ScrubPlatformConnection(string input);
     }
 }

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointAzureServiceBusEndpointTopologyTransport.g.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointAzureServiceBusEndpointTopologyTransport.g.cs
@@ -40,5 +40,6 @@
         public string Name => TransportNames.AzureServiceBusEndpointOrientedTopologyDeprecated;
         public string TypeName => $"{typeof(ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization).AssemblyQualifiedName}";
         public string ConnectionString { get; set; }
+        public string ScrubPlatformConnection(string input) => input;
     }
 }

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointAzureServiceBusForwardingTopologyTransport.g.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointAzureServiceBusForwardingTopologyTransport.g.cs
@@ -34,5 +34,6 @@
         public string TypeName => $"{typeof(ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization).AssemblyQualifiedName}";
 
         public string ConnectionString { get; set; }
+        public string ScrubPlatformConnection(string input) => input;
     }
 }

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointAzureServiceBusNetStandardTransport.g.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointAzureServiceBusNetStandardTransport.g.cs
@@ -35,5 +35,6 @@
         public string Name => TransportNames.AzureServiceBus;
         public string TypeName => $"{typeof(ServiceControl.Transports.ASBS.ASBSTransportCustomization).AssemblyQualifiedName}";
         public string ConnectionString { get; set; }
+        public string ScrubPlatformConnection(string input) => input;
     }
 }

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointAzureStorageQueueTransport.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointAzureStorageQueueTransport.cs
@@ -31,5 +31,6 @@
         public string Name => TransportNames.AzureStorageQueue;
         public string TypeName => $"{typeof(ASQTransportCustomization).AssemblyQualifiedName}";
         public string ConnectionString { get; set; }
+        public string ScrubPlatformConnection(string input) => input;
     }
 }

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointLearningTransport.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointLearningTransport.cs
@@ -33,5 +33,6 @@
         public string Name => "Learning";
         public string TypeName => $"{typeof(LearningTransportCustomization).AssemblyQualifiedName}";
         public string ConnectionString { get; set; } = Path.Combine(TestContext.CurrentContext.TestDirectory, @"..\..\..\.transport");
+        public string ScrubPlatformConnection(string input) => input;
     }
 }

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointMsmqTransport.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointMsmqTransport.cs
@@ -81,6 +81,16 @@
             return Task.FromResult(0);
         }
 
+        public string ScrubPlatformConnection(string input)
+        {
+            var result = input.Replace(
+                Environment.MachineName,
+                "MACHINE_NAME"
+            );
+
+            return result;
+        }
+
         public string Name => TransportNames.MSMQ;
         public string TypeName => $"{typeof(MsmqTransportCustomization).AssemblyQualifiedName}";
         public string ConnectionString { get; set; }

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointRabbitMQConventionalRoutingTransport.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointRabbitMQConventionalRoutingTransport.cs
@@ -37,6 +37,7 @@
         public string Name => TransportNames.RabbitMQConventionalRoutingTopology;
         public string TypeName => $"{typeof(RabbitMQConventionalRoutingTransportCustomization).AssemblyQualifiedName}";
         public string ConnectionString { get; set; }
+        public string ScrubPlatformConnection(string input) => input;
 
         void PurgeQueues()
         {

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointRabbitMQDirectRoutingTransport.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointRabbitMQDirectRoutingTransport.cs
@@ -37,6 +37,7 @@
         public string Name => TransportNames.RabbitMQDirectRoutingTopology;
         public string TypeName => $"{typeof(RabbitMQDirectRoutingTransportCustomization).AssemblyQualifiedName}";
         public string ConnectionString { get; set; }
+        public string ScrubPlatformConnection(string input) => input;
 
         void PurgeQueues()
         {

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointSQSTransport.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointSQSTransport.cs
@@ -58,6 +58,27 @@
 
         public string ConnectionString { get; set; }
 
+        public string ScrubPlatformConnection(string input)
+        {
+            var result = input;
+
+            var builder = new DbConnectionStringBuilder { ConnectionString = ConnectionString };
+
+            if (builder.TryGetValue("QueueNamePrefix", out var queueNamePrefix))
+            {
+                var queueNamePrefixAsString = (string)queueNamePrefix;
+                if (!string.IsNullOrEmpty(queueNamePrefixAsString))
+                {
+                    result = result.Replace(
+                        queueNamePrefixAsString,
+                        "queue-prefix-"
+                    );
+                }
+            }
+
+            return result;
+        }
+
         static IAmazonSQS CreateSQSClient()
         {
             var credentials = new EnvironmentVariablesAWSCredentials();

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointSQSTransport.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointSQSTransport.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTesting.InfrastructureConfig
 {
     using System;
+    using System.Data.Common;
     using System.Threading.Tasks;
     using Amazon.Runtime;
     using Amazon.S3;
@@ -27,6 +28,20 @@
             {
                 var s3Configuration = transportConfig.S3(S3BucketName, S3Prefix);
                 s3Configuration.ClientFactory(CreateS3Client);
+            }
+
+            if (string.IsNullOrWhiteSpace(ConnectionString) == false)
+            {
+                var builder = new DbConnectionStringBuilder { ConnectionString = ConnectionString };
+
+                if (builder.TryGetValue("QueueNamePrefix", out var queueNamePrefix))
+                {
+                    var queueNamePrefixAsString = (string)queueNamePrefix;
+                    if (!string.IsNullOrEmpty(queueNamePrefixAsString))
+                    {
+                        transportConfig.QueueNamePrefix(queueNamePrefixAsString);
+                    }
+                }
             }
 
             return Task.FromResult(0);

--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointSqlServerTransport.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointSqlServerTransport.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTesting.InfrastructureConfig
 {
     using System;
+    using System.Data.Common;
     using System.Data.SqlClient;
     using System.Linq;
     using System.Threading.Tasks;
@@ -45,6 +46,27 @@
         public string Name => TransportNames.SQLServer;
         public string TypeName => $"{typeof(SqlServerTransportCustomization).AssemblyQualifiedName}";
         public string ConnectionString { get; set; }
+
+        public string ScrubPlatformConnection(string input)
+        {
+            var builder = new DbConnectionStringBuilder { ConnectionString = ConnectionString };
+
+            var result = input;
+
+            if (builder.TryGetValue("Database", out var database))
+            {
+                var databaseAsString = (string)database;
+                if (!string.IsNullOrEmpty(databaseAsString))
+                {
+                    result = result.Replace(
+                        $"[{databaseAsString}]",
+                        "[DATABASE]"
+                    );
+                }
+            }
+
+            return result;
+        }
 
         static async Task TryDeleteTable(SqlConnection conn, QueueAddress address)
         {

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -131,6 +131,16 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         }
     }
 }
+namespace ServiceControl.Audit.Connection
+{
+    public class ConnectionController : System.Web.Http.ApiController
+    {
+        public ConnectionController(ServiceControl.Audit.Infrastructure.Settings.Settings settings) { }
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("connection")]
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetConnectionDetails() { }
+    }
+}
 namespace ServiceControl.Audit.Infrastructure.Installers
 {
     public class CreateEventSource : NServiceBus.Installation.INeedToInstallSomething

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -138,7 +138,7 @@ namespace ServiceControl.Audit.Connection
         public ConnectionController(ServiceControl.Audit.Infrastructure.Settings.Settings settings) { }
         [System.Web.Http.HttpGet]
         [System.Web.Http.Route("connection")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetConnectionDetails() { }
+        public System.Web.Http.IHttpActionResult GetConnectionDetails() { }
     }
 }
 namespace ServiceControl.Audit.Infrastructure.Installers

--- a/src/ServiceControl.Audit/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Audit/Connection/ConnectionController.cs
@@ -1,0 +1,26 @@
+namespace ServiceControl.Audit.Connection
+{
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using System.Web.Http;
+    using Infrastructure.Settings;
+
+    public class ConnectionController : ApiController
+    {
+        readonly Settings settings;
+
+        public ConnectionController(Settings settings) => this.settings = settings;
+
+        [Route("connection")]
+        [HttpGet]
+        public Task<HttpResponseMessage> GetConnectionDetails() => Task.FromResult(Request.CreateResponse(HttpStatusCode.OK, new
+        {
+            settings.AuditQueue,
+            SagaAudit = new
+            {
+                SagaAuditQueue = settings.AuditQueue
+            }
+        }));
+    }
+}

--- a/src/ServiceControl.Audit/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Audit/Connection/ConnectionController.cs
@@ -1,26 +1,27 @@
 namespace ServiceControl.Audit.Connection
 {
-    using System.Net;
-    using System.Net.Http;
-    using System.Threading.Tasks;
     using System.Web.Http;
     using Infrastructure.Settings;
+    using Newtonsoft.Json;
 
     public class ConnectionController : ApiController
     {
         readonly Settings settings;
+        readonly JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings();
 
         public ConnectionController(Settings settings) => this.settings = settings;
 
         [Route("connection")]
         [HttpGet]
-        public Task<HttpResponseMessage> GetConnectionDetails() => Task.FromResult(Request.CreateResponse(HttpStatusCode.OK, new
-        {
-            settings.AuditQueue,
-            SagaAudit = new
+        public IHttpActionResult GetConnectionDetails() =>
+            Json(new
             {
-                SagaAuditQueue = settings.AuditQueue
-            }
-        }));
+                settings.AuditQueue,
+                SagaAudit = new
+                {
+                    SagaAuditQueue = settings.AuditQueue
+                }
+            },
+            jsonSerializerSettings);
     }
 }

--- a/src/ServiceControl.Audit/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Audit/Connection/ConnectionController.cs
@@ -16,7 +16,10 @@ namespace ServiceControl.Audit.Connection
         public IHttpActionResult GetConnectionDetails() =>
             Json(new
             {
-                settings.AuditQueue,
+                MessageAudit = new
+                {
+                    settings.AuditQueue
+                },
                 SagaAudit = new
                 {
                     SagaAuditQueue = settings.AuditQueue

--- a/src/ServiceControl.Audit/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Audit/Connection/ConnectionController.cs
@@ -16,17 +16,31 @@ namespace ServiceControl.Audit.Connection
         public IHttpActionResult GetConnectionDetails() =>
             Json(new
             {
-                MessageAudit = new
+                MessageAudit = new MessageAuditConnectionDetails
                 {
                     Enabled = true,
-                    settings.AuditQueue
+                    AuditQueue = settings.AuditQueue
                 },
-                SagaAudit = new
+                SagaAudit = new SagaAuditConnectionDetails
                 {
                     Enabled = true,
                     SagaAuditQueue = settings.AuditQueue
                 }
             },
             jsonSerializerSettings);
+    }
+
+    // HINT: This should match the type in the PlatformConnector package
+    class MessageAuditConnectionDetails
+    {
+        public bool Enabled { get; set; }
+        public string AuditQueue { get; set; }
+    }
+
+    // HINT: This should match the type in the PlatformConnector package
+    class SagaAuditConnectionDetails
+    {
+        public bool Enabled { get; set; }
+        public string SagaAuditQueue { get; set; }
     }
 }

--- a/src/ServiceControl.Audit/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Audit/Connection/ConnectionController.cs
@@ -18,10 +18,12 @@ namespace ServiceControl.Audit.Connection
             {
                 MessageAudit = new
                 {
+                    Enabled = true,
                     settings.AuditQueue
                 },
                 SagaAudit = new
                 {
+                    Enabled = true,
                     SagaAuditQueue = settings.AuditQueue
                 }
             },

--- a/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
@@ -22,6 +22,7 @@
                 {
                     Metrics = new
                     {
+                        Enabled = true,
                         MetricsQueue = mainInputQueue,
                         Interval = defaultInterval
                     }

--- a/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
@@ -1,0 +1,32 @@
+﻿namespace ServiceControl.Monitoring.Connection
+{
+    using System;
+    using System.Web.Http;
+    using Newtonsoft.Json;
+    using NServiceBus;
+    using NServiceBus.Settings;
+
+    public class ConnectionController : ApiController
+    {
+        readonly JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings();
+        readonly string mainInputQueue;
+        readonly TimeSpan defaultInterval = TimeSpan.FromSeconds(1);
+
+        public ConnectionController(ReadOnlySettings nsbSettings) => mainInputQueue = nsbSettings.LocalAddress();
+
+        [Route("connection")]
+        [HttpGet]
+        public IHttpActionResult GetConnectionDetails() =>
+            Json(
+                new
+                {
+                    Metrics = new
+                    {
+                        MetricsQueue = mainInputQueue,
+                        Interval = defaultInterval
+                    }
+                },
+                jsonSerializerSettings
+        );
+    }
+}

--- a/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
@@ -20,7 +20,7 @@
             Json(
                 new
                 {
-                    Metrics = new
+                    Metrics = new MetricsConnectionDetails
                     {
                         Enabled = true,
                         MetricsQueue = mainInputQueue,
@@ -29,5 +29,13 @@
                 },
                 jsonSerializerSettings
         );
+
+        // HINT: This should match the type in the PlatformConnector package
+        class MetricsConnectionDetails
+        {
+            public bool Enabled { get; set; }
+            public string MetricsQueue { get; set; }
+            public TimeSpan Interval { get; set; }
+        }
     }
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.Old.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.Old.approved.txt
@@ -1,15 +1,20 @@
 {
-  "Heartbeats": {
-    "HeartbeatsQueue": "Particular.ServiceControl",
-    "Frequency": "00:00:10",
-    "TimeToLive": "00:00:40"
+  "settings": {
+    "Heartbeats": {
+      "HeartbeatsQueue": "Particular.ServiceControl",
+      "Frequency": "00:00:10",
+      "TimeToLive": "00:00:40"
+    },
+    "MessageAudit": {
+      "AuditQueue": "audit"
+    },
+    "CustomChecks": {
+      "CustomChecksQueue": "Particular.ServiceControl"
+    },
+    "ErrorQueue": "error",
+    "SagaAudit": {
+      "SagaAuditQueue": "audit"
+    }
   },
-  "CustomChecks": {
-    "CustomChecksQueue": "Particular.ServiceControl"
-  },
-  "ErrorQueue": "error",
-  "SagaAudit": {
-    "SagaAuditQueue": "audit"
-  },
-  "AuditQueue": "audit"
+  "errors": []
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.Old.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.Old.approved.txt
@@ -1,18 +1,22 @@
 {
   "settings": {
     "Heartbeats": {
+      "Enabled": true,
       "HeartbeatsQueue": "Particular.ServiceControl",
       "Frequency": "00:00:10",
       "TimeToLive": "00:00:40"
     },
     "MessageAudit": {
+      "Enabled": true,
       "AuditQueue": "audit"
     },
     "CustomChecks": {
+      "Enabled": true,
       "CustomChecksQueue": "Particular.ServiceControl"
     },
     "ErrorQueue": "error",
     "SagaAudit": {
+      "Enabled": true,
       "SagaAuditQueue": "audit"
     }
   },

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.Old.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.Old.approved.txt
@@ -1,15 +1,15 @@
 {
-  "audit_queue": "audit",
-  "heartbeats": {
-    "heartbeats_queue": "Particular.ServiceControl",
-    "frequency": "00:00:10",
-    "time_to_live": "00:00:40"
+  "Heartbeats": {
+    "HeartbeatsQueue": "Particular.ServiceControl",
+    "Frequency": "00:00:10",
+    "TimeToLive": "00:00:40"
   },
-  "custom_checks": {
-    "custom_checks_queue": "Particular.ServiceControl"
+  "CustomChecks": {
+    "CustomChecksQueue": "Particular.ServiceControl"
   },
-  "error_queue": "error",
-  "saga_audit": {
-    "saga_audit_queue": "audit"
-  }
+  "ErrorQueue": "error",
+  "SagaAudit": {
+    "SagaAuditQueue": "audit"
+  },
+  "AuditQueue": "audit"
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.Old.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.Old.approved.txt
@@ -1,0 +1,15 @@
+{
+  "audit_queue": "audit",
+  "heartbeats": {
+    "heartbeats_queue": "Particular.ServiceControl",
+    "frequency": "00:00:10",
+    "time_to_live": "00:00:40"
+  },
+  "custom_checks": {
+    "custom_checks_queue": "Particular.ServiceControl"
+  },
+  "error_queue": "error",
+  "saga_audit": {
+    "saga_audit_queue": "audit"
+  }
+}

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.approved.txt
@@ -1,15 +1,20 @@
 {
-  "Heartbeats": {
-    "HeartbeatsQueue": "Particular.ServiceControl",
-    "Frequency": "00:00:10",
-    "TimeToLive": "00:00:40"
+  "settings": {
+    "Heartbeats": {
+      "HeartbeatsQueue": "Particular.ServiceControl",
+      "Frequency": "00:00:10",
+      "TimeToLive": "00:00:40"
+    },
+    "MessageAudit": {
+      "AuditQueue": "audit"
+    },
+    "CustomChecks": {
+      "CustomChecksQueue": "Particular.ServiceControl"
+    },
+    "ErrorQueue": "error",
+    "SagaAudit": {
+      "SagaAuditQueue": "audit"
+    }
   },
-  "CustomChecks": {
-    "CustomChecksQueue": "Particular.ServiceControl"
-  },
-  "ErrorQueue": "error",
-  "SagaAudit": {
-    "SagaAuditQueue": "audit"
-  },
-  "AuditQueue": "audit"
+  "errors": []
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.approved.txt
@@ -1,18 +1,22 @@
 {
   "settings": {
     "Heartbeats": {
+      "Enabled": true,
       "HeartbeatsQueue": "Particular.ServiceControl",
       "Frequency": "00:00:10",
       "TimeToLive": "00:00:40"
     },
     "MessageAudit": {
+      "Enabled": true,
       "AuditQueue": "audit"
     },
     "CustomChecks": {
+      "Enabled": true,
       "CustomChecksQueue": "Particular.ServiceControl"
     },
     "ErrorQueue": "error",
     "SagaAudit": {
+      "Enabled": true,
       "SagaAuditQueue": "audit"
     }
   },

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.approved.txt
@@ -1,15 +1,15 @@
 {
-  "audit_queue": "audit",
-  "heartbeats": {
-    "heartbeats_queue": "Particular.ServiceControl",
-    "frequency": "00:00:10",
-    "time_to_live": "00:00:40"
+  "Heartbeats": {
+    "HeartbeatsQueue": "Particular.ServiceControl",
+    "Frequency": "00:00:10",
+    "TimeToLive": "00:00:40"
   },
-  "custom_checks": {
-    "custom_checks_queue": "Particular.ServiceControl"
+  "CustomChecks": {
+    "CustomChecksQueue": "Particular.ServiceControl"
   },
-  "error_queue": "error",
-  "saga_audit": {
-    "saga_audit_queue": "audit"
-  }
+  "ErrorQueue": "error",
+  "SagaAudit": {
+    "SagaAuditQueue": "audit"
+  },
+  "AuditQueue": "audit"
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASB.approved.txt
@@ -1,0 +1,15 @@
+{
+  "audit_queue": "audit",
+  "heartbeats": {
+    "heartbeats_queue": "Particular.ServiceControl",
+    "frequency": "00:00:10",
+    "time_to_live": "00:00:40"
+  },
+  "custom_checks": {
+    "custom_checks_queue": "Particular.ServiceControl"
+  },
+  "error_queue": "error",
+  "saga_audit": {
+    "saga_audit_queue": "audit"
+  }
+}

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASQ.approved.txt
@@ -1,0 +1,15 @@
+{
+  "audit_queue": "audit",
+  "heartbeats": {
+    "heartbeats_queue": "particular-servicecontrol",
+    "frequency": "00:00:10",
+    "time_to_live": "00:00:40"
+  },
+  "custom_checks": {
+    "custom_checks_queue": "particular-servicecontrol"
+  },
+  "error_queue": "error",
+  "saga_audit": {
+    "saga_audit_queue": "audit"
+  }
+}

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASQ.approved.txt
@@ -1,18 +1,22 @@
 {
   "settings": {
     "Heartbeats": {
+      "Enabled": true,
       "HeartbeatsQueue": "particular-servicecontrol",
       "Frequency": "00:00:10",
       "TimeToLive": "00:00:40"
     },
     "MessageAudit": {
+      "Enabled": true,
       "AuditQueue": "audit"
     },
     "CustomChecks": {
+      "Enabled": true,
       "CustomChecksQueue": "particular-servicecontrol"
     },
     "ErrorQueue": "error",
     "SagaAudit": {
+      "Enabled": true,
       "SagaAuditQueue": "audit"
     }
   },

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASQ.approved.txt
@@ -1,15 +1,15 @@
 {
-  "audit_queue": "audit",
-  "heartbeats": {
-    "heartbeats_queue": "particular-servicecontrol",
-    "frequency": "00:00:10",
-    "time_to_live": "00:00:40"
+  "Heartbeats": {
+    "HeartbeatsQueue": "particular-servicecontrol",
+    "Frequency": "00:00:10",
+    "TimeToLive": "00:00:40"
   },
-  "custom_checks": {
-    "custom_checks_queue": "particular-servicecontrol"
+  "CustomChecks": {
+    "CustomChecksQueue": "particular-servicecontrol"
   },
-  "error_queue": "error",
-  "saga_audit": {
-    "saga_audit_queue": "audit"
-  }
+  "ErrorQueue": "error",
+  "SagaAudit": {
+    "SagaAuditQueue": "audit"
+  },
+  "AuditQueue": "audit"
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.ASQ.approved.txt
@@ -1,15 +1,20 @@
 {
-  "Heartbeats": {
-    "HeartbeatsQueue": "particular-servicecontrol",
-    "Frequency": "00:00:10",
-    "TimeToLive": "00:00:40"
+  "settings": {
+    "Heartbeats": {
+      "HeartbeatsQueue": "particular-servicecontrol",
+      "Frequency": "00:00:10",
+      "TimeToLive": "00:00:40"
+    },
+    "MessageAudit": {
+      "AuditQueue": "audit"
+    },
+    "CustomChecks": {
+      "CustomChecksQueue": "particular-servicecontrol"
+    },
+    "ErrorQueue": "error",
+    "SagaAudit": {
+      "SagaAuditQueue": "audit"
+    }
   },
-  "CustomChecks": {
-    "CustomChecksQueue": "particular-servicecontrol"
-  },
-  "ErrorQueue": "error",
-  "SagaAudit": {
-    "SagaAuditQueue": "audit"
-  },
-  "AuditQueue": "audit"
+  "errors": []
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.Learning.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.Learning.approved.txt
@@ -1,15 +1,20 @@
 {
-  "Heartbeats": {
-    "HeartbeatsQueue": "Particular.ServiceControl",
-    "Frequency": "00:00:10",
-    "TimeToLive": "00:00:40"
+  "settings": {
+    "Heartbeats": {
+      "HeartbeatsQueue": "Particular.ServiceControl",
+      "Frequency": "00:00:10",
+      "TimeToLive": "00:00:40"
+    },
+    "MessageAudit": {
+      "AuditQueue": "audit"
+    },
+    "CustomChecks": {
+      "CustomChecksQueue": "Particular.ServiceControl"
+    },
+    "ErrorQueue": "error",
+    "SagaAudit": {
+      "SagaAuditQueue": "audit"
+    }
   },
-  "CustomChecks": {
-    "CustomChecksQueue": "Particular.ServiceControl"
-  },
-  "ErrorQueue": "error",
-  "SagaAudit": {
-    "SagaAuditQueue": "audit"
-  },
-  "AuditQueue": "audit"
+  "errors": []
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.Learning.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.Learning.approved.txt
@@ -1,18 +1,22 @@
 {
   "settings": {
     "Heartbeats": {
+      "Enabled": true,
       "HeartbeatsQueue": "Particular.ServiceControl",
       "Frequency": "00:00:10",
       "TimeToLive": "00:00:40"
     },
     "MessageAudit": {
+      "Enabled": true,
       "AuditQueue": "audit"
     },
     "CustomChecks": {
+      "Enabled": true,
       "CustomChecksQueue": "Particular.ServiceControl"
     },
     "ErrorQueue": "error",
     "SagaAudit": {
+      "Enabled": true,
       "SagaAuditQueue": "audit"
     }
   },

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.Learning.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.Learning.approved.txt
@@ -1,15 +1,15 @@
 {
-  "audit_queue": "audit",
-  "heartbeats": {
-    "heartbeats_queue": "Particular.ServiceControl",
-    "frequency": "00:00:10",
-    "time_to_live": "00:00:40"
+  "Heartbeats": {
+    "HeartbeatsQueue": "Particular.ServiceControl",
+    "Frequency": "00:00:10",
+    "TimeToLive": "00:00:40"
   },
-  "custom_checks": {
-    "custom_checks_queue": "Particular.ServiceControl"
+  "CustomChecks": {
+    "CustomChecksQueue": "Particular.ServiceControl"
   },
-  "error_queue": "error",
-  "saga_audit": {
-    "saga_audit_queue": "audit"
-  }
+  "ErrorQueue": "error",
+  "SagaAudit": {
+    "SagaAuditQueue": "audit"
+  },
+  "AuditQueue": "audit"
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.Learning.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.Learning.approved.txt
@@ -1,0 +1,15 @@
+{
+  "audit_queue": "audit",
+  "heartbeats": {
+    "heartbeats_queue": "Particular.ServiceControl",
+    "frequency": "00:00:10",
+    "time_to_live": "00:00:40"
+  },
+  "custom_checks": {
+    "custom_checks_queue": "Particular.ServiceControl"
+  },
+  "error_queue": "error",
+  "saga_audit": {
+    "saga_audit_queue": "audit"
+  }
+}

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.MSMQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.MSMQ.approved.txt
@@ -1,18 +1,22 @@
 {
   "settings": {
     "Heartbeats": {
+      "Enabled": true,
       "HeartbeatsQueue": "Particular.ServiceControl@MACHINE_NAME",
       "Frequency": "00:00:10",
       "TimeToLive": "00:00:40"
     },
     "MessageAudit": {
+      "Enabled": true,
       "AuditQueue": "audit"
     },
     "CustomChecks": {
+      "Enabled": true,
       "CustomChecksQueue": "Particular.ServiceControl@MACHINE_NAME"
     },
     "ErrorQueue": "error",
     "SagaAudit": {
+      "Enabled": true,
       "SagaAuditQueue": "audit"
     }
   },

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.MSMQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.MSMQ.approved.txt
@@ -1,15 +1,20 @@
 {
-  "Heartbeats": {
-    "HeartbeatsQueue": "Particular.ServiceControl@MACHINE_NAME",
-    "Frequency": "00:00:10",
-    "TimeToLive": "00:00:40"
+  "settings": {
+    "Heartbeats": {
+      "HeartbeatsQueue": "Particular.ServiceControl@MACHINE_NAME",
+      "Frequency": "00:00:10",
+      "TimeToLive": "00:00:40"
+    },
+    "MessageAudit": {
+      "AuditQueue": "audit"
+    },
+    "CustomChecks": {
+      "CustomChecksQueue": "Particular.ServiceControl@MACHINE_NAME"
+    },
+    "ErrorQueue": "error",
+    "SagaAudit": {
+      "SagaAuditQueue": "audit"
+    }
   },
-  "CustomChecks": {
-    "CustomChecksQueue": "Particular.ServiceControl@MACHINE_NAME"
-  },
-  "ErrorQueue": "error",
-  "SagaAudit": {
-    "SagaAuditQueue": "audit"
-  },
-  "AuditQueue": "audit"
+  "errors": []
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.MSMQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.MSMQ.approved.txt
@@ -1,15 +1,15 @@
 {
-  "audit_queue": "audit",
-  "heartbeats": {
-    "heartbeats_queue": "Particular.ServiceControl@MACHINE_NAME",
-    "frequency": "00:00:10",
-    "time_to_live": "00:00:40"
+  "Heartbeats": {
+    "HeartbeatsQueue": "Particular.ServiceControl@MACHINE_NAME",
+    "Frequency": "00:00:10",
+    "TimeToLive": "00:00:40"
   },
-  "custom_checks": {
-    "custom_checks_queue": "Particular.ServiceControl@MACHINE_NAME"
+  "CustomChecks": {
+    "CustomChecksQueue": "Particular.ServiceControl@MACHINE_NAME"
   },
-  "error_queue": "error",
-  "saga_audit": {
-    "saga_audit_queue": "audit"
-  }
+  "ErrorQueue": "error",
+  "SagaAudit": {
+    "SagaAuditQueue": "audit"
+  },
+  "AuditQueue": "audit"
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.MSMQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.MSMQ.approved.txt
@@ -1,0 +1,15 @@
+{
+  "audit_queue": "audit",
+  "heartbeats": {
+    "heartbeats_queue": "Particular.ServiceControl@MACHINE_NAME",
+    "frequency": "00:00:10",
+    "time_to_live": "00:00:40"
+  },
+  "custom_checks": {
+    "custom_checks_queue": "Particular.ServiceControl@MACHINE_NAME"
+  },
+  "error_queue": "error",
+  "saga_audit": {
+    "saga_audit_queue": "audit"
+  }
+}

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.RabbitMQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.RabbitMQ.approved.txt
@@ -1,15 +1,20 @@
 {
-  "Heartbeats": {
-    "HeartbeatsQueue": "Particular.ServiceControl",
-    "Frequency": "00:00:10",
-    "TimeToLive": "00:00:40"
+  "settings": {
+    "Heartbeats": {
+      "HeartbeatsQueue": "Particular.ServiceControl",
+      "Frequency": "00:00:10",
+      "TimeToLive": "00:00:40"
+    },
+    "MessageAudit": {
+      "AuditQueue": "audit"
+    },
+    "CustomChecks": {
+      "CustomChecksQueue": "Particular.ServiceControl"
+    },
+    "ErrorQueue": "error",
+    "SagaAudit": {
+      "SagaAuditQueue": "audit"
+    }
   },
-  "CustomChecks": {
-    "CustomChecksQueue": "Particular.ServiceControl"
-  },
-  "ErrorQueue": "error",
-  "SagaAudit": {
-    "SagaAuditQueue": "audit"
-  },
-  "AuditQueue": "audit"
+  "errors": []
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.RabbitMQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.RabbitMQ.approved.txt
@@ -1,18 +1,22 @@
 {
   "settings": {
     "Heartbeats": {
+      "Enabled": true,
       "HeartbeatsQueue": "Particular.ServiceControl",
       "Frequency": "00:00:10",
       "TimeToLive": "00:00:40"
     },
     "MessageAudit": {
+      "Enabled": true,
       "AuditQueue": "audit"
     },
     "CustomChecks": {
+      "Enabled": true,
       "CustomChecksQueue": "Particular.ServiceControl"
     },
     "ErrorQueue": "error",
     "SagaAudit": {
+      "Enabled": true,
       "SagaAuditQueue": "audit"
     }
   },

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.RabbitMQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.RabbitMQ.approved.txt
@@ -1,15 +1,15 @@
 {
-  "audit_queue": "audit",
-  "heartbeats": {
-    "heartbeats_queue": "Particular.ServiceControl",
-    "frequency": "00:00:10",
-    "time_to_live": "00:00:40"
+  "Heartbeats": {
+    "HeartbeatsQueue": "Particular.ServiceControl",
+    "Frequency": "00:00:10",
+    "TimeToLive": "00:00:40"
   },
-  "custom_checks": {
-    "custom_checks_queue": "Particular.ServiceControl"
+  "CustomChecks": {
+    "CustomChecksQueue": "Particular.ServiceControl"
   },
-  "error_queue": "error",
-  "saga_audit": {
-    "saga_audit_queue": "audit"
-  }
+  "ErrorQueue": "error",
+  "SagaAudit": {
+    "SagaAuditQueue": "audit"
+  },
+  "AuditQueue": "audit"
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.RabbitMQ.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.RabbitMQ.approved.txt
@@ -1,0 +1,15 @@
+{
+  "audit_queue": "audit",
+  "heartbeats": {
+    "heartbeats_queue": "Particular.ServiceControl",
+    "frequency": "00:00:10",
+    "time_to_live": "00:00:40"
+  },
+  "custom_checks": {
+    "custom_checks_queue": "Particular.ServiceControl"
+  },
+  "error_queue": "error",
+  "saga_audit": {
+    "saga_audit_queue": "audit"
+  }
+}

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQL.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQL.approved.txt
@@ -1,18 +1,22 @@
 {
   "settings": {
     "Heartbeats": {
+      "Enabled": true,
       "HeartbeatsQueue": "Particular.ServiceControl@[dbo]@[DATABASE]",
       "Frequency": "00:00:10",
       "TimeToLive": "00:00:40"
     },
     "MessageAudit": {
+      "Enabled": true,
       "AuditQueue": "audit"
     },
     "CustomChecks": {
+      "Enabled": true,
       "CustomChecksQueue": "Particular.ServiceControl@[dbo]@[DATABASE]"
     },
     "ErrorQueue": "error",
     "SagaAudit": {
+      "Enabled": true,
       "SagaAuditQueue": "audit"
     }
   },

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQL.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQL.approved.txt
@@ -1,0 +1,15 @@
+{
+  "audit_queue": "audit",
+  "heartbeats": {
+    "heartbeats_queue": "Particular.ServiceControl@[dbo]@[ServiceControl]",
+    "frequency": "00:00:10",
+    "time_to_live": "00:00:40"
+  },
+  "custom_checks": {
+    "custom_checks_queue": "Particular.ServiceControl@[dbo]@[ServiceControl]"
+  },
+  "error_queue": "error",
+  "saga_audit": {
+    "saga_audit_queue": "audit"
+  }
+}

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQL.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQL.approved.txt
@@ -1,11 +1,11 @@
 {
   "Heartbeats": {
-    "HeartbeatsQueue": "Particular.ServiceControl@[dbo]@[ServiceControl]",
+    "HeartbeatsQueue": "Particular.ServiceControl@[dbo]@[DATABASE]",
     "Frequency": "00:00:10",
     "TimeToLive": "00:00:40"
   },
   "CustomChecks": {
-    "CustomChecksQueue": "Particular.ServiceControl@[dbo]@[ServiceControl]"
+    "CustomChecksQueue": "Particular.ServiceControl@[dbo]@[DATABASE]"
   },
   "ErrorQueue": "error",
   "SagaAudit": {

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQL.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQL.approved.txt
@@ -1,15 +1,15 @@
 {
-  "audit_queue": "audit",
-  "heartbeats": {
-    "heartbeats_queue": "Particular.ServiceControl@[dbo]@[ServiceControl]",
-    "frequency": "00:00:10",
-    "time_to_live": "00:00:40"
+  "Heartbeats": {
+    "HeartbeatsQueue": "Particular.ServiceControl@[dbo]@[ServiceControl]",
+    "Frequency": "00:00:10",
+    "TimeToLive": "00:00:40"
   },
-  "custom_checks": {
-    "custom_checks_queue": "Particular.ServiceControl@[dbo]@[ServiceControl]"
+  "CustomChecks": {
+    "CustomChecksQueue": "Particular.ServiceControl@[dbo]@[ServiceControl]"
   },
-  "error_queue": "error",
-  "saga_audit": {
-    "saga_audit_queue": "audit"
-  }
+  "ErrorQueue": "error",
+  "SagaAudit": {
+    "SagaAuditQueue": "audit"
+  },
+  "AuditQueue": "audit"
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQL.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQL.approved.txt
@@ -1,15 +1,20 @@
 {
-  "Heartbeats": {
-    "HeartbeatsQueue": "Particular.ServiceControl@[dbo]@[DATABASE]",
-    "Frequency": "00:00:10",
-    "TimeToLive": "00:00:40"
+  "settings": {
+    "Heartbeats": {
+      "HeartbeatsQueue": "Particular.ServiceControl@[dbo]@[DATABASE]",
+      "Frequency": "00:00:10",
+      "TimeToLive": "00:00:40"
+    },
+    "MessageAudit": {
+      "AuditQueue": "audit"
+    },
+    "CustomChecks": {
+      "CustomChecksQueue": "Particular.ServiceControl@[dbo]@[DATABASE]"
+    },
+    "ErrorQueue": "error",
+    "SagaAudit": {
+      "SagaAuditQueue": "audit"
+    }
   },
-  "CustomChecks": {
-    "CustomChecksQueue": "Particular.ServiceControl@[dbo]@[DATABASE]"
-  },
-  "ErrorQueue": "error",
-  "SagaAudit": {
-    "SagaAuditQueue": "audit"
-  },
-  "AuditQueue": "audit"
+  "errors": []
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQS.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQS.approved.txt
@@ -1,15 +1,15 @@
 {
-  "audit_queue": "audit",
-  "heartbeats": {
-    "heartbeats_queue": "mikeminutillo-Particular-ServiceControl",
-    "frequency": "00:00:10",
-    "time_to_live": "00:00:40"
+  "Heartbeats": {
+    "HeartbeatsQueue": "mikeminutillo-Particular-ServiceControl",
+    "Frequency": "00:00:10",
+    "TimeToLive": "00:00:40"
   },
-  "custom_checks": {
-    "custom_checks_queue": "mikeminutillo-Particular-ServiceControl"
+  "CustomChecks": {
+    "CustomChecksQueue": "mikeminutillo-Particular-ServiceControl"
   },
-  "error_queue": "error",
-  "saga_audit": {
-    "saga_audit_queue": "audit"
-  }
+  "ErrorQueue": "error",
+  "SagaAudit": {
+    "SagaAuditQueue": "audit"
+  },
+  "AuditQueue": "audit"
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQS.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQS.approved.txt
@@ -1,18 +1,22 @@
 {
   "settings": {
     "Heartbeats": {
+      "Enabled": true,
       "HeartbeatsQueue": "queue-prefix-Particular-ServiceControl",
       "Frequency": "00:00:10",
       "TimeToLive": "00:00:40"
     },
     "MessageAudit": {
+      "Enabled": true,
       "AuditQueue": "audit"
     },
     "CustomChecks": {
+      "Enabled": true,
       "CustomChecksQueue": "queue-prefix-Particular-ServiceControl"
     },
     "ErrorQueue": "error",
     "SagaAudit": {
+      "Enabled": true,
       "SagaAuditQueue": "audit"
     }
   },

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQS.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQS.approved.txt
@@ -1,0 +1,15 @@
+{
+  "audit_queue": "audit",
+  "heartbeats": {
+    "heartbeats_queue": "mikeminutillo-Particular-ServiceControl",
+    "frequency": "00:00:10",
+    "time_to_live": "00:00:40"
+  },
+  "custom_checks": {
+    "custom_checks_queue": "mikeminutillo-Particular-ServiceControl"
+  },
+  "error_queue": "error",
+  "saga_audit": {
+    "saga_audit_queue": "audit"
+  }
+}

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQS.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQS.approved.txt
@@ -1,15 +1,20 @@
 {
-  "Heartbeats": {
-    "HeartbeatsQueue": "queue-prefix-Particular-ServiceControl",
-    "Frequency": "00:00:10",
-    "TimeToLive": "00:00:40"
+  "settings": {
+    "Heartbeats": {
+      "HeartbeatsQueue": "queue-prefix-Particular-ServiceControl",
+      "Frequency": "00:00:10",
+      "TimeToLive": "00:00:40"
+    },
+    "MessageAudit": {
+      "AuditQueue": "audit"
+    },
+    "CustomChecks": {
+      "CustomChecksQueue": "queue-prefix-Particular-ServiceControl"
+    },
+    "ErrorQueue": "error",
+    "SagaAudit": {
+      "SagaAuditQueue": "audit"
+    }
   },
-  "CustomChecks": {
-    "CustomChecksQueue": "queue-prefix-Particular-ServiceControl"
-  },
-  "ErrorQueue": "error",
-  "SagaAudit": {
-    "SagaAuditQueue": "audit"
-  },
-  "AuditQueue": "audit"
+  "errors": []
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQS.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.SQS.approved.txt
@@ -1,11 +1,11 @@
 {
   "Heartbeats": {
-    "HeartbeatsQueue": "mikeminutillo-Particular-ServiceControl",
+    "HeartbeatsQueue": "queue-prefix-Particular-ServiceControl",
     "Frequency": "00:00:10",
     "TimeToLive": "00:00:40"
   },
   "CustomChecks": {
-    "CustomChecksQueue": "mikeminutillo-Particular-ServiceControl"
+    "CustomChecksQueue": "queue-prefix-Particular-ServiceControl"
   },
   "ErrorQueue": "error",
   "SagaAudit": {

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
@@ -53,32 +53,39 @@
 
             if (!string.IsNullOrWhiteSpace(TransportIntegration.ConnectionString))
             {
-                var builder = new DbConnectionStringBuilder { ConnectionString = TransportIntegration.ConnectionString };
-
-                // SQS
-                if (builder.TryGetValue("QueueNamePrefix", out var queueNamePrefix))
+                try
                 {
-                    var queueNamePrefixAsString = (string)queueNamePrefix;
-                    if (!string.IsNullOrEmpty(queueNamePrefixAsString))
+                    var builder = new DbConnectionStringBuilder { ConnectionString = TransportIntegration.ConnectionString };
+
+                    // SQS
+                    if (builder.TryGetValue("QueueNamePrefix", out var queueNamePrefix))
                     {
-                        result = result.Replace(
-                            queueNamePrefixAsString,
-                            "queue-prefix-"
-                        );
+                        var queueNamePrefixAsString = (string)queueNamePrefix;
+                        if (!string.IsNullOrEmpty(queueNamePrefixAsString))
+                        {
+                            result = result.Replace(
+                                queueNamePrefixAsString,
+                                "queue-prefix-"
+                            );
+                        }
+                    }
+
+                    // SQL
+                    if (builder.TryGetValue("Database", out var database))
+                    {
+                        var databaseAsString = (string)database;
+                        if (!string.IsNullOrEmpty(databaseAsString))
+                        {
+                            result = result.Replace(
+                                $"[{databaseAsString}]",
+                                "[DATABASE]"
+                            );
+                        }
                     }
                 }
-
-                // SQL
-                if (builder.TryGetValue("Database", out var database))
+                catch
                 {
-                    var databaseAsString = (string)database;
-                    if (!string.IsNullOrEmpty(databaseAsString))
-                    {
-                        result = result.Replace(
-                            $"[{databaseAsString}]",
-                            "[DATABASE]"
-                        );
-                    }
+                    // NOTE: Learning Transport has a connection string in an invalid format
                 }
             }
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
@@ -39,57 +39,8 @@
             Approver.Verify(
                 formatted,
                 scenario: ScenarioName,
-                scrubber: Scrub
+                scrubber: TransportIntegration.ScrubPlatformConnection
             );
-        }
-
-        string Scrub(string input)
-        {
-            // MSMQ
-            var result = input.Replace(
-                Environment.MachineName,
-                "MACHINE_NAME"
-            );
-
-            if (!string.IsNullOrWhiteSpace(TransportIntegration.ConnectionString))
-            {
-                try
-                {
-                    var builder = new DbConnectionStringBuilder { ConnectionString = TransportIntegration.ConnectionString };
-
-                    // SQS
-                    if (builder.TryGetValue("QueueNamePrefix", out var queueNamePrefix))
-                    {
-                        var queueNamePrefixAsString = (string)queueNamePrefix;
-                        if (!string.IsNullOrEmpty(queueNamePrefixAsString))
-                        {
-                            result = result.Replace(
-                                queueNamePrefixAsString,
-                                "queue-prefix-"
-                            );
-                        }
-                    }
-
-                    // SQL
-                    if (builder.TryGetValue("Database", out var database))
-                    {
-                        var databaseAsString = (string)database;
-                        if (!string.IsNullOrEmpty(databaseAsString))
-                        {
-                            result = result.Replace(
-                                $"[{databaseAsString}]",
-                                "[DATABASE]"
-                            );
-                        }
-                    }
-                }
-                catch
-                {
-                    // NOTE: Learning Transport has a connection string in an invalid format
-                }
-            }
-
-            return result;
         }
 
         string ScenarioName

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
@@ -1,0 +1,93 @@
+﻿namespace ServiceControl.MultiInstance.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+    using Particular.Approvals;
+    using TestSupport;
+    using TestSupport.EndpointTemplates;
+    using ServiceControl.AcceptanceTesting;
+    using ServiceControlInstaller.Engine.Instances;
+
+    [RunOnAllTransports]
+    class PlatformConnectionTests : AcceptanceTest
+    {
+        [Test]
+        public async Task ExposesConnectionDetails()
+        {
+            var config = await Define<MyContext>()
+                .WithEndpoint<MyEndpoint>()
+                .Done(async x =>
+                {
+                    var result = await this.GetRaw("/api/connection", ServiceControlInstanceName);
+                    x.Connection = await result.Content.ReadAsStringAsync();
+                    return true;
+                })
+                .Run();
+
+            Assert.IsNotNull(config.Connection);
+
+            var formatted =
+                JsonConvert.SerializeObject(
+                    JsonConvert.DeserializeObject(config.Connection),
+                    Formatting.Indented
+                );
+
+            Approver.Verify(
+                formatted,
+                scenario: ScenarioName,
+                scrubber: input => input.Replace(
+                    Environment.MachineName,
+                    "MACHINE_NAME"
+                    )
+                );
+        }
+
+        string ScenarioName
+        {
+            get
+            {
+                switch (TransportIntegration.Name)
+                {
+                    case TransportNames.AmazonSQS:
+                        return "SQS";
+                    case TransportNames.AzureServiceBus:
+                        return "ASB";
+                    case TransportNames.AzureServiceBusEndpointOrientedTopologyDeprecated:
+                    case TransportNames.AzureServiceBusEndpointOrientedTopologyLegacy:
+                    case TransportNames.AzureServiceBusEndpointOrientedTopologyOld:
+                    case TransportNames.AzureServiceBusForwardingTopologyDeprecated:
+                    case TransportNames.AzureServiceBusForwardingTopologyLegacy:
+                    case TransportNames.AzureServiceBusForwardingTopologyOld:
+                        return "ASB.Old";
+                    case TransportNames.AzureStorageQueue:
+                        return "ASQ";
+                    case TransportNames.MSMQ:
+                        return "MSMQ";
+                    case TransportNames.SQLServer:
+                        return "SQL";
+                    case TransportNames.RabbitMQConventionalRoutingTopology:
+                    case TransportNames.RabbitMQDirectRoutingTopology:
+                        return "RabbitMQ";
+                    default:
+                        return TransportIntegration.Name;
+                }
+            }
+        }
+
+        class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint()
+            {
+                EndpointSetup<DefaultServerWithoutAudit>();
+            }
+        }
+
+        class MyContext : ScenarioContext
+        {
+            public string Connection { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
@@ -51,11 +51,11 @@
                 "MACHINE_NAME"
             );
 
-            // SQS
             if (!string.IsNullOrWhiteSpace(TransportIntegration.ConnectionString))
             {
                 var builder = new DbConnectionStringBuilder { ConnectionString = TransportIntegration.ConnectionString };
 
+                // SQS
                 if (builder.TryGetValue("QueueNamePrefix", out var queueNamePrefix))
                 {
                     var queueNamePrefixAsString = (string)queueNamePrefix;
@@ -68,6 +68,18 @@
                     }
                 }
 
+                // SQL
+                if (builder.TryGetValue("Database", out var database))
+                {
+                    var databaseAsString = (string)database;
+                    if (!string.IsNullOrEmpty(databaseAsString))
+                    {
+                        result = result.Replace(
+                            $"[{databaseAsString}]",
+                            "[DATABASE]"
+                        );
+                    }
+                }
             }
 
             return result;

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace ServiceControl.MultiInstance.AcceptanceTests
 {
-    using System;
-    using System.Data.Common;
     using System.Threading.Tasks;
     using Newtonsoft.Json;
     using NServiceBus.AcceptanceTesting;

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
@@ -42,5 +42,6 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="OwinHttpMessageHandler" Version="2.0.2" />
+    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
   </ItemGroup>
 </Project>

--- a/src/ServiceControl.Transports.SQS/QueueNameHelper.cs
+++ b/src/ServiceControl.Transports.SQS/QueueNameHelper.cs
@@ -14,7 +14,11 @@
                 throw new ArgumentNullException(nameof(queue));
             }
 
-            var s = queueNamePrefix + queue;
+            var s = queue;
+            if (!string.IsNullOrWhiteSpace(queueNamePrefix) && !s.StartsWith(queueNamePrefix))
+            {
+                s = queueNamePrefix + queue;
+            }
 
             if (s.Length > 80)
             {

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -263,8 +263,14 @@ namespace ServiceControl.Connection
     public class PlatformConnectionDetails
     {
         public PlatformConnectionDetails() { }
+        public System.Collections.Concurrent.ConcurrentBag<string> Errors { get; }
         public void Add(string key, object value) { }
         public System.Collections.Generic.IDictionary<string, object> ToDictionary() { }
+    }
+    public class PlatformConnectionQueryStatus
+    {
+        public PlatformConnectionQueryStatus() { }
+        public System.Collections.Concurrent.ConcurrentBag<string> Exceptions { get; set; }
     }
 }
 namespace ServiceControl.Contracts.CustomChecks

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -247,6 +247,26 @@ namespace ServiceControl.CompositeViews.Messages
         }
     }
 }
+namespace ServiceControl.Connection
+{
+    public class ConnectionController : System.Web.Http.ApiController
+    {
+        public ConnectionController(ServiceControl.Connection.IPlatformConnectionBuilder connectionBuilder) { }
+        [System.Web.Http.HttpGet]
+        [System.Web.Http.Route("connection")]
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetConnectionDetails() { }
+    }
+    public interface IPlatformConnectionBuilder
+    {
+        System.Threading.Tasks.Task<ServiceControl.Connection.PlatformConnectionDetails> BuildPlatformConnection();
+    }
+    public class PlatformConnectionDetails
+    {
+        public PlatformConnectionDetails() { }
+        public void Add(string key, object value) { }
+        public System.Collections.Generic.IDictionary<string, object> ToDictionary() { }
+    }
+}
 namespace ServiceControl.Contracts.CustomChecks
 {
     public class CustomCheckFailed : ServiceControl.Infrastructure.SignalR.IUserInterfaceEvent

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -254,7 +254,7 @@ namespace ServiceControl.Connection
         public ConnectionController(ServiceControl.Connection.IPlatformConnectionBuilder connectionBuilder) { }
         [System.Web.Http.HttpGet]
         [System.Web.Http.Route("connection")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetConnectionDetails() { }
+        public System.Threading.Tasks.Task<System.Web.Http.IHttpActionResult> GetConnectionDetails() { }
     }
     public interface IPlatformConnectionBuilder
     {

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -267,11 +267,6 @@ namespace ServiceControl.Connection
         public void Add(string key, object value) { }
         public System.Collections.Generic.IDictionary<string, object> ToDictionary() { }
     }
-    public class PlatformConnectionQueryStatus
-    {
-        public PlatformConnectionQueryStatus() { }
-        public System.Collections.Concurrent.ConcurrentBag<string> Exceptions { get; set; }
-    }
 }
 namespace ServiceControl.Contracts.CustomChecks
 {

--- a/src/ServiceControl/Connection/ConnectionController.cs
+++ b/src/ServiceControl/Connection/ConnectionController.cs
@@ -1,25 +1,25 @@
 ﻿namespace ServiceControl.Connection
 {
-    using System.Net;
-    using System.Net.Http;
     using System.Threading.Tasks;
     using System.Web.Http;
+    using Newtonsoft.Json;
 
     public class ConnectionController : ApiController
     {
         readonly IPlatformConnectionBuilder connectionBuilder;
+        readonly JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings();
 
         public ConnectionController(IPlatformConnectionBuilder connectionBuilder) => this.connectionBuilder = connectionBuilder;
 
         [Route("connection")]
         [HttpGet]
-        public async Task<HttpResponseMessage> GetConnectionDetails()
+        public async Task<IHttpActionResult> GetConnectionDetails()
         {
             var connectionDetails = await connectionBuilder.BuildPlatformConnection().ConfigureAwait(false);
 
-            return Request.CreateResponse(
-                HttpStatusCode.OK,
-                connectionDetails.ToDictionary()
+            return Json(
+                connectionDetails.ToDictionary(),
+                jsonSerializerSettings
             );
         }
     }

--- a/src/ServiceControl/Connection/ConnectionController.cs
+++ b/src/ServiceControl/Connection/ConnectionController.cs
@@ -18,7 +18,11 @@
             var connectionDetails = await connectionBuilder.BuildPlatformConnection().ConfigureAwait(false);
 
             return Json(
-                connectionDetails.ToDictionary(),
+                new
+                {
+                    Settings = connectionDetails.ToDictionary(),
+                    QueryStatus = connectionDetails.Status
+                },
                 jsonSerializerSettings
             );
         }

--- a/src/ServiceControl/Connection/ConnectionController.cs
+++ b/src/ServiceControl/Connection/ConnectionController.cs
@@ -20,8 +20,8 @@
             return Json(
                 new
                 {
-                    Settings = connectionDetails.ToDictionary(),
-                    QueryStatus = connectionDetails.Status
+                    settings = connectionDetails.ToDictionary(),
+                    errors = connectionDetails.Errors
                 },
                 jsonSerializerSettings
             );

--- a/src/ServiceControl/Connection/ConnectionController.cs
+++ b/src/ServiceControl/Connection/ConnectionController.cs
@@ -1,0 +1,26 @@
+﻿namespace ServiceControl.Connection
+{
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using System.Web.Http;
+
+    public class ConnectionController : ApiController
+    {
+        readonly IPlatformConnectionBuilder connectionBuilder;
+
+        public ConnectionController(IPlatformConnectionBuilder connectionBuilder) => this.connectionBuilder = connectionBuilder;
+
+        [Route("connection")]
+        [HttpGet]
+        public async Task<HttpResponseMessage> GetConnectionDetails()
+        {
+            var connectionDetails = await connectionBuilder.BuildPlatformConnection().ConfigureAwait(false);
+
+            return Request.CreateResponse(
+                HttpStatusCode.OK,
+                connectionDetails.ToDictionary()
+            );
+        }
+    }
+}

--- a/src/ServiceControl/Connection/ConnectionProvidersServiceCollectionExtensions.cs
+++ b/src/ServiceControl/Connection/ConnectionProvidersServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace ServiceControl.Connection
+{
+    using Microsoft.Extensions.DependencyInjection;
+
+    static class ConnectionProvidersServiceCollectionExtensions
+    {
+        public static void AddPlatformConnectionProvider<T>(this IServiceCollection serviceCollection)
+            where T : class, IProvidePlatformConnectionDetails
+        {
+            serviceCollection.AddSingleton<IProvidePlatformConnectionDetails, T>();
+        }
+    }
+}

--- a/src/ServiceControl/Connection/IPlatformConnectionBuilder.cs
+++ b/src/ServiceControl/Connection/IPlatformConnectionBuilder.cs
@@ -1,0 +1,9 @@
+﻿namespace ServiceControl.Connection
+{
+    using System.Threading.Tasks;
+
+    public interface IPlatformConnectionBuilder
+    {
+        Task<PlatformConnectionDetails> BuildPlatformConnection();
+    }
+}

--- a/src/ServiceControl/Connection/IProvidePlatformConnectionDetails.cs
+++ b/src/ServiceControl/Connection/IProvidePlatformConnectionDetails.cs
@@ -1,0 +1,9 @@
+﻿namespace ServiceControl.Connection
+{
+    using System.Threading.Tasks;
+
+    interface IProvidePlatformConnectionDetails
+    {
+        Task ProvideConnectionDetails(PlatformConnectionDetails connection);
+    }
+}

--- a/src/ServiceControl/Connection/PlatformConnectionBuilder.cs
+++ b/src/ServiceControl/Connection/PlatformConnectionBuilder.cs
@@ -14,7 +14,6 @@
         {
             var connectionDetails = new PlatformConnectionDetails();
 
-            // TODO: Handle errors in providers (including timeouts?)
             await Task.WhenAll(
                 from provider in platformConnectionProviders
                 select provider.ProvideConnectionDetails(connectionDetails)

--- a/src/ServiceControl/Connection/PlatformConnectionBuilder.cs
+++ b/src/ServiceControl/Connection/PlatformConnectionBuilder.cs
@@ -1,0 +1,26 @@
+﻿namespace ServiceControl.Connection
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    class PlatformConnectionBuilder : IPlatformConnectionBuilder
+    {
+        readonly IProvidePlatformConnectionDetails[] platformConnectionProviders;
+
+        public PlatformConnectionBuilder(IProvidePlatformConnectionDetails[] platformConnectionProviders)
+            => this.platformConnectionProviders = platformConnectionProviders;
+
+        public async Task<PlatformConnectionDetails> BuildPlatformConnection()
+        {
+            var connectionDetails = new PlatformConnectionDetails();
+
+            // TODO: Handle errors in providers (including timeouts?)
+            await Task.WhenAll(
+                from provider in platformConnectionProviders
+                select provider.ProvideConnectionDetails(connectionDetails)
+            ).ConfigureAwait(false);
+
+            return connectionDetails;
+        }
+    }
+}

--- a/src/ServiceControl/Connection/PlatformConnectionDetails.cs
+++ b/src/ServiceControl/Connection/PlatformConnectionDetails.cs
@@ -14,7 +14,7 @@
                 return;
             }
 
-            // Add a numeric suffix to duplicated keys
+            // Add a numeric suffix to duplicated keys e.g. can happen when there are two audit instances configured
             var suffix = 0;
             do
             {

--- a/src/ServiceControl/Connection/PlatformConnectionDetails.cs
+++ b/src/ServiceControl/Connection/PlatformConnectionDetails.cs
@@ -1,0 +1,27 @@
+﻿namespace ServiceControl.Connection
+{
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+
+    public class PlatformConnectionDetails
+    {
+        readonly ConcurrentDictionary<string, object> values = new ConcurrentDictionary<string, object>();
+
+        public void Add(string key, object value)
+        {
+            if (values.TryAdd(key, value))
+            {
+                return;
+            }
+
+            // Add a numeric suffix to duplicated keys
+            var suffix = 0;
+            do
+            {
+                suffix++;
+            } while (!values.TryAdd($"{key}{suffix}", value));
+        }
+
+        public IDictionary<string, object> ToDictionary() => values;
+    }
+}

--- a/src/ServiceControl/Connection/PlatformConnectionDetails.cs
+++ b/src/ServiceControl/Connection/PlatformConnectionDetails.cs
@@ -23,5 +23,7 @@
         }
 
         public IDictionary<string, object> ToDictionary() => values;
+
+        public PlatformConnectionQueryStatus Status { get; } = new PlatformConnectionQueryStatus();
     }
 }

--- a/src/ServiceControl/Connection/PlatformConnectionDetails.cs
+++ b/src/ServiceControl/Connection/PlatformConnectionDetails.cs
@@ -24,6 +24,6 @@
 
         public IDictionary<string, object> ToDictionary() => values;
 
-        public PlatformConnectionQueryStatus Status { get; } = new PlatformConnectionQueryStatus();
+        public ConcurrentBag<string> Errors { get; } = new ConcurrentBag<string>();
     }
 }

--- a/src/ServiceControl/Connection/PlatformConnectionQueryStatus.cs
+++ b/src/ServiceControl/Connection/PlatformConnectionQueryStatus.cs
@@ -1,9 +1,0 @@
-﻿namespace ServiceControl.Connection
-{
-    using System.Collections.Concurrent;
-
-    public class PlatformConnectionQueryStatus
-    {
-        public ConcurrentBag<string> Exceptions { get; set; } = new ConcurrentBag<string>();
-    }
-}

--- a/src/ServiceControl/Connection/PlatformConnectionQueryStatus.cs
+++ b/src/ServiceControl/Connection/PlatformConnectionQueryStatus.cs
@@ -1,0 +1,10 @@
+﻿namespace ServiceControl.Connection
+{
+    using System.Collections.Concurrent;
+
+    public class PlatformConnectionQueryStatus
+    {
+        public bool IsSuccess { get; set; }
+        public ConcurrentBag<string> Exceptions { get; set; } = new ConcurrentBag<string>();
+    }
+}

--- a/src/ServiceControl/Connection/PlatformConnectionQueryStatus.cs
+++ b/src/ServiceControl/Connection/PlatformConnectionQueryStatus.cs
@@ -4,7 +4,6 @@
 
     public class PlatformConnectionQueryStatus
     {
-        public bool IsSuccess { get; set; }
         public ConcurrentBag<string> Exceptions { get; set; } = new ConcurrentBag<string>();
     }
 }

--- a/src/ServiceControl/Connection/RemotePlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Connection/RemotePlatformConnectionDetailsProvider.cs
@@ -1,0 +1,45 @@
+﻿namespace ServiceControl.Connection
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    class RemotePlatformConnectionDetailsProvider : IProvidePlatformConnectionDetails
+    {
+        readonly Settings settings;
+        readonly Func<HttpClient> httpClientFactory;
+
+        public RemotePlatformConnectionDetailsProvider(Settings settings, Func<HttpClient> httpClientFactory)
+        {
+            this.settings = settings;
+            this.httpClientFactory = httpClientFactory;
+        }
+
+        public async Task ProvideConnectionDetails(PlatformConnectionDetails connection)
+        {
+            using (var client = httpClientFactory())
+            {
+                // TODO: Do this in parallel
+                foreach (var remoteInstance in settings.RemoteInstances)
+                {
+                    // TODO: Handle failures properly
+                    var result = await client.GetStringAsync($"{remoteInstance.ApiUri}/connection")
+                        .ConfigureAwait(false);
+                    var dictionary = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(result);
+                    if (dictionary == null)
+                    {
+                        // TODO: Handle this condition properly
+                        continue;
+                    }
+                    foreach (var kvp in dictionary)
+                    {
+                        connection.Add(kvp.Key, kvp.Value);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl/Connection/RemotePlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Connection/RemotePlatformConnectionDetailsProvider.cs
@@ -48,7 +48,11 @@
                 }
                 catch (Exception ex)
                 {
-                    Log.Error($"Unable to get connection details from ${remote.ApiUri}/connection", ex);
+                    var message = $"Unable to get connection details from ${remote.ApiUri}/connection";
+                    connection.Status.Exceptions.Add(message);
+                    connection.Status.IsSuccess = false;
+
+                    Log.Error(message, ex);
                 }
             }
         }

--- a/src/ServiceControl/Connection/RemotePlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Connection/RemotePlatformConnectionDetailsProvider.cs
@@ -49,8 +49,8 @@
                 catch (Exception ex)
                 {
                     var message = $"Unable to get connection details from ${remote.ApiUri}/connection";
-                    connection.Status.Exceptions.Add(message);
-                    connection.Status.IsSuccess = false;
+
+                    connection.Errors.Add(message);
 
                     Log.Error(message, ex);
                 }

--- a/src/ServiceControl/Connection/RemotePlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Connection/RemotePlatformConnectionDetailsProvider.cs
@@ -37,7 +37,7 @@
                     var dictionary = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(result);
                     if (dictionary == null)
                     {
-                        Log.Warn($"Unexpected response from ${remote.ApiUri}/connection: ${result}");
+                        Log.Warn($"Unexpected response from {remote.ApiUri}/connection: {result}");
                         return;
                     }
 
@@ -48,7 +48,7 @@
                 }
                 catch (Exception ex)
                 {
-                    var message = $"Unable to get connection details from ${remote.ApiUri}/connection";
+                    var message = $"Unable to get connection details from ServiceControl Audit instance at {remote.ApiUri}/connection.";
 
                     connection.Errors.Add(message);
 

--- a/src/ServiceControl/Connection/RemotePlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Connection/RemotePlatformConnectionDetailsProvider.cs
@@ -2,9 +2,11 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
     using Newtonsoft.Json;
+    using NServiceBus.Logging;
     using ServiceBus.Management.Infrastructure.Settings;
 
     class RemotePlatformConnectionDetailsProvider : IProvidePlatformConnectionDetails
@@ -18,28 +20,39 @@
             this.httpClientFactory = httpClientFactory;
         }
 
-        public async Task ProvideConnectionDetails(PlatformConnectionDetails connection)
+        public Task ProvideConnectionDetails(PlatformConnectionDetails connection) =>
+            Task.WhenAll(
+                settings.RemoteInstances
+                    .Select(remote => UpdateFromRemote(remote, connection))
+            );
+
+        async Task UpdateFromRemote(RemoteInstanceSetting remote, PlatformConnectionDetails connection)
         {
             using (var client = httpClientFactory())
             {
-                // TODO: Do this in parallel
-                foreach (var remoteInstance in settings.RemoteInstances)
+                try
                 {
-                    // TODO: Handle failures properly
-                    var result = await client.GetStringAsync($"{remoteInstance.ApiUri}/connection")
+                    var result = await client.GetStringAsync($"{remote.ApiUri}/connection")
                         .ConfigureAwait(false);
                     var dictionary = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(result);
                     if (dictionary == null)
                     {
-                        // TODO: Handle this condition properly
-                        continue;
+                        Log.Warn($"Unexpected response from ${remote.ApiUri}/connection: ${result}");
+                        return;
                     }
+
                     foreach (var kvp in dictionary)
                     {
                         connection.Add(kvp.Key, kvp.Value);
                     }
                 }
+                catch (Exception ex)
+                {
+                    Log.Error($"Unable to get connection details from ${remote.ApiUri}/connection", ex);
+                }
             }
         }
+
+        static readonly ILog Log = LogManager.GetLogger<RemotePlatformConnectionDetailsProvider>();
     }
 }

--- a/src/ServiceControl/CustomChecks/CustomChecksComponent.cs
+++ b/src/ServiceControl/CustomChecks/CustomChecksComponent.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.CustomChecks
 {
+    using Connection;
     using ExternalIntegrations;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
@@ -17,6 +18,8 @@
 
                 serviceCollection.AddIntegrationEventPublisher<CustomCheckFailedPublisher>();
                 serviceCollection.AddIntegrationEventPublisher<CustomCheckSucceededPublisher>();
+
+                serviceCollection.AddPlatformConnectionProvider<CustomChecksPlatformConnectionDetailsProvider>();
             });
         }
 

--- a/src/ServiceControl/CustomChecks/CustomChecksConnectionDetailsProvider.cs
+++ b/src/ServiceControl/CustomChecks/CustomChecksConnectionDetailsProvider.cs
@@ -15,7 +15,7 @@
         public Task ProvideConnectionDetails(PlatformConnectionDetails connection)
         {
             connection.Add(
-                "customChecks",
+                "CustomChecks",
                 new
                 {
                     CustomChecksQueue = instanceMainQueue

--- a/src/ServiceControl/CustomChecks/CustomChecksConnectionDetailsProvider.cs
+++ b/src/ServiceControl/CustomChecks/CustomChecksConnectionDetailsProvider.cs
@@ -1,0 +1,26 @@
+﻿namespace ServiceControl.CustomChecks
+{
+    using System.Threading.Tasks;
+    using Connection;
+    using NServiceBus;
+    using NServiceBus.Settings;
+
+    class CustomChecksPlatformConnectionDetailsProvider : IProvidePlatformConnectionDetails
+    {
+        readonly string instanceMainQueue;
+
+        public CustomChecksPlatformConnectionDetailsProvider(ReadOnlySettings endpointSettings)
+            => instanceMainQueue = endpointSettings.LocalAddress();
+
+        public Task ProvideConnectionDetails(PlatformConnectionDetails connection)
+        {
+            connection.Add(
+                "customChecks",
+                new
+                {
+                    CustomChecksQueue = instanceMainQueue
+                });
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/ServiceControl/CustomChecks/CustomChecksConnectionDetailsProvider.cs
+++ b/src/ServiceControl/CustomChecks/CustomChecksConnectionDetailsProvider.cs
@@ -18,6 +18,7 @@
                 "CustomChecks",
                 new
                 {
+                    Enabled = true,
                     CustomChecksQueue = instanceMainQueue
                 });
             return Task.CompletedTask;

--- a/src/ServiceControl/CustomChecks/CustomChecksConnectionDetailsProvider.cs
+++ b/src/ServiceControl/CustomChecks/CustomChecksConnectionDetailsProvider.cs
@@ -16,12 +16,19 @@
         {
             connection.Add(
                 "CustomChecks",
-                new
+                new CustomChecksConnectionDetails
                 {
                     Enabled = true,
                     CustomChecksQueue = instanceMainQueue
                 });
             return Task.CompletedTask;
+        }
+
+        // HINT: This should match the type in the PlatformConnector package
+        class CustomChecksConnectionDetails
+        {
+            public bool Enabled { get; set; }
+            public string CustomChecksQueue { get; set; }
         }
     }
 }

--- a/src/ServiceControl/HostingComponent.cs
+++ b/src/ServiceControl/HostingComponent.cs
@@ -12,7 +12,7 @@ namespace Particular.ServiceControl
             hostBuilder.ConfigureServices(services =>
             {
                 services.AddPlatformConnectionProvider<RemotePlatformConnectionDetailsProvider>();
-                services.AddTransient<IPlatformConnectionBuilder, PlatformConnectionBuilder>();
+                services.AddSingleton<IPlatformConnectionBuilder, PlatformConnectionBuilder>();
             });
 
         public override void Setup(Settings settings, IComponentSetupContext context)

--- a/src/ServiceControl/HostingComponent.cs
+++ b/src/ServiceControl/HostingComponent.cs
@@ -1,14 +1,19 @@
 
 namespace Particular.ServiceControl
 {
+    using global::ServiceControl.Connection;
+    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using ServiceBus.Management.Infrastructure.Settings;
 
     class HostingComponent : ServiceControlComponent
     {
-        public override void Configure(Settings settings, IHostBuilder hostBuilder)
-        {
-        }
+        public override void Configure(Settings settings, IHostBuilder hostBuilder) =>
+            hostBuilder.ConfigureServices(services =>
+            {
+                services.AddPlatformConnectionProvider<RemotePlatformConnectionDetailsProvider>();
+                services.AddTransient<IPlatformConnectionBuilder, PlatformConnectionBuilder>();
+            });
 
         public override void Setup(Settings settings, IComponentSetupContext context)
         {

--- a/src/ServiceControl/Monitoring/HeartbeatMonitoringComponent.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatMonitoringComponent.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Monitoring
 {
+    using Connection;
     using EndpointControl.Handlers;
     using ExternalIntegrations;
     using Infrastructure.DomainEvents;
@@ -25,6 +26,8 @@
 
                 collection.AddIntegrationEventPublisher<HeartbeatRestoredPublisher>();
                 collection.AddIntegrationEventPublisher<HeartbeatStoppedPublisher>();
+
+                collection.AddPlatformConnectionProvider<HeartbeatsPlatformConnectionDetailsProvider>();
             });
         }
 

--- a/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
@@ -33,6 +33,7 @@
                     Frequency = frequency,
                     TimeToLive = timeToLive
                 });
+
             return Task.CompletedTask;
         }
     }

--- a/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
@@ -27,7 +27,7 @@
             var timeToLive = TimeSpan.FromTicks(frequency.Ticks * 4);
             connection.Add(
                 "Heartbeats",
-                new
+                new HeartbeatsConnectionDetails
                 {
                     Enabled = true,
                     HeartbeatsQueue = instanceMainQueue,
@@ -36,6 +36,15 @@
                 });
 
             return Task.CompletedTask;
+        }
+
+        // HINT: This should match the type in the PlatformConnector package
+        class HeartbeatsConnectionDetails
+        {
+            public bool Enabled { get; set; }
+            public string HeartbeatsQueue { get; set; }
+            public TimeSpan Frequency { get; set; }
+            public TimeSpan TimeToLive { get; set; }
         }
     }
 }

--- a/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
@@ -23,7 +23,6 @@
             // NOTE: The default grace period is 40s and the default frequency is 10s.
             // In a low-latency environment, an endpoint would need to miss more than 4 heartbeats to be considered down
             var frequency = TimeSpan.FromTicks(settings.HeartbeatGracePeriod.Ticks / 4);
-            // TODO: Figure out if we should even provide this. The default in the plugin is 4xFrequency
             var timeToLive = TimeSpan.FromTicks(frequency.Ticks * 4);
             connection.Add(
                 "Heartbeats",

--- a/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
@@ -1,0 +1,39 @@
+﻿namespace ServiceControl.Monitoring
+{
+    using System;
+    using System.Threading.Tasks;
+    using Connection;
+    using NServiceBus;
+    using NServiceBus.Settings;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    class HeartbeatsPlatformConnectionDetailsProvider : IProvidePlatformConnectionDetails
+    {
+        readonly Settings settings;
+        readonly string instanceMainQueue;
+
+        public HeartbeatsPlatformConnectionDetailsProvider(Settings settings, ReadOnlySettings endpointSettings)
+        {
+            this.settings = settings;
+            instanceMainQueue = endpointSettings.LocalAddress();
+        }
+
+        public Task ProvideConnectionDetails(PlatformConnectionDetails connection)
+        {
+            // NOTE: The default grace period is 40s and the default frequency is 10s.
+            // In a low-latency environment, an endpoint would need to miss more than 4 heartbeats to be considered down
+            var frequency = TimeSpan.FromTicks(settings.HeartbeatGracePeriod.Ticks / 4);
+            // TODO: Figure out if we should even provide this. The default in the plugin is 4xFrequency
+            var timeToLive = TimeSpan.FromTicks(frequency.Ticks * 4);
+            connection.Add(
+                "heartbeats",
+                new
+                {
+                    HeartbeatsQueue = instanceMainQueue,
+                    Frequency = frequency,
+                    TimeToLive = timeToLive
+                });
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
@@ -29,6 +29,7 @@
                 "Heartbeats",
                 new
                 {
+                    Enabled = true,
                     HeartbeatsQueue = instanceMainQueue,
                     Frequency = frequency,
                     TimeToLive = timeToLive

--- a/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatsPlatformConnectionDetailsProvider.cs
@@ -26,7 +26,7 @@
             // TODO: Figure out if we should even provide this. The default in the plugin is 4xFrequency
             var timeToLive = TimeSpan.FromTicks(frequency.Ticks * 4);
             connection.Add(
-                "heartbeats",
+                "Heartbeats",
                 new
                 {
                     HeartbeatsQueue = instanceMainQueue,

--- a/src/ServiceControl/Recoverability/RecoverabilityComponent.cs
+++ b/src/ServiceControl/Recoverability/RecoverabilityComponent.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Connection;
     using CustomChecks;
     using ExternalIntegration;
     using ExternalIntegrations;
@@ -29,6 +30,8 @@
         {
             hostBuilder.ConfigureServices(collection =>
             {
+                collection.AddPlatformConnectionProvider<RecoverabilityPlatformConnectionDetailsProvider>();
+
                 //Archiving
                 collection.AddSingleton<ArchivingManager>();
                 collection.AddSingleton<ArchiveDocumentManager>();

--- a/src/ServiceControl/Recoverability/RecoverabilityPlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Recoverability/RecoverabilityPlatformConnectionDetailsProvider.cs
@@ -1,0 +1,19 @@
+﻿namespace ServiceControl.Recoverability
+{
+    using System.Threading.Tasks;
+    using Connection;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    class RecoverabilityPlatformConnectionDetailsProvider : IProvidePlatformConnectionDetails
+    {
+        readonly Settings settings;
+
+        public RecoverabilityPlatformConnectionDetailsProvider(Settings settings) => this.settings = settings;
+
+        public Task ProvideConnectionDetails(PlatformConnectionDetails connection)
+        {
+            connection.Add("errorQueue", settings.ErrorQueue);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/ServiceControl/Recoverability/RecoverabilityPlatformConnectionDetailsProvider.cs
+++ b/src/ServiceControl/Recoverability/RecoverabilityPlatformConnectionDetailsProvider.cs
@@ -12,7 +12,7 @@
 
         public Task ProvideConnectionDetails(PlatformConnectionDetails connection)
         {
-            connection.Add("errorQueue", settings.ErrorQueue);
+            connection.Add("ErrorQueue", settings.ErrorQueue);
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
A companion to https://github.com/Particular/ServiceControl/pull/2669

This creates a new api at `/api/connection` which exposes the info needed for the platform connection package.

```json
{
  "Heartbeats": {
    "Enabled": true,
    "HeartbeatsQueue": "Particular.ServiceControl",
    "Frequency": "00:00:10",
    "TimeToLive": "00:00:40"
  },
  "CustomChecks": {
    "Enabled": true,
    "CustomChecksQueue": "Particular.ServiceControl"
  },
  "ErrorQueue": "error",
  "MessageAudit": {
    "Enabled": true,
    "AuditQueue": "audit"
  },
  "SagaAudit": {
    "Enabled": true,
    "SagaAuditQueue": "audit"
  }
}
```

NOTE: The `MessageAudit` and `SagaAudit` entries come from the audit instance. If you have multiple audit instances then subsequent ones will be rendered as `MessageAudit1`, `MessageAudit2`, and so on. The order that this happens is not defined.