### PR TITLE
Add upgrade requirements acknowlegement parameter to PowerShell commands

### DIFF
--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -8,7 +8,7 @@
     using Framework;
     using Framework.Commands;
     using Framework.Modules;
-    using ServiceControl.Config.Extensions;
+    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;

--- a/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
@@ -8,7 +8,7 @@
     using Framework;
     using Framework.Commands;
     using Framework.Modules;
-    using ServiceControl.Config.Extensions;
+    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
     using UI.InstanceDetails;

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -9,7 +9,7 @@
     using Framework;
     using Framework.Commands;
     using Framework.Modules;
-    using ServiceControl.Config.Extensions;
+    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;

--- a/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddAttachment.cs
@@ -7,7 +7,7 @@
     using Framework;
     using Framework.Modules;
     using ReactiveUI;
-    using ServiceControl.Config.Extensions;
+    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.Validation;
     using Validation;

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
@@ -7,7 +7,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
     using Framework;
     using Framework.Modules;
     using ReactiveUI;
-    using ServiceControl.Config.Extensions;
+    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.Validation;
     using Validation;

--- a/src/ServiceControlInstaller.Engine/Extensions/TransportInfoExtensions.cs
+++ b/src/ServiceControlInstaller.Engine/Extensions/TransportInfoExtensions.cs
@@ -1,8 +1,8 @@
-﻿namespace ServiceControl.Config.Extensions
+﻿namespace ServiceControl.Engine.Extensions
 {
     using ServiceControlInstaller.Engine.Instances;
 
-    static class TransportInfoExtensions
+    public static class TransportInfoExtensions
     {
         public static bool IsLatestRabbitMQTransport(this TransportInfo transport)
         {

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
@@ -51,7 +51,7 @@ namespace ServiceControlInstaller.PowerShell
                      instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
                     !AcknowledgeTransportMinimumRequirements.ToBool())
                 {
-                    throw new EngineValidationException($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements.");
+                    ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Upgrade Error", ErrorCategory.InvalidArgument, null));
                 }
 
                 if (!installer.Upgrade(instance))

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
@@ -4,6 +4,7 @@ namespace ServiceControlInstaller.PowerShell
     using System.Management.Automation;
     using Engine.Instances;
     using Engine.Unattended;
+    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Validation;
 
     [Cmdlet(VerbsLifecycle.Invoke, "ServiceControlAuditInstanceUpgrade")]
@@ -47,8 +48,7 @@ namespace ServiceControlInstaller.PowerShell
                     instance.EnableFullTextSearchOnBodies = false;
                 }
 
-                if ((instance.TransportPackage.Name == TransportNames.RabbitMQConventionalRoutingTopologyDeprecated ||
-                     instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
+                if (instance.TransportPackage.IsOldRabbitMQTransport() &&
                     !AcknowledgeTransportMinimumRequirements.ToBool())
                 {
                     ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Upgrade Error", ErrorCategory.InvalidArgument, null));

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
@@ -1,11 +1,12 @@
 namespace ServiceControlInstaller.PowerShell
 {
     using System;
+    using System.Linq;
     using System.Management.Automation;
     using Engine.Instances;
     using Engine.Unattended;
     using ServiceControl.Engine.Extensions;
-    using ServiceControlInstaller.Engine.Validation;
+    using ServiceControlInstaller.PowerShell.Validation;
 
     [Cmdlet(VerbsLifecycle.Invoke, "ServiceControlAuditInstanceUpgrade")]
     public class InvokeServiceControlAuditInstanceUpgrade : PSCmdlet
@@ -16,8 +17,8 @@ namespace ServiceControlInstaller.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Disable full text search on audit messages.")]
         public SwitchParameter DisableFullTextSearchOnBodies { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Acknowledge transport prerequisites have been met.")]
-        public SwitchParameter AcknowledgeTransportMinimumRequirements { get; set; }
+        [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]
+        public string[] Acknowledgements { get; set; }
 
         protected override void BeginProcessing()
         {
@@ -49,9 +50,9 @@ namespace ServiceControlInstaller.PowerShell
                 }
 
                 if (instance.TransportPackage.IsOldRabbitMQTransport() &&
-                    !AcknowledgeTransportMinimumRequirements.ToBool())
+                   (Acknowledgements == null || !Acknowledgements.Any(ack => ack.Equals(AcknowledgementValues.RabbitMQBrokerVersion310, StringComparison.OrdinalIgnoreCase))))
                 {
-                    ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Upgrade Error", ErrorCategory.InvalidArgument, null));
+                    ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -Acknowledgements {AcknowledgementValues.RabbitMQBrokerVersion310} if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
                 }
 
                 if (!installer.Upgrade(instance))

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
@@ -165,7 +165,7 @@
                  details.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
                 !AcknowledgeTransportMinimumRequirements.ToBool())
             {
-                throw new EngineValidationException($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements.");
+                ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
             }
 
             try

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
@@ -8,6 +8,7 @@
     using Engine.Unattended;
     using Engine.Validation;
     using ServiceControl.Engine.Extensions;
+    using ServiceControlInstaller.PowerShell.Validation;
     using PathInfo = Engine.Validation.PathInfo;
 
     [Cmdlet(VerbsCommon.New, "ServiceControlAuditInstance")]
@@ -93,8 +94,8 @@
         [Parameter(Mandatory = false, HelpMessage = "Reuse the specified log, db, and install paths even if they are not empty")]
         public SwitchParameter Force { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Acknowledge transport prerequisites have been met.")]
-        public SwitchParameter AcknowledgeTransportMinimumRequirements { get; set; }
+        [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]
+        public string[] Acknowledgements { get; set; }
 
         protected override void BeginProcessing()
         {
@@ -161,9 +162,9 @@
             var installer = new UnattendAuditInstaller(logger, zipfolder);
 
             if (details.TransportPackage.IsLatestRabbitMQTransport() &&
-                !AcknowledgeTransportMinimumRequirements.ToBool())
+               (Acknowledgements == null || !Acknowledgements.Any(ack => ack.Equals(AcknowledgementValues.RabbitMQBrokerVersion310, StringComparison.OrdinalIgnoreCase))))
             {
-                ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
+                ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -Acknowledgements {AcknowledgementValues.RabbitMQBrokerVersion310} if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
             }
 
             try

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
@@ -7,6 +7,7 @@
     using Engine.Instances;
     using Engine.Unattended;
     using Engine.Validation;
+    using ServiceControl.Engine.Extensions;
     using PathInfo = Engine.Validation.PathInfo;
 
     [Cmdlet(VerbsCommon.New, "ServiceControlAuditInstance")]
@@ -159,10 +160,7 @@
 
             var installer = new UnattendAuditInstaller(logger, zipfolder);
 
-            if ((details.TransportPackage.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology ||
-                 details.TransportPackage.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology ||
-                 details.TransportPackage.Name == TransportNames.RabbitMQClassicDirectRoutingTopology ||
-                 details.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
+            if (details.TransportPackage.IsLatestRabbitMQTransport() &&
                 !AcknowledgeTransportMinimumRequirements.ToBool())
             {
                 ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
@@ -92,6 +92,9 @@
         [Parameter(Mandatory = false, HelpMessage = "Reuse the specified log, db, and install paths even if they are not empty")]
         public SwitchParameter Force { get; set; }
 
+        [Parameter(Mandatory = false, HelpMessage = "Acknowledge transport prerequisites have been met.")]
+        public SwitchParameter AcknowledgeTransportMinimumRequirements { get; set; }
+
         protected override void BeginProcessing()
         {
             AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
@@ -155,6 +158,16 @@
             var logger = new PSLogger(Host);
 
             var installer = new UnattendAuditInstaller(logger, zipfolder);
+
+            if ((details.TransportPackage.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology ||
+                 details.TransportPackage.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology ||
+                 details.TransportPackage.Name == TransportNames.RabbitMQClassicDirectRoutingTopology ||
+                 details.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
+                !AcknowledgeTransportMinimumRequirements.ToBool())
+            {
+                throw new EngineValidationException($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements.");
+            }
+
             try
             {
                 logger.Info("Installing Service Control Audit instance...");

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/InvokeMonitoringUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/InvokeMonitoringUpgrade.cs
@@ -4,6 +4,7 @@ namespace ServiceControlInstaller.PowerShell
     using System.Management.Automation;
     using Engine.Instances;
     using Engine.Unattended;
+    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Validation;
 
     [Cmdlet(VerbsLifecycle.Invoke, "MonitoringInstanceUpgrade")]
@@ -38,8 +39,7 @@ namespace ServiceControlInstaller.PowerShell
                     break;
                 }
 
-                if ((instance.TransportPackage.Name == TransportNames.RabbitMQConventionalRoutingTopologyDeprecated ||
-                     instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
+                if (instance.TransportPackage.IsOldRabbitMQTransport() &&
                     !AcknowledgeTransportMinimumRequirements.ToBool())
                 {
                     ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Upgrade Error", ErrorCategory.InvalidArgument, null));

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/InvokeMonitoringUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/InvokeMonitoringUpgrade.cs
@@ -42,7 +42,7 @@ namespace ServiceControlInstaller.PowerShell
                      instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
                     !AcknowledgeTransportMinimumRequirements.ToBool())
                 {
-                    throw new EngineValidationException($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements.");
+                    ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Upgrade Error", ErrorCategory.InvalidArgument, null));
                 }
 
                 instance.SkipQueueCreation = SkipQueueCreation;

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/InvokeMonitoringUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/InvokeMonitoringUpgrade.cs
@@ -4,6 +4,7 @@ namespace ServiceControlInstaller.PowerShell
     using System.Management.Automation;
     using Engine.Instances;
     using Engine.Unattended;
+    using ServiceControlInstaller.Engine.Validation;
 
     [Cmdlet(VerbsLifecycle.Invoke, "MonitoringInstanceUpgrade")]
     public class InvokeMonitoringUpgrade : PSCmdlet
@@ -11,6 +12,8 @@ namespace ServiceControlInstaller.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Do not automatically create new queues")]
         public SwitchParameter SkipQueueCreation { get; set; }
 
+        [Parameter(Mandatory = false, HelpMessage = "Acknowledge transport prerequisites have been met.")]
+        public SwitchParameter AcknowledgeTransportMinimumRequirements { get; set; }
 
         protected override void BeginProcessing()
         {
@@ -33,6 +36,13 @@ namespace ServiceControlInstaller.PowerShell
                 {
                     WriteWarning($"No action taken. An instance called {name} was not found");
                     break;
+                }
+
+                if ((instance.TransportPackage.Name == TransportNames.RabbitMQConventionalRoutingTopologyDeprecated ||
+                     instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
+                    !AcknowledgeTransportMinimumRequirements.ToBool())
+                {
+                    throw new EngineValidationException($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements.");
                 }
 
                 instance.SkipQueueCreation = SkipQueueCreation;

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
@@ -8,6 +8,7 @@ namespace ServiceControlInstaller.PowerShell
     using Engine.Instances;
     using Engine.Unattended;
     using Engine.Validation;
+    using ServiceControl.Engine.Extensions;
     using PathInfo = Engine.Validation.PathInfo;
 
     [Cmdlet(VerbsCommon.New, "MonitoringInstance")]
@@ -126,10 +127,7 @@ namespace ServiceControlInstaller.PowerShell
 
             var installer = new UnattendMonitoringInstaller(logger, zipfolder);
 
-            if ((details.TransportPackage.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology ||
-                 details.TransportPackage.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology ||
-                 details.TransportPackage.Name == TransportNames.RabbitMQClassicDirectRoutingTopology ||
-                 details.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
+            if (details.TransportPackage.IsLatestRabbitMQTransport() &&
                 !AcknowledgeTransportMinimumRequirements.ToBool())
             {
                 ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
@@ -67,6 +67,8 @@ namespace ServiceControlInstaller.PowerShell
         [Parameter(Mandatory = false)]
         public SwitchParameter Force { get; set; }
 
+        [Parameter(Mandatory = false, HelpMessage = "Acknowledge transport prerequisites have been met.")]
+        public SwitchParameter AcknowledgeTransportMinimumRequirements { get; set; }
         protected override void BeginProcessing()
         {
             AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
@@ -123,6 +125,16 @@ namespace ServiceControlInstaller.PowerShell
             var logger = new PSLogger(Host);
 
             var installer = new UnattendMonitoringInstaller(logger, zipfolder);
+
+            if ((details.TransportPackage.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology ||
+                 details.TransportPackage.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology ||
+                 details.TransportPackage.Name == TransportNames.RabbitMQClassicDirectRoutingTopology ||
+                 details.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
+                !AcknowledgeTransportMinimumRequirements.ToBool())
+            {
+                throw new EngineValidationException($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements.");
+            }
+
             try
             {
                 logger.Info("Installing Monitoring instance...");

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
@@ -132,7 +132,7 @@ namespace ServiceControlInstaller.PowerShell
                  details.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
                 !AcknowledgeTransportMinimumRequirements.ToBool())
             {
-                throw new EngineValidationException($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements.");
+                ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
             }
 
             try

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
@@ -9,6 +9,7 @@ namespace ServiceControlInstaller.PowerShell
     using Engine.Unattended;
     using Engine.Validation;
     using ServiceControl.Engine.Extensions;
+    using ServiceControlInstaller.PowerShell.Validation;
     using PathInfo = Engine.Validation.PathInfo;
 
     [Cmdlet(VerbsCommon.New, "MonitoringInstance")]
@@ -68,8 +69,9 @@ namespace ServiceControlInstaller.PowerShell
         [Parameter(Mandatory = false)]
         public SwitchParameter Force { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Acknowledge transport prerequisites have been met.")]
-        public SwitchParameter AcknowledgeTransportMinimumRequirements { get; set; }
+        [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]
+        public string[] Acknowledgements { get; set; }
+
         protected override void BeginProcessing()
         {
             AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
@@ -128,9 +130,9 @@ namespace ServiceControlInstaller.PowerShell
             var installer = new UnattendMonitoringInstaller(logger, zipfolder);
 
             if (details.TransportPackage.IsLatestRabbitMQTransport() &&
-                !AcknowledgeTransportMinimumRequirements.ToBool())
+               (Acknowledgements == null || !Acknowledgements.Any(ack => ack.Equals(AcknowledgementValues.RabbitMQBrokerVersion310, StringComparison.OrdinalIgnoreCase))))
             {
-                ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
+                ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -Acknowledgements {AcknowledgementValues.RabbitMQBrokerVersion310} if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
             }
 
             try

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
@@ -7,6 +7,7 @@ namespace ServiceControlInstaller.PowerShell
     using Engine.Instances;
     using Engine.Unattended;
     using Engine.Validation;
+    using ServiceControl.Engine.Extensions;
     using PathInfo = Engine.Validation.PathInfo;
 
     [Cmdlet(VerbsLifecycle.Invoke, "ServiceControlInstanceUpgrade")]
@@ -154,8 +155,7 @@ namespace ServiceControlInstaller.PowerShell
                     UpgradeControl.GetUpgradeInfoForTargetVersion(installer.ZipInfo.Version, instance.Version),
             };
 
-            if ((instance.TransportPackage.Name == TransportNames.RabbitMQConventionalRoutingTopologyDeprecated ||
-                 instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
+            if (instance.TransportPackage.IsOldRabbitMQTransport() &&
                 !AcknowledgeTransportMinimumRequirements.ToBool())
             {
                 ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Upgrade Error", ErrorCategory.InvalidArgument, null));

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
@@ -158,7 +158,7 @@ namespace ServiceControlInstaller.PowerShell
                  instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
                 !AcknowledgeTransportMinimumRequirements.ToBool())
             {
-                throw new EngineValidationException($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements.");
+                ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Upgrade Error", ErrorCategory.InvalidArgument, null));
             }
 
             if (!installer.Upgrade(instance, options))

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
@@ -48,6 +48,9 @@ namespace ServiceControlInstaller.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Reuse the specified log, db, and install paths even if they are not empty")]
         public SwitchParameter Force { get; set; }
 
+        [Parameter(Mandatory = false, HelpMessage = "Acknowledge transport prerequisites have been met.")]
+        public SwitchParameter AcknowledgeTransportMinimumRequirements { get; set; }
+
         protected override void BeginProcessing()
         {
             AppDomain.CurrentDomain.AssemblyResolve += BindingRedirectAssemblyLoader.CurrentDomain_BindingRedirect;
@@ -150,6 +153,13 @@ namespace ServiceControlInstaller.PowerShell
                 UpgradeInfo =
                     UpgradeControl.GetUpgradeInfoForTargetVersion(installer.ZipInfo.Version, instance.Version),
             };
+
+            if ((instance.TransportPackage.Name == TransportNames.RabbitMQConventionalRoutingTopologyDeprecated ||
+                 instance.TransportPackage.Name == TransportNames.RabbitMQDirectRoutingTopologyDeprecated) &&
+                !AcknowledgeTransportMinimumRequirements.ToBool())
+            {
+                throw new EngineValidationException($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements.");
+            }
 
             if (!installer.Upgrade(instance, options))
             {

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
@@ -9,6 +9,7 @@ namespace ServiceControlInstaller.PowerShell
     using Engine.Unattended;
     using Engine.Validation;
     using ServiceControl.Engine.Extensions;
+    using ServiceControlInstaller.PowerShell.Validation;
     using PathInfo = Engine.Validation.PathInfo;
 
     [Cmdlet(VerbsCommon.New, "ServiceControlInstance")]
@@ -96,8 +97,8 @@ namespace ServiceControlInstaller.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Reuse the specified log, db, and install paths even if they are not empty")]
         public SwitchParameter Force { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Acknowledge transport prerequisites have been met.")]
-        public SwitchParameter AcknowledgeTransportMinimumRequirements { get; set; }
+        [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]
+        public string[] Acknowledgements { get; set; }
 
         protected override void BeginProcessing()
         {
@@ -177,9 +178,9 @@ namespace ServiceControlInstaller.PowerShell
             try
             {
                 if (details.TransportPackage.IsLatestRabbitMQTransport() &&
-                    !AcknowledgeTransportMinimumRequirements.ToBool())
+                   (Acknowledgements == null || !Acknowledgements.Any(ack => ack.Equals(AcknowledgementValues.RabbitMQBrokerVersion310, StringComparison.OrdinalIgnoreCase))))
                 {
-                    ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
+                    ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -Acknowledgements {AcknowledgementValues.RabbitMQBrokerVersion310} if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
                 }
 
                 logger.Info("Module root at " + modulePath);

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
@@ -8,6 +8,7 @@ namespace ServiceControlInstaller.PowerShell
     using Engine.Instances;
     using Engine.Unattended;
     using Engine.Validation;
+    using ServiceControl.Engine.Extensions;
     using PathInfo = Engine.Validation.PathInfo;
 
     [Cmdlet(VerbsCommon.New, "ServiceControlInstance")]
@@ -175,11 +176,8 @@ namespace ServiceControlInstaller.PowerShell
             var installer = new UnattendServiceControlInstaller(logger, zipfolder);
             try
             {
-                if ((details.TransportPackage.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology ||
-                 details.TransportPackage.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology ||
-                 details.TransportPackage.Name == TransportNames.RabbitMQClassicDirectRoutingTopology ||
-                 details.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
-                !AcknowledgeTransportMinimumRequirements.ToBool())
+                if (details.TransportPackage.IsLatestRabbitMQTransport() &&
+                    !AcknowledgeTransportMinimumRequirements.ToBool())
                 {
                     ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
                 }

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
@@ -181,7 +181,7 @@ namespace ServiceControlInstaller.PowerShell
                  details.TransportPackage.Name == TransportNames.RabbitMQQuorumDirectRoutingTopology) &&
                 !AcknowledgeTransportMinimumRequirements.ToBool())
                 {
-                    throw new EngineValidationException($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements.");
+                    ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -AcknowledgeTransportMinimumRequirements if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
                 }
 
                 logger.Info("Module root at " + modulePath);

--- a/src/ServiceControlInstaller.PowerShell/Validation/AcknowledgementValues.cs
+++ b/src/ServiceControlInstaller.PowerShell/Validation/AcknowledgementValues.cs
@@ -1,0 +1,7 @@
+﻿namespace ServiceControlInstaller.PowerShell.Validation
+{
+    static class AcknowledgementValues
+    {
+        public const string RabbitMQBrokerVersion310 = "RabbitMQBrokerVersion310";
+    }
+}


### PR DESCRIPTION
Add a parameter to the PowerShell commands that is required to install or upgrade instances that use the RabbitMQ Transport.  This is to prevent users from upgrading before they have met the newly added minimum broker requirements for RabbitMQ transport 7.0.  