### PR TITLE
Extract endpoint detection

### DIFF
--- a/src/ServiceControl/Monitoring/Contracts/EndpointControl/EndpointsDetectedFromIngestion.cs
+++ b/src/ServiceControl/Monitoring/Contracts/EndpointControl/EndpointsDetectedFromIngestion.cs
@@ -1,0 +1,10 @@
+namespace ServiceControl.EndpointControl.Contracts
+{
+    using Infrastructure.DomainEvents;
+    using ServiceControl.Contracts.Operations;
+
+    public class EndpointsDetectedFromIngestion : IDomainEvent
+    {
+        public EndpointDetails[] Endpoints { get; set; }
+    }
+}

--- a/src/ServiceControl/Monitoring/DetectNewEndpointsFromErrorImportsEnricher.cs
+++ b/src/ServiceControl/Monitoring/DetectNewEndpointsFromErrorImportsEnricher.cs
@@ -1,17 +1,10 @@
 ﻿namespace ServiceControl.EndpointControl.Handlers
 {
-    using System;
-    using Monitoring;
     using Operations;
     using ServiceControl.Contracts.Operations;
 
     class DetectNewEndpointsFromErrorImportsEnricher : IEnrichImportedErrorMessages
     {
-        public DetectNewEndpointsFromErrorImportsEnricher(EndpointInstanceMonitoring monitoring)
-        {
-            this.monitoring = monitoring;
-        }
-
         public void Enrich(ErrorEnricherContext context)
         {
             var sendingEndpoint = EndpointDetailsParser.SendingEndpoint(context.Headers);
@@ -20,7 +13,6 @@
             // have the relevant information via the headers, which were added in v4.
             if (sendingEndpoint != null)
             {
-                TryAddEndpoint(sendingEndpoint, context);
                 context.Metadata.Add("SendingEndpoint", sendingEndpoint);
             }
 
@@ -30,24 +22,7 @@
             if (receivingEndpoint != null)
             {
                 context.Metadata.Add("ReceivingEndpoint", receivingEndpoint);
-                TryAddEndpoint(receivingEndpoint, context);
             }
         }
-
-        void TryAddEndpoint(EndpointDetails endpointDetails, ErrorEnricherContext context)
-        {
-            // for backwards compat with version before 4_5 we might not have a hostid
-            if (endpointDetails.HostId == Guid.Empty)
-            {
-                return;
-            }
-
-            if (monitoring.IsNewInstance(endpointDetails))
-            {
-                context.Add(endpointDetails);
-            }
-        }
-
-        EndpointInstanceMonitoring monitoring;
     }
 }

--- a/src/ServiceControl/Monitoring/HeartbeatMonitoringComponent.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatMonitoringComponent.cs
@@ -49,7 +49,7 @@
                 collection.AddIntegrationEventPublisher<HeartbeatStoppedPublisher>();
 
                 collection.AddErrorMessageEnricher<DetectNewEndpointsFromErrorImportsEnricher>();
-                collection.AddErrorMessageBatchPlugin<SaveNewEndpointsErrorMessageBatchPlugin>();
+                collection.AddErrorMessageBatchPlugin<MonitorEndpointsFoundInFailedMessageHeaders>();
 
                 collection.AddPlatformConnectionProvider<HeartbeatsPlatformConnectionDetailsProvider>();
             });

--- a/src/ServiceControl/Monitoring/HeartbeatMonitoringComponent.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatMonitoringComponent.cs
@@ -49,6 +49,7 @@
                 collection.AddIntegrationEventPublisher<HeartbeatStoppedPublisher>();
 
                 collection.AddErrorMessageEnricher<DetectNewEndpointsFromErrorImportsEnricher>();
+                collection.AddErrorMessageBatchPlugin<SaveNewEndpointsErrorMessageBatchPlugin>();
 
                 collection.AddPlatformConnectionProvider<HeartbeatsPlatformConnectionDetailsProvider>();
             });

--- a/src/ServiceControl/Monitoring/IMonitoringDataStore.cs
+++ b/src/ServiceControl/Monitoring/IMonitoringDataStore.cs
@@ -11,5 +11,6 @@
         Task UpdateEndpointMonitoring(EndpointDetails endpoint, bool isMonitored);
         Task WarmupMonitoringFromPersistence(EndpointInstanceMonitoring endpointInstanceMonitoring);
         Task Delete(Guid endpointId);
