### PR TITLE
Moving message body storage behind the persistence abstraction

### DIFF
--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditIngestionUnitOfWork.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Audit.Persistence.InMemory
 {
     using System.Threading.Tasks;
+    using Auditing.BodyStorage;
     using ServiceControl.Audit.Auditing;
     using ServiceControl.Audit.Monitoring;
     using ServiceControl.Audit.Persistence.UnitOfWork;
@@ -8,7 +9,12 @@
 
     class InMemoryAuditIngestionUnitOfWork : IAuditIngestionUnitOfWork
     {
-        public InMemoryAuditIngestionUnitOfWork(InMemoryAuditDataStore dataStore) => this.dataStore = dataStore;
+        public InMemoryAuditIngestionUnitOfWork(InMemoryAuditDataStore dataStore,
+            BodyStorageEnricher bodyStorageEnricher)
+        {
+            this.dataStore = dataStore;
+            this.bodyStorageEnricher = bodyStorageEnricher;
+        }
 
         public ValueTask DisposeAsync()
         {
@@ -21,9 +27,13 @@
             return Task.CompletedTask;
         }
 
-        public Task RecordProcessedMessage(ProcessedMessage processedMessage)
+        public async Task RecordProcessedMessage(ProcessedMessage processedMessage, byte[] body)
         {
-            return dataStore.SaveProcessedMessage(processedMessage);
+            if (body != null)
+            {
+                await bodyStorageEnricher.StoreAuditMessageBody(body, processedMessage).ConfigureAwait(false);
+            }
+            await dataStore.SaveProcessedMessage(processedMessage).ConfigureAwait(false);
         }
 
         public Task RecordSagaSnapshot(SagaSnapshot sagaSnapshot)
@@ -32,5 +42,6 @@
         }
 
         InMemoryAuditDataStore dataStore;
+        BodyStorageEnricher bodyStorageEnricher;
     }
 }

--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditIngestionUnitOfWorkFactory.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditIngestionUnitOfWorkFactory.cs
@@ -1,17 +1,24 @@
 ﻿namespace ServiceControl.Audit.Persistence.InMemory
 {
+    using Infrastructure.Settings;
+    using ServiceControl.Audit.Auditing.BodyStorage;
     using ServiceControl.Audit.Persistence.UnitOfWork;
 
     class InMemoryAuditIngestionUnitOfWorkFactory : IAuditIngestionUnitOfWorkFactory
     {
-        public InMemoryAuditIngestionUnitOfWorkFactory(InMemoryAuditDataStore dataStore) => this.dataStore = dataStore;
+        public InMemoryAuditIngestionUnitOfWorkFactory(InMemoryAuditDataStore dataStore, IBodyStorage bodyStorage, Settings settings)
+        {
+            this.dataStore = dataStore;
+            bodyStorageEnricher = new BodyStorageEnricher(bodyStorage, settings);
+        }
 
         public IAuditIngestionUnitOfWork StartNew(int batchSize)
         {
             //The batchSize argument is ignored: the in-memory storage implementation doesn't support batching.
-            return new InMemoryAuditIngestionUnitOfWork(dataStore);
+            return new InMemoryAuditIngestionUnitOfWork(dataStore, bodyStorageEnricher);
         }
 
         InMemoryAuditDataStore dataStore;
+        BodyStorageEnricher bodyStorageEnricher;
     }
 }

