### PR TITLE
Remove unused constants

### DIFF
--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/SettingConstants.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/SettingConstants.cs
@@ -3,16 +3,10 @@
     public class SettingConstants
     {
         public const int ErrorRetentionPeriodMaxInDays = 45;
-        public const int ErrorRetentionPeriodMaxInHours = 1080;
-
         public const int ErrorRetentionPeriodMinInDays = 5;
-        public const int ErrorRetentionPeriodMinInHours = 240;
 
         public const int AuditRetentionPeriodMaxInDays = 365;
-        public const int AuditRetentionPeriodMaxInHours = 8760;
-
         public const int AuditRetentionPeriodMinInDays = 1;
-        public const int AuditRetentionPeriodMinInHours = 1;
 
         public const int AuditRetentionPeriodDefaultInDaysForUI = 7;
 


### PR DESCRIPTION
Follow-up to #3199

No need to keep constants that aren't being used, and could be defined inconsistently.