### PR TITLE
Fix sample packaging

### DIFF
--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -8,6 +8,7 @@
     <PackageProjectUrl>https://docs.particular.net/servicecontrol/</PackageProjectUrl>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
     <IsPackable>true</IsPackable>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddFilesToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,23 +19,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\ServiceControl\$(OutputPath)**\*" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\servicecontrol-instance" Visible="false" Link="hidden" />
-    <Content Include="..\ServiceControl.Transports.Learning\$(OutputPath)\ServiceControl.Transports.Learning.dll" PackagePath="platform\servicecontrol\servicecontrol-instance" Visible="false" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\ServiceControl.Audit\$(OutputPath)**\*" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" Visible="false" Link="hidden" />
-    <Content Include="..\ServiceControl.Transports.Learning\$(OutputPath)\ServiceControl.Transports.Learning.dll" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" Visible="false" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\ServiceControl.Monitoring\$(OutputPath)**\*" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\monitoring-instance" Visible="false" Link="hidden" />
-    <Content Include="..\ServiceControl.Transports.Learning\$(OutputPath)\ServiceControl.Transports.Learning.dll" PackagePath="platform\servicecontrol\monitoring-instance" Visible="false" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Remove="buildProps\**\*" />
     <Content Include="buildProps\**\*" PackagePath="" />
   </ItemGroup>
+
+  <Target Name="AddFilesToPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="..\ServiceControl\$(OutputPath)**\*" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\servicecontrol-instance" />
+      <TfmSpecificPackageFile Include="..\ServiceControl.Audit\$(OutputPath)**\*" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
+      <TfmSpecificPackageFile Include="..\ServiceControl.Monitoring\$(OutputPath)**\*" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\monitoring-instance" />
+      <TfmSpecificPackageFile Include="..\ServiceControl.Transports.Learning\$(OutputPath)\ServiceControl.Transports.Learning.dll" PackagePath="platform\servicecontrol\servicecontrol-instance;platform\servicecontrol\servicecontrol-audit-instance;platform\servicecontrol\monitoring-instance" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
+    <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
     <ProjectReference Include="..\ServiceControl.Monitoring\ServiceControl.Monitoring.csproj" />
-    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" PrivateAssets="All" />
-    <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" PrivateAssets="All" />
-    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" PrivateAssets="All" />
+    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.PowerShell/ServiceControlInstaller.PowerShell.csproj
+++ b/src/ServiceControlInstaller.PowerShell/ServiceControlInstaller.PowerShell.csproj
@@ -24,7 +24,7 @@
     <None Update="ShortcutStartup.ps1" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <UsingTask TaskName="FileUpdate" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+  <UsingTask TaskName="FileUpdate" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
       <Pattern ParameterType="System.String" Required="true" />


### PR DESCRIPTION
This change ensures that the Particular.PlatformSample.ServiceControl package will always have the correct contents regardless of how the solution is built.

This also includes a future-proofing change in ServiceControlInstaller.PowerShell to use `RoslynCodeTaskFactory` instead.