--- a/src/ServiceControl.Audit.Persistence.InMemory/MessagesViewFactory.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/MessagesViewFactory.cs
@@ -1,0 +1,63 @@
+﻿namespace ServiceControl.Audit.Persistence.InMemory
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Auditing;
+    using Auditing.MessagesView;
+    using Monitoring;
+
+    static class MessagesViewFactory
+    {
+        static ILookup<string, PropertyInfo> writeableMessageViewProperties
+            = typeof(MessagesView).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(p => p.CanWrite)
+                .ToLookup(p => p.Name, StringComparer.InvariantCultureIgnoreCase);
+
+        static ILookup<string, string> propertyMapping
+            = new Dictionary<string, string>
+            {
+                // Metadata key, Property name
+                { "ContentLength", "BodySize" }
+            }.ToLookup(
+                x => x.Key,
+                x => x.Value,
+                StringComparer.InvariantCultureIgnoreCase);
+
+        public static MessagesView Create(ProcessedMessage message)
+        {
+            var result = new MessagesView
+            {
+                Id = message.UniqueMessageId,
+                ProcessedAt = message.ProcessedAt,
+                Status = MessageStatus.Successful,
+                Headers = message.Headers.Select(header => new KeyValuePair<string, object>(header.Key, header.Value))
+            };
+
+            foreach (var metadata in message.MessageMetadata)
+            {
+                foreach (var property in writeableMessageViewProperties[metadata.Key])
+                {
+                    // TODO: Check types
+                    property.SetValue(result, metadata.Value);
+                }
+                foreach (var mappedName in propertyMapping[metadata.Key])
+                {
+                    foreach (var property in writeableMessageViewProperties[mappedName])
+                    {
+                        // TODO: Check types
+                        property.SetValue(result, metadata.Value);
+                    }
+                }
+            }
+
+            if (message.MessageMetadata.TryGetValue("IsRetried", out var isRetried) && (bool)isRetried)
+            {
+                result.Status = MessageStatus.ResolvedSuccessfully;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/Indexes/MessagesViewIndex.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/Indexes/MessagesViewIndex.cs
@@ -24,7 +24,11 @@ namespace ServiceControl.Audit.Persistence.RavenDb.Indexes
                                   CriticalTime = (TimeSpan?)message.MessageMetadata["CriticalTime"],
                                   ProcessingTime = (TimeSpan?)message.MessageMetadata["ProcessingTime"],
                                   DeliveryTime = (TimeSpan?)message.MessageMetadata["DeliveryTime"],
-                                  Query = message.MessageMetadata.Select(_ => _.Value.ToString()).Union(new[] { string.Join(" ", message.Headers.Select(x => x.Value)) }).ToArray(),
+                                  Query = message.MessageMetadata.Select(_ => _.Value.ToString()).Union(new[]
+                                  {
+                                      string.Join(" ", message.Headers.Select(x => x.Value)),
+                                      LoadAttachment(message, "body").GetContentAsString()
+                                  }).ToArray(),
                                   ConversationId = (string)message.MessageMetadata["ConversationId"]
                               };
 

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
@@ -3,9 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Net;
-    using System.Net.Http;
-    using System.Net.Http.Headers;
     using System.Threading.Tasks;
     using Raven.Client.Documents;
     using Auditing.MessagesView;
@@ -126,58 +123,6 @@
                     .ConfigureAwait(false);
 
                 return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
-            }
-        }
-
-        public async Task<HttpResponseMessage> TryFetchFromIndex(HttpRequestMessage request, string messageId)
-        {
-            using (var session = documentStore.OpenAsyncSession())
-            {
-                var message = await session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
-                    .Statistics(out var stats)
-                    .Select(msg =>
-                        new
-                        {
-                            // TODO: Load these values properly
-                            msg.MessageId,
-                            Body = "",
-                            //!string.IsNullOrEmpty(message.Body) ? message.Body : metadata["Body"],
-                            BodySize = 0,
-                            //(int)metadata["ContentLength"],
-                            ContentType = "",
-                            //metadata["ContentType"],
-                            BodyNotStored = false
-                            //(bool)metadata["BodyNotStored"]
-                        }
-                    )
-                    .FirstOrDefaultAsync(f => f.MessageId == messageId)
-                    .ConfigureAwait(false);
-
-                if (message == null)
-                {
-                    return request.CreateResponse(HttpStatusCode.NotFound);
-                }
-
-                if (message.BodyNotStored && message.Body == null)
-                {
-                    return request.CreateResponse(HttpStatusCode.NoContent);
-                }
-
-                if (message.Body == null)
-                {
-                    return request.CreateResponse(HttpStatusCode.NotFound);
-                }
-
-                var response = request.CreateResponse(HttpStatusCode.OK);
-                var content = new StringContent(message.Body);
-
-                MediaTypeHeaderValue.TryParse(message.ContentType, out var parsedContentType);
-                content.Headers.ContentType = parsedContentType ?? new MediaTypeHeaderValue("text/*");
-
-                content.Headers.ContentLength = message.BodySize;
-                response.Headers.ETag = new EntityTagHeaderValue($"\"{stats.ResultEtag}\"");
-                response.Content = content;
-                return response;
             }
         }
 

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
@@ -126,7 +126,25 @@
             }
         }
 
