### PR TITLE
Adding a smart mechanism to not do rest requests to audit instances if down

### DIFF
--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -38,6 +38,8 @@ namespace ServiceBus.Management.Infrastructure.Settings
         [Newtonsoft.Json.JsonIgnore]
         public System.Uri ApiAsUri { get; }
         public string ApiUri { get; set; }
+        [Newtonsoft.Json.JsonIgnore]
+        public bool TemporarilyUnavailable { get; set; }
     }
     public class Settings
     {

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
@@ -123,7 +123,7 @@ namespace ServiceControl.CompositeViews.Messages
             catch (HttpRequestException httpRequestException)
             {
                 DisableRemoteInstance(remoteUri);
-                logger.Warn($"Failed with HttpRequestException to query remote instance at {remoteUri}. The instance at uri: {remoteUri} will be temporarily disabled.", httpRequestException);
+                logger.Warn($"An HttpRequestException occurred when quering remote instance at {remoteUri}. The instance at uri: {remoteUri} will be temporarily disabled.", httpRequestException);
                 return QueryResult<TOut>.Empty();
             }
             catch (Exception exception)

--- a/src/ServiceControl/Infrastructure/Settings/RemoteInstanceSetting.cs
+++ b/src/ServiceControl/Infrastructure/Settings/RemoteInstanceSetting.cs
@@ -6,6 +6,11 @@
     public class RemoteInstanceSetting
     {
         public string ApiUri { get; set; }
+        /// <summary>
+        /// If for any reason we fail to connect to remove instance they will be disabled. Any <see cref="ScatterGatherApiBase"/> query will skip that instance. <see cref="CheckRemotes"/> custom check takes care of that. 
+        /// </summary>
+        [JsonIgnore]
+        public bool TemporarilyUnavailable { get; set; }
 
         [JsonIgnore]
         public Uri ApiAsUri

--- a/src/ServiceControl/Infrastructure/Settings/RemoteInstanceSetting.cs
+++ b/src/ServiceControl/Infrastructure/Settings/RemoteInstanceSetting.cs
@@ -7,7 +7,7 @@
     {
         public string ApiUri { get; set; }
         /// <summary>
-        /// If for any reason we fail to connect to remove instance they will be disabled. Any <see cref="ScatterGatherApiBase"/> query will skip that instance. <see cref="CheckRemotes"/> custom check takes care of that. 
+        /// If we fail to connect to a remote instance, it will be temporarily disabled. Any <see cref="ScatterGatherApiBase"/> query will skip disabled instances. The <see cref="CheckRemotes"/> custom check will enable any disabled remote instance the first time it succeeds in connecting it. 
         /// </summary>
         [JsonIgnore]
         public bool TemporarilyUnavailable { get; set; }

--- a/src/ServiceControl/Operations/CheckRemotes.cs
+++ b/src/ServiceControl/Operations/CheckRemotes.cs
@@ -74,12 +74,12 @@
             catch (HttpRequestException e)
             {
                 remoteSettings.TemporarilyUnavailable = true;
-                throw new TimeoutException($"Remote at '{remoteSettings.ApiUri}' doesn't seem to be available. Remote instance will be temporarily disabled. Reason: {e.Message}", e);
+                throw new TimeoutException($"The remote instance at '{remoteSettings.ApiUri}' doesn't seem to be available. It will be temporarily disabled. Reason: {e.Message}", e);
             }
             catch (OperationCanceledException e)
             {
                 remoteSettings.TemporarilyUnavailable = true;
-                throw new TimeoutException($"Remote at '{remoteSettings.ApiUri}' did not respond within the allotted timespan of '{queryTimeout}'. Remote instance will be temporarily disabled.", e);
+                throw new TimeoutException($"The remote at '{remoteSettings.ApiUri}' did not respond within the allotted time of '{queryTimeout}'. It will be temporarily disabled.", e);
             }
         }
 

--- a/src/ServiceControl/Operations/CheckRemotes.cs
+++ b/src/ServiceControl/Operations/CheckRemotes.cs
@@ -69,14 +69,17 @@
             {
                 var response = await client.GetAsync(remoteSettings.ApiUri, cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
+                remoteSettings.TemporarilyUnavailable = false;
             }
             catch (HttpRequestException e)
             {
-                throw new TimeoutException($"Remote at '{remoteSettings.ApiUri}' doesn't seem to be available. Reason: {e.Message}", e);
+                remoteSettings.TemporarilyUnavailable = true;
+                throw new TimeoutException($"Remote at '{remoteSettings.ApiUri}' doesn't seem to be available. Remote instance will be temporarily disabled. Reason: {e.Message}", e);
             }
             catch (OperationCanceledException e)
             {
-                throw new TimeoutException($"Remote at '{remoteSettings.ApiUri}' did not respond within the allotted timespan of '{queryTimeout}'.", e);
+                remoteSettings.TemporarilyUnavailable = true;
+                throw new TimeoutException($"Remote at '{remoteSettings.ApiUri}' did not respond within the allotted timespan of '{queryTimeout}'. Remote instance will be temporarily disabled.", e);
             }
         }
 


### PR DESCRIPTION
Changing CustomCheck to mark failing audit instances as the ones that should not participate in the scatter-gather algorithm. This makes ServiceControl to not wait for the audit instance check to time out. 