### PR TITLE
Enable installers for monitoring instance in setup mode

### DIFF
--- a/src/ServiceControl.Monitoring/Infrastructure/SetupBootstrapper.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/SetupBootstrapper.cs
@@ -35,6 +35,8 @@ namespace ServiceControl.Monitoring.Infrastructure
 
                 bootstrapper.ConfigureEndpoint(endpointConfig);
 
+                endpointConfig.EnableInstallers(settings.Username);
+
                 if (settings.SkipQueueCreation)
                 {
                     Logger.Info("Skipping queue creation");


### PR DESCRIPTION
The monitoring instance is not creating queues when run in setup mode. This prevents the instance from starting.