### PR TITLE
Show host name on heart beat events

### DIFF
--- a/src/ServiceControl/Monitoring/EventLog/EndpointFailedToHeartbeatDefinition.cs
+++ b/src/ServiceControl/Monitoring/EventLog/EndpointFailedToHeartbeatDefinition.cs
@@ -9,7 +9,7 @@
         {
             TreatAsError();
 
-            Description(m => $"Endpoint {m.Endpoint.Name} has failed to send expected heartbeat to ServiceControl. It is possible that the endpoint could be down or is unresponsive. If this condition persists restart the endpoint.");
+            Description(m => $"Endpoint {m.Endpoint.Name} has failed to send expected heartbeat to ServiceControl on host {m.Endpoint.Host}. It is possible that the endpoint could be down or is unresponsive. If this condition persists restart the endpoint.");
 
             RelatesToEndpoint(m => m.Endpoint.Name);
             RelatesToHost(m => m.Endpoint.HostId);

--- a/src/ServiceControl/Monitoring/EventLog/EndpointHeartbeatRestoredDefinition.cs
+++ b/src/ServiceControl/Monitoring/EventLog/EndpointHeartbeatRestoredDefinition.cs
@@ -7,7 +7,7 @@
     {
         public EndpointHeartbeatRestoredDefinition()
         {
-            Description(m => $"Endpoint {m.Endpoint.Name} heartbeats have been restored.");
+            Description(m => $"Endpoint {m.Endpoint.Name} heartbeats have been restored on host {m.Endpoint.Host}.");
 
             RelatesToEndpoint(m => m.Endpoint.Name);
             RelatesToHost(m => m.Endpoint.HostId);

--- a/src/ServiceControl/Monitoring/EventLog/EndpointStartedDefinition.cs
+++ b/src/ServiceControl/Monitoring/EventLog/EndpointStartedDefinition.cs
@@ -7,7 +7,7 @@
     {
         public EndpointStartedDefinition()
         {
-            Description(m => $"Endpoint '{m.EndpointDetails.Name}' started on host {m.EndpointDetails.Host}");
+            Description(m => $"Endpoint '{m.EndpointDetails.Name}' started on host {m.EndpointDetails.Host}.");
 
             RelatesToEndpoint(m => m.EndpointDetails.Name);
             RelatesToHost(m => m.EndpointDetails.HostId);

--- a/src/ServiceControl/Monitoring/EventLog/HeartbeatingEndpointDetectedDefinition.cs
+++ b/src/ServiceControl/Monitoring/EventLog/HeartbeatingEndpointDetectedDefinition.cs
@@ -7,7 +7,7 @@
     {
         public HeartbeatingEndpointDetectedDefinition()
         {
-            Description(m => $"Endpoint {m.Endpoint.Name} running on host {m.Endpoint.Host} has been confirmed to have heartbeats enabled");
+            Description(m => $"Endpoint {m.Endpoint.Name} running on host {m.Endpoint.Host} has been confirmed to have heartbeats enabled.");
 
             RelatesToEndpoint(m => m.Endpoint.Host);
             RelatesToHost(m => m.Endpoint.HostId);


### PR DESCRIPTION
This adds missing periods to events. It also adds the showing of the host name of endpoint associated with heartbeat stops and starts.

Closes #2769 