### PR TITLE
Tool to find mismatched dependencies

### DIFF
--- a/tools/Find-Assembly-Version-Mismatches.linq
+++ b/tools/Find-Assembly-Version-Mismatches.linq
@@ -1,0 +1,42 @@
+<Query Kind="Statements" />
+
+// After a debug build, find all assemblies where we have different versions
+
+var root = Path.Combine(Path.GetDirectoryName(Util.CurrentQueryPath), "..", "src");
+
+// NOTE: These are not .NET assemblies
+var ignoredAssemblies = new[]
+{
+	"Microsoft.Data.SqlClient.SNI.x64",
+	"Microsoft.Data.SqlClient.SNI.x86"
+};
+
+(
+from path in Directory.EnumerateFiles(root, "*.dll", SearchOption.AllDirectories)
+where path.Contains(@"bin\Debug")
+let assembly = Path.GetFileNameWithoutExtension(path)
+where ignoredAssemblies.Contains(assembly) == false
+group path by assembly into byAssemblyName
+let referenceCount = byAssemblyName.Count()
+where referenceCount > 1
+let versions =  
+				(from p in byAssemblyName
+			   let assemblyName = AssemblyName.GetAssemblyName(p)
+			   let projectName = p.Substring(root.Length +1).Split(Path.DirectorySeparatorChar).First()
+			   orderby projectName
+			   group projectName by assemblyName.Version.ToString() into byVersion
+			   let projectCount = byVersion.Count()
+			   orderby projectCount descending
+			   select new {
+			   	Version = byVersion.Key,
+				   Projects = Util.OnDemand($"{projectCount}", () => byVersion.ToArray())
+			   }).ToArray()
+where versions.Count() > 1
+orderby versions.Count(), referenceCount descending
+select new 
+{
+	Assembly = byAssemblyName.Key,
+	ProjectReferences = referenceCount,
+	Versions = versions
+}
+).Dump();


### PR DESCRIPTION
This LINQPad script helps to identify when we have mismatched dependencies.

After a debug build, the script looks for assemblies in the output folders of all projects. For any assembly which appears multiple times, we look for cases where they are different versions and list the projects for them. At the time of creation, the results look like this:

![image](https://user-images.githubusercontent.com/124014/141031896-07129823-cb17-4de2-a4d3-5b0304337d7f.png)

This can be helpful in dealling with [Assembly Mismatches](https://github.com/Particular/ServiceControl/blob/master/docs/packaging.md#assembly-mismatches)