### PR TITLE
Always use Learning transport for multi instance tests

### DIFF
--- a/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
@@ -16,6 +16,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests
     using NServiceBus.AcceptanceTesting.Support;
     using NUnit.Framework;
     using ServiceBus.Management.Infrastructure.Settings;
+    using ServiceControl.AcceptanceTesting.InfrastructureConfig;
     using TestSupport;
 
     [TestFixture]
@@ -65,13 +66,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests
             textWriterTraceListener = new TextWriterTraceListener(logFile);
             Trace.Listeners.Add(textWriterTraceListener);
 
-            TransportIntegration = (ITransportIntegration)TestSuiteConstraints.Current.CreateTransportConfiguration();
-
-            var shouldBeRunOnAllTransports = GetType().GetCustomAttributes(typeof(RunOnAllTransportsAttribute), true).Any();
-            if (!shouldBeRunOnAllTransports && TransportIntegration.Name != "Learning")
-            {
-                Assert.Inconclusive($"Not flagged with [RunOnAllTransports] therefore skipping this test with '{TransportIntegration.Name}'");
-            }
+            TransportIntegration = new ConfigureEndpointLearningTransport();
 
             TestContext.WriteLine($"Using transport {TransportIntegration.Name}");
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
@@ -66,7 +66,12 @@ namespace ServiceControl.MultiInstance.AcceptanceTests
             textWriterTraceListener = new TextWriterTraceListener(logFile);
             Trace.Listeners.Add(textWriterTraceListener);
 
-            TransportIntegration = new ConfigureEndpointLearningTransport();
+            TransportIntegration = (ITransportIntegration)TestSuiteConstraints.Current.CreateTransportConfiguration();
+
+            if (TransportIntegration.GetType() != typeof(ConfigureEndpointLearningTransport))
+            {
+                Assert.Inconclusive($"Multi instance tests are only run for the learning transport");
+            }
 
             TestContext.WriteLine($"Using transport {TransportIntegration.Name}");
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
@@ -7,33 +7,15 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.AcceptanceTesting\ServiceControl.AcceptanceTesting.csproj" />
-    <ProjectReference Include="..\ServiceControl.Audit.Persistence.InMemory\ServiceControl.Audit.Persistence.InMemory.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb\ServiceControl.Audit.Persistence.RavenDb.csproj" />
-    <ProjectReference Include="..\ServiceControl.Audit.Persistence.SqlServer\ServiceControl.Audit.Persistence.SqlServer.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.InMemory\ServiceControl.Persistence.InMemory.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.SqlServer\ServiceControl.Persistence.SqlServer.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
     <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.ASQ\ServiceControl.Transports.ASQ.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" />
   </ItemGroup>
-
-  <!-- Workaround. See: https://github.com/NuGet/Home/issues/4989 -->
-  <Target Name="ChangeAliasesOfNugetRefs" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'NServiceBus.Transport.AzureServiceBus'">
-        <Aliases>TransportASBS</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
 
   <ItemGroup>
     <Reference Include="System.Net.Http" />


### PR DESCRIPTION
I got tired of SQS constantly failing and since we hardcode storage to ravendb35 I think we should also use the learning transport only since we're testing instance interactions and not persisters and storages