### PR TITLE
ReAdd IsDebugEnabled check for logging

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -59,6 +59,7 @@ namespace ServiceControl.Audit.Infrastructure
                     builder.ClearProviders();
                     //HINT: configuration used by NLog comes from LoggingConfigurator.cs
                     builder.AddNLog();
+                    builder.SetMinimumLevel(loggingSettings.ToHostLogLevel());
                 })
                 .UseServiceProviderFactory(new AutofacServiceProviderFactory())
                 .ConfigureServices(services =>

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/AuditMessageCleaner.cs
@@ -86,10 +86,16 @@
 
             var deletedAuditDocuments = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
-                logger.Debug($"Batching deletion of {s}-{e} audit documents.");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} audit documents.");
+                }
 
                 var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
-                logger.Debug($"Batching deletion of {s}-{e} audit documents completed.");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} audit documents completed.");
+                }
 
                 return results.Count(x => x.Deleted == true);
             }, items, database, cancellationToken);
@@ -97,7 +103,10 @@
             var deletedAttachments = Chunker.ExecuteInChunks(attachments.Count, (att, db, s, e) =>
             {
                 var deleted = 0;
-                logger.Debug($"Batching deletion of {s}-{e} attachment audit documents.");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} attachment audit documents.");
+                }
 
                 db.TransactionalStorage.Batch(accessor =>
                 {
@@ -110,18 +119,27 @@
                         deleted++;
                     }
                 });
-                logger.Debug($"Batching deletion of {s}-{e} attachment audit documents completed.");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} attachment audit documents completed.");
+                }
 
                 return deleted;
             }, attachments, database, cancellationToken);
 
             if (deletedAttachments + deletedAuditDocuments == 0)
             {
-                logger.Debug("No expired audit documents found");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug("No expired audit documents found");
+                }
             }
             else
             {
-                logger.Debug($"Deleted {deletedAuditDocuments} expired audit documents and {deletedAttachments} message body attachments. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Deleted {deletedAuditDocuments} expired audit documents and {deletedAttachments} message body attachments. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                }
             }
         }
 

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
@@ -15,7 +15,10 @@
         {
             var threshold = SystemTime.UtcNow.Add(-settings.AuditRetentionPeriod);
 
-            logger.Debug($"Trying to find expired ProcessedMessage, SagaHistory and KnownEndpoint documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
+            if (logger.IsDebugEnabled)
+            {
+                logger.Debug($"Trying to find expired ProcessedMessage, SagaHistory and KnownEndpoint documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
+            }
             AuditMessageCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
             KnownEndpointsCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
             SagaHistoryCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);

--- a/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/KnownEndpointsCleaner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/RavenDB/Expiration/KnownEndpointsCleaner.cs
@@ -77,10 +77,16 @@
 
             var deleteKnownEndpointDocuments = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
-                logger.Debug($"Batching deletion of {s}-{e} known endpoint documents.");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} known endpoint documents.");
+                }
 
                 var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
-                logger.Debug($"Batching deletion of {s}-{e} known endpoint documents completed.");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} known endpoint documents completed.");
+                }
 
                 return results.Count(x => x.Deleted == true);
             }, items, database, cancellationToken);
@@ -88,11 +94,17 @@
 
             if (deleteKnownEndpointDocuments == 0)
             {
-                logger.Debug("No expired known endpoints documents found");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug("No expired known endpoints documents found");
+                }
             }
             else
             {
-                logger.Debug($"Deleted {deleteKnownEndpointDocuments} expired known endpoint documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Deleted {deleteKnownEndpointDocuments} expired known endpoint documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                }
             }
         }
 

--- a/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
@@ -51,5 +51,35 @@ namespace ServiceControl.Audit.Infrastructure.Settings
 
             return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"Particular\\{serviceName}\\logs");
         }
+
+        public Microsoft.Extensions.Logging.LogLevel ToHostLogLevel()
+        {
+            if (LoggingLevel == LogLevel.Debug)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Debug;
+            }
+            if (LoggingLevel == LogLevel.Error)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Error;
+            }
+            if (LoggingLevel == LogLevel.Fatal)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Critical;
+            }
+            if (LoggingLevel == LogLevel.Warn)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Warning;
+            }
+            if (LoggingLevel == LogLevel.Info)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Information;
+            }
+            if (LoggingLevel == LogLevel.Trace)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Trace;
+            }
+
+            return Microsoft.Extensions.Logging.LogLevel.None;
+        }
     }
 }

