### PR TITLE
Remove the IsDebugEnabled check from audit expiration

### DIFF
--- a/src/ServiceControl.Audit/Auditing/BodyStorage/BodyStorageFeature.cs
+++ b/src/ServiceControl.Audit/Auditing/BodyStorage/BodyStorageFeature.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceControl.Audit.Auditing.BodyStorage
 {
-    using System;
     using System.Collections.Generic;
     using System.Text;
     using System.Threading.Tasks;

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/EmbeddedRavenDbHostedService.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/EmbeddedRavenDbHostedService.cs
@@ -57,6 +57,5 @@
         }
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(EmbeddedRavenDbHostedService));
-
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
@@ -86,16 +86,10 @@
 
             var deletedAuditDocuments = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Batching deletion of {s}-{e} audit documents.");
-                }
+                logger.Debug($"Batching deletion of {s}-{e} audit documents.");
 
                 var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Batching deletion of {s}-{e} audit documents completed.");
-                }
+                logger.Debug($"Batching deletion of {s}-{e} audit documents completed.");
 
                 return results.Count(x => x.Deleted == true);
             }, items, database, cancellationToken);
@@ -103,10 +97,7 @@
             var deletedAttachments = Chunker.ExecuteInChunks(attachments.Count, (att, db, s, e) =>
             {
                 var deleted = 0;
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Batching deletion of {s}-{e} attachment audit documents.");
-                }
+                logger.Debug($"Batching deletion of {s}-{e} attachment audit documents.");
 
                 db.TransactionalStorage.Batch(accessor =>
                 {
@@ -119,27 +110,18 @@
                         deleted++;
                     }
                 });
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Batching deletion of {s}-{e} attachment audit documents completed.");
-                }
+                logger.Debug($"Batching deletion of {s}-{e} attachment audit documents completed.");
 
                 return deleted;
             }, attachments, database, cancellationToken);
 
             if (deletedAttachments + deletedAuditDocuments == 0)
             {
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug("No expired audit documents found");
-                }
+                logger.Debug("No expired audit documents found");
             }
             else
             {
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Deleted {deletedAuditDocuments} expired audit documents and {deletedAttachments} message body attachments. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
-                }
+                logger.Debug($"Deleted {deletedAuditDocuments} expired audit documents and {deletedAttachments} message body attachments. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
             }
         }
 

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
@@ -15,7 +15,7 @@
         {
             var threshold = SystemTime.UtcNow.Add(-settings.AuditRetentionPeriod);
 
-            logger.DebugFormat("Trying to find expired ProcessedMessage, SagaHistory and KnownEndpoint documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+            logger.Debug($"Trying to find expired ProcessedMessage, SagaHistory and KnownEndpoint documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
             AuditMessageCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
             KnownEndpointsCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
             SagaHistoryCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
@@ -3,8 +3,8 @@
     using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
+    using NServiceBus.Logging;
     using Raven.Abstractions;
-    using Raven.Abstractions.Logging;
     using Raven.Database;
     using ServiceControl.SagaAudit;
     using Settings;
@@ -15,7 +15,7 @@
         {
             var threshold = SystemTime.UtcNow.Add(-settings.AuditRetentionPeriod);
 
-            logger.Debug("Trying to find expired ProcessedMessage, SagaHistory and KnownEndpoint documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+            logger.DebugFormat("Trying to find expired ProcessedMessage, SagaHistory and KnownEndpoint documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
             AuditMessageCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
             KnownEndpointsCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
             SagaHistoryCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
@@ -3,7 +3,7 @@
     using System;
     using System.ComponentModel.Composition;
     using System.Threading.Tasks;
-    using Raven.Abstractions.Logging;
+    using NServiceBus.Logging;
     using Raven.Database;
     using Raven.Database.Plugins;
 
@@ -50,12 +50,12 @@
             var due = TimeSpan.FromSeconds(deleteFrequencyInSeconds);
             var deletionBatchSize = RavenBootstrapper.Settings.ExpirationProcessBatchSize;
 
-            logger.Info("Running deletion of expired documents every {0} seconds", deleteFrequencyInSeconds);
-            logger.Info("Deletion batch size set to {0}", deletionBatchSize);
-            logger.Info("Retention period for audits and saga history is {0}", RavenBootstrapper.Settings.AuditRetentionPeriod);
+            logger.InfoFormat("Running deletion of expired documents every {0} seconds", deleteFrequencyInSeconds);
+            logger.InfoFormat("Deletion batch size set to {0}", deletionBatchSize);
+            logger.InfoFormat("Retention period for audits and saga history is {0}", RavenBootstrapper.Settings.AuditRetentionPeriod);
 
             timer = new AsyncTimer(
-                token => ExpiredDocumentsCleaner.RunCleanup(deletionBatchSize, database, RavenBootstrapper.Settings, token), due, due, e => { logger.ErrorException("Error when trying to find expired documents", e); });
+                token => ExpiredDocumentsCleaner.RunCleanup(deletionBatchSize, database, RavenBootstrapper.Settings, token), due, due, e => { logger.Error("Error when trying to find expired documents", e); });
         }
 
         ILog logger = LogManager.GetLogger(typeof(ExpiredDocumentsCleanerBundle));

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
@@ -50,9 +50,9 @@
             var due = TimeSpan.FromSeconds(deleteFrequencyInSeconds);
             var deletionBatchSize = RavenBootstrapper.Settings.ExpirationProcessBatchSize;
 
-            logger.InfoFormat("Running deletion of expired documents every {0} seconds", deleteFrequencyInSeconds);
-            logger.InfoFormat("Deletion batch size set to {0}", deletionBatchSize);
-            logger.InfoFormat("Retention period for audits and saga history is {0}", RavenBootstrapper.Settings.AuditRetentionPeriod);
+            logger.Info($"Running deletion of expired documents every {deleteFrequencyInSeconds} seconds");
+            logger.Info($"Deletion batch size set to {deletionBatchSize}");
+            logger.Info($"Retention period for audits and saga history is {RavenBootstrapper.Settings.AuditRetentionPeriod}");
 
             timer = new AsyncTimer(
                 token => ExpiredDocumentsCleaner.RunCleanup(deletionBatchSize, database, RavenBootstrapper.Settings, token), due, due, e => { logger.Error("Error when trying to find expired documents", e); });

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/KnownEndpointsCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/KnownEndpointsCleaner.cs
@@ -77,16 +77,10 @@
 
             var deleteKnownEndpointDocuments = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Batching deletion of {s}-{e} known endpoint documents.");
-                }
+                logger.Debug($"Batching deletion of {s}-{e} known endpoint documents.");
 
                 var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Batching deletion of {s}-{e} known endpoint documents completed.");
-                }
+                logger.Debug($"Batching deletion of {s}-{e} known endpoint documents completed.");
 
                 return results.Count(x => x.Deleted == true);
             }, items, database, cancellationToken);
