### PR TITLE
Remove custom Autofac constructor finder

### DIFF
--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/FailedAuditsController.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/FailedAuditsController.cs
@@ -9,9 +9,9 @@
     using Infrastructure.WebApi;
     using Raven.Client;
 
-    public class FailedAuditsController : ApiController
+    class FailedAuditsController : ApiController
     {
-        internal FailedAuditsController(IDocumentStore store, ImportFailedAudits failedAuditIngestion)
+        public FailedAuditsController(IDocumentStore store, ImportFailedAudits failedAuditIngestion)
         {
             this.store = store;
             this.failedAuditIngestion = failedAuditIngestion;

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -36,38 +36,6 @@ namespace ServiceControl.Audit.Auditing
 }
 namespace ServiceControl.Audit.Auditing.MessagesView
 {
-    public class GetMessagesController : System.Web.Http.ApiController
-    {
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("messages/{*catchAll}")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> CatchAll(string catchAll) { }
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("messages/{id}/body")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Get(string id) { }
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("messages")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetAllMessages() { }
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("endpoints/{endpoint}/messages")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetEndpointMessages(string endpoint) { }
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("messages/search")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Search(string q) { }
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("endpoints/{endpoint}/messages/search")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Search(string endpoint, string q) { }
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("messages/search/{keyword}")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SearchByKeyWord(string keyword) { }
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("endpoints/{endpoint}/messages/search/{keyword}")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SearchByKeyword(string endpoint, string keyword) { }
-    }
-    public class MessagesConversationController : System.Web.Http.ApiController
-    {
-        [System.Web.Http.Route("conversations/{conversationid}")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Get(string conversationid) { }
-    }
     public class MessagesView
     {
         public MessagesView() { }
@@ -124,16 +92,6 @@ namespace ServiceControl.Audit.Auditing.MessagesView
             public System.DateTime ProcessedAt { get; set; }
             public string UniqueMessageId { get; set; }
         }
-    }
-}
-namespace ServiceControl.Audit.Connection
-{
-    public class ConnectionController : System.Web.Http.ApiController
-    {
-        public ConnectionController(ServiceControl.Audit.Infrastructure.Settings.Settings settings) { }
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("connection")]
-        public System.Web.Http.IHttpActionResult GetConnectionDetails() { }
     }
 }
 namespace ServiceControl.Audit.Infrastructure.Installers
@@ -210,30 +168,6 @@ namespace ServiceControl.Audit.Infrastructure.Settings
         public ServiceControl.Transports.TransportCustomization LoadTransportCustomization() { }
     }
 }
-namespace ServiceControl.Audit.Infrastructure.WebApi
-{
-    public class RootController : System.Web.Http.ApiController
-    {
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("configuration")]
-        [System.Web.Http.Route("instance-info")]
-        public System.Web.Http.Results.OkNegotiatedContentResult<object> Config() { }
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("")]
-        public System.Web.Http.Results.OkNegotiatedContentResult<ServiceControl.Audit.Infrastructure.WebApi.RootController.RootUrls> Urls() { }
-        public class RootUrls
-        {
-            public RootUrls() { }
-            public string Configuration { get; set; }
-            public string Description { get; set; }
-            public string EndpointsMessageSearchUrl { get; set; }
-            public string EndpointsMessagesUrl { get; set; }
-            public string KnownEndpointsUrl { get; set; }
-            public string MessageSearchUrl { get; set; }
-            public string Name { get; set; }
-        }
-    }
-}
 namespace ServiceControl.Audit.Monitoring
 {
     public class EndpointDetails
@@ -252,12 +186,6 @@ namespace ServiceControl.Audit.Monitoring
         public string Id { get; set; }
         public System.DateTime LastSeen { get; set; }
         public string Name { get; set; }
-    }
-    public class KnownEndpointsController : System.Web.Http.ApiController
-    {
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("endpoints/known")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> GetAll() { }
     }
     public class KnownEndpointsView
     {
@@ -279,15 +207,6 @@ namespace ServiceControl.Audit.Recoverability
         public QueueAddress() { }
         public int FailedMessageCount { get; set; }
         public string PhysicalAddress { get; set; }
-    }
-}
-namespace ServiceControl.Audit.SagaAudit
-{
-    public class SagasController : System.Web.Http.ApiController
-    {
-        [System.Web.Http.HttpGet]
-        [System.Web.Http.Route("sagas/{id}")]
-        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> Sagas(System.Guid id) { }
     }
 }
 namespace ServiceControl.Contracts.EndpointControl

--- a/src/ServiceControl.Audit/Auditing/MessagesView/GetMessagesController.cs
+++ b/src/ServiceControl.Audit/Auditing/MessagesView/GetMessagesController.cs
@@ -6,9 +6,9 @@ namespace ServiceControl.Audit.Auditing.MessagesView
 
     // All routes matching `messages/*` must be in this controller as WebAPI cannot figure out the overlapping routes
     // from `messages/{*catchAll}` if they're in separate controllers.
