### PR TITLE
Split ingestion transport from SC transport

### DIFF
--- a/src/ServiceControl.Audit/Auditing/AuditIngestionComponent.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestionComponent.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Audit.Auditing
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
@@ -32,8 +33,8 @@
             RawEndpointFactory rawEndpointFactory,
             EndpointInstanceMonitoring endpointInstanceMonitoring,
             IEnumerable<IEnrichImportedAuditMessages> auditEnrichers, // allows extending message enrichers with custom enrichers registered in the DI container
-            IMessageSession messageSession
-        )
+            IMessageSession messageSession,
+            IServiceProvider serviceProvider)
         {
             var ingestedAuditMeter = metrics.GetCounter("Audit ingestion - ingested audit");
             var ingestedSagaAuditMeter = metrics.GetCounter("Audit ingestion - ingested saga audit");
@@ -52,7 +53,7 @@
             }.Concat(auditEnrichers).ToArray();
 
             var bodyStorageEnricher = new BodyStorageEnricher(bodyStorage, settings);
-            auditPersister = new AuditPersister(documentStore, bodyStorageEnricher, enrichers, ingestedAuditMeter, ingestedSagaAuditMeter, auditBulkInsertDurationMeter, sagaAuditBulkInsertDurationMeter, bulkInsertCommitDurationMeter, messageSession);
+            auditPersister = new AuditPersister(documentStore, bodyStorageEnricher, enrichers, ingestedAuditMeter, ingestedSagaAuditMeter, auditBulkInsertDurationMeter, sagaAuditBulkInsertDurationMeter, bulkInsertCommitDurationMeter, messageSession, serviceProvider);
             Ingestor = new AuditIngestor(auditPersister, settings);
 
             failedImporter = new ImportFailedAudits(documentStore, Ingestor, rawEndpointFactory);

--- a/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
@@ -24,7 +24,7 @@
                 log.Debug($"Ingesting {contexts.Count} message contexts");
             }
 
-            var stored = await auditPersister.Persist(contexts, dispatcher).ConfigureAwait(false);
+            var stored = await auditPersister.Persist(contexts).ConfigureAwait(false);
 
             try
             {


### PR DESCRIPTION
The `AuditPersister` used both the full NServiceBus endpoint's `IMessageSession` as well as the raw transport's `IDispatchMessages` to send messages. Since there is no need to float the raw transport dispatcher to the persisted, it can use the dispatcher from the NServiceBus endpoint instead to further split the transport usage from the "queue ingestion logic", using the raw transport, and the "audit processing logic", using the NServiceBus endpoint (which could technically use a different transport).

Since the `IDispatchMessages` cannot be resolved directly via DI until the NServiceBus endpoint has been fully started (a limit that NSB handles with a wrapper class for the `IMessageSession`), the dispatcher needs to be resolved at "runtime".