### PR TITLE
Consolidate all configuration to a single place

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDb5/DatabaseConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/DatabaseConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace ServiceControl.Audit.Persistence.RavenDb5
+﻿namespace ServiceControl.Audit.Persistence.RavenDb
 {
     using System;
     using System.Collections.Generic;

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/DatabaseConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/DatabaseConfiguration.cs
@@ -7,12 +7,20 @@
 
     public class DatabaseConfiguration
     {
-        public DatabaseConfiguration(string name, int expirationProcessTimerInSeconds, bool enableFullTextSearch, ServerOptions serverOptions)
+        public DatabaseConfiguration(
+            string name,
+            int expirationProcessTimerInSeconds,
+            bool enableFullTextSearch,
+            TimeSpan auditRetentionPeriod,
+            int maxBodySizeToStore,
+            ServerConfiguration serverConfiguration)
         {
             Name = name;
             ExpirationProcessTimerInSeconds = expirationProcessTimerInSeconds;
             EnableFullTextSearch = enableFullTextSearch;
-            ServerOptions = serverOptions;
+            AuditRetentionPeriod = auditRetentionPeriod;
+            MaxBodySizeToStore = maxBodySizeToStore;
+            ServerConfiguration = serverConfiguration;
         }
 
         public string Name { get; }
@@ -27,6 +35,10 @@
 
         public Func<string, BlittableJsonReaderObject, string> FindClrType { get; }
 
-        public ServerOptions ServerOptions { get; }
+        public ServerConfiguration ServerConfiguration { get; }
+
+        public TimeSpan AuditRetentionPeriod { get; }
+
+        public int MaxBodySizeToStore { get; }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/DatabaseConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/DatabaseConfiguration.cs
@@ -1,25 +1,32 @@
 ﻿namespace ServiceControl.Audit.Persistence.RavenDb5
 {
-    using Sparrow.Json;
+    using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System;
+    using Sparrow.Json;
 
     public class DatabaseConfiguration
     {
-        public DatabaseConfiguration(string name, int expirationProcessTimerInSeconds, bool enableFullTextSearch)
+        public DatabaseConfiguration(string name, int expirationProcessTimerInSeconds, bool enableFullTextSearch, ServerOptions serverOptions)
         {
             Name = name;
             ExpirationProcessTimerInSeconds = expirationProcessTimerInSeconds;
             EnableFullTextSearch = enableFullTextSearch;
+            ServerOptions = serverOptions;
         }
 
         public string Name { get; }
+
         public int ExpirationProcessTimerInSeconds { get; }
+
         public bool EnableFullTextSearch { get; }
 
         public IEnumerable<string> CollectionsToCompress => Enumerable.Empty<string>();
+
         public bool EnableDocumentCompression => CollectionsToCompress.Any();
+
         public Func<string, BlittableJsonReaderObject, string> FindClrType { get; }
+
+        public ServerOptions ServerOptions { get; }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/DatabaseSetup.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/DatabaseSetup.cs
@@ -1,4 +1,4 @@
-﻿namespace ServiceControl.Audit.Persistence.RavenDb5
+﻿namespace ServiceControl.Audit.Persistence.RavenDb
 {
     using System.Collections.Generic;
     using System.Linq;

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -15,15 +15,15 @@
 
     public class EmbeddedDatabase : IDisposable
     {
-        public EmbeddedDatabase(DatabaseConfiguration configuration, string serverUrl)
+        public EmbeddedDatabase(DatabaseConfiguration configuration)
         {
             this.configuration = configuration;
-            ServerUrl = serverUrl;
+            ServerUrl = configuration.ServerConfiguration.ServerUrl;
         }
 
         public string ServerUrl { get; private set; }
 
-        public static EmbeddedDatabase Start(string dbPath, string serverUrl, DatabaseConfiguration auditDatabaseConfiguration)
+        public static EmbeddedDatabase Start(DatabaseConfiguration databaseConfiguration)
         {
             var commandLineArgs = new List<string>();
             var localRavenLicense = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "RavenLicense.json");
@@ -44,14 +44,14 @@
             {
                 CommandLineArgs = commandLineArgs,
                 AcceptEula = true,
-                DataDirectory = dbPath,
-                ServerUrl = serverUrl,
+                DataDirectory = databaseConfiguration.ServerConfiguration.DbPath,
+                ServerUrl = databaseConfiguration.ServerConfiguration.ServerUrl,
                 MaxServerStartupTimeDuration = TimeSpan.FromDays(1) //TODO: RAVEN5 allow command line override?
             };
 
             EmbeddedServer.Instance.StartServer(serverOptions);
 
-            return new EmbeddedDatabase(auditDatabaseConfiguration, serverUrl);
+            return new EmbeddedDatabase(databaseConfiguration);
         }
 
         public async Task<IDocumentStore> Connect(CancellationToken cancellationToken)

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -11,7 +11,7 @@
     using Raven.Client.Documents.Conventions;
     using Raven.Client.ServerWide;
     using Raven.Embedded;
-    using ServiceControl.Audit.Persistence.RavenDb5;
+    using ServiceControl.Audit.Persistence.RavenDb;
 
     public class EmbeddedDatabase : IDisposable
     {

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/Infrastructure/Memory.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/Infrastructure/Memory.cs
@@ -1,4 +1,4 @@
-﻿namespace ServiceControl.Audit.Persistence.RavenDb5.Infrastructure
+﻿namespace ServiceControl.Audit.Persistence.RavenDb.Infrastructure
 {
     using Microsoft.IO;
 

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Installer.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Installer.cs
@@ -2,7 +2,6 @@
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using RavenDb5;
 
     class RavenDb5Installer : IPersistenceInstaller
     {

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Persistence.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Persistence.cs
@@ -2,7 +2,6 @@
 {
     using Microsoft.Extensions.DependencyInjection;
     using Persistence.UnitOfWork;
-    using RavenDb5;
     using UnitOfWork;
 
     class RavenDb5Persistence : IPersistence

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Persistence.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Persistence.cs
@@ -7,16 +7,15 @@
 
     class RavenDb5Persistence : IPersistence
     {
-        public RavenDb5Persistence(DatabaseConfiguration databaseConfiguration, DatabaseSetup databaseSetup, PersistenceSettings settings)
+        public RavenDb5Persistence(DatabaseConfiguration databaseConfiguration, DatabaseSetup databaseSetup)
         {
             this.databaseConfiguration = databaseConfiguration;
             this.databaseSetup = databaseSetup;
-            this.settings = settings;
         }
 
         public IPersistenceLifecycle Configure(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddSingleton(settings);
+            serviceCollection.AddSingleton(databaseConfiguration);
             serviceCollection.AddSingleton<IRavenDbSessionProvider, RavenDbSessionProvider>();
             serviceCollection.AddSingleton<IAuditDataStore, RavenDbAuditDataStore>();
             serviceCollection.AddSingleton<IAuditIngestionUnitOfWorkFactory, RavenDbAuditIngestionUnitOfWorkFactory>();
@@ -60,6 +59,5 @@
 
         readonly DatabaseConfiguration databaseConfiguration;
         readonly DatabaseSetup databaseSetup;
-        readonly PersistenceSettings settings;
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Persistence.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDb5Persistence.cs
@@ -32,29 +32,14 @@
 
         IRavenDbPersistenceLifecycle CreateLifecycle()
         {
-            if (UseEmbeddedInstance(settings))
-            {
-                var dbPath = settings.PersisterSpecificSettings["ServiceControl.Audit/DbPath"];
-                var hostName = settings.PersisterSpecificSettings["ServiceControl.Audit/HostName"];
-                var databaseMaintenancePort =
-                    int.Parse(settings.PersisterSpecificSettings["ServiceControl.Audit/DatabaseMaintenancePort"]);
-                var databaseMaintenanceUrl = $"http://{hostName}:{databaseMaintenancePort}";
+            var serverConfiguration = databaseConfiguration.ServerConfiguration;
 
-                return new RavenDbEmbeddedPersistenceLifecycle(dbPath, databaseMaintenanceUrl, databaseConfiguration);
+            if (serverConfiguration.UseEmbeddedServer)
+            {
+                return new RavenDbEmbeddedPersistenceLifecycle(databaseConfiguration);
             }
 
-            var connectionString = settings.PersisterSpecificSettings["ServiceControl/Audit/RavenDb5/ConnectionString"];
-            return new RavenDbExternalPersistenceLifecycle(connectionString, databaseConfiguration);
-        }
-
-        static bool UseEmbeddedInstance(PersistenceSettings settings)
-        {
-            if (settings.PersisterSpecificSettings.TryGetValue("ServiceControl/Audit/RavenDb5/UseEmbeddedInstance", out var useEmbeddedInstanceString))
-            {
-                return bool.Parse(useEmbeddedInstanceString);
-            }
-
-            return false;
+            return new RavenDbExternalPersistenceLifecycle(databaseConfiguration);
         }
 
         readonly DatabaseConfiguration databaseConfiguration;

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
@@ -14,13 +14,14 @@
     using Transformers;
     using ServiceControl.Audit.Infrastructure;
     using ServiceControl.Audit.Monitoring;
+    using ServiceControl.Audit.Persistence.RavenDb5;
 
     class RavenDbAuditDataStore : IAuditDataStore
     {
-        public RavenDbAuditDataStore(IRavenDbSessionProvider sessionProvider, PersistenceSettings settings)
+        public RavenDbAuditDataStore(IRavenDbSessionProvider sessionProvider, DatabaseConfiguration databaseConfiguration)
         {
             this.sessionProvider = sessionProvider;
-            isFullTextSearchEnabled = settings.EnableFullTextSearchOnBodies;
+            isFullTextSearchEnabled = databaseConfiguration.EnableFullTextSearch;
         }
 
         public async Task<QueryResult<SagaHistory>> QuerySagaHistoryById(Guid input)

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
@@ -8,13 +8,12 @@
     using Auditing.MessagesView;
     using ServiceControl.SagaAudit;
     using Monitoring;
-    using Infrastructure;
     using Extensions;
     using Indexes;
     using Transformers;
     using ServiceControl.Audit.Infrastructure;
     using ServiceControl.Audit.Monitoring;
-    using ServiceControl.Audit.Persistence.RavenDb5;
+    using ServiceControl.Audit.Persistence.Infrastructure;
 
     class RavenDbAuditDataStore : IAuditDataStore
     {

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbEmbeddedPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbEmbeddedPersistenceLifecycle.cs
@@ -8,11 +8,9 @@
 
     class RavenDbEmbeddedPersistenceLifecycle : IRavenDbPersistenceLifecycle
     {
-        public RavenDbEmbeddedPersistenceLifecycle(string dbPath, string databaseMaintenanceUrl, DatabaseConfiguration dataBaseConfiguration)
+        public RavenDbEmbeddedPersistenceLifecycle(DatabaseConfiguration databaseConfiguration)
         {
-            this.dbPath = dbPath;
-            this.databaseMaintenanceUrl = databaseMaintenanceUrl;
-            this.dataBaseConfiguration = dataBaseConfiguration;
+            this.databaseConfiguration = databaseConfiguration;
         }
 
         public IDocumentStore GetDocumentStore()
@@ -27,7 +25,7 @@
 
         public async Task Start(CancellationToken cancellationToken)
         {
-            database = EmbeddedDatabase.Start(dbPath, databaseMaintenanceUrl, dataBaseConfiguration);
+            database = EmbeddedDatabase.Start(databaseConfiguration);
 
             documentStore = await database.Connect(cancellationToken).ConfigureAwait(false);
         }
@@ -43,8 +41,6 @@
         IDocumentStore documentStore;
         EmbeddedDatabase database;
 
-        readonly string dbPath;
-        readonly string databaseMaintenanceUrl;
-        readonly DatabaseConfiguration dataBaseConfiguration;
+        readonly DatabaseConfiguration databaseConfiguration;
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbEmbeddedPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbEmbeddedPersistenceLifecycle.cs
@@ -4,7 +4,7 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Raven.Client.Documents;
-    using ServiceControl.Audit.Persistence.RavenDb5;
+    using ServiceControl.Audit.Persistence.RavenDb;
 
     class RavenDbEmbeddedPersistenceLifecycle : IRavenDbPersistenceLifecycle
     {

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbExternalPersistenceLifecycle.cs
@@ -9,9 +9,8 @@
 
     class RavenDbExternalPersistenceLifecycle : IRavenDbPersistenceLifecycle
     {
-        public RavenDbExternalPersistenceLifecycle(string connectionString, DatabaseConfiguration configuration)
+        public RavenDbExternalPersistenceLifecycle(DatabaseConfiguration configuration)
         {
-            this.connectionString = connectionString;
             this.configuration = configuration;
         }
 
@@ -30,7 +29,7 @@
             var store = new DocumentStore
             {
                 Database = configuration.Name,
-                Urls = new[] { connectionString },
+                Urls = new[] { configuration.ServerConfiguration.ConnectionString },
                 Conventions = new DocumentConventions
                 {
                     SaveEnumsAsIntegers = true
@@ -59,6 +58,5 @@
         IDocumentStore documentStore;
 
         readonly DatabaseConfiguration configuration;
-        readonly string connectionString;
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbExternalPersistenceLifecycle.cs
@@ -5,7 +5,7 @@
     using System.Threading.Tasks;
     using Raven.Client.Documents;
     using Raven.Client.Documents.Conventions;
-    using ServiceControl.Audit.Persistence.RavenDb5;
+    using ServiceControl.Audit.Persistence.RavenDb;
 
     class RavenDbExternalPersistenceLifecycle : IRavenDbPersistenceLifecycle
     {

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbPersistenceConfiguration.cs
@@ -27,12 +27,24 @@
             {
                 if (settings.PersisterSpecificSettings.ContainsKey(ConnectionStringKey))
                 {
-                    throw new InvalidOperationException($"{DatabasePathKey} and {ConnectionStringKey} cannot be specified at the same time");
+                    throw new InvalidOperationException($"{DatabasePathKey} and {ConnectionStringKey} cannot be specified at the same time.");
                 }
 
-                var hostName = settings.PersisterSpecificSettings[HostNameKey];
-                var databaseMaintenancePort =
-                    int.Parse(settings.PersisterSpecificSettings[DatabaseMaintenancePortKey]);
+                if (!settings.PersisterSpecificSettings.TryGetValue(HostNameKey, out var hostName))
+                {
+                    throw new InvalidOperationException($"{HostNameKey} must be specified when using embedded server.");
+                }
+
+                if (!settings.PersisterSpecificSettings.TryGetValue(DatabaseMaintenancePortKey, out var databaseMaintenancePortString))
+                {
+                    throw new InvalidOperationException($"{DatabaseMaintenancePortKey} must be specified when using embedded server.");
+                }
+
+                if (!int.TryParse(databaseMaintenancePortString, out var databaseMaintenancePort))
+                {
+                    throw new InvalidOperationException($"{DatabaseMaintenancePortKey} must be an integer.");
+                }
+
                 var serverUrl = $"http://{hostName}:{databaseMaintenancePort}";
 
                 serverConfiguration = new ServerConfiguration(dbPath, serverUrl);
@@ -43,7 +55,7 @@
             }
             else
             {
-                throw new InvalidOperationException($"Either {DatabasePathKey} or {ConnectionStringKey} must be specified");
+                throw new InvalidOperationException($"Either {DatabasePathKey} or {ConnectionStringKey} must be specified.");
             }
 
             var expirationProcessTimerInSeconds = GetExpirationProcessTimerInSeconds(settings);

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbPersistenceConfiguration.cs
@@ -20,22 +20,22 @@
                 databaseName = "audit";
             }
 
-            ServerOptions serverOptions;
+            ServerConfiguration serverConfiguration;
 
             if (settings.PersisterSpecificSettings.TryGetValue("ServiceControl.Audit/DbPath", out var dbPath))
             {
                 var hostName = settings.PersisterSpecificSettings["ServiceControl.Audit/HostName"];
                 var databaseMaintenancePort =
                     int.Parse(settings.PersisterSpecificSettings["ServiceControl.Audit/DatabaseMaintenancePort"]);
-                var databaseMaintenanceUrl = $"http://{hostName}:{databaseMaintenancePort}";
+                var serverUrl = $"http://{hostName}:{databaseMaintenancePort}";
 
-                serverOptions = new ServerOptions(dbPath, databaseMaintenanceUrl);
+                serverConfiguration = new ServerConfiguration(dbPath, serverUrl);
             }
             else
             {
                 var connectionString = settings.PersisterSpecificSettings["ServiceControl/Audit/RavenDb5/ConnectionString"];
 
-                serverOptions = new ServerOptions(connectionString);
+                serverConfiguration = new ServerConfiguration(connectionString);
             }
 
             var expirationProcessTimerInSeconds = GetExpirationProcessTimerInSeconds(settings);
@@ -44,10 +44,10 @@
                 databaseName,
                 expirationProcessTimerInSeconds,
                 settings.EnableFullTextSearchOnBodies,
-                serverOptions);
+                settings.AuditRetentionPeriod,
+                settings.MaxBodySizeToStore,
+                serverConfiguration);
         }
-
-
 
         static int GetExpirationProcessTimerInSeconds(PersistenceSettings settings)
         {

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbPersistenceConfiguration.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using NServiceBus.Logging;
-    using ServiceControl.Audit.Persistence.RavenDb5;
+    using ServiceControl.Audit.Persistence.RavenDb;
 
     public class RavenDbPersistenceConfiguration : IPersistenceConfiguration
     {

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/ServerConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/ServerConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace ServiceControl.Audit.Persistence.RavenDb5
+﻿namespace ServiceControl.Audit.Persistence.RavenDb
 {
     public class ServerConfiguration
     {

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/ServerConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/ServerConfiguration.cs
@@ -1,22 +1,23 @@
 ﻿namespace ServiceControl.Audit.Persistence.RavenDb5
 {
-    public class ServerOptions
+    public class ServerConfiguration
     {
-        public ServerOptions(string connectionString)
+        public ServerConfiguration(string connectionString)
         {
             UseEmbeddedServer = false;
             ConnectionString = connectionString;
         }
-        public ServerOptions(string dbPath, string maintenanceUrl)
+        public ServerConfiguration(string dbPath, string serverUrl)
         {
             UseEmbeddedServer = true;
             DbPath = dbPath;
-            MaintenanceUrl = maintenanceUrl;
+
+            ServerUrl = serverUrl;
         }
 
         public string ConnectionString { get; }
         public bool UseEmbeddedServer { get; }
         public string DbPath { get; }
-        public string MaintenanceUrl { get; }
+        public string ServerUrl { get; }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/ServerOptions.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/ServerOptions.cs
@@ -1,0 +1,22 @@
+﻿namespace ServiceControl.Audit.Persistence.RavenDb5
+{
+    public class ServerOptions
+    {
+        public ServerOptions(string connectionString)
+        {
+            UseEmbeddedServer = false;
+            ConnectionString = connectionString;
+        }
+        public ServerOptions(string dbPath, string maintenanceUrl)
+        {
+            UseEmbeddedServer = true;
+            DbPath = dbPath;
+            MaintenanceUrl = maintenanceUrl;
+        }
+
+        public string ConnectionString { get; }
+        public bool UseEmbeddedServer { get; }
+        public string DbPath { get; }
+        public string MaintenanceUrl { get; }
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditIngestionUnitOfWork.cs
@@ -10,7 +10,7 @@
     using Raven.Client;
     using Raven.Client.Documents.BulkInsert;
     using Raven.Client.Json;
-    using ServiceControl.Audit.Persistence.RavenDb5.Infrastructure;
+    using ServiceControl.Audit.Persistence.RavenDb.Infrastructure;
     using ServiceControl.SagaAudit;
 
     class RavenDbAuditIngestionUnitOfWork : IAuditIngestionUnitOfWork

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditUnitOfWorkFactory.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditUnitOfWorkFactory.cs
@@ -3,17 +3,15 @@
     using System;
     using Persistence.UnitOfWork;
     using Raven.Client.Documents.BulkInsert;
+    using ServiceControl.Audit.Persistence.RavenDb5;
 
     class RavenDbAuditIngestionUnitOfWorkFactory : IAuditIngestionUnitOfWorkFactory
     {
-
-        public RavenDbAuditIngestionUnitOfWorkFactory(IRavenDbDocumentStoreProvider documentStoreProvider, IRavenDbSessionProvider sessionProvider, PersistenceSettings settings)
+        public RavenDbAuditIngestionUnitOfWorkFactory(IRavenDbDocumentStoreProvider documentStoreProvider, IRavenDbSessionProvider sessionProvider, DatabaseConfiguration databaseConfiguration)
         {
             this.documentStoreProvider = documentStoreProvider;
             this.sessionProvider = sessionProvider;
-
-            auditRetentionPeriod = settings.AuditRetentionPeriod;
-            settingsMaxBodySizeToStore = settings.MaxBodySizeToStore;
+            this.databaseConfiguration = databaseConfiguration;
         }
 
         public IAuditIngestionUnitOfWork StartNew(int batchSize)
@@ -23,13 +21,12 @@
                 options: new BulkInsertOptions { SkipOverwriteIfUnchanged = true, });
 
             return new RavenDbAuditIngestionUnitOfWork(
-                bulkInsert, auditRetentionPeriod, new RavenAttachmentsBodyStorage(sessionProvider, bulkInsert, settingsMaxBodySizeToStore)
+                bulkInsert, databaseConfiguration.AuditRetentionPeriod, new RavenAttachmentsBodyStorage(sessionProvider, bulkInsert, databaseConfiguration.MaxBodySizeToStore)
             );
         }
 
-        readonly TimeSpan auditRetentionPeriod;
-        readonly int settingsMaxBodySizeToStore;
         readonly IRavenDbDocumentStoreProvider documentStoreProvider;
         readonly IRavenDbSessionProvider sessionProvider;
+        readonly DatabaseConfiguration databaseConfiguration;
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditUnitOfWorkFactory.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditUnitOfWorkFactory.cs
@@ -3,7 +3,7 @@
     using System;
     using Persistence.UnitOfWork;
     using Raven.Client.Documents.BulkInsert;
-    using ServiceControl.Audit.Persistence.RavenDb5;
+    using ServiceControl.Audit.Persistence.RavenDb;
 
     class RavenDbAuditIngestionUnitOfWorkFactory : IAuditIngestionUnitOfWorkFactory
     {

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ConfigurationValidationTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ConfigurationValidationTests.cs
@@ -53,6 +53,43 @@
         }
 
         [Test]
+        public void Should_throw_if_hostname_is_missing()
+        {
+            var settings = BuildSettings();
+            var dpPath = "c://some-path";
+
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabasePathKey] = dpPath;
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabaseMaintenancePortKey] = "11111";
+
+            Assert.Throws<InvalidOperationException>(() => RavenDbPersistenceConfiguration.GetDatabaseConfiguration(settings));
+        }
+
+        [Test]
+        public void Should_throw_if_port_is_missing()
+        {
+            var settings = BuildSettings();
+            var dpPath = "c://some-path";
+
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabasePathKey] = dpPath;
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.HostNameKey] = "localhost";
+
+            Assert.Throws<InvalidOperationException>(() => RavenDbPersistenceConfiguration.GetDatabaseConfiguration(settings));
+        }
+
+        [Test]
+        public void Should_throw_if_port_is_not_an_integer()
+        {
+            var settings = BuildSettings();
+            var dpPath = "c://some-path";
+
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabasePathKey] = dpPath;
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.HostNameKey] = "localhost";
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabaseMaintenancePortKey] = "not an int";
+
+            Assert.Throws<InvalidOperationException>(() => RavenDbPersistenceConfiguration.GetDatabaseConfiguration(settings));
+        }
+
+        [Test]
         public void Should_throw_if_no_path_or_connection_string_is_configured()
         {
             var settings = BuildSettings();

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ConfigurationValidationTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ConfigurationValidationTests.cs
@@ -1,0 +1,79 @@
+﻿namespace ServiceControl.UnitTests
+{
+    using System;
+    using NUnit.Framework;
+    using ServiceControl.Audit.Persistence;
+    using ServiceControl.Audit.Persistence.RavenDb;
+
+    class ConfigurationValidationTests
+    {
+        [Test]
+        public void Should_apply_persistence_settings()
+        {
+            var settings = BuildSettings();
+
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.ConnectionStringKey] = "connection string";
+
+            var configuration = RavenDbPersistenceConfiguration.GetDatabaseConfiguration(settings);
+
+            Assert.AreEqual(settings.AuditRetentionPeriod, configuration.AuditRetentionPeriod);
+            Assert.AreEqual(settings.MaxBodySizeToStore, configuration.MaxBodySizeToStore);
+            Assert.AreEqual(settings.EnableFullTextSearchOnBodies, configuration.EnableFullTextSearch);
+        }
+
+        [Test]
+        public void Should_support_external_server()
+        {
+            var settings = BuildSettings();
+            var connectionString = "http://someserver:44444";
+
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.ConnectionStringKey] = connectionString;
+
+            var configuration = RavenDbPersistenceConfiguration.GetDatabaseConfiguration(settings);
+
+            Assert.False(configuration.ServerConfiguration.UseEmbeddedServer);
+            Assert.AreEqual(connectionString, configuration.ServerConfiguration.ConnectionString);
+        }
+
+        [Test]
+        public void Should_support_embedded_server()
+        {
+            var settings = BuildSettings();
+            var dpPath = "c://some-path";
+
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabasePathKey] = dpPath;
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.HostNameKey] = "localhost";
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabaseMaintenancePortKey] = "11111";
+
+            var configuration = RavenDbPersistenceConfiguration.GetDatabaseConfiguration(settings);
+
+            Assert.True(configuration.ServerConfiguration.UseEmbeddedServer);
+            Assert.AreEqual(dpPath, configuration.ServerConfiguration.DbPath);
+            Assert.AreEqual("http://localhost:11111", configuration.ServerConfiguration.ServerUrl);
+        }
+
+        [Test]
+        public void Should_throw_if_no_path_or_connection_string_is_configured()
+        {
+            var settings = BuildSettings();
+
+            Assert.Throws<InvalidOperationException>(() => RavenDbPersistenceConfiguration.GetDatabaseConfiguration(settings));
+        }
+
+        [Test]
+        public void Should_throw_if_both_path_or_connection_string_is_configured()
+        {
+            var settings = BuildSettings();
+
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabasePathKey] = "path";
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.ConnectionStringKey] = "connection string";
+
+            Assert.Throws<InvalidOperationException>(() => RavenDbPersistenceConfiguration.GetDatabaseConfiguration(settings));
+        }
+
+        PersistenceSettings BuildSettings()
+        {
+            return new PersistenceSettings(TimeSpan.FromMinutes(2), true, 100000);
+        }
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
@@ -22,8 +22,7 @@
                 var dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "AuditData");
                 var serverUrl = $"http://localhost:{FindAvailablePort(33334)}";
 
-    
-            embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl)));
+                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl)));
 
                 return embeddedDatabase;
             }

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
@@ -6,7 +6,6 @@
     using System.Net.NetworkInformation;
     using NUnit.Framework;
     using ServiceControl.Audit.Persistence.RavenDb;
-    using ServiceControl.Audit.Persistence.RavenDb5;
 
     class SharedEmbeddedServer
     {

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Audit.Persistence.Tests
 {
+    using System;
     using System.IO;
     using System.Linq;
     using System.Net.NetworkInformation;
@@ -21,7 +22,8 @@
                 var dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "AuditData");
                 var serverUrl = $"http://localhost:{FindAvailablePort(33334)}";
 
-                embeddedDatabase = EmbeddedDatabase.Start(dbPath, serverUrl, new DatabaseConfiguration("audit", 60, true, new ServerOptions(serverUrl)));
+    
+            embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl)));
 
                 return embeddedDatabase;
             }

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
@@ -21,7 +21,7 @@
                 var dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "AuditData");
                 var serverUrl = $"http://localhost:{FindAvailablePort(33334)}";
 
-                embeddedDatabase = EmbeddedDatabase.Start(dbPath, serverUrl, new DatabaseConfiguration("audit", 60, true));
+                embeddedDatabase = EmbeddedDatabase.Start(dbPath, serverUrl, new DatabaseConfiguration("audit", 60, true, new ServerOptions(serverUrl)));
 
                 return embeddedDatabase;
             }


### PR DESCRIPTION
Talking to Mike we figured it was a smell to register the PersistenceSettings in DI since it passed from the outside. This removes that need and centralized all config in a single place. Also adds unit tests to check the parsing of config values.