### PR TITLE
Make sure that startup errors for Monitoring are reported to the service controller

### DIFF
--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -3,31 +3,24 @@ namespace ServiceControl.Monitoring
     using System;
     using System.IO;
     using System.Reflection;
+    using System.Threading.Tasks;
 
     static class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
 
-            try
-            {
-                var arguments = new HostArguments(args);
+            var arguments = new HostArguments(args);
 
-                var settings = LoadSettings(arguments);
+            var settings = LoadSettings(arguments);
 
-                var runAsWindowsService = !Environment.UserInteractive && !arguments.Portable;
-                MonitorLogs.Configure(settings, !runAsWindowsService);
+            var runAsWindowsService = !Environment.UserInteractive && !arguments.Portable;
+            MonitorLogs.Configure(settings, !runAsWindowsService);
 
-                var runner = new CommandRunner(arguments.Commands);
-
-                runner.Run(settings).GetAwaiter().GetResult();
-            }
-            catch (Exception exception)
-            {
-                Console.Error.WriteLine(exception);
-                Environment.Exit(-1);
-            }
+            await new CommandRunner(arguments.Commands)
+                .Run(settings)
+                .ConfigureAwait(false);
         }
 
         static Settings LoadSettings(HostArguments args)


### PR DESCRIPTION
To align with the behavior of the other instances.

Fixes https://github.com/Particular/ServiceControl/issues/2749


With this change monitoring instances produces the same logging and entries in the event log on a failed start up as the other instance types

![image](https://user-images.githubusercontent.com/125028/156176938-d408b657-5b1b-4b2b-91e7-f8eedf2dcc1d.png)
