### PR TITLE
Custom check deletion

### DIFF
--- a/src/ServiceControl.Persistence.InMemory/InMemoryCustomCheckDataStore.cs
+++ b/src/ServiceControl.Persistence.InMemory/InMemoryCustomCheckDataStore.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Persistence.InMemory
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -53,6 +54,16 @@ namespace ServiceControl.Persistence.InMemory
             return Task.FromResult(new QueryResult<IList<CustomCheck>>(result, stats));
         }
 
-        Dictionary<string, CustomCheckDetail> storage = new Dictionary<string, CustomCheckDetail>();
+        public Task DeleteCustomCheck(Guid id)
+        {
+            var toRemove = storage.FirstOrDefault(x => x.Key == id);
+            if (storage.ContainsKey(toRemove.Key))
+            {
+                storage.Remove(toRemove.Key);
+            }
+            return Task.CompletedTask;
+        }
+
+        Dictionary<Guid, CustomCheckDetail> storage = new Dictionary<Guid, CustomCheckDetail>();
     }
 }

--- a/src/ServiceControl.Persistence.InMemory/InMemoryCustomCheckDataStore.cs
+++ b/src/ServiceControl.Persistence.InMemory/InMemoryCustomCheckDataStore.cs
@@ -21,6 +21,8 @@ namespace ServiceControl.Persistence.InMemory
                 {
                     return Task.FromResult(CheckStateChange.Unchanged);
                 }
+
+                storedCheck.HasFailed = detail.HasFailed;
             }
             else
             {

--- a/src/ServiceControl.Persistence.InMemory/InMemoryCustomCheckDataStore.cs
+++ b/src/ServiceControl.Persistence.InMemory/InMemoryCustomCheckDataStore.cs
@@ -13,9 +13,10 @@ namespace ServiceControl.Persistence.InMemory
     {
         public Task<CheckStateChange> UpdateCustomCheckStatus(CustomCheckDetail detail)
         {
-            if (storage.ContainsKey(detail.CustomCheckId))
+            var id = detail.GetDeterministicId();
+            if (storage.ContainsKey(id))
             {
-                var storedCheck = storage[detail.CustomCheckId];
+                var storedCheck = storage[id];
                 if (storedCheck.HasFailed == detail.HasFailed)
                 {
                     return Task.FromResult(CheckStateChange.Unchanged);
@@ -23,7 +24,7 @@ namespace ServiceControl.Persistence.InMemory
             }
             else
             {
-                storage.Add(detail.CustomCheckId, detail);
+                storage.Add(id, detail);
             }
 
             return Task.FromResult(CheckStateChange.Changed);
@@ -40,7 +41,7 @@ namespace ServiceControl.Persistence.InMemory
                     Status = x.Value.HasFailed ? Status.Fail : Status.Pass,
                     FailureReason = x.Value.FailureReason,
                     ReportedAt = x.Value.ReportedAt,
-                    CustomCheckId = x.Key,
+                    CustomCheckId = x.Value.CustomCheckId,
                     OriginatingEndpoint = x.Value.OriginatingEndpoint
                 })
                 .ToList();

--- a/src/ServiceControl.Persistence.RavenDb/RavenDbCustomCheckDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDb/RavenDbCustomCheckDataStore.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Persistence.RavenDb
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -75,6 +76,12 @@
 
                 return new QueryResult<IList<CustomCheck>>(results, new QueryStatsInfo(stats.IndexEtag, stats.TotalResults));
             }
+        }
+
+        public async Task DeleteCustomCheck(Guid id)
+        {
+            await store.AsyncDatabaseCommands.DeleteAsync(store.Conventions.DefaultFindFullDocumentKeyFromNonStringIdentifier(id, typeof(CustomCheck), false), null)
+                .ConfigureAwait(false);
         }
 
         static IRavenQueryable<CustomCheck> AddStatusFilter(IRavenQueryable<CustomCheck> query, string status)

--- a/src/ServiceControl.Persistence.SqlServer/SqlDbCustomCheckDataStore.cs
+++ b/src/ServiceControl.Persistence.SqlServer/SqlDbCustomCheckDataStore.cs
@@ -114,6 +114,19 @@ namespace ServiceControl.Persistence.SqlServer
             }).ConfigureAwait(false);
         }
 
+        public async Task DeleteCustomCheck(Guid id)
+        {
+            await connectionManager.Perform(async connection =>
+            {
+                await connection.ExecuteAsync(
+                    @"DELETE FROM [dbo].[CustomChecks] WHERE [Id] = @Id",
+                    new
+                    {
+                        Id = id
+                    }).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+        }
+
         readonly SqlDbConnectionManager connectionManager;
     }
 }

