### PR TITLE
Fix embedded resource path for help text file

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
@@ -149,7 +149,7 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
             using (
                 var stream =
                     Assembly.GetCallingAssembly()
-                        .GetManifestResourceStream("ServiceControl.Hosting.Help.txt"))
+                        .GetManifestResourceStream("ServiceControl.Audit.Infrastructure.Hosting.Help.txt"))
             {
                 if (stream != null)
                 {


### PR DESCRIPTION
Currently, using `--help` on the audit instance's executable returns no help text as the path to the embedded resource isn't correct  as the text file is located in a different folder than the file in the primary instance.