-        public Task<MessageBodyView> GetMessageBody(string messageId) => throw new NotImplementedException();
+        public async Task<MessageBodyView> GetMessageBody(string messageId)
+        {
+            using (var session = documentStore.OpenAsyncSession())
+            {
+                var result = await session.Advanced.Attachments.GetAsync(messageId, "body").ConfigureAwait(false);
+
+                if (result == null)
+                {
+                    return MessageBodyView.NotFound();
+                }
+
+                return MessageBodyView.FromStream(
+                    result.Stream,
+                    result.Details.ContentType,
+                    (int)result.Details.Size,
+                    result.Details.ChangeVector
+                );
+            }
+        }
 
         public async Task<QueryResult<IList<KnownEndpointsView>>> QueryKnownEndpoints()
         {

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
@@ -181,6 +181,8 @@
             }
         }
 
+        public Task<MessageBodyView> GetMessageBody(string messageId) => throw new NotImplementedException();
+
         public async Task<QueryResult<IList<KnownEndpointsView>>> QueryKnownEndpoints()
         {
             using (var session = documentStore.OpenAsyncSession())

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/Transformers/MessagesViewTransformer.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/Transformers/MessagesViewTransformer.cs
@@ -32,7 +32,7 @@ namespace ServiceControl.Audit.Persistence.RavenDb.Transformers
                 IsSystemMessage = (bool)message.MessageMetadata["IsSystemMessage"],
                 ConversationId = message.MessageMetadata["ConversationId"].ToString(),
                 //Headers = message.Headers.ToArray(),
-                //Status = message.MessageMetadata["IsRetried"] ? MessageStatus.ResolvedSuccessfully : MessageStatus.Successful,
+                Status = (bool)message.MessageMetadata["IsRetried"] ? MessageStatus.ResolvedSuccessfully : MessageStatus.Successful,
                 MessageIntent = (MessageIntentEnum)message.MessageMetadata["MessageIntent"],
                 BodyUrl = message.MessageMetadata["BodyUrl"].ToString(),
                 BodySize = (int)message.MessageMetadata["ContentLength"],

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditIngestionUnitOfWork.cs
@@ -24,7 +24,7 @@
             {
                 // TODO: Pull both of these up to the higher level
                 processedMessage.MessageMetadata["ContentLength"] = body.Length;
-                processedMessage.MessageMetadata["BodyUrl"] = $"/messages/{processedMessage.MessageMetadata["MessageId"]}/body";
+                processedMessage.MessageMetadata["BodyUrl"] = $"/messages/{processedMessage.Id}/body";
             }
 
             await bulkInsert.StoreAsync(processedMessage).ConfigureAwait(false);

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditIngestionUnitOfWork.cs
@@ -1,8 +1,11 @@
 ﻿namespace ServiceControl.Audit.Persistence.RavenDb.UnitOfWork
 {
+    using System;
     using System.Threading.Tasks;
     using Auditing;
+    using Infrastructure;
     using Monitoring;
+    using NServiceBus;
     using Persistence.UnitOfWork;
     using Raven.Client.Documents.BulkInsert;
     using ServiceControl.SagaAudit;
@@ -14,8 +17,30 @@
         public RavenDbAuditIngestionUnitOfWork(BulkInsertOperation bulkInsert)
             => this.bulkInsert = bulkInsert;
 
-        public Task RecordProcessedMessage(ProcessedMessage processedMessage, byte[] body)
-            => bulkInsert.StoreAsync(processedMessage);
+        public async Task RecordProcessedMessage(ProcessedMessage processedMessage, byte[] body)
+        {
+
+            if (body != null)
+            {
+                // TODO: Pull both of these up to the higher level
+                processedMessage.MessageMetadata["ContentLength"] = body.Length;
+                processedMessage.MessageMetadata["BodyUrl"] = $"/messages/{processedMessage.MessageMetadata["MessageId"]}/body";
+            }
+
+            await bulkInsert.StoreAsync(processedMessage).ConfigureAwait(false);
+
+            if (body != null)
+            {
+                using (var stream = Memory.Manager.GetStream(Guid.NewGuid(), processedMessage.Id, body, 0, body.Length))
+                {
+                    processedMessage.Headers.TryGetValue(Headers.ContentType, out var contentType);
+
+                    await bulkInsert.AttachmentsFor(processedMessage.Id)
+                        .StoreAsync("body", stream, contentType)
+                        .ConfigureAwait(false);
+                }
+            }
+        }
 
         public Task RecordSagaSnapshot(SagaSnapshot sagaSnapshot)
             => bulkInsert.StoreAsync(sagaSnapshot);

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditIngestionUnitOfWork.cs
@@ -14,7 +14,7 @@
         public RavenDbAuditIngestionUnitOfWork(BulkInsertOperation bulkInsert)
             => this.bulkInsert = bulkInsert;
 
-        public Task RecordProcessedMessage(ProcessedMessage processedMessage)
+        public Task RecordProcessedMessage(ProcessedMessage processedMessage, byte[] body)
             => bulkInsert.StoreAsync(processedMessage);
 
         public Task RecordSagaSnapshot(SagaSnapshot sagaSnapshot)

--- a/src/ServiceControl.Audit.Persistence.SqlServer/SqlDbAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.SqlServer/SqlDbAuditDataStore.cs
@@ -2,13 +2,9 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Net.Http;
     using System.Threading.Tasks;
     using Dapper;
     using Infrastructure;
-    using NServiceBus.CustomChecks;
-    using NServiceBus.Logging;
-    using ServiceControl.Audit.Auditing;
     using ServiceControl.Audit.Auditing.MessagesView;
     using ServiceControl.Audit.Monitoring;
     using ServiceControl.SagaAudit;
@@ -214,7 +210,6 @@
 
         }
 
-        public Task<HttpResponseMessage> TryFetchFromIndex(HttpRequestMessage request, string messageId) => throw new NotImplementedException();
         public Task<MessageBodyView> GetMessageBody(string messageId) => throw new NotImplementedException();
     }
 }

