### PR TITLE
Fix event data for multiple subscribers missing in API

### DIFF
--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_event_processed_by_multiple_endpoints.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_event_processed_by_multiple_endpoints.cs
@@ -1,0 +1,134 @@
+﻿namespace ServiceControl.MultiInstance.AcceptanceTests.Auditing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using CompositeViews.Messages;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Settings;
+    using NUnit.Framework;
+    using TestSupport;
+    using TestSupport.EndpointTemplates;
+    using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+    // HINT: If this is included inside of the test class, the learning transport cannot set up the subscriptions
+    class SomeEvent : IEvent { }
+
+    class When_event_processed_by_multiple_endpoints : AcceptanceTest
+    {
+        [Test]
+        public async Task Should_find_both_occurrences()
+        {
+            CustomEndpointConfiguration = config => config.OnEndpointSubscribed<MyContext>(
+                (subscription, context) =>
+                {
+                    context.Subscriber1Subscribed = subscription.SubscriberEndpoint ==
+                                                    Conventions.EndpointNamingConvention(typeof(Subscriber1));
+                    context.Subscriber2Subscribed = subscription.SubscriberEndpoint ==
+                                                    Conventions.EndpointNamingConvention(typeof(Subscriber2));
+                }
+            );
+
+            await Define<MyContext>()
+                .WithEndpoint<Subscriber1>(b => b.When(async (session, ctx) =>
+                {
+                    await session.Subscribe<SomeEvent>();
+
+                    if (ctx.HasNativePubSubSupport)
+                    {
+                        ctx.Subscriber1Subscribed = true;
+                    }
+                }))
+                .WithEndpoint<Subscriber2>(b => b.When(async (session, ctx) =>
+                {
+                    await session.Subscribe<SomeEvent>();
+
+                    if (ctx.HasNativePubSubSupport)
+                    {
+                        ctx.Subscriber2Subscribed = true;
+                    }
+                }))
+                .WithEndpoint<Publisher>(b => b.When(
+                    ctx => ctx.Subscriber1Subscribed && ctx.Subscriber2Subscribed,
+                    session => session.Publish(new SomeEvent())))
+                .Done(async c => c.MessageId != null && (await this.TryGetMany<MessagesView>("/api/messages")).Items.Count == 2)
+                .Run();
+        }
+
+        class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServerWithAudit>();
+            }
+        }
+
+        class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServerWithAudit>(
+                    _ => { },
+                    publisherMetaData => publisherMetaData.RegisterPublisherFor<SomeEvent>(typeof(Publisher))
+                );
+            }
+
+            class SomeEventHandler : IHandleMessages<SomeEvent>
+            {
+                readonly MyContext scenarioContext;
+                readonly ReadOnlySettings settings;
+
+                public SomeEventHandler(MyContext scenarioContext, ReadOnlySettings settings)
+                {
+                    this.scenarioContext = scenarioContext;
+                    this.settings = settings;
+                }
+
+                public Task Handle(SomeEvent message, IMessageHandlerContext context)
+                {
+                    scenarioContext.Subscriber1Endpoint = settings.EndpointName();
+                    scenarioContext.MessageId = context.MessageId;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServerWithAudit>(
+                    _ => { },
+                    publisherMetaData => publisherMetaData.RegisterPublisherFor<SomeEvent>(typeof(Publisher))
+                );
+            }
+
+            class SomeEventHandler : IHandleMessages<SomeEvent>
+            {
+                readonly MyContext scenarioContext;
+                readonly ReadOnlySettings settings;
+
+                public SomeEventHandler(MyContext scenarioContext, ReadOnlySettings settings)
+                {
+                    this.scenarioContext = scenarioContext;
+                    this.settings = settings;
+                }
+
+                public Task Handle(SomeEvent message, IMessageHandlerContext context)
+                {
+                    scenarioContext.Subscriber2Endpoint = settings.EndpointName();
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        class MyContext : ScenarioContext
+        {
+            public string MessageId { get; set; }
+            public bool Subscriber1Subscribed { get; set; }
+            public string Subscriber1Endpoint { get; set; }
+            public bool Subscriber2Subscribed { get; set; }
+            public string Subscriber2Endpoint { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApiMessageView.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApiMessageView.cs
@@ -34,9 +34,10 @@ namespace ServiceControl.CompositeViews.Messages
                     //HINT: De-duplicate the results as some messages might be present in multiple instances (e.g. when they initially failed and later were successfully processed)
                     //The Execute method guarantees that the first item in the results collection comes from the main SC instance so the data fetched from failed messages has
                     //precedence over the data from the audit instances.
-                    if (!deduplicated.ContainsKey(result.MessageId))
+                    var key = $"{result.ReceivingEndpoint?.Name}-{result.MessageId}";
+                    if (!deduplicated.ContainsKey(key))
                     {
-                        deduplicated.Add(result.MessageId, result);
+                        deduplicated.Add(key, result);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #3164 

Before this fix:

![image](https://user-images.githubusercontent.com/124014/199635953-4f1a62c1-4444-4ebc-b83d-13fe7c8587af.png)

After this fix:

![image](https://user-images.githubusercontent.com/124014/199636211-471ec2e8-8d52-4b58-83e9-490b63c9bff3.png)

Note that the OrderAccepted event shows up twice, because it had two subscribers.