+        Task BulkCreate(EndpointDetails[] newEndpoints);
     }
 }

--- a/src/ServiceControl/Monitoring/InMemoryMonitoringDataStore.cs
+++ b/src/ServiceControl/Monitoring/InMemoryMonitoringDataStore.cs
@@ -71,6 +71,28 @@ namespace ServiceControl.Monitoring
             return Task.CompletedTask;
         }
 
+        public Task BulkCreate(EndpointDetails[] newEndpoints)
+        {
+            foreach (var endpoint in newEndpoints)
+            {
+                var id = DeterministicGuid.MakeId(endpoint.Name, endpoint.HostId.ToString());
+
+                if (!endpoints.Any(a => a.Id == id))
+                {
+                    endpoints.Add(new InMemoryEndpoint
+                    {
+                        Id = id,
+                        HostId = endpoint.HostId,
+                        Host = endpoint.Host,
+                        HostDisplayName = endpoint.Name,
+                        Monitored = false
+                    });
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
         public Task UpdateEndpointMonitoring(EndpointDetails endpoint, bool isMonitored)
         {
             var id = DeterministicGuid.MakeId(endpoint.Name, endpoint.HostId.ToString());

--- a/src/ServiceControl/Monitoring/MonitorEndpointsFoundInFailedMessageHeaders.cs
+++ b/src/ServiceControl/Monitoring/MonitorEndpointsFoundInFailedMessageHeaders.cs
@@ -11,7 +11,7 @@
     using Raven.Json.Linq;
     using ServiceControl.Contracts.Operations;
 
-    class SaveNewEndpointsErrorMessageBatchPlugin : IErrorMessageBatchPlugin
+    class MonitorEndpointsFoundInFailedMessageHeaders : IErrorMessageBatchPlugin
     {
         public void AfterProcessing(List<MessageContext> batch, ICollection<ICommandData> commands)
         {
@@ -74,12 +74,12 @@
             };
 
 
-        public SaveNewEndpointsErrorMessageBatchPlugin(EndpointInstanceMonitoring endpointInstanceMonitoring)
+        public MonitorEndpointsFoundInFailedMessageHeaders(EndpointInstanceMonitoring endpointInstanceMonitoring)
         {
             this.endpointInstanceMonitoring = endpointInstanceMonitoring;
         }
 
-        static SaveNewEndpointsErrorMessageBatchPlugin()
+        static MonitorEndpointsFoundInFailedMessageHeaders()
         {
             KnownEndpointMetadata = RavenJObject.Parse($@"
                                     {{
@@ -90,6 +90,6 @@
 
         EndpointInstanceMonitoring endpointInstanceMonitoring;
         static readonly RavenJObject KnownEndpointMetadata;
-        static readonly ILog Logger = LogManager.GetLogger<SaveNewEndpointsErrorMessageBatchPlugin>();
+        static readonly ILog Logger = LogManager.GetLogger<MonitorEndpointsFoundInFailedMessageHeaders>();
     }
 }

--- a/src/ServiceControl/Monitoring/MonitoringDataPersister.cs
+++ b/src/ServiceControl/Monitoring/MonitoringDataPersister.cs
@@ -10,7 +10,8 @@
         IDomainHandler<EndpointDetected>,
         IDomainHandler<HeartbeatingEndpointDetected>,
         IDomainHandler<MonitoringEnabledForEndpoint>,
-        IDomainHandler<MonitoringDisabledForEndpoint>
+        IDomainHandler<MonitoringDisabledForEndpoint>,
+        IDomainHandler<EndpointsDetectedFromIngestion>
     {
         public MonitoringDataPersister(IMonitoringDataStore monitoringDataStore, EndpointInstanceMonitoring endpointInstanceMonitoring)
         {
@@ -36,6 +37,11 @@
         public Task Handle(MonitoringDisabledForEndpoint domainEvent)
         {
             return _monitoringDataStore.UpdateEndpointMonitoring(domainEvent.Endpoint, false);
+        }
+
+        public Task Handle(EndpointsDetectedFromIngestion domainEvent)
+        {
+            return _monitoringDataStore.BulkCreate(domainEvent.Endpoints);
         }
 
         IMonitoringDataStore _monitoringDataStore;

--- a/src/ServiceControl/Monitoring/RavenDbMonitoringDataStore.cs
+++ b/src/ServiceControl/Monitoring/RavenDbMonitoringDataStore.cs
@@ -119,6 +119,27 @@
             }
         }
 
+        public async Task BulkCreate(EndpointDetails[] endpoints)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                foreach (var endpoint in endpoints)
+                {
+                    var id = DeterministicGuid.MakeId(endpoint.Name, endpoint.HostId.ToString());
+
+                    await session.StoreAsync(new KnownEndpoint
+                    {
+                        Id = id,
+                        EndpointDetails = endpoint,
+                        HostDisplayName = endpoint.Host,
+                        Monitored = false
+                    }).ConfigureAwait(false);
+                }
+
+                await session.SaveChangesAsync().ConfigureAwait(false);
+            }
+        }
+
         IDocumentStore store;
     }
 }

--- a/src/ServiceControl/Monitoring/SaveNewEndpoints.cs
+++ b/src/ServiceControl/Monitoring/SaveNewEndpoints.cs
@@ -1,0 +1,95 @@
+﻿namespace ServiceControl.EndpointControl.Handlers
+{
+    using System;
+    using System.Collections.Generic;
+    using Infrastructure;
+    using Monitoring;
+    using NServiceBus.Logging;
+    using NServiceBus.Transport;
+    using Operations;
+    using Raven.Abstractions.Commands;
+    using Raven.Json.Linq;
+    using ServiceControl.Contracts.Operations;
+
+    class SaveNewEndpointsErrorMessageBatchPlugin : IErrorMessageBatchPlugin
+    {
+        public void AfterProcessing(List<MessageContext> batch, ICollection<ICommandData> commands)
+        {
+            var knownEndpoints = new Dictionary<string, KnownEndpoint>();
+            foreach (var context in batch)
+            {
+                var errorEnricherContext = context.Extensions.Get<ErrorEnricherContext>();
+
+                void RecordKnownEndpoint(string key)
+                {
+                    if (errorEnricherContext.Metadata.TryGetValue(key, out var endpointObject)
+                        && endpointObject is EndpointDetails endpointDetails
+                        && endpointDetails.HostId != Guid.Empty) // for backwards compat with version before 4_5 we might not have a hostid
+                    {
+                        if (endpointInstanceMonitoring.IsNewInstance(endpointDetails))
+                        {
+                            RecordKnownEndpoints(endpointDetails, knownEndpoints);
+                        }
+                    }
+                }
+
+                RecordKnownEndpoint("SendingEndpoint");
+                RecordKnownEndpoint("ReceivingEndpoint");
+            }
+
+            foreach (var endpoint in knownEndpoints.Values)
+            {
+                if (Logger.IsDebugEnabled)
+                {
+                    Logger.Debug($"Adding known endpoint '{endpoint.EndpointDetails.Name}' for bulk storage");
+                }
+
+                commands.Add(CreateKnownEndpointsPutCommand(endpoint));
+            }
+
+        }
+
+        static void RecordKnownEndpoints(EndpointDetails observedEndpoint, Dictionary<string, KnownEndpoint> observedEndpoints)
+        {
+            var uniqueEndpointId = $"{observedEndpoint.Name}{observedEndpoint.HostId}";
+            if (!observedEndpoints.TryGetValue(uniqueEndpointId, out KnownEndpoint _))
+            {
+                observedEndpoints.Add(uniqueEndpointId, new KnownEndpoint
+                {
+                    Id = DeterministicGuid.MakeId(observedEndpoint.Name, observedEndpoint.HostId.ToString()),
+                    EndpointDetails = observedEndpoint,
+                    HostDisplayName = observedEndpoint.Host,
+                    Monitored = false
+                });
+            }
+        }
+
+        static PutCommandData CreateKnownEndpointsPutCommand(KnownEndpoint endpoint) =>
+            new PutCommandData
+            {
+                Document = RavenJObject.FromObject(endpoint),
+                Etag = null,
+                Key = endpoint.Id.ToString(),
+                Metadata = KnownEndpointMetadata
+            };
+
+
+        public SaveNewEndpointsErrorMessageBatchPlugin(EndpointInstanceMonitoring endpointInstanceMonitoring)
+        {
+            this.endpointInstanceMonitoring = endpointInstanceMonitoring;
+        }
+
+        static SaveNewEndpointsErrorMessageBatchPlugin()
+        {
+            KnownEndpointMetadata = RavenJObject.Parse($@"
+                                    {{
+                                        ""Raven-Entity-Name"": ""{KnownEndpoint.CollectionName}"",
+                                        ""Raven-Clr-Type"": ""{typeof(KnownEndpoint).AssemblyQualifiedName}""
+                                    }}");
+        }
+
+        EndpointInstanceMonitoring endpointInstanceMonitoring;
+        static readonly RavenJObject KnownEndpointMetadata;
+        static readonly ILog Logger = LogManager.GetLogger<SaveNewEndpointsErrorMessageBatchPlugin>();
+    }
+}

--- a/src/ServiceControl/Operations/ErrorEnricherContext.cs
+++ b/src/ServiceControl/Operations/ErrorEnricherContext.cs
@@ -1,13 +1,9 @@
 ﻿namespace ServiceControl.Operations
 {
     using System.Collections.Generic;
-    using System.Linq;
-    using Contracts.Operations;
 
     class ErrorEnricherContext
     {
-        List<EndpointDetails> newEndpoints;
-
         public ErrorEnricherContext(IReadOnlyDictionary<string, string> headers, IDictionary<string, object> metadata)
         {
             Headers = headers;
@@ -17,17 +13,5 @@
         public IReadOnlyDictionary<string, string> Headers { get; }
 
         public IDictionary<string, object> Metadata { get; }
-
-        public IEnumerable<EndpointDetails> NewEndpoints => newEndpoints ?? Enumerable.Empty<EndpointDetails>();
-
-        public void Add(EndpointDetails endpointDetails)
-        {
-            if (newEndpoints == null)
-            {
-                newEndpoints = new List<EndpointDetails>();
-            }
-
-            newEndpoints.Add(endpointDetails);
-        }
     }
 }

--- a/src/ServiceControl/Operations/ErrorIngestor.cs
+++ b/src/ServiceControl/Operations/ErrorIngestor.cs
@@ -9,7 +9,6 @@
     using Contracts.Operations;
     using Infrastructure.DomainEvents;
     using Infrastructure.Metrics;
-    using Monitoring;
     using NServiceBus.Extensibility;
     using NServiceBus.Logging;
     using NServiceBus.Routing;
@@ -25,10 +24,10 @@
         public ErrorIngestor(Metrics metrics,
             IEnumerable<IEnrichImportedErrorMessages> errorEnrichers,
             IFailedMessageEnricher[] failedMessageEnrichers,
+            IErrorMessageBatchPlugin[] batchPlugins,
             IDomainEvents domainEvents,
             IBodyStorage bodyStorage,
-            IDocumentStore store, Settings settings,
-            EndpointInstanceMonitoring endpointInstanceMonitoring)
+            IDocumentStore store, Settings settings)
         {
             this.store = store;
             this.settings = settings;
@@ -45,7 +44,7 @@
             }.Concat(errorEnrichers).ToArray();
 
             var bodyStorageEnricher = new BodyStorageEnricher(bodyStorage, settings);
-            errorProcessor = new ErrorProcessor(bodyStorageEnricher, enrichers, failedMessageEnrichers, domainEvents, ingestedMeter, endpointInstanceMonitoring);
+            errorProcessor = new ErrorProcessor(bodyStorageEnricher, enrichers, failedMessageEnrichers, domainEvents, ingestedMeter, batchPlugins);
             retryConfirmationProcessor = new RetryConfirmationProcessor(domainEvents);
         }
 

--- a/src/ServiceControl/Operations/ErrorIngestor.cs
+++ b/src/ServiceControl/Operations/ErrorIngestor.cs
@@ -7,9 +7,9 @@
     using System.Threading.Tasks;
     using BodyStorage;
     using Contracts.Operations;
-    using EndpointControl.Handlers;
     using Infrastructure.DomainEvents;
     using Infrastructure.Metrics;
+    using Monitoring;
     using NServiceBus.Extensibility;
     using NServiceBus.Logging;
     using NServiceBus.Routing;
@@ -27,7 +27,8 @@
             IFailedMessageEnricher[] failedMessageEnrichers,
             IDomainEvents domainEvents,
             IBodyStorage bodyStorage,
-            IDocumentStore store, Settings settings)
+            IDocumentStore store, Settings settings,
+            EndpointInstanceMonitoring endpointInstanceMonitoring)
         {
             this.store = store;
             this.settings = settings;
@@ -44,7 +45,7 @@
             }.Concat(errorEnrichers).ToArray();
 
             var bodyStorageEnricher = new BodyStorageEnricher(bodyStorage, settings);
-            errorProcessor = new ErrorProcessor(bodyStorageEnricher, enrichers, failedMessageEnrichers, domainEvents, ingestedMeter);
+            errorProcessor = new ErrorProcessor(bodyStorageEnricher, enrichers, failedMessageEnrichers, domainEvents, ingestedMeter, endpointInstanceMonitoring);
             retryConfirmationProcessor = new RetryConfirmationProcessor(domainEvents);
         }
 