--- a/src/ServiceControl.Audit.Persistence.SqlServer/SqlDbAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.SqlServer/SqlDbAuditDataStore.cs
@@ -215,5 +215,6 @@
         }
 
         public Task<HttpResponseMessage> TryFetchFromIndex(HttpRequestMessage request, string messageId) => throw new NotImplementedException();
+        public Task<MessageBodyView> GetMessageBody(string messageId) => throw new NotImplementedException();
     }
 }

--- a/src/ServiceControl.Audit.Persistence.SqlServer/UnitOfWork/SqlDbAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.SqlServer/UnitOfWork/SqlDbAuditIngestionUnitOfWork.cs
@@ -10,7 +10,7 @@
     {
         public ValueTask DisposeAsync() => throw new System.NotImplementedException();
 
-        public Task RecordProcessedMessage(ProcessedMessage processedMessage) => throw new System.NotImplementedException();
+        public Task RecordProcessedMessage(ProcessedMessage processedMessage, byte[] body) => throw new System.NotImplementedException();
 
         public Task RecordSagaSnapshot(SagaSnapshot sagaSnapshot) => throw new System.NotImplementedException();
 

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/PersistenceTestsConfiguration.cs
@@ -25,6 +25,8 @@
                 RunInMemory = true
             };
 
+            serviceCollection.AddSingleton<Settings>(settings);
+
             config.ConfigureServices(serviceCollection, settings, false, true);
 
             var serviceProvider = serviceCollection.BuildServiceProvider();

--- a/src/ServiceControl.Audit.Persistence.Tests/InMemory/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/InMemory/PersistenceTestsConfiguration.cs
@@ -2,6 +2,7 @@
 {
     using System.Threading.Tasks;
     using Auditing.BodyStorage;
+    using Infrastructure.Settings;
     using Microsoft.Extensions.DependencyInjection;
     using ServiceControl.Audit.Persistence.InMemory;
     using UnitOfWork;
@@ -18,7 +19,11 @@
             var config = new InMemoryPersistenceConfiguration();
             var serviceCollection = new ServiceCollection();
 
-            config.ConfigureServices(serviceCollection, null, false, true);
+            var settings = new FakeSettings();
+
+            serviceCollection.AddSingleton<Settings>(settings);
+
+            config.ConfigureServices(serviceCollection, settings, false, true);
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
             AuditDataStore = serviceProvider.GetRequiredService<IAuditDataStore>();
@@ -31,5 +36,14 @@
         public Task CompleteDBOperation() => Task.CompletedTask;
 
         public Task Cleanup() => Task.CompletedTask;
+
+        class FakeSettings : Settings
+        {
+            //bypass the public ctor to avoid all mandatory settings
+            public FakeSettings() : base()
+            {
+            }
+        }
+
     }
 }

