### PR TITLE
Fix saga info mapping

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDb/Migrations/MigratedTypeAwareBinder.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb/Migrations/MigratedTypeAwareBinder.cs
@@ -25,6 +25,8 @@
             {
                 case nameof(EndpointDetails):
                     return typeof(EndpointDetails);
+                case nameof(SagaInfo):
+                    return typeof(SagaInfo);
                 default:
                     return base.BindToType(assemblyName, typeName);
             }

--- a/src/ServiceControl.Audit.UnitTests/Infrastructure/MigrationTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/Infrastructure/MigrationTests.cs
@@ -6,14 +6,15 @@ using ServiceControl.Audit.Infrastructure.Migration;
 [TestFixture]
 class MigrationTests
 {
-    [Test]
-    public void VerifyMigration()
+    [TestCase("ServiceControl.SagaAudit.SagaInfo, ServiceControl.Audit")]
+    [TestCase("ServiceControl.SagaAudit.SagaInfo, ServiceControl.SagaAudit")]
+    public void VerifyMigration(string oldType)
     {
-        var serializedForm = @"{
-""$type"":""ServiceControl.SagaAudit.SagaInfo, ServiceControl.Audit"",
+        var serializedForm = $@"{{
+""$type"":""{oldType}"",
 ""ChangeStatus"":null,
 ""SagaType"":null,
-""SagaId"":""00000000-0000-0000-0000-000000000000""}";
+""SagaId"":""00000000-0000-0000-0000-000000000000""}}";
 
         var serializer = new JsonSerializer
         {


### PR DESCRIPTION
4.26.0 was throwing a serialization exception when trying to deserialize SagaAudit information