### PR TITLE
Don't log `DecoderFallbackException` exception/stacktrace

### DIFF
--- a/src/ServiceControl.Audit/Auditing/BodyStorage/BodyStorageEnricher.cs
+++ b/src/ServiceControl.Audit/Auditing/BodyStorage/BodyStorageEnricher.cs
@@ -76,7 +76,7 @@
                     catch (DecoderFallbackException e)
                     {
                         useBodyStore = true;
-                        log.Info($"Body for {bodyId} could not be stored embedded, fallback to body storage", e);
+                        log.Info($"Body for {bodyId} could not be stored embedded, fallback to body storage ({e.Message})");
                     }
                 }
 

--- a/src/ServiceControl/Operations/BodyStorage/BodyStorageEnricher.cs
+++ b/src/ServiceControl/Operations/BodyStorage/BodyStorageEnricher.cs
@@ -69,7 +69,7 @@
                 catch (DecoderFallbackException e)
                 {
                     useBodyStore = true;
-                    log.Info($"Body for {bodyId} could not be stored embedded, fallback to body storage", e);
+                    log.Info($"Body for {bodyId} could not be stored embedded, fallback to body storage ({e.Message})");
                 }
             }
 


### PR DESCRIPTION
Don't log `DecoderFallbackException` exception/stacktrace but only message to reduce log IO pressure.

Currently, the following is logged for every **binary** message that is not classified as being binary or not too large:

```txt
Body for {bodyId} could not be stored embedded, fallback to body storage
System.Text.DecoderFallbackException: Unable to translate bytes [AB] at index -1 from specified code page to Unicode.
   at System.Text.DecoderExceptionFallbackBuffer.Throw(Byte[] bytesUnknown, Int32 index)
   at System.Text.DecoderExceptionFallbackBuffer.Fallback(Byte[] bytesUnknown, Int32 index)
   at System.Text.DecoderFallbackBuffer.InternalFallback(Byte[] bytes, Byte* pBytes)
   at System.Text.UTF8Encoding.GetCharCount(Byte* bytes, Int32 count, DecoderNLS baseDecoder)
   at System.String.CreateStringFromEncoding(Byte* bytes, Int32 byteLength, Encoding encoding)
   at System.Text.UTF8Encoding.GetString(Byte[] bytes, Int32 index, Int32 count)
   at ServiceControl.Audit.Auditing.BodyStorage.BodyStorageFeature.BodyStorageEnricher.<TryStoreBody>d__3.MoveNext() in /_/src/ServiceControl.Audit/Auditing/BodyStorage/BodyStorageFeature.cs:line 92
```

This unnecessarily floods the log file with worthless stacktrace data.


This PR results in the message to be written like:

```txt
Body for {bodyId} could not be stored embedded, fallback to body storage (Unable to translate bytes [AB] at index -1 from specified code page to Unicode.)
```