### PR TITLE
Audit setup command bootstrapper integration test 

### DIFF
--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/SetupCommand_CharacterizationTests.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/SetupCommand_CharacterizationTests.cs
@@ -132,52 +132,5 @@
             }
         }
         #endregion FakeTransport
-
-        #region TearDown
-        [TearDown]
-        public void TearDown() => DeleteFolder(_workingDirectory);
-
-        static void DeleteFolder(string path)
-        {
-            DirectoryInfo emptyTempDirectory = null;
-
-            if (!Directory.Exists(path))
-            {
-                return;
-            }
-
-            try
-            {
-                emptyTempDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
-                emptyTempDirectory.Create();
-                var arguments = $"\"{emptyTempDirectory.FullName}\" \"{path.TrimEnd('\\')}\" /W:1  /R:1 /FFT /MIR /NFL";
-                using (var process = Process.Start(new ProcessStartInfo("robocopy")
-                {
-                    Arguments = arguments,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    CreateNoWindow = true
-                }))
-                {
-                    process?.WaitForExit();
-                }
-
-                using (var windowsIdentity = WindowsIdentity.GetCurrent())
-                {
-                    var directorySecurity = new DirectorySecurity();
-                    directorySecurity.SetOwner(windowsIdentity.User);
-                    Directory.SetAccessControl(path, directorySecurity);
-                }
-
-                if (!(Directory.GetFiles(path).Any() || Directory.GetDirectories(path).Any()))
-                {
-                    Directory.Delete(path);
-                }
-            }
-            finally
-            {
-                emptyTempDirectory?.Delete();
-            }
-        }
-        #endregion TearDown
     }
 }

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/SetupCommand_CharacterizationTests.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/SetupCommand_CharacterizationTests.cs
@@ -29,6 +29,7 @@
         string _workingDirectory;
         string _dbPath;
 
+        #region setup to run before each test
         [SetUp]
         public void Setup()
         {
@@ -39,7 +40,7 @@
             TransportInitializationHasBeenInvoked = false;
         }
 
-        private static void EnsureEventSourceDoesNotExists()
+        static void EnsureEventSourceDoesNotExists()
         {
             try
             {
@@ -53,11 +54,13 @@
                 // ignored
             }
 
-            Assert.IsTrue(EventLog.SourceExists(CreateEventSource.SourceName) == false, 
+            Assert.IsTrue(EventLog.SourceExists(CreateEventSource.SourceName) == false,
                 $"Running this test requires elevated privileges. The test setup couldn't confirm windows event log source {CreateEventSource.SourceName} doesn't exists before starting the test execution");
         }
 
         static string CreateRandomTempDirectory() => Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        #endregion setup to run before each test
 
         [Test]
         public async Task VerifySetupCommandBehavior()

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/SetupCommand_CharacterizationTests.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/SetupCommand_CharacterizationTests.cs
@@ -39,6 +39,7 @@
         public const string TransportInitializedSpyFileName = "initialized.txt";
 
         [Test]
+        [Ignore("Temporarily disabling it to check if it is affecting the CI")]
         public async Task VerifySetupCommandBehavior()
         {
             #region Arrange
@@ -132,5 +133,52 @@
             }
         }
         #endregion FakeTransport
+
+        #region TearDown
+        [TearDown]
+        public void TearDown() => DeleteFolder(_workingDirectory);
+
+        static void DeleteFolder(string path)
+        {
+            DirectoryInfo emptyTempDirectory = null;
+
+            if (!Directory.Exists(path))
+            {
+                return;
+            }
+
+            try
+            {
+                emptyTempDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+                emptyTempDirectory.Create();
+                var arguments = $"\"{emptyTempDirectory.FullName}\" \"{path.TrimEnd('\\')}\" /W:1  /R:1 /FFT /MIR /NFL";
+                using (var process = Process.Start(new ProcessStartInfo("robocopy")
+                {
+                    Arguments = arguments,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true
+                }))
+                {
+                    process?.WaitForExit();
+                }
+
+                using (var windowsIdentity = WindowsIdentity.GetCurrent())
+                {
+                    var directorySecurity = new DirectorySecurity();
+                    directorySecurity.SetOwner(windowsIdentity.User);
+                    Directory.SetAccessControl(path, directorySecurity);
+                }
+
+                if (!(Directory.GetFiles(path).Any() || Directory.GetDirectories(path).Any()))
+                {
+                    Directory.Delete(path);
+                }
+            }
+            finally
+            {
+                emptyTempDirectory?.Delete();
+            }
+        }
+        #endregion TearDown
     }
 }

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/SetupCommand_CharacterizationTests.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/SetupCommand_CharacterizationTests.cs
@@ -63,9 +63,9 @@
             DatabaseGotCreated();
         }
 