--- a/src/ServiceControl.Audit.UnitTests/BodyStorage/BodyStorageEnricherTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/BodyStorage/BodyStorageEnricherTests.cs
@@ -32,6 +32,7 @@ namespace ServiceControl.UnitTests.BodyStorage
             var headers = new Dictionary<string, string>
             {
                 { Headers.MessageId, "someid" },
+                { Headers.ProcessingEndpoint, "someendpoint" },
                 { "ServiceControl.Retry.UniqueMessageId", "someid" }
             };
 
@@ -63,6 +64,7 @@ namespace ServiceControl.UnitTests.BodyStorage
             {
                 { Headers.ContentType, "application/binary" },
                 { Headers.MessageId, "someid" },
+                { Headers.ProcessingEndpoint, "someendpoint" },
                 { "ServiceControl.Retry.UniqueMessageId", "someid" }
             };
 
@@ -96,6 +98,7 @@ namespace ServiceControl.UnitTests.BodyStorage
             {
                 [Headers.MessageId] = "someid",
                 ["ServiceControl.Retry.UniqueMessageId"] = "someid",
+                [Headers.ProcessingEndpoint] = "someendpoint",
                 [Headers.ContentType] = "text/xml"
             };
 
@@ -129,6 +132,7 @@ namespace ServiceControl.UnitTests.BodyStorage
             {
                 [Headers.MessageId] = "someid",
                 ["ServiceControl.Retry.UniqueMessageId"] = "someid",
+                [Headers.ProcessingEndpoint] = "someendpoint",
                 [Headers.ContentType] = "text/xml"
             };
 
@@ -162,6 +166,7 @@ namespace ServiceControl.UnitTests.BodyStorage
             {
                 [Headers.MessageId] = "someid",
                 ["ServiceControl.Retry.UniqueMessageId"] = "someid",
+                [Headers.ProcessingEndpoint] = "someendpoint",
                 [Headers.ContentType] = "text/xml"
             };
 
@@ -194,6 +199,7 @@ namespace ServiceControl.UnitTests.BodyStorage
             {
                 { Headers.ContentType, "application/binary" },
                 { Headers.MessageId, "someid" },
+                { Headers.ProcessingEndpoint, "someendpoint" },
                 { "ServiceControl.Retry.UniqueMessageId", "someid" }
             };
 
@@ -226,6 +232,7 @@ namespace ServiceControl.UnitTests.BodyStorage
             var headers = new Dictionary<string, string>
             {
                 { Headers.MessageId, "someid" },
+                { Headers.ProcessingEndpoint, "someendpoint" },
                 { "ServiceControl.Retry.UniqueMessageId", "someid" }
             };
 
@@ -257,6 +264,7 @@ namespace ServiceControl.UnitTests.BodyStorage
             var headers = new Dictionary<string, string>
             {
                 { Headers.MessageId, "someid" },
+                { Headers.ProcessingEndpoint, "someendpoint" },
                 { "ServiceControl.Retry.UniqueMessageId", "someid" }
             };
 

--- a/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
@@ -5,7 +5,6 @@
     using System.Diagnostics;
     using System.Linq;
     using System.Threading.Tasks;
-    using BodyStorage;
     using Infrastructure.Settings;
     using Monitoring;
     using NServiceBus;
@@ -26,7 +25,6 @@
             Metrics metrics,
             Settings settings,
             IAuditIngestionUnitOfWorkFactory unitOfWorkFactory,
-            IBodyStorage bodyStorage,
             EndpointInstanceMonitoring endpointInstanceMonitoring,
             IEnumerable<IEnrichImportedAuditMessages> auditEnrichers, // allows extending message enrichers with custom enrichers registered in the DI container
             IMessageSession messageSession
