### PR TITLE
Add warning when installing new RabbitMQ instances

### DIFF
--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -8,6 +8,7 @@
     using Framework;
     using Framework.Commands;
     using Framework.Modules;
+    using ServiceControl.Config.Extensions;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
@@ -72,9 +73,8 @@
                 }
             }
 
-            if ((instance.TransportPackage.Name == TransportNames.RabbitMQConventionalRoutingTopologyDeprecated ||
-                 instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
-                 !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
+            if (instance.TransportPackage.IsOldRabbitMQTransport() &&
+                !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
                    "Do you want to proceed?",
                    "Yes, my RabbitMQ broker meets the minimum requirements",
                    "No, cancel the upgrade"))

--- a/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
@@ -8,6 +8,7 @@
     using Framework;
     using Framework.Commands;
     using Framework.Modules;
+    using ServiceControl.Config.Extensions;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
     using UI.InstanceDetails;
@@ -45,9 +46,8 @@
 
             instance.Service.Refresh();
 
-            if ((instance.TransportPackage.Name == TransportNames.RabbitMQConventionalRoutingTopologyDeprecated ||
-                 instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
-                 !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
+            if (instance.TransportPackage.IsOldRabbitMQTransport() &&
+                !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
                    "Do you want to proceed?",
                    "Yes, my RabbitMQ broker meets the minimum requirements",
                    "No, cancel the upgrade"))

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -9,6 +9,7 @@
     using Framework;
     using Framework.Commands;
     using Framework.Modules;
+    using ServiceControl.Config.Extensions;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
@@ -201,9 +202,8 @@
                 }
             }
 
-            if ((instance.TransportPackage.Name == TransportNames.RabbitMQConventionalRoutingTopologyDeprecated ||
-                 instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
-                 !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
+            if (instance.TransportPackage.IsOldRabbitMQTransport() &&
+                !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
                    "Do you want to proceed?",
                    "Yes, my RabbitMQ broker meets the minimum requirements",
                    "No, cancel the upgrade"))

--- a/src/ServiceControl.Config/Extensions/TransportInfoExtensions.cs
+++ b/src/ServiceControl.Config/Extensions/TransportInfoExtensions.cs
@@ -1,0 +1,21 @@
+﻿namespace ServiceControl.Config.Extensions
+{
+    using ServiceControlInstaller.Engine.Instances;
+
+    static class TransportInfoExtensions
+    {
+        public static bool IsLatestRabbitMQTransport(this TransportInfo transport)
+        {
+            return transport.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology ||
+                   transport.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology ||
+                   transport.Name == TransportNames.RabbitMQClassicDirectRoutingTopology ||
+                   transport.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology;
+        }
+
+        public static bool IsOldRabbitMQTransport(this TransportInfo transport)
+        {
+            return transport.Name == TransportNames.RabbitMQConventionalRoutingTopologyDeprecated ||
+                   transport.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated;
+        }
+    }
+}

--- a/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddAttachment.cs
@@ -68,6 +68,19 @@
                 ServiceAccountPwd = viewModel.Password
             };
 
+            if ((instanceMetadata.TransportPackage.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology ||
+                 instanceMetadata.TransportPackage.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology ||
+                 instanceMetadata.TransportPackage.Name == TransportNames.RabbitMQClassicDirectRoutingTopology ||
+                 instanceMetadata.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
+                !await windowManager.ShowYesNoDialog("INSTALL WARNING", $"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before installing.",
+                                                     "Do you want to proceed?",
+                                                     "Yes, my RabbitMQ broker meets the minimum requirements",
+                                                     "No, cancel the install"))
+            {
+                viewModel.InProgress = false;
+                return;
+            }
+
             using (var progress = viewModel.GetProgressObject("ADDING INSTANCE"))
             {
                 var reportCard = await Task.Run(() => installer.Add(instanceMetadata, progress, PromptToProceed));

--- a/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddAttachment.cs
@@ -7,6 +7,7 @@
     using Framework;
     using Framework.Modules;
     using ReactiveUI;
+    using ServiceControl.Config.Extensions;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.Validation;
     using Validation;
@@ -68,10 +69,7 @@
                 ServiceAccountPwd = viewModel.Password
             };
 
-            if ((instanceMetadata.TransportPackage.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology ||
-                 instanceMetadata.TransportPackage.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology ||
-                 instanceMetadata.TransportPackage.Name == TransportNames.RabbitMQClassicDirectRoutingTopology ||
-                 instanceMetadata.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
+            if (instanceMetadata.TransportPackage.IsLatestRabbitMQTransport() &&
                 !await windowManager.ShowYesNoDialog("INSTALL WARNING", $"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before installing.",
                                                      "Do you want to proceed?",
                                                      "Yes, my RabbitMQ broker meets the minimum requirements",

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
@@ -7,6 +7,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
     using Framework;
     using Framework.Modules;
     using ReactiveUI;
+    using ServiceControl.Config.Extensions;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.Validation;
     using Validation;
@@ -99,10 +100,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 EnableFullTextSearchOnBodies = viewModel.ServiceControlAudit.EnableFullTextSearchOnBodies.Value
             };
 
-            if ((serviceControlNewInstance.TransportPackage.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology ||
-                 serviceControlNewInstance.TransportPackage.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology ||
-                 serviceControlNewInstance.TransportPackage.Name == TransportNames.RabbitMQClassicDirectRoutingTopology ||
-                 serviceControlNewInstance.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
+            if (serviceControlNewInstance.TransportPackage.IsLatestRabbitMQTransport() &&
                 !await windowManager.ShowYesNoDialog("INSTALL WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before installing.",
                                                      "Do you want to proceed?",
                                                      "Yes, my RabbitMQ broker meets the minimum requirements",

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
@@ -99,6 +99,19 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 EnableFullTextSearchOnBodies = viewModel.ServiceControlAudit.EnableFullTextSearchOnBodies.Value
             };
 
+            if ((serviceControlNewInstance.TransportPackage.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology ||
+                 serviceControlNewInstance.TransportPackage.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology ||
+                 serviceControlNewInstance.TransportPackage.Name == TransportNames.RabbitMQClassicDirectRoutingTopology ||
+                 serviceControlNewInstance.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
+                !await windowManager.ShowYesNoDialog("INSTALL WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before installing.",
+                                                     "Do you want to proceed?",
+                                                     "Yes, my RabbitMQ broker meets the minimum requirements",
+                                                     "No, cancel the install"))
+            {
+                viewModel.InProgress = false;
+                return;
+            }
+
             serviceControlNewInstance.AddRemoteInstance(auditNewInstance.Url);
 
             using (var progress = viewModel.GetProgressObject("ADDING INSTANCE"))


### PR DESCRIPTION
When installing new instances (including Monitoring instances) that use RabbitMQ, a warning dialog will pop up requiring confirmation that the RabbitMQ transport 7.0 prerequisites have been met (version 3.10+, and quorum queues and stream queue feature flags enabled).   