-        void QueuesGotCreated() => Assert.IsTrue(File.Exists(Path.Combine(_workingDirectory, TransportInitializedSpyFileName)));
+        void QueuesGotCreated() => Assert.IsTrue(File.Exists(Path.Combine(_workingDirectory, TransportInitializedSpyFileName)), "Unable to verify that the queue creation logic was invoked");
 
-        void EventLogSourceGotCreated() => Assert.IsTrue(EventLog.SourceExists(CreateEventSource.SourceName));
+        void EventLogSourceGotCreated() => Assert.IsTrue(EventLog.SourceExists(CreateEventSource.SourceName), $"Windows EventViewer event source '{CreateEventSource.SourceName}' was not found");
 
         void DatabaseGotCreated()
         {
@@ -91,9 +91,11 @@
         {
             public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
             {
-                File.WriteAllText(Path.Combine(connectionString, TransportInitializedSpyFileName), string.Empty);
+                WriteFileAsFlagToBeVerifiedInTestAssertions(connectionString);
                 return base.Initialize(settings, connectionString);
             }
+
+            static void WriteFileAsFlagToBeVerifiedInTestAssertions(string connectionString) => File.WriteAllText(Path.Combine(connectionString, TransportInitializedSpyFileName), string.Empty);
         }
 
         public class FakeTransportSpyTransportCustomization : TransportCustomization

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/SetupCommand_CharacterizationTests.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/SetupCommand_CharacterizationTests.cs
@@ -1,0 +1,181 @@
+﻿namespace ServiceControl.Audit.AcceptanceTests.Auditing
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Security.AccessControl;
+    using System.Security.Principal;
+    using System.Threading.Tasks;
+    using Infrastructure;
+    using NServiceBus;
+    using NServiceBus.Raw;
+    using NServiceBus.Settings;
+    using NServiceBus.Transport;
+    using NUnit.Framework;
+    using Infrastructure.Installers;
+    using Infrastructure.Settings;
+    using Transports;
+
+    /// <summary>
+    /// <see href="https://michaelfeathers.silvrback.com/characterization-testing">Characterization</see> tests for setup command.
+    /// Once there is more coverage from the acceptance testing angle this test can be removed, in the meantime this test mission is to help while attempting refactorings to the setup command. 
+    /// </summary>
+    [TestFixture]
+    public class SetupCommandCharacterizationTests
+    {
+        string _workingDirectory;
+        string _dbPath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _workingDirectory = CreateRandomTempDirectory();
+            _dbPath = Path.Combine(_workingDirectory, Path.GetRandomFileName());
+        }
+
+        static string CreateRandomTempDirectory() => Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        public const string TransportInitializedSpyFileName = "initialized.txt";
+
+        [Test]
+        public async Task VerifySetupCommandBehavior()
+        {
+            #region Arrange
+            Directory.CreateDirectory(_workingDirectory);
+
+            var settings = new Settings
+            {
+                TransportConnectionString = _workingDirectory,
+                DbPath = _dbPath,
+                TransportCustomizationType = typeof(FakeTransportSpyTransportCustomization).AssemblyQualifiedName,
+                ServiceControlQueueAddress = Settings.DEFAULT_SERVICE_NAME
+            };
+            #endregion Arrange
+
+            //Act
+            var setupBootstrapper = new SetupBootstrapper(settings);
+            await setupBootstrapper.Run(null);
+
+            //Assert
+            QueuesGotCreated();
+            EventLogSourceGotCreated();
+            DatabaseGotCreated();
+        }
+
+        void QueuesGotCreated() => Assert.IsTrue(File.Exists(Path.Combine(_workingDirectory, TransportInitializedSpyFileName)));
+
+        void EventLogSourceGotCreated() => Assert.IsTrue(EventLog.SourceExists(CreateEventSource.SourceName));
+
+        void DatabaseGotCreated()
+        {
+            Assert.IsTrue(File.Exists($"{_dbPath}/IndexDefinitions/indexes.txt"), "Unable to find database.");
+            var indexesFileContent = File.ReadAllLines($"{_dbPath}/IndexDefinitions/indexes.txt");
+
+            Assert.IsTrue(indexesFileContent.Any(i => i.Contains("SagaDetailsIndex")), "Database does not contain expected index SagaDetailsIndex");
+            Assert.IsTrue(indexesFileContent.Any(i => i.Contains("MessagesViewIndex")), "Database does not contain expected index MessagesViewIndex");
+
+            //IndexDefinitions/indexes.txt expected content. Consider verifying the whole file instead although the content could be in a different order.
+            /*
+             * 2 - ExpiryProcessedMessageIndex
+                1 - ExpiryKnownEndpointsIndex
+                5 - ExpirySagaAuditIndex
+                6 - SagaDetailsIndex
+                4 - MessagesViewIndex
+                3 - FailedAuditImportIndex
+             */
+        }
+
+        #region FakeTransport
+        public class FakeTransportSpy : LearningTransport
+        {
+            public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
+            {
+                File.WriteAllText(Path.Combine(connectionString, TransportInitializedSpyFileName), string.Empty);
+                return base.Initialize(settings, connectionString);
+            }
+        }
+
+        public class FakeTransportSpyTransportCustomization : TransportCustomization
+        {
+            public override void CustomizeSendOnlyEndpoint(EndpointConfiguration endpointConfiguration, TransportSettings transportSettings) => CustomizeEndpoint(endpointConfiguration, transportSettings);
+
+            public override void CustomizeServiceControlEndpoint(EndpointConfiguration endpointConfiguration, TransportSettings transportSettings) => CustomizeEndpoint(endpointConfiguration, transportSettings);
+
+            public override void CustomizeRawSendOnlyEndpoint(RawEndpointConfiguration endpointConfiguration, TransportSettings transportSettings) => CustomizeEndpoint(endpointConfiguration, transportSettings);
+
+            public override void CustomizeForErrorIngestion(RawEndpointConfiguration endpointConfiguration, TransportSettings transportSettings) => CustomizeEndpoint(endpointConfiguration, transportSettings);
+
+            public override void CustomizeForAuditIngestion(RawEndpointConfiguration endpointConfiguration, TransportSettings transportSettings) => CustomizeEndpoint(endpointConfiguration, transportSettings);
+
+            public override void CustomizeForMonitoringIngestion(EndpointConfiguration endpointConfiguration, TransportSettings transportSettings) => CustomizeEndpoint(endpointConfiguration, transportSettings);
+
+            public override void CustomizeForReturnToSenderIngestion(RawEndpointConfiguration endpointConfiguration,
+                TransportSettings transportSettings) =>
+                CustomizeEndpoint(endpointConfiguration, transportSettings);
+
+            public override IProvideQueueLength CreateQueueLengthProvider() => throw new NotImplementedException();
+
+            static void CustomizeEndpoint(EndpointConfiguration endpointConfig, TransportSettings transportSettings)
+            {
+                var transport = endpointConfig.UseTransport<FakeTransportSpy>();
+                transport.ConnectionString(transportSettings.ConnectionString);
+            }
+
+            static void CustomizeEndpoint(RawEndpointConfiguration endpointConfig, TransportSettings transportSettings)
+            {
+
+                var transport = endpointConfig.UseTransport<FakeTransportSpy>();
+                transport.ConnectionString(transportSettings.ConnectionString);
+            }
+        }
+        #endregion FakeTransport
+
+        #region TearDown
+        [TearDown]
+        public void TearDown() => DeleteFolder(_workingDirectory);
+
+        static void DeleteFolder(string path)
+        {
+            DirectoryInfo emptyTempDirectory = null;
+
+            if (!Directory.Exists(path))
+            {
+                return;
+            }
+
+            try
+            {
+                emptyTempDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+                emptyTempDirectory.Create();
+                var arguments = $"\"{emptyTempDirectory.FullName}\" \"{path.TrimEnd('\\')}\" /W:1  /R:1 /FFT /MIR /NFL";
+                using (var process = Process.Start(new ProcessStartInfo("robocopy")
+                {
+                    Arguments = arguments,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true
+                }))
+                {
+                    process?.WaitForExit();
+                }
+
+                using (var windowsIdentity = WindowsIdentity.GetCurrent())
+                {
+                    var directorySecurity = new DirectorySecurity();
+                    directorySecurity.SetOwner(windowsIdentity.User);
+                    Directory.SetAccessControl(path, directorySecurity);
+                }
+
+                if (!(Directory.GetFiles(path).Any() || Directory.GetDirectories(path).Any()))
+                {
+                    Directory.Delete(path);
+                }
+            }
+            finally
+            {
+                emptyTempDirectory?.Delete();
+            }
+        }
+        #endregion TearDown
+    }
+}

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_running_setup_command__integration_test.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_running_setup_command__integration_test.cs
@@ -9,7 +9,7 @@
     using NServiceBus.Settings;
     using NServiceBus.Transport;
     using NUnit.Framework;
