### PR TITLE
Adding another missing Path.GetDirectoryName

### DIFF
--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditNewInstance.cs
@@ -16,7 +16,7 @@
     {
         public static ServiceControlAuditNewInstance CreateWithDefaultPersistence()
         {
-            return CreateWithDefaultPersistence(Assembly.GetExecutingAssembly().Location);
+            return CreateWithDefaultPersistence(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
         }
 
         public static ServiceControlAuditNewInstance CreateWithDefaultPersistence(string deploymentCachePath)


### PR DESCRIPTION
Another example of that. When creating Audit instance it was passing file path and not directory path