### PR TITLE
Ensure that embedded RavenDB 5 is available before running tests

### DIFF
--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/AcceptanceTestStorageConfiguration.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/AcceptanceTestStorageConfiguration.cs
@@ -10,16 +10,14 @@
     {
         public string PersistenceType { get; protected set; }
 
-        public Task CustomizeSettings(IDictionary<string, string> settings)
+        public async Task CustomizeSettings(IDictionary<string, string> settings)
         {
             var databaseName = Guid.NewGuid().ToString();
 
-            var instance = SharedEmbeddedServer.GetInstance();
+            var instance = await SharedEmbeddedServer.GetInstance();
 
             settings[RavenDbPersistenceConfiguration.ConnectionStringKey] = instance.ServerUrl;
             settings[RavenDbPersistenceConfiguration.DatabaseNameKey] = databaseName;
-
-            return Task.CompletedTask;
         }
 
         public Task Configure()

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/EmbeddedLifecycleTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/EmbeddedLifecycleTests.cs
@@ -22,7 +22,7 @@
             };
 
             //make sure to stop the global instance first
-            SharedEmbeddedServer.Stop();
+            await SharedEmbeddedServer.Stop();
 
             await base.Setup();
         }

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/PersistenceTestsConfiguration.cs
@@ -28,7 +28,7 @@
 
             if (!settings.PersisterSpecificSettings.ContainsKey(RavenDbPersistenceConfiguration.DatabasePathKey))
             {
-                var instance = SharedEmbeddedServer.GetInstance();
+                var instance = await SharedEmbeddedServer.GetInstance();
 
                 settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.ConnectionStringKey] = instance.ServerUrl;
             }


### PR DESCRIPTION
I've seen [tests fail quite often](https://github.com/Particular/ServiceControl/actions/runs/3326655234/jobs/5500579228) with

```
Starting test execution, please wait...
  A total of 1 test files matched the specified pattern.
  Using transport MSMQ
  Using persistence ServiceControl.Audit.Persistence.RavenDb.RavenDbPersistenceConfiguration, ServiceControl.Audit.Persistence.RavenDb5, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null
  current context: ServiceControl.Audit.AcceptanceTests.Auditing.When_a_message_fails_to_import+MyContext
  Started test @ 10/26/2022 06:31:20
  00:00:05.9905796 - Creating infrastructure for Particular.ServiceControl.Audit
  System.AggregateException: Failed to retrieve database topology from all known nodes.
  http://localhost:33334 -> An error occurred while sending the request. -> Unable to connect to the remote server -> No connection could be made because the target machine actively refused it 127.0.0.1:33334 ---> System.Net.Http.HttpRequestException: An error occurred while sending the request. ---> System.Net.WebException: Unable to connect to the remote server ---> System.Net.Sockets.SocketException: No connection could be made because the target machine actively refused it 127.0.0.1:33334
```

This should fix that problem since we now wait for a successful connection before returning the instance