-    public class GetMessagesController : ApiController
+    class GetMessagesController : ApiController
     {
-        internal GetMessagesController(GetAllMessagesApi getAllMessagesApi,
+        public GetMessagesController(GetAllMessagesApi getAllMessagesApi,
             GetAllMessagesForEndpointApi getAllMessagesForEndpointApi,
             GetBodyByIdApi getBodyByIdApi,
             SearchApi searchApi,

--- a/src/ServiceControl.Audit/Auditing/MessagesView/MessagesConversationController.cs
+++ b/src/ServiceControl.Audit/Auditing/MessagesView/MessagesConversationController.cs
@@ -4,9 +4,9 @@ namespace ServiceControl.Audit.Auditing.MessagesView
     using System.Threading.Tasks;
     using System.Web.Http;
 
-    public class MessagesConversationController : ApiController
+    class MessagesConversationController : ApiController
     {
-        internal MessagesConversationController(MessagesByConversationApi api)
+        public MessagesConversationController(MessagesByConversationApi api)
         {
             this.api = api;
         }

--- a/src/ServiceControl.Audit/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Audit/Connection/ConnectionController.cs
@@ -4,7 +4,7 @@ namespace ServiceControl.Audit.Connection
     using Infrastructure.Settings;
     using Newtonsoft.Json;
 
-    public class ConnectionController : ApiController
+    class ConnectionController : ApiController
     {
         readonly Settings settings;
         readonly JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings();

--- a/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
@@ -4,9 +4,9 @@
     using System.Web.Http.Results;
     using Settings;
 
-    public class RootController : ApiController
+    class RootController : ApiController
     {
-        internal RootController(LoggingSettings loggingSettings, Settings settings)
+        public RootController(LoggingSettings loggingSettings, Settings settings)
         {
             this.settings = settings;
             this.loggingSettings = loggingSettings;

--- a/src/ServiceControl.Audit/Infrastructure/WebApi/WebApiHostBuilderExtensions.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/WebApiHostBuilderExtensions.cs
@@ -41,20 +41,8 @@
 
             foreach (var controllerType in controllerTypes)
             {
-                containerBuilder.RegisterType(controllerType).FindConstructorsWith(new AllConstructorFinder());
+                containerBuilder.RegisterType(controllerType);
             }
-        }
-
-        class AllConstructorFinder : IConstructorFinder
-        {
-            public ConstructorInfo[] FindConstructors(Type targetType)
-            {
-                var result = Cache.GetOrAdd(targetType, t => t.GetTypeInfo().DeclaredConstructors.ToArray());
-
-                return result.Length > 0 ? result : throw new Exception($"No constructor found for type {targetType.FullName}");
-            }
-
-            static readonly ConcurrentDictionary<Type, ConstructorInfo[]> Cache = new ConcurrentDictionary<Type, ConstructorInfo[]>();
         }
     }
 }

--- a/src/ServiceControl.Audit/Monitoring/KnownEndpoints/KnownEndpointsController.cs
+++ b/src/ServiceControl.Audit/Monitoring/KnownEndpoints/KnownEndpointsController.cs
@@ -4,9 +4,9 @@ namespace ServiceControl.Audit.Monitoring
     using System.Threading.Tasks;
     using System.Web.Http;
 
-    public class KnownEndpointsController : ApiController
+    class KnownEndpointsController : ApiController
     {
-        internal KnownEndpointsController(GetKnownEndpointsApi knownEndpointsApi) => getKnownEndpointsApi = knownEndpointsApi;
+        public KnownEndpointsController(GetKnownEndpointsApi knownEndpointsApi) => getKnownEndpointsApi = knownEndpointsApi;
 
         [Route("endpoints/known")]
         [HttpGet]

--- a/src/ServiceControl.Audit/SagaAudit/SagasController.cs
+++ b/src/ServiceControl.Audit/SagaAudit/SagasController.cs
@@ -5,9 +5,9 @@ namespace ServiceControl.Audit.SagaAudit
     using System.Threading.Tasks;
     using System.Web.Http;
 
-    public class SagasController : ApiController
+    class SagasController : ApiController
     {
-        internal SagasController(GetSagaByIdApi getSagaByIdApi)
+        public SagasController(GetSagaByIdApi getSagaByIdApi)
         {
             this.getSagaByIdApi = getSagaByIdApi;
         }


### PR DESCRIPTION
Removes the `AllConstructorFinder` for Autofac that is used to allow resolving the public controller classes that have private actors. If the goal is to move away from Autofac, we should avoid these DI customizations as other DI containers (e.g. `ServiceProvider`) won't support this and need the constructors to be public.

To prevent the rippling effect of making all controller dependencies public for now, a custom controller resolver type, inspired by the default implementation, allows resolving controllers that aren't public classes instead.