### PR TITLE
Fix queue length monitoring when using Queue Name Prefix

### DIFF
--- a/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointSQSTransport.cs
+++ b/src/ServiceControl.AcceptanceTesting/InfrastructureConfig/ConfigureEndpointSQSTransport.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTesting.InfrastructureConfig
 {
     using System;
+    using System.Data.Common;
     using System.Threading.Tasks;
     using Amazon.Runtime;
     using Amazon.S3;
@@ -27,6 +28,20 @@
             {
                 var s3Configuration = transportConfig.S3(S3BucketName, S3Prefix);
                 s3Configuration.ClientFactory(CreateS3Client);
+            }
+
+            if (string.IsNullOrWhiteSpace(ConnectionString) == false)
+            {
+                var builder = new DbConnectionStringBuilder { ConnectionString = ConnectionString };
+
+                if (builder.TryGetValue("QueueNamePrefix", out var queueNamePrefix))
+                {
+                    var queueNamePrefixAsString = (string)queueNamePrefix;
+                    if (!string.IsNullOrEmpty(queueNamePrefixAsString))
+                    {
+                        transportConfig.QueueNamePrefix(queueNamePrefixAsString);
+                    }
+                }
             }
 
             return Task.FromResult(0);

--- a/src/ServiceControl.Transports.SQS/QueueNameHelper.cs
+++ b/src/ServiceControl.Transports.SQS/QueueNameHelper.cs
@@ -14,7 +14,11 @@
                 throw new ArgumentNullException(nameof(queue));
             }
 
-            var s = queueNamePrefix + queue;
+            var s = queue;
+            if (!string.IsNullOrWhiteSpace(queueNamePrefix) && !s.StartsWith(queueNamePrefix))
+            {
+                s = queueNamePrefix + queue;
+            }
 
             if (s.Length > 80)
             {


### PR DESCRIPTION
Fixes #2712 

Checks to see if a queue name already includes a prefix before adding it.

NOTE: This change allows the build server to run the tests with a queue name prefix