### PR TITLE
Show persistence package name in powershell

### DIFF
--- a/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/PsAuditInstance.cs
+++ b/src/ServiceControlInstaller.PowerShell/Cmdlets/AuditInstances/PsAuditInstance.cs
@@ -18,6 +18,8 @@
         public string TransportPackageName { get; set; }
         public string ConnectionString { get; set; }
 
+        public string PersistencePackageName { get; set; }
+
         public string AuditQueue { get; set; }
         public string AuditLogQueue { get; set; }
         public bool ForwardAuditMessages { get; set; }
@@ -53,6 +55,7 @@
                 AuditRetentionPeriod = instance.AuditRetentionPeriod,
                 ServiceControlQueueAddress = instance.ServiceControlQueueAddress,
                 EnableFullTextSearchOnBodies = instance.EnableFullTextSearchOnBodies,
+                PersistencePackageName = instance.PersistenceManifest?.DisplayName,
             };
     }
 }


### PR DESCRIPTION
Adds a `PersistencePackageName` property to the powershell output for audit instances.

![image](https://user-images.githubusercontent.com/124014/197468578-f0b9e47d-8a05-4be7-b25c-753ebd77121e.png)

This mirrors the transport package name property that was already present.