### PR TITLE
Use WriteMinVerProperties property to prevent GitHub Actions errors

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Particular.Packaging" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -16,4 +16,8 @@
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <WriteMinVerProperties>false</WriteMinVerProperties>
+  </PropertyGroup>
+
 </Project>

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
     <ApplicationIcon>Operations.ico</ApplicationIcon>
+    <WriteMinVerProperties>true</WriteMinVerProperties>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,7 +27,7 @@
     <PackageReference Include="ByteSize" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
-    <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />    
+    <PackageReference Include="Autofac.WebApi2" Version="4.3.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.0" />
     <PackageReference Include="RavenDB.Database" Version="3.5.10-patch-35311" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
@@ -49,7 +50,7 @@
     <PackageReference Include="Particular.Licensing.Sources" Version="4.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />    
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates Particular.Packaging to 2.2.0, which introduces the `WriteMinVerProperties` property.

The property is globally disabled and then re-enabled in single project.

This solves the problem described in https://github.com/Particular/Particular.Packaging/issues/141