### PR TITLE
Show persistence package name in powershell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,19 +52,19 @@ jobs:
           client-secret: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
           certificate-name: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
       - name: Publish installer
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: installer
           path: assets/*
           retention-days: 1
       - name: Publish NuGet packages
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: nugets
           path: nugets/*
           retention-days: 1
       - name: Publish zips
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: zips
           path: zip/*
@@ -126,7 +126,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.1.0
       - name: Download zip artifacts
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3.0.1
         with:
           name: zips
           path: zip

--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/PsAuditInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/PsAuditInstance.cs
@@ -18,6 +18,8 @@
         public string TransportPackageName { get; set; }
         public string ConnectionString { get; set; }
 
+        public string PersistencePackageName { get; set; }
+
         public string AuditQueue { get; set; }
         public string AuditLogQueue { get; set; }
         public bool ForwardAuditMessages { get; set; }
@@ -53,6 +55,7 @@
                 AuditRetentionPeriod = instance.AuditRetentionPeriod,
                 ServiceControlQueueAddress = instance.ServiceControlQueueAddress,
                 EnableFullTextSearchOnBodies = instance.EnableFullTextSearchOnBodies,
+                PersistencePackageName = instance.PersistenceManifest?.Name
             };
     }
 }


### PR DESCRIPTION
Adds a `PersistencePackageName` property to the powershell output for audit instances.

![image](https://user-images.githubusercontent.com/124014/197457525-c53f2baf-b64b-4924-9165-cf5de1424662.png)

This mirrors the transport package name property that was already present.