### PR TITLE
Prevent capitalization of certain boolean config values

### DIFF
--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
@@ -45,11 +45,11 @@ namespace ServiceControlInstaller.Engine.Instances
             settings.Set(AuditInstanceSettingsList.Port, Port.ToString());
             settings.Set(AuditInstanceSettingsList.DatabaseMaintenancePort, DatabaseMaintenancePort.ToString(), Version);
             settings.Set(AuditInstanceSettingsList.LogPath, LogPath);
-            settings.Set(AuditInstanceSettingsList.ForwardAuditMessages, ForwardAuditMessages.ToString(), Version);
+            settings.Set(AuditInstanceSettingsList.ForwardAuditMessages, ForwardAuditMessages.ToString().ToLowerInvariant(), Version);
             settings.Set(AuditInstanceSettingsList.AuditRetentionPeriod, AuditRetentionPeriod.ToString(), Version);
             settings.Set(AuditInstanceSettingsList.AuditQueue, AuditQueue, Version);
             settings.Set(AuditInstanceSettingsList.AuditLogQueue, AuditLogQueue, Version);
-            settings.Set(AuditInstanceSettingsList.EnableFullTextSearchOnBodies, EnableFullTextSearchOnBodies.ToString(), Version);
+            settings.Set(AuditInstanceSettingsList.EnableFullTextSearchOnBodies, EnableFullTextSearchOnBodies.ToString().ToLowerInvariant(), Version);
             settings.Set(AuditInstanceSettingsList.PersistenceType, PersistenceManifest.TypeName);
         }
 


### PR DESCRIPTION
Some boolean app settings are being capitalized and some are not. This is causing developers who write configuration management code (puppet, chef, ansible, etc) to have to ensure they properly capitalize or not capitalize settings which is rather annoying.