--- a/src/ServiceControl.PersistenceTests/CustomChecksDataStoreTests.cs
+++ b/src/ServiceControl.PersistenceTests/CustomChecksDataStoreTests.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Persistence.Tests
 {
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
     using Contracts.CustomChecks;
     using Contracts.Operations;
@@ -40,7 +41,7 @@ namespace ServiceControl.Persistence.Tests
                 OriginatingEndpoint = new EndpointDetails
                 {
                     Host = "localhost",
-                    HostId = Guid.Parse("5F41DEEA-783C-4B88-8558-9371A61F1027"),
+                    HostId = Guid.Parse("55D0800D-CC90-47C3-83EB-DDE292140C28"),
                     Name = "test-host"
                 },
             };
@@ -93,7 +94,7 @@ namespace ServiceControl.Persistence.Tests
                 OriginatingEndpoint = new EndpointDetails
                 {
                     Host = "localhost",
-                    HostId = Guid.Parse("5F41DEEA-783C-4B88-8558-9371A61F1027"),
+                    HostId = Guid.Parse("C4BDF251-5D22-4A29-AB47-7F1F3226E614"),
                     Name = "test-host"
                 },
             };
@@ -105,6 +106,38 @@ namespace ServiceControl.Persistence.Tests
             var stats = await fixture.CustomCheckDataStore.GetStats(new PagingInfo(), "pass").ConfigureAwait(false);
 
             Assert.AreEqual(1, stats.Results.Count);
+        }
+
+        [Test]
+        public async Task Should_delete_custom_checks()
+        {
+            var checkDetails = new CustomCheckDetail
+            {
+                Category = "test-category",
+                CustomCheckId = "deletion-test-check",
+                HasFailed = false,
+                OriginatingEndpoint = new EndpointDetails
+                {
+                    Host = "localhost",
+                    HostId = Guid.Parse("80996916-9B8D-4DE1-864A-4EDD359CC98F"),
+                    Name = "test-host"
+                },
+            };
+
+            var checkId = checkDetails.GetDeterministicId();
+
+            var _ = await fixture.CustomCheckDataStore.UpdateCustomCheckStatus(checkDetails).ConfigureAwait(false);
+
+            await fixture.CompleteDBOperation().ConfigureAwait(false);
+
+            await fixture.CustomCheckDataStore.DeleteCustomCheck(checkId).ConfigureAwait(false);
+
+            await fixture.CompleteDBOperation().ConfigureAwait(false);
+
+            var storedChecks = await fixture.CustomCheckDataStore.GetStats(new PagingInfo()).ConfigureAwait(false);
+            var check = storedChecks.Results.Where(c => c.Id == checkId).ToList();
+
+            Assert.AreEqual(0, check.Count);
         }
 
         readonly PersistenceDataStoreFixture fixture;

--- a/src/ServiceControl/CustomChecks/DeleteCustomCheckHandler.cs
+++ b/src/ServiceControl/CustomChecks/DeleteCustomCheckHandler.cs
@@ -3,26 +3,27 @@
     using System.Threading.Tasks;
     using Infrastructure.DomainEvents;
     using NServiceBus;
+    using Persistence;
     using Raven.Client;
 
     class DeleteCustomCheckHandler : IHandleMessages<DeleteCustomCheck>
     {
-        public DeleteCustomCheckHandler(IDocumentStore store, IDomainEvents domainEvents)
+        public DeleteCustomCheckHandler(ICustomChecksDataStore customChecksDataStore, IDomainEvents domainEvents)
         {
-            this.store = store;
+            this.customChecksDataStore = customChecksDataStore;
             this.domainEvents = domainEvents;
         }
 
         public async Task Handle(DeleteCustomCheck message, IMessageHandlerContext context)
         {
-            await store.AsyncDatabaseCommands.DeleteAsync(store.Conventions.DefaultFindFullDocumentKeyFromNonStringIdentifier(message.Id, typeof(CustomCheck), false), null)
+            await customChecksDataStore.DeleteCustomCheck(message.Id)
                 .ConfigureAwait(false);
 
             await domainEvents.Raise(new CustomCheckDeleted { Id = message.Id })
                 .ConfigureAwait(false);
         }
 
-        IDocumentStore store;
+        ICustomChecksDataStore customChecksDataStore;
         IDomainEvents domainEvents;
     }
 }

--- a/src/ServiceControl/Persistence/ICustomChecksDataStore.cs
+++ b/src/ServiceControl/Persistence/ICustomChecksDataStore.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Persistence
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using CompositeViews.Messages;
@@ -12,5 +13,6 @@ namespace ServiceControl.Persistence
         Task<CheckStateChange> UpdateCustomCheckStatus(CustomCheckDetail detail);
 
         Task<QueryResult<IList<CustomCheck>>> GetStats(PagingInfo paging, string status = null);
+        Task DeleteCustomCheck(Guid id);
     }
 }


### PR DESCRIPTION
- Refactors the deletion of custom checks to go through the storage abstraction
- Adds tests for the deletion scenario
- Change the in-memory storage to update the status of the custom check when it changes