### PR TITLE
Allow Web Sockets for ASBS

### DIFF
--- a/src/ServiceControl.Transports.ASBS/ASBSTransportCustomization.cs
+++ b/src/ServiceControl.Transports.ASBS/ASBSTransportCustomization.cs
@@ -1,6 +1,8 @@
 ﻿namespace ServiceControl.Transports.ASBS
 {
+    using System;
     using System.Data.Common;
+    using Azure.Messaging.ServiceBus;
     using NServiceBus;
     using NServiceBus.Raw;
 
@@ -84,8 +86,14 @@
             {
                 transport.TopicName((string)topicName);
             }
+
+            if (builder.TryGetValue(TransportTypePart, out var transportTypeString) && Enum.TryParse((string)transportTypeString, true, out ServiceBusTransportType transportType) && transportType == ServiceBusTransportType.AmqpWebSockets)
+            {
+                transport.UseWebSockets();
+            }
         }
 
         static string TopicNamePart = "TopicName";
+        static string TransportTypePart = "TransportType";
     }
 }


### PR DESCRIPTION
Fix to allow WebSockets to be used.  Before upgrading to Azure.Messaging.Servicebus this could be setup via the connection string.
Continue to use the values in the connection string to setup the web socket connection if required.  

This resolves #2721