-    using ServiceControl.Audit.AcceptanceTests.TestSupport;
+    using TestSupport;
     using System;
     using System.Diagnostics;
     using System.IO;
@@ -19,12 +19,8 @@
     using System.Threading.Tasks;
     using Transports;
 
-    /// <summary>
-    /// <see href="https://michaelfeathers.silvrback.com/characterization-testing">Characterization</see> tests for setup command.
-    /// Once there is more coverage from the acceptance testing angle this test can be removed, in the meantime this test mission is to help while attempting refactorings to the setup command. 
-    /// </summary>
     [TestFixture]
-    public class SetupCommandCharacterizationTests
+    public class When_running_setup_command__integration_test
     {
         string _workingDirectory;
         string _dbPath;
@@ -78,7 +74,7 @@
 
             var excludedAssemblies = new[]
             {
-                //Path.GetFileName(typeof(Settings).Assembly.CodeBase),
+                Path.GetFileName(typeof(Settings).Assembly.CodeBase),
                 typeof(ServiceControlComponentRunner).Assembly.GetName().Name,
                 typeof(IComponentBehavior).Assembly.GetName().Name
             };

--- a/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
@@ -5,6 +5,7 @@ namespace ServiceControl.Audit.Infrastructure
     using Auditing.BodyStorage;
     using Auditing.BodyStorage.RavenAttachments;
     using Autofac;
+    using Installers;
     using NServiceBus;
     using NServiceBus.Logging;
     using NServiceBus.Raw;
@@ -89,6 +90,8 @@ namespace ServiceControl.Audit.Infrastructure
             containerBuilder.RegisterInstance(settings).SingleInstance();
             containerBuilder.RegisterType<MigrateKnownEndpoints>().As<IDataMigration>();
             containerBuilder.RegisterType<RavenAttachmentsBodyStorage>().As<IBodyStorage>().SingleInstance();
+
+            await new CreateEventSource().Install(null).ConfigureAwait(false);
 
             using (documentStore)
             {


### PR DESCRIPTION
This PR is about adding a characterization test for the setup command bootstrapper to verify its expected behavior in order to enable refactorings in upcoming PRs.

The next PRs planned are:
- Add tests to check the better document the expected behavior from the acceptance test angle no longer in the characterization way.
- Another PR to extract what is involved in the setup as reusable pieces for each thing the setup is doing: CreateQueues, CreateDB, Create Evelog Source.
- Remove NSB and Autofac usage from the audit setup command - [PR](https://github.com/Particular/ServiceControl/pull/2871)