@@ -94,17 +88,11 @@
 
             if (deleteKnownEndpointDocuments == 0)
             {
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug("No expired known endpoints documents found");
-                }
+                logger.Debug("No expired known endpoints documents found");
             }
             else
             {
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Deleted {deleteKnownEndpointDocuments} expired known endpoint documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
-                }
+                logger.Debug($"Deleted {deleteKnownEndpointDocuments} expired known endpoint documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
             }
         }
 

--- a/src/ServiceControl.SagaAudit/SagaHistoryCleaner.cs
+++ b/src/ServiceControl.SagaAudit/SagaHistoryCleaner.cs
@@ -77,33 +77,21 @@
 
             var deletionCount = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Batching deletion of {s}-{e} saga history documents.");
-                }
+                logger.Debug($"Batching deletion of {s}-{e} saga history documents.");
 
                 var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Batching deletion of {s}-{e} saga history documents completed.");
-                }
+                logger.Debug($"Batching deletion of {s}-{e} saga history documents completed.");
 
                 return results.Count(x => x.Deleted == true);
             }, items, database, cancellationToken);
 
             if (deletionCount == 0)
             {
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug("No expired saga history documents found");
-                }
+                logger.Debug("No expired saga history documents found");
             }
             else
             {
-                if (logger.IsDebugEnabled)
-                {
-                    logger.Debug($"Deleted {deletionCount} expired saga history documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
-                }
+                logger.Debug($"Deleted {deletionCount} expired saga history documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
             }
         }
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
@@ -16,19 +16,19 @@
         {
             var threshold = SystemTime.UtcNow.Add(-settings.ErrorRetentionPeriod);
 
-            logger.DebugFormat("Trying to find expired FailedMessage documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+            logger.Debug($"Trying to find expired FailedMessage documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
             ErrorMessageCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
 
             threshold = SystemTime.UtcNow.Add(-settings.EventsRetentionPeriod);
 
-            logger.DebugFormat("Trying to find expired EventLogItem documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+            logger.Debug($"Trying to find expired EventLogItem documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
             EventLogItemsCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
 
             if (settings.AuditRetentionPeriod.HasValue)
             {
                 threshold = SystemTime.UtcNow.Add(-settings.AuditRetentionPeriod.Value);
 
-                logger.DebugFormat("Trying to find expired ProcessedMessage and SagaHistory documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+                logger.Debug($"Trying to find expired ProcessedMessage and SagaHistory documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
                 AuditMessageCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
                 SagaHistoryCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
             }

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
@@ -4,8 +4,8 @@
     using System.Threading;
     using System.Threading.Tasks;
     using BackgroundTasks;
+    using NServiceBus.Logging;
     using Raven.Abstractions;
-    using Raven.Abstractions.Logging;
     using Raven.Database;
     using SagaAudit;
     using ServiceBus.Management.Infrastructure.Settings;
@@ -16,19 +16,19 @@
         {
             var threshold = SystemTime.UtcNow.Add(-settings.ErrorRetentionPeriod);
 
-            logger.Debug("Trying to find expired FailedMessage documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+            logger.DebugFormat("Trying to find expired FailedMessage documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
             ErrorMessageCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
 
             threshold = SystemTime.UtcNow.Add(-settings.EventsRetentionPeriod);
 
-            logger.Debug("Trying to find expired EventLogItem documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+            logger.DebugFormat("Trying to find expired EventLogItem documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
             EventLogItemsCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
 
             if (settings.AuditRetentionPeriod.HasValue)
             {
                 threshold = SystemTime.UtcNow.Add(-settings.AuditRetentionPeriod.Value);
 
-                logger.Debug("Trying to find expired ProcessedMessage and SagaHistory documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
+                logger.DebugFormat("Trying to find expired ProcessedMessage and SagaHistory documents to delete (with threshold {0})", threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture));
                 AuditMessageCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
                 SagaHistoryCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
             }

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
@@ -51,9 +51,9 @@
             var due = TimeSpan.FromSeconds(deleteFrequencyInSeconds);
             var deletionBatchSize = RavenBootstrapper.Settings.ExpirationProcessBatchSize;
 
-            logger.InfoFormat("Running deletion of expired documents every {0} seconds", deleteFrequencyInSeconds);
-            logger.InfoFormat("Deletion batch size set to {0}", deletionBatchSize);
-            logger.InfoFormat("Retention period for errors is {0}", RavenBootstrapper.Settings.ErrorRetentionPeriod);
+            logger.Info($"Running deletion of expired documents every {deleteFrequencyInSeconds} seconds");
+            logger.Info($"Deletion batch size set to {deletionBatchSize}");
+            logger.Info($"Retention period for errors is {RavenBootstrapper.Settings.ErrorRetentionPeriod}");
 
             var auditRetention = RavenBootstrapper.Settings.AuditRetentionPeriod;
 

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleanerBundle.cs
@@ -4,7 +4,7 @@
     using System.ComponentModel.Composition;
     using System.Threading.Tasks;
     using BackgroundTasks;
-    using Raven.Abstractions.Logging;
+    using NServiceBus.Logging;
     using Raven.Database;
     using Raven.Database.Plugins;
 
@@ -51,19 +51,19 @@
             var due = TimeSpan.FromSeconds(deleteFrequencyInSeconds);
             var deletionBatchSize = RavenBootstrapper.Settings.ExpirationProcessBatchSize;
 
-            logger.Info("Running deletion of expired documents every {0} seconds", deleteFrequencyInSeconds);
-            logger.Info("Deletion batch size set to {0}", deletionBatchSize);
-            logger.Info("Retention period for errors is {0}", RavenBootstrapper.Settings.ErrorRetentionPeriod);
+            logger.InfoFormat("Running deletion of expired documents every {0} seconds", deleteFrequencyInSeconds);
+            logger.InfoFormat("Deletion batch size set to {0}", deletionBatchSize);
+            logger.InfoFormat("Retention period for errors is {0}", RavenBootstrapper.Settings.ErrorRetentionPeriod);
 
             var auditRetention = RavenBootstrapper.Settings.AuditRetentionPeriod;
 
             if (auditRetention.HasValue)
             {
-                logger.Info("Retention period for audits and saga history is {0}", RavenBootstrapper.Settings.AuditRetentionPeriod);
+                logger.InfoFormat("Retention period for audits and saga history is {0}", RavenBootstrapper.Settings.AuditRetentionPeriod);
             }
 
             timer = new TimerJob(
-                token => ExpiredDocumentsCleaner.RunCleanup(deletionBatchSize, database, RavenBootstrapper.Settings, token), due, due, e => { logger.ErrorException("Error when trying to find expired documents", e); });
+                token => ExpiredDocumentsCleaner.RunCleanup(deletionBatchSize, database, RavenBootstrapper.Settings, token), due, due, e => { logger.Error("Error when trying to find expired documents", e); });
         }
 
         ILog logger = LogManager.GetLogger(typeof(ExpiredDocumentsCleanerBundle));


### PR DESCRIPTION
`IsDebugEnabled` appears to be incorrectly set to `false` possibly due to caching of the value in [core](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Logging/DefaultLoggerFactory.cs#L31-L35). This makes it impossible to get insight into the expiration cleanup process.

This PR removes the `IsDebugEnabled` check from the expiration process. This process is not on the hot path for ingestion so skipping the check here should not incur a major performance penalty.