@@ -50,8 +48,7 @@
                 new SagaRelationshipsEnricher()
             }.Concat(auditEnrichers).ToArray();
 
-            var bodyStorageEnricher = new BodyStorageEnricher(bodyStorage, settings);
-            auditPersister = new AuditPersister(unitOfWorkFactory, bodyStorageEnricher, enrichers, ingestedAuditMeter, ingestedSagaAuditMeter, auditBulkInsertDurationMeter, sagaAuditBulkInsertDurationMeter, bulkInsertCommitDurationMeter, messageSession);
+            auditPersister = new AuditPersister(unitOfWorkFactory, enrichers, ingestedAuditMeter, ingestedSagaAuditMeter, auditBulkInsertDurationMeter, sagaAuditBulkInsertDurationMeter, bulkInsertCommitDurationMeter, messageSession);
         }
 
         public async Task Ingest(List<MessageContext> contexts, IDispatchMessages dispatcher)

--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -253,17 +253,7 @@
                     enricher.Enrich(enricherContext);
                 }
 
-                var processingStartedTicks =
-                    context.Headers.TryGetValue(Headers.ProcessingStarted, out var processingStartedValue)
-                        ? DateTimeExtensions.ToUtcDateTime(processingStartedValue).Ticks.ToString()
-                        : DateTime.UtcNow.Ticks.ToString();
-
-                var documentId = $"{processingStartedTicks}-{context.Headers.ProcessingId()}";
-
-                var auditMessage = new ProcessedMessage(context.Headers, new Dictionary<string, object>(metadata))
-                {
-                    Id = $"ProcessedMessages/{documentId}"
-                };
+                var auditMessage = new ProcessedMessage(context.Headers, new Dictionary<string, object>(metadata));
 
                 if (Logger.IsDebugEnabled)
                 {

--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -5,7 +5,6 @@
     using System.Diagnostics;
     using System.IO;
     using System.Threading.Tasks;
-    using BodyStorage;
     using EndpointPlugin.Messages.SagaState;
     using Infrastructure;
     using Monitoring;
@@ -21,13 +20,12 @@
 
     class AuditPersister
     {
-        public AuditPersister(IAuditIngestionUnitOfWorkFactory unitOfWorkFactory, BodyStorageEnricher bodyStorageEnricher,
+        public AuditPersister(IAuditIngestionUnitOfWorkFactory unitOfWorkFactory,
             IEnrichImportedAuditMessages[] enrichers,
             Counter ingestedAuditMeter, Counter ingestedSagaAuditMeter, Meter auditBulkInsertDurationMeter,
             Meter sagaAuditBulkInsertDurationMeter, Meter bulkInsertCommitDurationMeter, IMessageSession messageSession)
         {
             this.unitOfWorkFactory = unitOfWorkFactory;
-            this.bodyStorageEnricher = bodyStorageEnricher;
             this.enrichers = enrichers;
 
             this.ingestedAuditMeter = ingestedAuditMeter;
@@ -85,7 +83,7 @@
 
                         using (auditBulkInsertDurationMeter.Measure())
                         {
-                            await unitOfWork.RecordProcessedMessage(processedMessage).ConfigureAwait(false);
+                            await unitOfWork.RecordProcessedMessage(processedMessage, context.Body).ConfigureAwait(false);
                         }
 
                         storedContexts.Add(context);
@@ -267,9 +265,6 @@
                     Id = $"ProcessedMessages/{documentId}"
                 };
 
-                await bodyStorageEnricher.StoreAuditMessageBody(context.Body, auditMessage)
-                    .ConfigureAwait(false);
-
                 if (Logger.IsDebugEnabled)
                 {
                     Logger.Debug($"Emitting {commandsToEmit.Count} commands and {messagesToEmit.Count} control messages.");
@@ -323,7 +318,6 @@
         readonly JsonSerializer sagaAuditSerializer = new JsonSerializer();
         readonly IEnrichImportedAuditMessages[] enrichers;
         readonly IAuditIngestionUnitOfWorkFactory unitOfWorkFactory;
-        readonly BodyStorageEnricher bodyStorageEnricher;
         static readonly ILog Logger = LogManager.GetLogger<AuditPersister>();
     }
 }

--- a/src/ServiceControl.Audit/Auditing/GetBodyByIdApi.cs
+++ b/src/ServiceControl.Audit/Auditing/GetBodyByIdApi.cs
@@ -1,59 +1,60 @@
 ﻿namespace ServiceControl.Audit.Auditing
 {
+    using System;
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Threading.Tasks;
-    using BodyStorage;
     using MessagesView;
-    using ServiceControl.Audit.Persistence;
+    using Persistence;
 
     class GetBodyByIdApi : IApi
     {
-        public GetBodyByIdApi(IAuditDataStore dataStore, IBodyStorage bodyStorage)
-        {
-            this.dataStore = dataStore;
-            this.bodyStorage = bodyStorage;
-        }
+        public GetBodyByIdApi(IAuditDataStore dataStore) => this.dataStore = dataStore;
 
         public async Task<HttpResponseMessage> Execute(HttpRequestMessage request, string messageId)
         {
             messageId = messageId?.Replace("/", @"\");
-            var indexResponse = await dataStore.TryFetchFromIndex(request, messageId).ConfigureAwait(false);
-            // when fetching result from index is successful go ahead
-            if (indexResponse.IsSuccessStatusCode)
+
+            var result = await dataStore.GetMessageBody(messageId).ConfigureAwait(false);
+
+            if (result.Found == false)
             {
-                return indexResponse;
+                return request.CreateResponse(HttpStatusCode.NotFound);
             }
 
-            // try to fetch from body
-            var bodyStorageResponse = await TryFetchFromStorage(request, messageId).ConfigureAwait(false);
-            // if found return, if not the result from the index takes precedence to by backward compatible
-            return bodyStorageResponse.IsSuccessStatusCode ? bodyStorageResponse : indexResponse;
-        }
-
-        async Task<HttpResponseMessage> TryFetchFromStorage(HttpRequestMessage request, string messageId)
-        {
-            //We want to continue using attachments for now
-            var result = await bodyStorage.TryFetch(messageId).ConfigureAwait(false);
-            if (result.HasResult)
+            if (result.HasContent == false)
             {
-                var response = request.CreateResponse(HttpStatusCode.OK);
-                var content = new StreamContent(result.Stream);
-
-                MediaTypeHeaderValue.TryParse(result.ContentType, out var parsedContentType);
-                content.Headers.ContentType = parsedContentType ?? new MediaTypeHeaderValue("text/*");
-
-                content.Headers.ContentLength = result.BodySize;
-                response.Headers.ETag = new EntityTagHeaderValue($"\"{result.Etag}\"");
-                response.Content = content;
-                return response;
+                return request.CreateResponse(HttpStatusCode.NoContent);
             }
 
-            return request.CreateResponse(HttpStatusCode.NotFound);
+            var response = request.CreateResponse(HttpStatusCode.OK);
+
+            HttpContent content;
+            if (result.StringContent != null)
+            {
+                content = new StringContent(result.StringContent);
+            }
+            else if (result.StreamContent != null)
+            {
+                content = new StreamContent(result.StreamContent);
+            }
+            else
+            {
+                // TODO: What do we do here
+                throw new Exception("We should never get here");
+            }
+
+            MediaTypeHeaderValue.TryParse(result.ContentType, out var parsedContentType);
+            content.Headers.ContentType = parsedContentType ?? new MediaTypeHeaderValue("text/*");
+
+            content.Headers.ContentLength = result.ContentLength;
+            response.Headers.ETag = new EntityTagHeaderValue($"\"{result.ETag}\"");
+            response.Content = content;
+
+            return response;
         }
 
         IAuditDataStore dataStore;
-        IBodyStorage bodyStorage;
     }
 }

--- a/src/ServiceControl.Audit/Auditing/ProcessedMessage.cs
+++ b/src/ServiceControl.Audit/Auditing/ProcessedMessage.cs
@@ -19,6 +19,15 @@
             MessageMetadata = metadata;
             Headers = headers;
 
+            var processingStartedTicks =
+                headers.TryGetValue(NServiceBus.Headers.ProcessingStarted, out var processingStartedValue)
+                    ? DateTimeExtensions.ToUtcDateTime(processingStartedValue).Ticks.ToString()
+                    : DateTime.UtcNow.Ticks.ToString();
+
+            var documentId = $"{processingStartedTicks}-{headers.ProcessingId()}";
+
+            Id = $"ProcessedMessages/{documentId}";
+
             if (Headers.TryGetValue(NServiceBus.Headers.ProcessingEnded, out var processedAt))
             {
                 ProcessedAt = DateTimeExtensions.ToUtcDateTime(processedAt);

--- a/src/ServiceControl.Audit/Persistence/IAuditDataStore.cs
+++ b/src/ServiceControl.Audit/Persistence/IAuditDataStore.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Net.Http;
     using System.Threading.Tasks;
     using Infrastructure;
     using ServiceControl.Audit.Auditing.MessagesView;
@@ -18,7 +17,6 @@
         Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(SearchEndpointApi.Input input, PagingInfo pagingInfo, SortInfo sortInfo);
         Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo);
         Task<QueryResult<IList<MessagesView>>> QueryMessagesByConversationId(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo);
-        Task<HttpResponseMessage> TryFetchFromIndex(HttpRequestMessage request, string messageId);
         Task<MessageBodyView> GetMessageBody(string messageId);
     }
 }

--- a/src/ServiceControl.Audit/Persistence/IAuditDataStore.cs
+++ b/src/ServiceControl.Audit/Persistence/IAuditDataStore.cs
@@ -19,5 +19,6 @@
         Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo);
         Task<QueryResult<IList<MessagesView>>> QueryMessagesByConversationId(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo);
         Task<HttpResponseMessage> TryFetchFromIndex(HttpRequestMessage request, string messageId);
