### PR TITLE
Use Microsoft.Data.SqlClient for Sql Connection String Validation

### DIFF
--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetZip" Version="1.16.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
     <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/src/ServiceControlInstaller.Engine/Validation/ConnectionStringValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/ConnectionStringValidator.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Data.Common;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Linq;
     using Accounts;
     using Instances;


### PR DESCRIPTION
To install instances with ServiceControl Management and/or the PowerShell modules using an Azure Active Directory identity to configure the connection string for the Sql Transport.

If it's not desirable to add this dependency in this place, there are probably other ways it could be managed, but if connecting to the database from this library is the desired method of validation, this is the shortest path.

This doesn't seem it should impact any of the existing tests, but getting the tests running on my machine seems it would take setting up dependencies in a way that was going to take more cycles than I wanted in the moment. I didn't add any test for this here. It's not obvious to me what that would like like with trying to test Azure in the contexts the tests run, so will leave that for something to talk about here if it's necessary/desirable.

This resolves #2767 