--- a/src/ServiceControl/Operations/ErrorProcessor.cs
+++ b/src/ServiceControl/Operations/ErrorProcessor.cs
@@ -72,7 +72,8 @@
 
             foreach (var batchPlugin in batchPlugins)
             {
-                batchPlugin.AfterProcessing(contexts, commands);
+                await batchPlugin.AfterProcessing(storedContexts)
+                    .ConfigureAwait(false);
             }
 
             return (storedContexts, commands);

--- a/src/ServiceControl/Operations/ErrorProcessor.cs
+++ b/src/ServiceControl/Operations/ErrorProcessor.cs
@@ -76,7 +76,7 @@
                 storedContexts.Add(context);
                 ingestedCounter.Mark();
 
-                foreach (var endpointDetail in context.Extensions.Get<IEnumerable<EndpointDetails>>())
+                foreach (var endpointDetail in context.Extensions.Get<ErrorEnricherContext>().NewEndpoints)
                 {
                     RecordKnownEndpoints(endpointDetail, knownEndpoints);
                 }
@@ -174,7 +174,7 @@
 
                 context.Extensions.Set(patchCommand);
                 context.Extensions.Set(failureDetails);
-                context.Extensions.Set(enricherContext.NewEndpoints);
+                context.Extensions.Set(enricherContext);
             }
             catch (Exception e)
             {

--- a/src/ServiceControl/Operations/IFailedMessageProcessPlugin.cs
+++ b/src/ServiceControl/Operations/IFailedMessageProcessPlugin.cs
@@ -1,11 +1,11 @@
 namespace ServiceControl.Operations
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.Transport;
-    using Raven.Abstractions.Commands;
 
     interface IErrorMessageBatchPlugin
     {
-        void AfterProcessing(List<MessageContext> batch, ICollection<ICommandData> commands);
+        Task AfterProcessing(List<MessageContext> batch);
     }
 }

