### PR TITLE
Change AuditImporter from startup task to hosted service

### DIFF
--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/FailedAuditsController.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/FailedAuditsController.cs
@@ -7,14 +7,12 @@
     using System.Web.Http;
     using Audit.Auditing;
     using Infrastructure.WebApi;
-    using NServiceBus;
     using Raven.Client;
 
     public class FailedAuditsController : ApiController
     {
-        internal FailedAuditsController(IMessageSession bus, IDocumentStore store, AuditIngestionComponent auditIngestion)
+        internal FailedAuditsController(IDocumentStore store, AuditIngestionComponent auditIngestion)
         {
-            this.bus = bus;
             this.store = store;
             this.auditIngestion = auditIngestion;
         }
@@ -43,11 +41,10 @@
         public async Task<HttpResponseMessage> ImportFailedAudits(CancellationToken cancellationToken = default)
         {
             var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            await auditIngestion.ImportFailedAudits(bus, tokenSource.Token);
+            await auditIngestion.ImportFailedAudits(tokenSource.Token);
             return Request.CreateResponse(HttpStatusCode.OK);
         }
 
-        readonly IMessageSession bus;
         readonly IDocumentStore store;
         readonly AuditIngestionComponent auditIngestion;
     }

--- a/src/ServiceControl.Audit/Auditing/AuditImporter.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditImporter.cs
@@ -1,51 +1,24 @@
 ﻿namespace ServiceControl.Audit.Auditing
 {
+    using System.Threading;
     using System.Threading.Tasks;
-    using Infrastructure.Settings;
+    using Microsoft.Extensions.Hosting;
     using NServiceBus;
-    using NServiceBus.Features;
-    using NServiceBus.Transport;
 
-    class AuditImporter : Feature
+
+    class AuditImporter : IHostedService
     {
-        public AuditImporter()
+        readonly AuditIngestionComponent auditIngestion;
+        readonly IMessageSession messageSession;
+
+        public AuditImporter(AuditIngestionComponent auditIngestion, IMessageSession messageSession)
         {
-            EnableByDefault();
-            Prerequisite(c =>
-            {
-                var settings = c.Settings.Get<Settings>("ServiceControl.Settings");
-                return settings.IngestAuditMessages;
-            }, "Ingestion of audit messages has been disabled.");
+            this.auditIngestion = auditIngestion;
+            this.messageSession = messageSession;
         }
 
-        protected override void Setup(FeatureConfigurationContext context)
-        {
-            var settings = context.Settings.Get<Settings>("ServiceControl.Settings");
+        public Task StartAsync(CancellationToken cancellationToken) => auditIngestion.Start(messageSession);
 
-            var queueBindings = context.Settings.Get<QueueBindings>();
-            queueBindings.BindReceiving(settings.AuditQueue);
-
-            context.RegisterStartupTask(b => new StartupTask(b.Build<AuditIngestionComponent>()));
-        }
-
-        class StartupTask : FeatureStartupTask
-        {
-            readonly AuditIngestionComponent auditIngestion;
-
-            public StartupTask(AuditIngestionComponent auditIngestion)
-            {
-                this.auditIngestion = auditIngestion;
-            }
-
-            protected override Task OnStart(IMessageSession session)
-            {
-                return auditIngestion.Start(session);
-            }
-
-            protected override Task OnStop(IMessageSession session)
-            {
-                return auditIngestion.Stop();
-            }
-        }
+        public Task StopAsync(CancellationToken cancellationToken) => auditIngestion.Stop();
     }
 }

--- a/src/ServiceControl.Audit/Auditing/AuditImporter.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditImporter.cs
@@ -3,21 +3,17 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Hosting;
-    using NServiceBus;
-
 
     class AuditImporter : IHostedService
     {
         readonly AuditIngestionComponent auditIngestion;
-        readonly IMessageSession messageSession;
 
-        public AuditImporter(AuditIngestionComponent auditIngestion, IMessageSession messageSession)
+        public AuditImporter(AuditIngestionComponent auditIngestion)
         {
             this.auditIngestion = auditIngestion;
-            this.messageSession = messageSession;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken) => auditIngestion.Start(messageSession);
+        public Task StartAsync(CancellationToken cancellationToken) => auditIngestion.Start();
 
         public Task StopAsync(CancellationToken cancellationToken) => auditIngestion.Stop();
     }

--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -23,8 +23,10 @@
 
     class AuditPersister
     {
-        public AuditPersister(IDocumentStore store, BodyStorageEnricher bodyStorageEnricher, IEnrichImportedAuditMessages[] enrichers,
-            Counter ingestedAuditMeter, Counter ingestedSagaAuditMeter, Meter auditBulkInsertDurationMeter, Meter sagaAuditBulkInsertDurationMeter, Meter bulkInsertCommitDurationMeter)
+        public AuditPersister(IDocumentStore store, BodyStorageEnricher bodyStorageEnricher,
+            IEnrichImportedAuditMessages[] enrichers,
+            Counter ingestedAuditMeter, Counter ingestedSagaAuditMeter, Meter auditBulkInsertDurationMeter,
+            Meter sagaAuditBulkInsertDurationMeter, Meter bulkInsertCommitDurationMeter, IMessageSession messageSession)
         {
             this.store = store;
             this.bodyStorageEnricher = bodyStorageEnricher;
@@ -35,10 +37,6 @@
             this.auditBulkInsertDurationMeter = auditBulkInsertDurationMeter;
             this.sagaAuditBulkInsertDurationMeter = sagaAuditBulkInsertDurationMeter;
             this.bulkInsertCommitDurationMeter = bulkInsertCommitDurationMeter;
-        }
-
-        public void Initialize(IMessageSession messageSession)
-        {
             this.messageSession = messageSession;
         }
 
@@ -325,12 +323,12 @@
         readonly Meter auditBulkInsertDurationMeter;
         readonly Meter sagaAuditBulkInsertDurationMeter;
         readonly Meter bulkInsertCommitDurationMeter;
+        readonly IMessageSession messageSession;
 
         readonly JsonSerializer sagaAuditSerializer = new JsonSerializer();
         readonly IEnrichImportedAuditMessages[] enrichers;
         readonly IDocumentStore store;
         readonly BodyStorageEnricher bodyStorageEnricher;
-        IMessageSession messageSession;
         static readonly ILog Logger = LogManager.GetLogger<AuditPersister>();
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -97,6 +97,14 @@ namespace ServiceControl.Audit.Infrastructure
 
                     return configuration;
                 })
+                .ConfigureServices(services =>
+                {
+                    // Configure after the NServiceBus hosted service
+                    if (settings.IngestAuditMessages)
+                    {
+                        services.AddHostedService<AuditImporter>();
+                    }
+                })
                 .UseWebApi(settings.RootUrl, settings.ExposeApi);
         }
 

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
@@ -31,13 +31,12 @@
                 await host.StartAsync(tokenSource.Token).ConfigureAwait(false);
 
                 var importer = host.Services.GetRequiredService<AuditIngestionComponent>();
-                var session = host.Services.GetRequiredService<IMessageSession>();
 
                 Console.CancelKeyPress += (sender, eventArgs) => { tokenSource.Cancel(); };
 
                 try
                 {
-                    await importer.ImportFailedAudits(session, tokenSource.Token).ConfigureAwait(false);
+                    await importer.ImportFailedAudits(tokenSource.Token).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {


### PR DESCRIPTION
Converts the `AuditImporter` `FeatureStartupTask` to a `IHostedService` so that the generic host is handling the lifetime of the ingestion process and not the NServiceBus endpoint.