### PR TITLE
Extract explicit persistence component

### DIFF
--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryPersistence.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryPersistence.cs
@@ -1,0 +1,27 @@
+﻿namespace ServiceControl.Audit.Persistence.InMemory
+{
+    using Auditing.BodyStorage;
+    using Microsoft.Extensions.DependencyInjection;
+    using UnitOfWork;
+
+    public class InMemoryPersistence : IPersistence
+    {
+        public InMemoryPersistence(PersistenceSettings persistenceSettings) => settings = persistenceSettings;
+
+        public IPersistenceLifecycle CreateLifecycle(IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddSingleton(settings);
+            serviceCollection.AddSingleton<InMemoryAuditDataStore>();
+            serviceCollection.AddSingleton<IAuditDataStore>(sp => sp.GetRequiredService<InMemoryAuditDataStore>());
+            serviceCollection.AddSingleton<IBodyStorage, InMemoryAttachmentsBodyStorage>();
+            serviceCollection.AddSingleton<IFailedAuditStorage, InMemoryFailedAuditStorage>();
+            serviceCollection.AddSingleton<IAuditIngestionUnitOfWorkFactory, InMemoryAuditIngestionUnitOfWorkFactory>();
+
+            return new InMemoryPersistenceLifecycle();
+        }
+
+        public IPersistenceInstaller CreateInstaller() => new InMemoryPersistenceInstaller();
+
+        readonly PersistenceSettings settings;
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryPersistenceConfiguration.cs
@@ -1,29 +1,7 @@
 ﻿namespace ServiceControl.Audit.Persistence.InMemory
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Extensions.DependencyInjection;
-    using ServiceControl.Audit.Auditing.BodyStorage;
-    using ServiceControl.Audit.Persistence.UnitOfWork;
-
     public class InMemoryPersistenceConfiguration : IPersistenceConfiguration
     {
-        public IPersistenceLifecycle ConfigureServices(IServiceCollection serviceCollection, PersistenceSettings settings)
-        {
-            serviceCollection.AddSingleton(settings);
-            serviceCollection.AddSingleton<InMemoryAuditDataStore>();
-            serviceCollection.AddSingleton<IAuditDataStore>(sp => sp.GetRequiredService<InMemoryAuditDataStore>());
-            serviceCollection.AddSingleton<IBodyStorage, InMemoryAttachmentsBodyStorage>();
-            serviceCollection.AddSingleton<IFailedAuditStorage, InMemoryFailedAuditStorage>();
-            serviceCollection.AddSingleton<IAuditIngestionUnitOfWorkFactory, InMemoryAuditIngestionUnitOfWorkFactory>();
-
-            return new InMemoryPersistenceLifecycle();
-        }
-
-        public Task Setup(PersistenceSettings settings, CancellationToken cancellationToken)
-        {
-            //no-op
-            return Task.CompletedTask;
-        }
+        public IPersistence Create(PersistenceSettings settings) => new InMemoryPersistence(settings);
     }
 }

--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryPersistenceInstaller.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryPersistenceInstaller.cs
@@ -1,0 +1,10 @@
+﻿namespace ServiceControl.Audit.Persistence.InMemory
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class InMemoryPersistenceInstaller : IPersistenceInstaller
+    {
+        public Task Install(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.RavenDb/RavenDbInstaller.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb/RavenDbInstaller.cs
@@ -1,0 +1,45 @@
+﻿namespace ServiceControl.Audit.Persistence.RavenDb
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Audit.Infrastructure.Migration;
+    using NServiceBus.Logging;
+    using Raven.Client.Embedded;
+    using Raven.Client.Indexes;
+    using RavenDB;
+
+    class RavenDbInstaller : IPersistenceInstaller
+    {
+        public RavenDbInstaller(EmbeddableDocumentStore documentStore, RavenStartup ravenStartup)
+        {
+            this.documentStore = documentStore;
+            this.ravenStartup = ravenStartup;
+        }
+
+        public async Task Install(CancellationToken cancellationToken)
+        {
+            Logger.Info("Database initialization starting");
+            documentStore.Initialize();
+            Logger.Info("Database initialization complete");
+
+            Logger.Info("Index creation started");
+            var indexProvider = ravenStartup.CreateIndexProvider();
+            await IndexCreation.CreateIndexesAsync(indexProvider, documentStore)
+                .ConfigureAwait(false);
+            Logger.Info("Index creation complete");
+
+            Logger.Info("Data migrations starting");
+
+            var endpointMigrations = new MigrateKnownEndpoints(documentStore);
+            await endpointMigrations.Migrate(cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            Logger.Info("Data migrations complete");
+        }
+
+        readonly EmbeddableDocumentStore documentStore;
+        readonly RavenStartup ravenStartup;
+
+        static readonly ILog Logger = LogManager.GetLogger(typeof(RavenDbPersistenceLifecycle));
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.RavenDb/RavenDbPersistence.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb/RavenDbPersistence.cs
@@ -1,0 +1,42 @@
+﻿namespace ServiceControl.Audit.Persistence.RavenDb
+{
+    using Auditing.BodyStorage;
+    using Microsoft.Extensions.DependencyInjection;
+    using Persistence.UnitOfWork;
+    using Raven.Client;
+    using Raven.Client.Embedded;
+    using RavenDB;
+    using UnitOfWork;
+
+    class RavenDbPersistence : IPersistence
+    {
+        public RavenDbPersistence(PersistenceSettings settings, EmbeddableDocumentStore documentStore, RavenStartup ravenStartup)
+        {
+            this.settings = settings;
+            this.documentStore = documentStore;
+            this.ravenStartup = ravenStartup;
+        }
+
+        public IPersistenceLifecycle CreateLifecycle(IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddSingleton(settings);
+            serviceCollection.AddSingleton<IDocumentStore>(documentStore);
+
+            serviceCollection.AddSingleton<IAuditDataStore, RavenDbAuditDataStore>();
+            serviceCollection.AddSingleton<IBodyStorage, RavenAttachmentsBodyStorage>();
+            serviceCollection.AddSingleton<IAuditIngestionUnitOfWorkFactory, RavenDbAuditIngestionUnitOfWorkFactory>();
+            serviceCollection.AddSingleton<IFailedAuditStorage, RavenDbFailedAuditStorage>();
+
+            return new RavenDbPersistenceLifecycle(ravenStartup, documentStore);
+        }
+
+        public IPersistenceInstaller CreateInstaller()
+        {
+            return new RavenDbInstaller(documentStore, ravenStartup);
+        }
+
+        readonly PersistenceSettings settings;
+        readonly EmbeddableDocumentStore documentStore;
+        readonly RavenStartup ravenStartup;
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.RavenDb/RavenDbPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb/RavenDbPersistenceConfiguration.cs
@@ -1,32 +1,14 @@
 ﻿namespace ServiceControl.Audit.Persistence.RavenDb
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Extensions.DependencyInjection;
-    using NServiceBus.Logging;
-    using Persistence.UnitOfWork;
-    using Raven.Client;
     using Raven.Client.Embedded;
-    using Raven.Client.Indexes;
-    using ServiceControl.Audit.Auditing.BodyStorage;
-    using ServiceControl.Audit.Infrastructure.Migration;
     using ServiceControl.Audit.Persistence.RavenDB;
-    using UnitOfWork;
 
     public class RavenDbPersistenceConfiguration : IPersistenceConfiguration
     {
-        public IPersistenceLifecycle ConfigureServices(IServiceCollection serviceCollection, PersistenceSettings settings)
+        public IPersistence Create(PersistenceSettings settings)
         {
             var documentStore = new EmbeddableDocumentStore();
             RavenBootstrapper.Configure(documentStore, settings);
-
-            serviceCollection.AddSingleton(settings);
-            serviceCollection.AddSingleton<IDocumentStore>(documentStore);
-
-            serviceCollection.AddSingleton<IAuditDataStore, RavenDbAuditDataStore>();
-            serviceCollection.AddSingleton<IBodyStorage, RavenAttachmentsBodyStorage>();
-            serviceCollection.AddSingleton<IAuditIngestionUnitOfWorkFactory, RavenDbAuditIngestionUnitOfWorkFactory>();
-            serviceCollection.AddSingleton<IFailedAuditStorage, RavenDbFailedAuditStorage>();
 
             var ravenStartup = new RavenStartup();
 
@@ -35,42 +17,7 @@
                 ravenStartup.AddIndexAssembly(indexAssembly);
             }
 
-            return new RavenDbPersistenceLifecycle(ravenStartup, documentStore);
+            return new RavenDbPersistence(settings, documentStore, ravenStartup);
         }
-
-        public async Task Setup(PersistenceSettings settings, CancellationToken cancellationToken)
-        {
-            using (var documentStore = new EmbeddableDocumentStore())
-            {
-                RavenBootstrapper.Configure(documentStore, settings);
-
-                var ravenStartup = new RavenStartup();
-
-                foreach (var indexAssembly in RavenBootstrapper.IndexAssemblies)
-                {
-                    ravenStartup.AddIndexAssembly(indexAssembly);
-                }
-
-                Logger.Info("Database initialization starting");
-                documentStore.Initialize();
-                Logger.Info("Database initialization complete");
-
-                Logger.Info("Index creation started");
-                var indexProvider = ravenStartup.CreateIndexProvider();
-                await IndexCreation.CreateIndexesAsync(indexProvider, documentStore)
-                    .ConfigureAwait(false);
-                Logger.Info("Index creation complete");
-
-                Logger.Info("Data migrations starting");
-
-                var endpointMigrations = new MigrateKnownEndpoints(documentStore);
-                await endpointMigrations.Migrate(cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-
-                Logger.Info("Data migrations complete");
-            }
-        }
-
-        static readonly ILog Logger = LogManager.GetLogger(typeof(RavenDbPersistenceConfiguration));
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Installer.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Installer.cs
@@ -1,0 +1,36 @@
+﻿namespace ServiceControl.Audit.Persistence.RavenDb
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using RavenDb5;
+
+    class RavenDb5Installer : IPersistenceInstaller
+    {
+        public RavenDb5Installer(IRavenDbPersistenceLifecycle lifecycle, DatabaseSetup databaseSetup)
+        {
+            this.lifecycle = lifecycle;
+            this.databaseSetup = databaseSetup;
+        }
+
+        public async Task Install(CancellationToken cancellationToken)
+        {
+            await lifecycle.Start(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                using (var documentStore = lifecycle.GetDocumentStore())
+                {
+                    await databaseSetup.Execute(documentStore, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                await lifecycle.Stop(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        readonly IRavenDbPersistenceLifecycle lifecycle;
+        readonly DatabaseSetup databaseSetup;
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Persistence.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Persistence.cs
@@ -1,0 +1,35 @@
+﻿namespace ServiceControl.Audit.Persistence.RavenDb
+{
+    using Microsoft.Extensions.DependencyInjection;
+    using Persistence.UnitOfWork;
+    using RavenDb5;
+    using UnitOfWork;
+
+    class RavenDb5Persistence : IPersistence
+    {
+        public RavenDb5Persistence(IRavenDbPersistenceLifecycle lifecycle, DatabaseSetup databaseSetup, PersistenceSettings settings)
+        {
+            this.lifecycle = lifecycle;
+            this.databaseSetup = databaseSetup;
+            this.settings = settings;
+        }
+
+        public IPersistenceLifecycle CreateLifecycle(IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddSingleton(settings);
+            serviceCollection.AddSingleton<IRavenDbSessionProvider, RavenDbSessionProvider>();
+            serviceCollection.AddSingleton<IAuditDataStore, RavenDbAuditDataStore>();
+            serviceCollection.AddSingleton<IAuditIngestionUnitOfWorkFactory, RavenDbAuditIngestionUnitOfWorkFactory>();
+            serviceCollection.AddSingleton<IFailedAuditStorage, RavenDbFailedAuditStorage>();
+            serviceCollection.AddSingleton<IRavenDbDocumentStoreProvider>(_ => lifecycle);
+
+            return lifecycle;
+        }
+
+        public IPersistenceInstaller CreateInstaller() => new RavenDb5Installer(lifecycle, databaseSetup);
+
+        readonly IRavenDbPersistenceLifecycle lifecycle;
+        readonly DatabaseSetup databaseSetup;
+        readonly PersistenceSettings settings;
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.SqlServer/SqlDbPersistence.cs
+++ b/src/ServiceControl.Audit.Persistence.SqlServer/SqlDbPersistence.cs
@@ -1,0 +1,26 @@
+﻿namespace ServiceControl.Audit.Persistence.SqlServer
+{
+    using Auditing.BodyStorage;
+    using Microsoft.Extensions.DependencyInjection;
+    using Persistence.UnitOfWork;
+    using UnitOfWork;
+
+    class SqlDbPersistence : IPersistence
+    {
+        public SqlDbPersistence(string connectionString) => this.connectionString = connectionString;
+
+        public IPersistenceLifecycle CreateLifecycle(IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddSingleton(sp => new SqlDbConnectionManager(connectionString));
+            serviceCollection.AddSingleton<IAuditDataStore, SqlDbAuditDataStore>();
+            serviceCollection.AddSingleton<IBodyStorage, SqlAttachmentsBodyStorage>();
+            serviceCollection.AddSingleton<IAuditIngestionUnitOfWorkFactory, SqlDbAuditIngestionUnitOfWorkFactory>();
+
+            return new SqlDbPersistenceLifecycle();
+        }
+
+        public IPersistenceInstaller CreateInstaller() => new SqlDbPersistenceInstaller();
+
+        readonly string connectionString;
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.SqlServer/SqlDbPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.SqlServer/SqlDbPersistenceConfiguration.cs
@@ -1,30 +1,12 @@
 ﻿namespace ServiceControl.Audit.Persistence.SqlServer
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Auditing.BodyStorage;
-    using Microsoft.Extensions.DependencyInjection;
-    using Persistence.UnitOfWork;
-    using UnitOfWork;
-
     public class SqlDbPersistenceConfiguration : IPersistenceConfiguration
     {
-        public IPersistenceLifecycle ConfigureServices(IServiceCollection serviceCollection, PersistenceSettings settings)
+        public IPersistence Create(PersistenceSettings settings)
         {
             var connectionString = settings.PersisterSpecificSettings["Sql/ConnectionString"];
 
-            serviceCollection.AddSingleton(sp => new SqlDbConnectionManager(connectionString));
-            serviceCollection.AddSingleton<IAuditDataStore, SqlDbAuditDataStore>();
-            serviceCollection.AddSingleton<IBodyStorage, SqlAttachmentsBodyStorage>();
-            serviceCollection.AddSingleton<IAuditIngestionUnitOfWorkFactory, SqlDbAuditIngestionUnitOfWorkFactory>();
-
-            return new SqlDbPersistenceLifecycle();
-        }
-
-        public Task Setup(PersistenceSettings settings, CancellationToken cancellationToken)
-        {
-            //no-op for now
-            return Task.CompletedTask;
+            return new SqlDbPersistence(connectionString);
         }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.SqlServer/SqlDbPersistenceInstaller.cs
+++ b/src/ServiceControl.Audit.Persistence.SqlServer/SqlDbPersistenceInstaller.cs
@@ -1,0 +1,10 @@
+﻿namespace ServiceControl.Audit.Persistence.SqlServer
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class SqlDbPersistenceInstaller : IPersistenceInstaller
+    {
+        public Task Install(CancellationToken cancellationToken) => throw new System.NotImplementedException();
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/PersistenceTestsConfiguration.cs
@@ -30,7 +30,8 @@
 
             setSettings(settings);
 
-            persistenceLifecycle = config.ConfigureServices(serviceCollection, settings);
+            var persistence = config.Create(settings);
+            persistenceLifecycle = persistence.CreateLifecycle(serviceCollection);
 
             await persistenceLifecycle.Start();
 

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/PersistenceTestsConfiguration.cs
@@ -33,9 +33,9 @@
 
             setSettings(settings);
 
-            await config.Setup(settings);
-            persistenceLifecycle = config.ConfigureServices(serviceCollection, settings);
-
+            var persistence = config.Create(settings);
+            await persistence.CreateInstaller().Install();
+            persistenceLifecycle = persistence.CreateLifecycle(serviceCollection);
             await persistenceLifecycle.Start();
 
             var serviceProvider = serviceCollection.BuildServiceProvider();

--- a/src/ServiceControl.Audit.Persistence.Tests.SqlServer/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.SqlServer/PersistenceTestsConfiguration.cs
@@ -36,7 +36,8 @@
 
             settings.PersisterSpecificSettings["Sql/ConnectionString"] = connectionString;
 
-            config.ConfigureServices(serviceCollection, settings);
+            var persistence = config.Create(settings);
+            persistence.CreateLifecycle(serviceCollection);
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
             AuditDataStore = serviceProvider.GetRequiredService<IAuditDataStore>();

--- a/src/ServiceControl.Audit.Persistence.Tests/InMemory/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/InMemory/PersistenceTestsConfiguration.cs
@@ -21,7 +21,8 @@
             var settings = new PersistenceSettings(TimeSpan.FromHours(1), true, 100000);
 
             setSettings(settings);
-            config.ConfigureServices(serviceCollection, settings);
+            var persistence = config.Create(settings);
+            persistence.CreateLifecycle(serviceCollection);
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
             AuditDataStore = serviceProvider.GetRequiredService<IAuditDataStore>();

--- a/src/ServiceControl.Audit.Persistence/IPersistence.cs
+++ b/src/ServiceControl.Audit.Persistence/IPersistence.cs
@@ -1,0 +1,10 @@
+﻿namespace ServiceControl.Audit.Persistence
+{
+    using Microsoft.Extensions.DependencyInjection;
+
+    public interface IPersistence
+    {
+        IPersistenceLifecycle CreateLifecycle(IServiceCollection serviceCollection);
+        IPersistenceInstaller CreateInstaller();
+    }
+}

--- a/src/ServiceControl.Audit.Persistence/IPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence/IPersistenceConfiguration.cs
@@ -1,12 +1,7 @@
 ﻿namespace ServiceControl.Audit.Persistence
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Extensions.DependencyInjection;
-
     public interface IPersistenceConfiguration
     {
-        IPersistenceLifecycle ConfigureServices(IServiceCollection serviceCollection, PersistenceSettings settings);
-        Task Setup(PersistenceSettings settings, CancellationToken cancellationToken = default);
+        IPersistence Create(PersistenceSettings settings);
     }
 }

--- a/src/ServiceControl.Audit.Persistence/IPersistenceInstaller.cs
+++ b/src/ServiceControl.Audit.Persistence/IPersistenceInstaller.cs
@@ -1,0 +1,10 @@
+﻿namespace ServiceControl.Audit.Persistence
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public interface IPersistenceInstaller
+    {
+        Task Install(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/SetupBootstrapper.cs
@@ -89,8 +89,10 @@ namespace ServiceControl.Audit.Infrastructure
 
             var persistenceConfiguration = PersistenceConfigurationFactory.LoadPersistenceConfiguration();
 
-            await persistenceConfiguration.Setup(persistenceSettings)
-                 .ConfigureAwait(false);
+            var persistence = persistenceConfiguration.Create(persistenceSettings);
+            var installer = persistence.CreateInstaller();
+            await installer.Install()
+                .ConfigureAwait(false);
 
             NServiceBusFactory.Configure(settings, transportCustomization, transportSettings, loggingSettings,
                 ctx => { }, configuration, false);

--- a/src/ServiceControl.Audit/Persistence/PersistenceHostBuilderExtensions.cs
+++ b/src/ServiceControl.Audit/Persistence/PersistenceHostBuilderExtensions.cs
@@ -8,10 +8,11 @@ namespace ServiceControl.Audit.Persistence
         public static IHostBuilder SetupPersistence(this IHostBuilder hostBuilder, PersistenceSettings persistenceSettings)
         {
             var persistenceConfiguration = PersistenceConfigurationFactory.LoadPersistenceConfiguration();
+            var persistence = persistenceConfiguration.Create(persistenceSettings);
 
             hostBuilder.ConfigureServices(serviceCollection =>
             {
-                var lifecycle = persistenceConfiguration.ConfigureServices(serviceCollection, persistenceSettings);
+                var lifecycle = persistence.CreateLifecycle(serviceCollection);
 
                 serviceCollection.AddHostedService(_ => new PersistenceLifecycleHostedService(lifecycle));
             });


### PR DESCRIPTION
Pulls persistence out into an explicit `IPersistence` component. This separates the creation of the peristence from the lifecycle it will be attached to (installation or setup).