--- a/src/ServiceControl/Operations/IFailedMessageProcessPlugin.cs
+++ b/src/ServiceControl/Operations/IFailedMessageProcessPlugin.cs
@@ -1,0 +1,11 @@
+namespace ServiceControl.Operations
+{
+    using System.Collections.Generic;
+    using NServiceBus.Transport;
+    using Raven.Abstractions.Commands;
+
+    interface IErrorMessageBatchPlugin
+    {
+        void AfterProcessing(List<MessageContext> batch, ICollection<ICommandData> commands);
+    }
+}

--- a/src/ServiceControl/Recoverability/RecoverabilityServiceCollectionExtensions.cs
+++ b/src/ServiceControl/Recoverability/RecoverabilityServiceCollectionExtensions.cs
@@ -10,5 +10,11 @@ namespace ServiceControl.Recoverability
         {
             serviceCollection.AddSingleton<IEnrichImportedErrorMessages, T>();
         }
+
+        public static void AddErrorMessageBatchPlugin<T>(this IServiceCollection serviceCollection)
+            where T : class, IErrorMessageBatchPlugin
+        {
+            serviceCollection.AddSingleton<IErrorMessageBatchPlugin, T>();
+        }
     }
 }


### PR DESCRIPTION
_I recommend reviewing this PR one commit at a time_

We detect endpoints by looking in the headers of failed messages ingested from the error queue. These get added to the in-memory monitoring one at a time, and any that we're seeing for the first time get added to bulk database operation for persistence as `KnownEndpoint` documents.

This process is quite difficult to follow and very entangled with RavenDB which makes it challenging to switch to a different persistence.

This PR changes things so that all detected endpoints get handed off to the in-memory monitoring which raises a domain event for new endpoints, and they are persisted all in a batch. This matches the way that all other `KnownEndpoint` persistence is handled and allows us to swap isolate heartbeats from RavenDB. It provides cleaner separation between the ingestion pipeline and the monitoring components as well.

This should be safe to do as the number of endpoints detected this way should always be very low. It may be that the first batch discovers a lot of new endpoints but subsequent batches likely contain messages processed and sent by endpoints that we're already aware of.