### PR TITLE
To bump Microsoft.Extensions.Hosting.WindowsServices to 6.0.0

### DIFF
--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -33,8 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.4.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.15" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.4.2" />    
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.5.0" />
     <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />

--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -36,9 +36,8 @@
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.2" />
     <PackageReference Include="NServiceBus.Raw" Version="3.2.4" />
-    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.15" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.0" />    
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
     <PackageReference Include="ServiceControl.Contracts" Version="3.0.0" />
     <PackageReference Include="Lucene.Net" Version="3.0.3" />
     <PackageReference Include="Rx-Linq" Version="2.2.5" />
@@ -46,8 +45,7 @@
     <PackageReference Include="Particular.Licensing.Sources" Version="3.6.0" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -13,9 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.*" />
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.7" />
-    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.15" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.15" />
+    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />    
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
     <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNet.Cors" Version="5.2.7" />
     <PackageReference Include="Microsoft.Owin.Cors" Version="4.2.0" />

--- a/src/ServiceControl.Transports.ASB/ServiceControl.Transports.ASB.csproj
+++ b/src/ServiceControl.Transports.ASB/ServiceControl.Transports.ASB.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="10.1.0" />
     <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.ASBS/ServiceControl.Transports.ASBS.csproj
+++ b/src/ServiceControl.Transports.ASBS/ServiceControl.Transports.ASBS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
@@ -14,10 +14,10 @@
   </ItemGroup>
 
   <ItemGroup Label="ServiceControl compatibility transient dependencies">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.ASQ/ServiceControl.Transports.ASQ.csproj
+++ b/src/ServiceControl.Transports.ASQ/ServiceControl.Transports.ASQ.csproj
@@ -13,12 +13,12 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="10.0.3" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.Learning/ServiceControl.Transports.Learning.csproj
+++ b/src/ServiceControl.Transports.Learning/ServiceControl.Transports.Learning.csproj
@@ -7,9 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
-  </ItemGroup>
-
 </Project>

--- a/src/ServiceControl.Transports.Msmq/ServiceControl.Transports.Msmq.csproj
+++ b/src/ServiceControl.Transports.Msmq/ServiceControl.Transports.Msmq.csproj
@@ -10,8 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.2.0" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />    
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.RabbitMQ/ServiceControl.Transports.RabbitMQ.csproj
+++ b/src/ServiceControl.Transports.RabbitMQ/ServiceControl.Transports.RabbitMQ.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus.RabbitMQ" Version="6.1.1" />
-    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.SQS/ServiceControl.Transports.SQS.csproj
+++ b/src/ServiceControl.Transports.SQS/ServiceControl.Transports.SQS.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.AmazonSQS" Version="5.4.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.SqlServer/ServiceControl.Transports.SqlServer.csproj
+++ b/src/ServiceControl.Transports.SqlServer/ServiceControl.Transports.SqlServer.csproj
@@ -11,8 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.2" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI" Version="3.0.0" />
-    <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.3.2" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.3.2" />    
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports/ServiceControl.Transports.csproj
+++ b/src/ServiceControl.Transports/ServiceControl.Transports.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="NServiceBus.Raw" Version="3.2.4" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -26,10 +26,8 @@
     <PackageReference Include="ByteSize" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
-    <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.15" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.15" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.15" />
+    <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />    
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
     <PackageReference Include="RavenDB.Database" Version="3.5.10-patch-35311" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="NServiceBus" Version="7.5.0" />
@@ -51,8 +49,7 @@
     <PackageReference Include="Particular.Licensing.Sources" Version="3.6.0" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -13,8 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetZip" Version="1.15.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="5.0.1" />
+    <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TransitiveDependencies.Build.props
+++ b/src/TransitiveDependencies.Build.props
@@ -1,9 +1,8 @@
 <Project>
 
   <ItemGroup Label="Transitive dependency that needs to be identical to the one used in ServiceControl-*">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Changes in order to bump Microsoft.Extensions.Hosting.WindowsServices from 3.1.15 to 6.0.0 - dependabot PR https://github.com/Particular/ServiceControl/pull/2682/files