--- a/src/ServiceControl.SagaAudit/SagaHistoryCleaner.cs
+++ b/src/ServiceControl.SagaAudit/SagaHistoryCleaner.cs
@@ -77,21 +77,33 @@
 
             var deletionCount = Chunker.ExecuteInChunks(items.Count, (itemsForBatch, db, s, e) =>
             {
-                logger.Debug($"Batching deletion of {s}-{e} saga history documents.");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} saga history documents.");
+                }
 
                 var results = db.Batch(itemsForBatch.GetRange(s, e - s + 1), CancellationToken.None);
-                logger.Debug($"Batching deletion of {s}-{e} saga history documents completed.");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Batching deletion of {s}-{e} saga history documents completed.");
+                }
 
                 return results.Count(x => x.Deleted == true);
             }, items, database, cancellationToken);
 
             if (deletionCount == 0)
             {
-                logger.Debug("No expired saga history documents found");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug("No expired saga history documents found");
+                }
             }
             else
             {
-                logger.Debug($"Deleted {deletionCount} expired saga history documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Deleted {deletionCount} expired saga history documents. Batch execution took {stopwatch.ElapsedMilliseconds} ms");
+                }
             }
         }
 

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -100,6 +100,7 @@ namespace Particular.ServiceControl
                     builder.ClearProviders();
                     //HINT: configuration used by NLog comes from LoggingConfigurator.cs
                     builder.AddNLog();
+                    builder.SetMinimumLevel(loggingSettings.ToHostLogLevel());
                 })
                 .UseServiceProviderFactory(new AutofacServiceProviderFactory())
                 .ConfigureServices(services =>

--- a/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/ServiceControl/Infrastructure/RavenDB/Expiration/ExpiredDocumentsCleaner.cs
@@ -16,19 +16,28 @@
         {
             var threshold = SystemTime.UtcNow.Add(-settings.ErrorRetentionPeriod);
 
-            logger.Debug($"Trying to find expired FailedMessage documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
+            if (logger.IsDebugEnabled)
+            {
+                logger.Debug($"Trying to find expired FailedMessage documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
+            }
             ErrorMessageCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
 
             threshold = SystemTime.UtcNow.Add(-settings.EventsRetentionPeriod);
 
-            logger.Debug($"Trying to find expired EventLogItem documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
+            if (logger.IsDebugEnabled)
+            {
+                logger.Debug($"Trying to find expired EventLogItem documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
+            }
             EventLogItemsCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
 
             if (settings.AuditRetentionPeriod.HasValue)
             {
                 threshold = SystemTime.UtcNow.Add(-settings.AuditRetentionPeriod.Value);
 
-                logger.Debug($"Trying to find expired ProcessedMessage and SagaHistory documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
+                if (logger.IsDebugEnabled)
+                {
+                    logger.Debug($"Trying to find expired ProcessedMessage and SagaHistory documents to delete (with threshold {threshold.ToString(Default.DateTimeFormatsToWrite, CultureInfo.InvariantCulture)})");
+                }
                 AuditMessageCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
                 SagaHistoryCleaner.Clean(deletionBatchSize, database, threshold, cancellationToken);
             }

--- a/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
@@ -51,5 +51,35 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
             return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"Particular\\{serviceName}\\logs");
         }
+
+        public Microsoft.Extensions.Logging.LogLevel ToHostLogLevel()
+        {
+            if (LoggingLevel == LogLevel.Debug)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Debug;
+            }
+            if (LoggingLevel == LogLevel.Error)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Error;
+            }
+            if (LoggingLevel == LogLevel.Fatal)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Critical;
+            }
+            if (LoggingLevel == LogLevel.Warn)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Warning;
+            }
+            if (LoggingLevel == LogLevel.Info)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Information;
+            }
+            if (LoggingLevel == LogLevel.Trace)
+            {
+                return Microsoft.Extensions.Logging.LogLevel.Trace;
+            }
+
+            return Microsoft.Extensions.Logging.LogLevel.None;
+        }
     }
 }


### PR DESCRIPTION
Re-adds the `IsDebugEnabled` check that was removed in #2775.

The explicit call to `builder.SetMinimumLevel(loggingSettings.ToHostLogLevel());` sets the logging level correctly between the instances of `NServiceBus.Extensions.Hosting.DeferredLogger` and `NServiceBus.Extensions.Hosting.Logger` which means the fix for #2775 is no longer required.