### PR TITLE
Include RavenDB 3.5 persister in main instance docker images

### DIFF
--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AmazonSQS.Verify_amazonsqs_init_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AmazonSQS.Verify_amazonsqs_init_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AmazonSQS.Verify_amazonsqs_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AmazonSQS.Verify_amazonsqs_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AzureServiceBus.Verify_azureservicebus_init_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AzureServiceBus.Verify_azureservicebus_init_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AzureServiceBus.Verify_azureservicebus_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AzureServiceBus.Verify_azureservicebus_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AzureStorageQueues.Verify_azurestoragequeues_init_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AzureStorageQueues.Verify_azurestoragequeues_init_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AzureStorageQueues.Verify_azurestoragequeues_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/AzureStorageQueues.Verify_azurestoragequeues_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqConventional.Verify_rabbitmqclassicconventional_init_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqConventional.Verify_rabbitmqclassicconventional_init_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqConventional.Verify_rabbitmqclassicconventional_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqConventional.Verify_rabbitmqclassicconventional_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqConventional.Verify_rabbitmqquorumconventional_init_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqConventional.Verify_rabbitmqquorumconventional_init_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqConventional.Verify_rabbitmqquorumconventional_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqConventional.Verify_rabbitmqquorumconventional_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqDirect.Verify_rabbitmqclassicdirect_init_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqDirect.Verify_rabbitmqclassicdirect_init_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqDirect.Verify_rabbitmqclassicdirect_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqDirect.Verify_rabbitmqclassicdirect_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqDirect.Verify_rabbitmqquorumdirect_init_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqDirect.Verify_rabbitmqquorumdirect_init_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqDirect.Verify_rabbitmqquorumdirect_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/RabbitMqDirect.Verify_rabbitmqquorumdirect_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/SQLServer.Verify_sqlserver_init_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/SQLServer.Verify_sqlserver_init_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/SQLServer.Verify_sqlserver_windows.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/SQLServer.Verify_sqlserver_windows.approved.txt
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
+++ b/src/docker/servicecontrol.amazonsqs.init-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SQS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azureservicebus.init-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASBS/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
+++ b/src/docker/servicecontrol.azurestoragequeues.init-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.ASQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.classic.conventional-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.classic.conventional-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.classic.conventional.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.classic.conventional.init-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.classic.direct-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.classic.direct-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.classic.direct.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.classic.direct.init-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.quorum.conventional-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.quorum.conventional-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.quorum.conventional.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.quorum.conventional.init-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.quorum.direct-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.quorum.direct-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.rabbitmq.quorum.direct.init-windows.dockerfile
+++ b/src/docker/servicecontrol.rabbitmq.quorum.direct.init-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.RabbitMQ/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 

--- a/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
+++ b/src/docker/servicecontrol.sqlserver.init-windows.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /servicecontrol
 
 ADD /ServiceControl.Transports.SqlServer/bin/Release/net472 .
 ADD /ServiceControl/bin/Release/net472 .
+ADD /ServiceControl.Persistence.RavenDb/bin/Release/net472 .
 
 ENV "SERVICECONTROL_RUNNING_IN_DOCKER"="true"
 


### PR DESCRIPTION
I realized that when we adjusted how we package the main instance we broke the docker images. This should fix that.