### PR TITLE
-m parameter causes incorrect build output for Particular.PlatformSample

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
       - name: Build
-        run: msbuild src -p:Configuration=Release -restore -m -verbosity:minimal
+        run: msbuild src -p:Configuration=Release -restore -verbosity:minimal
       - name: Upload packages
         if: matrix.upload == true
         uses: actions/upload-artifact@v3.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build
         env:
           AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
-        run: msbuild src -p:Configuration=Release -restore -m -verbosity:minimal
+        run: msbuild src -p:Configuration=Release -restore -verbosity:minimal
       - id: save-version
         name: Save version
         run: |


### PR DESCRIPTION
Using the -m parameter (ostensibly to try to get faster builds by building in parallel?) results in the Particular.PlatformSample.ServiceControl package not having any of the ServiceControl assemblies needed to function correctly. Removing the parameter forces the right behavior.