+        Task<MessageBodyView> GetMessageBody(string messageId);
     }
 }

--- a/src/ServiceControl.Audit/Persistence/MessageBodyView.cs
+++ b/src/ServiceControl.Audit/Persistence/MessageBodyView.cs
@@ -1,0 +1,41 @@
+﻿namespace ServiceControl.Audit.Persistence
+{
+    using System.IO;
+
+    class MessageBodyView
+    {
+        public bool Found { get; private set; }
+        public bool HasContent { get; private set; }
+        public Stream StreamContent { get; private set; }
+        public string StringContent { get; private set; }
+        public string ContentType { get; private set; }
+        public int ContentLength { get; private set; }
+        public string ETag { get; private set; }
+
+        public static MessageBodyView NotFound() => new MessageBodyView { Found = false, HasContent = false };
+
+        public static MessageBodyView NoContent() => new MessageBodyView { Found = true, HasContent = false };
+
+        public static MessageBodyView FromString(string content, string contentType, int contentLength, string etag)
+            => new MessageBodyView
+            {
+                Found = true,
+                HasContent = true,
+                StringContent = content,
+                ContentType = contentType,
+                ContentLength = contentLength,
+                ETag = etag
+            };
+
+        public static MessageBodyView FromStream(Stream content, string contentType, int contentLength, string etag)
+            => new MessageBodyView
+            {
+                Found = true,
+                HasContent = true,
+                StreamContent = content,
+                ContentType = contentType,
+                ContentLength = contentLength,
+                ETag = etag
+            };
+    }
+}

--- a/src/ServiceControl.Audit/Persistence/UnitOfWork/IAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit/Persistence/UnitOfWork/IAuditIngestionUnitOfWork.cs
@@ -8,7 +8,7 @@
 
     interface IAuditIngestionUnitOfWork : IAsyncDisposable
     {
-        Task RecordProcessedMessage(ProcessedMessage processedMessage);
+        Task RecordProcessedMessage(ProcessedMessage processedMessage, byte[] body = null);
         Task RecordSagaSnapshot(SagaSnapshot sagaSnapshot);
         Task RecordKnownEndpoint(KnownEndpoint knownEndpoint);
     }


### PR DESCRIPTION
The way that RavenDB 3.5 and RavenDB 5 handle attachments is different enough that we need to push the entire implementation behind the persistence abstraction.

This will probably require changing the way some tests run as some of the current behavior (i.e. putting the contents of text-based messages into the index to make them searchable unless they are over some threshold) is probably not required.