### PR TITLE
Fix minor UI misalignment

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
@@ -223,6 +223,7 @@
         <GroupBox Grid.Row="7"
                   Grid.Column="1"
                   Header="ENDPOINT NAME"
+                  Margin="0 1 0 0"
                   HeaderTemplate="{StaticResource SimpleHeaderedGroupBox}">
             <TextBlock FontSize="14px" Text="{Binding Name}" />
         </GroupBox>


### PR DESCRIPTION
The ENDPOINT NAME header had the wrong margin throwing out the alignment.

Before this fix (Red line to show the misalignment):
![image](https://user-images.githubusercontent.com/124014/199637550-a13d45be-66bd-442f-8904-97bdf823e686.png)

After the fix:

![image](https://user-images.githubusercontent.com/124014/199637678-e3ba2b98-3936-4a6a-a94b-cbcdef7a796b.png)
