### PR TITLE
Add binding redirect to powershell Cmdlets to fix powershell scripts

### DIFF
--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
@@ -16,6 +16,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             Account.TestIfAdmin();
         }
 

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
@@ -94,6 +94,8 @@
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             if (Transport != TransportNames.MSMQ && string.IsNullOrEmpty(ConnectionString))
             {
                 throw new Exception($"ConnectionString is mandatory for '{Transport}'");

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/RemoveServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/RemoveServiceControlAuditInstance.cs
@@ -1,6 +1,6 @@
 namespace ServiceControlInstaller.PowerShell
 {
-    using System.IO;
+    using System;
     using System.Management.Automation;
     using Engine.Instances;
     using Engine.Unattended;
@@ -20,6 +20,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             Account.TestIfAdmin();
         }
 

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/License/ImportServiceControlLicense.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/License/ImportServiceControlLicense.cs
@@ -15,6 +15,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             Account.TestIfAdmin();
         }
 

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/InvokeMonitoringUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/InvokeMonitoringUpgrade.cs
@@ -1,7 +1,6 @@
 namespace ServiceControlInstaller.PowerShell
 {
     using System;
-    using System.IO;
     using System.Management.Automation;
     using Engine.Instances;
     using Engine.Unattended;
@@ -15,6 +14,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             Account.TestIfAdmin();
         }
 

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
@@ -69,6 +69,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             if (Transport != TransportNames.MSMQ && string.IsNullOrEmpty(ConnectionString))
             {
                 throw new Exception($"ConnectionString is mandatory for '{Transport}'");

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/RemoveMonitoringInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/RemoveMonitoringInstance.cs
@@ -1,6 +1,6 @@
 namespace ServiceControlInstaller.PowerShell
 {
-    using System.IO;
+    using System;
     using System.Management.Automation;
     using Engine.Instances;
     using Engine.Unattended;
@@ -17,6 +17,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             Account.TestIfAdmin();
         }
 

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
@@ -50,6 +50,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             Account.TestIfAdmin();
         }
 

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
@@ -97,6 +97,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             if (Transport != TransportNames.MSMQ && string.IsNullOrEmpty(ConnectionString))
             {
                 throw new Exception($"ConnectionString is mandatory for '{Transport}'");

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/RemoveServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/RemoveServiceControlInstance.cs
@@ -20,6 +20,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             Account.TestIfAdmin();
         }
 

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/UrlAcls/AddUrlAcl.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/UrlAcls/AddUrlAcl.cs
@@ -16,6 +16,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             Account.TestIfAdmin();
         }
 

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/UrlAcls/RemoveUrlAcl.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/UrlAcls/RemoveUrlAcl.cs
@@ -1,5 +1,6 @@
 namespace ServiceControlInstaller.PowerShell
 {
+    using System;
     using System.Management.Automation;
     using Engine.UrlAcl;
 
@@ -12,6 +13,8 @@ namespace ServiceControlInstaller.PowerShell
 
         protected override void BeginProcessing()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
+
             Account.TestIfAdmin();
         }
 

--- a/src/ServiceControlInstaller.PowerShell/Helpers/BindingRedirectAssemblyLoader.cs
+++ b/src/ServiceControlInstaller.PowerShell/Helpers/BindingRedirectAssemblyLoader.cs
@@ -1,0 +1,21 @@
+﻿namespace ServiceControlInstaller.PowerShell
+{
+    using System;
+    using System.Reflection;
+
+    public static class BindingRedirectAssemblyLoader
+    {
+        public static Assembly CurrentDomain_BindingRedirect(object sender, ResolveEventArgs args)
+        {
+            var name = new AssemblyName(args.Name);
+            switch (name.Name)
+            {
+                case "System.Runtime.CompilerServices.Unsafe":
+                    return Assembly.LoadFrom("System.Runtime.CompilerServices.Unsafe.dll");
+
+                default:
+                    return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2780 

Adds a runtime binding redirect. `System.Memory` is attempting to load `System.Runtime.CompilerServices.Unsafe` v4.X.X but we reference `System.Reflection.MetadataLoadContext` V6.0.0 which references `System.Runtime.CompilerServices.Unsafe` v6.X.X which results in a assembly load exception. Within the context of the SCMU installer the binding redirects work correctly, but these binding redirects do not exist within the powershell scripts and thus have to be done explicitly via `AppDomain.CurrentDomain.AssemblyResolve`.

This PR introduces the binding redirect within the powershell cmdlets.

Some details on why the redirects are needed:

1. `System.Reflection.MetadataLoadContext` is used to load the release date of the assemblies
2. `System.Reflection.MetadataLoadContext, Version=6.0.0.0`  attempts to load `System.Memory, Version=4.0.1.1`
3. `System.Memory, Version=4.0.1.1` loads `System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1`
4. `System.Reflection.MetadataLoadContext, Version=6.0.0.0`  loads `System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0`

The different versions conflict, and in a normal application can use binding redirects to resolve the differences. In Powershell scripts, this is harder.

Note that these conflicts happen within the same base assembly `System.Reflection.MetadataLoadContext, Version=6.0.0.0` meaning that we cannot utilize separate [Assembly Load Contexts](https://docs.microsoft.com/en-za/dotnet/api/system.runtime.loader.assemblyloadcontext?view=net-6.0) to work around the conflict.

```
LOG: DisplayName = System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 (Fully-specified)
LOG: Appbase = file:///C:/Windows/system32/WindowsPowerShell/v1.0/
LOG: Initial PrivatePath = NULL
LOG: Dynamic Base = NULL
LOG: Cache Base = NULL
LOG: AppName = powershell.exe
Calling assembly : System.Reflection.MetadataLoadContext, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51.
```

```
LOG: DisplayName = System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 (Fully-specified)
LOG: Appbase = file:///C:/Windows/system32/WindowsPowerShell/v1.0/
LOG: Initial PrivatePath = NULL
LOG: Dynamic Base = NULL
LOG: Cache Base = NULL
LOG: AppName = powershell.exe
Calling assembly : System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51.
```

![image](https://user-images.githubusercontent.com/1060960/152958210-37ddf63a-2eee-401b-b205-ceb4af69a491.png)
