### PR TITLE
Improve packaging by splitting responsibilities

### DIFF
--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -8,15 +8,17 @@
     <PackageProjectUrl>https://docs.particular.net/servicecontrol/</PackageProjectUrl>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
     <IsPackable>true</IsPackable>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PreparePrimaryInstance;PrepareAuditInstance;AddFilesToPackage</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PreparePrimaryInstance;PrepareAuditInstance;PrepareMonitoringInstance;AddFilesToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" />
-    <ProjectReference Include="..\ServiceControl.Monitoring\ServiceControl.Monitoring.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
+  <ItemGroup>  
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <DeployFolder>..\..\deploy\</DeployFolder>
+  </PropertyGroup>
+  
   <ItemGroup>
     <None Remove="buildProps\**\*" />
     <Content Include="buildProps\**\*" PackagePath="" />
@@ -29,18 +31,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ServiceControlZip Include="..\..\zip\Particular.ServiceControl-*.zip" />
+      <ServiceControl Include="$(DeployFolder)\Particular.ServiceControl\ServiceControl\**\*.*" Exclude="**\*.config;**\*.pdb" />
+      <LearningTransport Include="$(DeployFolder)\Particular.ServiceControl\Transports\LearningTransport\**\*.*" Exclude="**\*.config;**\*.pdb" />
     </ItemGroup>
 
-    <MakeDir Directories="$(PrimaryStagingFolder)" />
-    <Unzip SourceFiles="@(ServiceControlZip)" DestinationFolder="$(PrimaryStagingFolder)" />
-
-    <ItemGroup>
-      <ServiceControl Include="$(PrimaryStagingFolder)\ServiceControl\**\*.*" Exclude="**\*.config;**\*.pdb" />
-    </ItemGroup>
-
+    <RemoveDir Directories="$(PrimaryWithPersistenceFolder)" />
     <MakeDir Directories="$(PrimaryWithPersistenceFolder)" />
     <Copy SourceFiles="@(ServiceControl)" DestinationFolder="$(PrimaryWithPersistenceFolder)" />
+    <Copy SourceFiles="@(LearningTransport)" DestinationFolder="$(PrimaryWithPersistenceFolder)" />
   </Target>
 
   <Target Name="PrepareAuditInstance">
@@ -50,28 +48,40 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ServiceControlAuditZip Include="..\..\zip\Particular.ServiceControl.Audit-*.zip" />
+      <ServiceControlAudit Include="$(DeployFolder)\Particular.ServiceControl.Audit\ServiceControl.Audit\**\*.*" Exclude="**\*.config;**\*.pdb" />
+      <AuditRavenPersistence Include="$(DeployFolder)\Particular.ServiceControl.Audit\Persisters\RavenDB35\**\*.*" Exclude="**\*.config;**\*.pdb" />
+      <LearningTransport Include="$(DeployFolder)\Particular.ServiceControl.Audit\Transports\LearningTransport\**\*.*" Exclude="**\*.config;**\*.pdb" />
     </ItemGroup>
 
-    <MakeDir Directories="$(AuditStagingFolder)" />
-    <Unzip SourceFiles="@(ServiceControlAuditZip)" DestinationFolder="$(AuditStagingFolder)" />
-
-    <ItemGroup>
-      <ServiceControlAudit Include="$(AuditStagingFolder)\ServiceControl.Audit\**\*.*" Exclude="**\*.config;**\*.pdb" />
-      <AuditRavenPersistence Include="$(AuditStagingFolder)\Persisters\RavenDB35\**\*.*" Exclude="**\*.config;**\*.pdb" />
-    </ItemGroup>
-
+    <RemoveDir Directories="$(AuditWithPersistenceFolder)" />
     <MakeDir Directories="$(AuditWithPersistenceFolder)" />
     <Copy SourceFiles="@(ServiceControlAudit)" DestinationFolder="$(AuditWithPersistenceFolder)" />
     <Copy SourceFiles="@(AuditRavenPersistence)" DestinationFolder="$(AuditWithPersistenceFolder)" />
+    <Copy SourceFiles="@(LearningTransport)" DestinationFolder="$(AuditWithPersistenceFolder)" />
+  </Target>
+  
+  <Target Name="PrepareMonitoringInstance">
+    <PropertyGroup>
+      <MonitoringFolder>.\$(OutputPath)\monitoring-persistence\</MonitoringFolder>
+      <MonitoringStagingFolder>$(OutputPath)\monitoring-staging\</MonitoringStagingFolder>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ServiceControlMonitoring Include="$(DeployFolder)\Particular.ServiceControl.Monitoring\ServiceControl.Monitoring\**\*.*" Exclude="**\*.config;**\*.pdb" />
+      <LearningTransport Include="$(DeployFolder)\Particular.ServiceControl.Monitoring\Transports\LearningTransport\**\*.*" Exclude="**\*.config;**\*.pdb" />
+    </ItemGroup>
+
+    <RemoveDir Directories="$(MonitoringFolder)" />
+    <MakeDir Directories="$(MonitoringFolder)" />
+    <Copy SourceFiles="@(ServiceControlMonitoring)" DestinationFolder="$(MonitoringFolder)" />
+    <Copy SourceFiles="@(LearningTransport)" DestinationFolder="$(MonitoringFolder)" />
   </Target>
 
   <Target Name="AddFilesToPackage">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(PrimaryWithPersistenceFolder)" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\servicecontrol-instance" />
       <TfmSpecificPackageFile Include="$(AuditWithPersistenceFolder)" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
-      <TfmSpecificPackageFile Include="..\ServiceControl.Monitoring\$(OutputPath)**\*" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\monitoring-instance" />
-      <TfmSpecificPackageFile Include="..\ServiceControl.Transports.Learning\$(OutputPath)\ServiceControl.Transports.Learning.dll" PackagePath="platform\servicecontrol\servicecontrol-instance;platform\servicecontrol\servicecontrol-audit-instance;platform\servicecontrol\monitoring-instance" />
+      <TfmSpecificPackageFile Include="$(MonitoringFolder)" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\monitoring-instance" />
     </ItemGroup>
   </Target>
 

--- a/src/ServiceControl.Persistence.InMemory/InMemoryMonitoringDataStore.cs
+++ b/src/ServiceControl.Persistence.InMemory/InMemoryMonitoringDataStore.cs
@@ -104,9 +104,7 @@ namespace ServiceControl.Persistence.InMemory
 
         public Task WarmupMonitoringFromPersistence(EndpointInstanceMonitoring endpointInstanceMonitoring)
         {
-            if (endpoints != null)
-            {
-                endpoints.ForEach(e =>
+            endpoints?.ForEach(e =>
                 {
                     endpointInstanceMonitoring.DetectEndpointFromPersistentStore(new EndpointDetails
                     {
@@ -115,7 +113,6 @@ namespace ServiceControl.Persistence.InMemory
                         Name = e.HostDisplayName
                     }, e.Monitored);
                 });
-            }
 
             return Task.CompletedTask;
         }

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -21,6 +21,41 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj" />
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <DeployFolder>..\..\deploy\</DeployFolder>
+    <ZipFolder>..\..\zip\</ZipFolder>
+  </PropertyGroup>
+
+  <Target Name="CleanZipFolder" AfterTargets="Build">
+    <RemoveDir Directories="$(ZipFolder)" />
+    <MakeDir Directories="$(ZipFolder)" />
+  </Target>
+
+  <Target Name="ZipServiceControl" AfterTargets="CleanZipFolder">
+    <PropertyGroup>
+      <InstanceName>Particular.ServiceControl</InstanceName>
+      <ZipToCreate>$(ZipFolder)$(InstanceName)-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
+    </PropertyGroup>
+    <ZipDirectory SourceDirectory="$(DeployFolder)$(InstanceName)" DestinationFile="$(ZipToCreate)" />
+  </Target>
+
+  <Target Name="ZipServiceControlAudit" AfterTargets="CleanZipFolder">
+    <PropertyGroup>
+      <InstanceName>Particular.ServiceControl.Audit</InstanceName>
+      <ZipToCreate>$(ZipFolder)$(InstanceName)-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
+    </PropertyGroup>
+    <ZipDirectory SourceDirectory="$(DeployFolder)$(InstanceName)" DestinationFile="$(ZipToCreate)" />
+  </Target>
+
+  <Target Name="ZipServiceControlMonitoring" AfterTargets="CleanZipFolder">
+    <PropertyGroup>
+      <InstanceName>Particular.ServiceControl.Monitoring</InstanceName>
+      <ZipToCreate>$(ZipFolder)$(InstanceName)-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
+    </PropertyGroup>
+    <ZipDirectory SourceDirectory="$(DeployFolder)$(InstanceName)" DestinationFile="$(ZipToCreate)" />
+  </Target>
+  
 </Project>

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -40,19 +40,19 @@
   -->
 
   <PropertyGroup>
-    <PackagingFolder>..\..\deploy\</PackagingFolder>
+    <DeployFolder>..\..\deploy\</DeployFolder>
   </PropertyGroup>
 
 
-  <Target Name="CleanPackagingFolder" AfterTargets="Build">
+  <Target Name="CleanDeployFolder" AfterTargets="Build">
     <!-- Ensure Folder Exists  -->
-    <RemoveDir Directories="$(PackagingFolder)" />
-    <MakeDir Directories="$(PackagingFolder)" />
+    <RemoveDir Directories="$(DeployFolder)" />
+    <MakeDir Directories="$(DeployFolder)" />
   </Target>
 
-  <Target Name="PrepareServiceControl" AfterTargets="CleanPackagingFolder">
+  <Target Name="PrepareServiceControl" AfterTargets="CleanDeployFolder">
     <PropertyGroup>
-      <StagingFolder>$(PackagingFolder)Particular.ServiceControl\</StagingFolder>
+      <StagingFolder>$(DeployFolder)Particular.ServiceControl\</StagingFolder>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -152,9 +152,9 @@
   </Target>
   -->
 
-  <Target Name="PrepareServiceControlAudit" AfterTargets="CleanPackagingFolder">
+  <Target Name="PrepareServiceControlAudit" AfterTargets="CleanDeployFolder">
     <PropertyGroup>
-      <StagingFolder>$(PackagingFolder)Particular.ServiceControl.Audit\</StagingFolder>
+      <StagingFolder>$(DeployFolder)Particular.ServiceControl.Audit\</StagingFolder>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -261,9 +261,9 @@
   </Target>
   -->
 
-  <Target Name="PrepareServiceControlMonitoring" AfterTargets="CleanPackagingFolder">
+  <Target Name="PrepareServiceControlMonitoring" AfterTargets="CleanDeployFolder">
     <PropertyGroup>
-      <StagingFolder>$(PackagingFolder)Particular.ServiceControl.Monitoring\</StagingFolder>
+      <StagingFolder>$(DeployFolder)Particular.ServiceControl.Monitoring\</StagingFolder>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -22,23 +22,84 @@
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb5\ServiceControl.Audit.Persistence.RavenDb5.csproj" ReferenceOutputAssembly="false" Private="false"/>
   </ItemGroup>
 
+  <!--
   <Target Name="CleanStaging" AfterTargets="Build">
     <PropertyGroup>
       <ZipTargetFolder>..\..\zip\</ZipTargetFolder>
       <ZipToCreate>$(ZipTargetFolder)Particular.ServiceControl-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
       <StagingFolder>$(ZipTargetFolder)Staging\</StagingFolder>
     </PropertyGroup>
-    <!-- Ensure Folder Exists  -->
     <MakeDir Directories="$(ZipTargetFolder)" />
     <RemoveDir Directories="$(StagingFolder)" />
     <MakeDir Directories="$(StagingFolder)" />
-    <!-- Remove any existing files -->
     <ItemGroup>
       <OldZips Include="$(ZipTargetFolder)*.*" />
     </ItemGroup>
     <Delete Files="@(OldZips)" />
   </Target>
+  -->
 
+  <PropertyGroup>
+    <PackagingFolder>..\..\deploy\</PackagingFolder>
+  </PropertyGroup>
+
+
+  <Target Name="CleanPackagingFolder" AfterTargets="Build">
+    <!-- Ensure Folder Exists  -->
+    <RemoveDir Directories="$(PackagingFolder)" />
+    <MakeDir Directories="$(PackagingFolder)" />
+  </Target>
+
+  <Target Name="PrepareServiceControl" AfterTargets="CleanPackagingFolder">
+    <PropertyGroup>
+      <StagingFolder>$(PackagingFolder)Particular.ServiceControl\</StagingFolder>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <ServiceControlFolder>..\ServiceControl\$(OutputPath)\</ServiceControlFolder>
+      <SqlTransportFolder>..\ServiceControl.Transports.SqlServer\$(OutputPath)\</SqlTransportFolder>
+      <ASQTransportFolder>..\ServiceControl.Transports.ASQ\$(OutputPath)\</ASQTransportFolder>
+      <ASBTransportFolder>..\ServiceControl.Transports.ASB\$(OutputPath)\</ASBTransportFolder>
+      <ASBSTransportFolder>..\ServiceControl.Transports.ASBS\$(OutputPath)\</ASBSTransportFolder>
+      <RabbitMQTransportFolder>..\ServiceControl.Transports.RabbitMQ\$(OutputPath)\</RabbitMQTransportFolder>
+      <MSMQTransportFolder>..\ServiceControl.Transports.Msmq\$(OutputPath)\</MSMQTransportFolder>
+      <SQSTransportFolder>..\ServiceControl.Transports.SQS\$(OutputPath)\</SQSTransportFolder>
+      <LearningTransportFolder>..\ServiceControl.Transports.Learning\$(OutputPath)\</LearningTransportFolder>
+      <RavenDB35PersistenceFolder>..\ServiceControl.Persistence.RavenDb\$(OutputPath)\</RavenDB35PersistenceFolder>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <FilesToExclude Include="NServiceBus.Core.dll;NServiceBus.Raw.dll;ServiceControl.Transports.dll;ServiceControl.Transports.pdb;Newtonsoft.Json.dll;System.Runtime.CompilerServices.Unsafe.dll" />
+
+      <ServiceControl Include="$(ServiceControlFolder)*.*" Exclude="$(ServiceControlFolder)*.config" />
+      <RavenDB35Persister Include="$(RavenDB35PersistenceFolder)*.dll" Exclude="@(FilesToExclude->'$(RavenDB35PersistenceFolder)%(identity)')" />
+
+      <SqlTransport Include="$(SqlTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SqlTransportFolder)%(identity)')" />
+      <ASQTransport Include="$(ASQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASQTransportFolder)%(identity)')" />
+      <ASBTransport Include="$(ASBTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBTransportFolder)%(identity)')" />
+      <ASBSTransport Include="$(ASBSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBSTransportFolder)%(identity)')" />
+      <RabbitMQTransport Include="$(RabbitMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(RabbitMQTransportFolder)%(identity)')" />
+      <MSMQTransport Include="$(MSMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(MSMQTransportFolder)%(identity)')" />
+      <SQSTransport Include="$(SQSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SQSTransportFolder)%(identity)')" />
+      <LearningTransport Include="$(LearningTransportFolder)*.*" Exclude="@(FilesToExclude->'$(LearningTransportFolder)%(identity)')" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(ServiceControl)" DestinationFolder="$(StagingFolder)ServiceControl\" />
+    <Copy SourceFiles="@(RavenDB35Persister)" DestinationFolder="$(StagingFolder)ServiceControl\" />
+    <Copy SourceFiles="@(SqlTransport)" DestinationFolder="$(StagingFolder)Transports\SQLServer" />
+    <Copy SourceFiles="@(ASQTransport)" DestinationFolder="$(StagingFolder)Transports\AzureStorageQueue" />
+    <Copy SourceFiles="@(ASBTransport)" DestinationFolder="$(StagingFolder)Transports\AzureServiceBus" />
+    <Copy SourceFiles="@(ASBSTransport)" DestinationFolder="$(StagingFolder)Transports\NetStandardAzureServiceBus" />
+    <Copy SourceFiles="@(RabbitMQTransport)" DestinationFolder="$(StagingFolder)Transports\RabbitMQ" />
+    <Copy SourceFiles="@(MSMQTransport)" DestinationFolder="$(StagingFolder)Transports\MSMQ" />
+    <Copy SourceFiles="@(SQSTransport)" DestinationFolder="$(StagingFolder)Transports\AmazonSQS" />
+    <Copy SourceFiles="@(LearningTransport)" DestinationFolder="$(StagingFolder)Transports\LearningTransport" />
+
+  </Target>
+  
+  
+  
+  <!--
   <Target Name="CreateServiceControlZip" AfterTargets="CleanStaging">
     <PropertyGroup>
       <ZipTargetFolder>..\..\zip\</ZipTargetFolder>
@@ -89,7 +150,60 @@
     <ZipDirectory SourceDirectory="$(StagingFolder)" DestinationFile="$(ZipToCreate)" />
     <RemoveDir Directories="$(StagingFolder)" />
   </Target>
+  -->
 
+  <Target Name="PrepareServiceControlAudit" AfterTargets="CleanPackagingFolder">
+    <PropertyGroup>
+      <StagingFolder>$(PackagingFolder)Particular.ServiceControl.Audit\</StagingFolder>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <ServiceControlAuditFolder>..\ServiceControl.Audit\$(OutputPath)\</ServiceControlAuditFolder>
+      <SqlTransportFolder>..\ServiceControl.Transports.SqlServer\$(OutputPath)\</SqlTransportFolder>
+      <ASQTransportFolder>..\ServiceControl.Transports.ASQ\$(OutputPath)\</ASQTransportFolder>
+      <ASBTransportFolder>..\ServiceControl.Transports.ASB\$(OutputPath)\</ASBTransportFolder>
+      <ASBSTransportFolder>..\ServiceControl.Transports.ASBS\$(OutputPath)\</ASBSTransportFolder>
+      <RabbitMQTransportFolder>..\ServiceControl.Transports.RabbitMQ\$(OutputPath)\</RabbitMQTransportFolder>
+      <MSMQTransportFolder>..\ServiceControl.Transports.Msmq\$(OutputPath)\</MSMQTransportFolder>
+      <SQSTransportFolder>..\ServiceControl.Transports.SQS\$(OutputPath)\</SQSTransportFolder>
+      <LearningTransportFolder>..\ServiceControl.Transports.Learning\$(OutputPath)\</LearningTransportFolder>
+      <InMemoryPersistenceFolder>..\ServiceControl.Audit.Persistence.InMemory\$(OutputPath)\</InMemoryPersistenceFolder>
+      <RavenDbPersistenceFolder>..\ServiceControl.Audit.Persistence.RavenDb\$(OutputPath)\</RavenDbPersistenceFolder>
+      <RavenDb5PersistenceFolder>..\ServiceControl.Audit.Persistence.RavenDb5\$(OutputPath)\</RavenDb5PersistenceFolder>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <FilesToExclude Include="NServiceBus.Core.dll;NServiceBus.Raw.dll;ServiceControl.Transports.dll;ServiceControl.Transports.pdb;ServiceControl.Audit.Persistence.dll;ServiceControl.Audit.Persistence.pdb;ServiceControl.Audit.Persistence.SagaAudit.dll;ServiceControl.Audit.Persistence.SagaAudit.pdb;System.Runtime.CompilerServices.Unsafe.dll" />
+
+      <ServiceControlAudit Include="$(ServiceControlAuditFolder)*.*" Exclude="$(ServiceControlAuditFolder)*.config" />
+      <AuditSqlTransport Include="$(SqlTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SqlTransportFolder)%(identity)')" />
+      <AuditASQTransport Include="$(ASQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASQTransportFolder)%(identity)')" />
+      <AuditASBTransport Include="$(ASBTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBTransportFolder)%(identity)')" />
+      <AuditASBSTransport Include="$(ASBSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBSTransportFolder)%(identity)')" />
+      <AuditRabbitMQTransport Include="$(RabbitMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(RabbitMQTransportFolder)%(identity)')" />
+      <AuditMSMQTransport Include="$(MSMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(MSMQTransportFolder)%(identity)')" />
+      <AuditSQSTransport Include="$(SQSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SQSTransportFolder)%(identity)')" />
+      <AuditLearningTransport Include="$(LearningTransportFolder)*.*" Exclude="@(FilesToExclude->'$(LearningTransportFolder)%(identity)')" />
+      <AuditInMemoryPersistence Include="$(InMemoryPersistenceFolder)*.*" Exclude="@(FilesToExclude->'$(InMemoryPersistenceFolder)%(identity)')" />
+      <AuditRavenDbPersistence Include="$(RavenDbPersistenceFolder)*.*" Exclude="@(FilesToExclude->'$(RavenDbPersistenceFolder)%(identity)')" />
+      <AuditRavenDb5Persistence Include="$(RavenDb5PersistenceFolder)\**\*.*" Exclude="@(FilesToExclude->'$(RavenDb5PersistenceFolder)%(identity)')" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(ServiceControlAudit)" DestinationFolder="$(StagingFolder)ServiceControl.Audit\" />
+    <Copy SourceFiles="@(AuditSqlTransport)" DestinationFolder="$(StagingFolder)Transports\SQLServer" />
+    <Copy SourceFiles="@(AuditASQTransport)" DestinationFolder="$(StagingFolder)Transports\AzureStorageQueue" />
+    <Copy SourceFiles="@(AuditASBTransport)" DestinationFolder="$(StagingFolder)Transports\AzureServiceBus" />
+    <Copy SourceFiles="@(AuditASBSTransport)" DestinationFolder="$(StagingFolder)Transports\NetStandardAzureServiceBus" />
+    <Copy SourceFiles="@(AuditRabbitMQTransport)" DestinationFolder="$(StagingFolder)Transports\RabbitMQ" />
+    <Copy SourceFiles="@(AuditMSMQTransport)" DestinationFolder="$(StagingFolder)Transports\MSMQ" />
+    <Copy SourceFiles="@(AuditSQSTransport)" DestinationFolder="$(StagingFolder)Transports\AmazonSQS" />
+    <Copy SourceFiles="@(AuditLearningTransport)" DestinationFolder="$(StagingFolder)Transports\LearningTransport" />
+    <Copy SourceFiles="@(AuditInMemoryPersistence)" DestinationFolder="$(StagingFolder)Persisters\InMemory" />
+    <Copy SourceFiles="@(AuditRavenDbPersistence)" DestinationFolder="$(StagingFolder)Persisters\RavenDB35" />
+    <Copy SourceFiles="@(AuditRavenDb5Persistence)" DestinationFolder="$(StagingFolder)Persisters\RavenDB5\%(RecursiveDir)" />
+  </Target>
+
+  <!--
   <Target Name="CreateServiceControlAuditZip" AfterTargets="CreateServiceControlZip">
     <PropertyGroup>
       <ZipTargetFolder>..\..\zip\</ZipTargetFolder>
@@ -145,7 +259,52 @@
     <ZipDirectory SourceDirectory="$(StagingFolder)" DestinationFile="$(ZipToCreate)" />
     <RemoveDir Directories="$(StagingFolder)" />
   </Target>
+  -->
 
+  <Target Name="PrepareServiceControlMonitoring" AfterTargets="CleanPackagingFolder">
+    <PropertyGroup>
+      <StagingFolder>$(PackagingFolder)Particular.ServiceControl.Monitoring\</StagingFolder>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <ServiceControlMonitoringFolder>..\ServiceControl.Monitoring\$(OutputPath)\</ServiceControlMonitoringFolder>
+      <SqlTransportFolder>..\ServiceControl.Transports.SqlServer\$(OutputPath)\</SqlTransportFolder>
+      <ASQTransportFolder>..\ServiceControl.Transports.ASQ\$(OutputPath)\</ASQTransportFolder>
+      <ASBTransportFolder>..\ServiceControl.Transports.ASB\$(OutputPath)\</ASBTransportFolder>
+      <ASBSTransportFolder>..\ServiceControl.Transports.ASBS\$(OutputPath)\</ASBSTransportFolder>
+      <RabbitMQTransportFolder>..\ServiceControl.Transports.RabbitMQ\$(OutputPath)\</RabbitMQTransportFolder>
+      <MSMQTransportFolder>..\ServiceControl.Transports.Msmq\$(OutputPath)\</MSMQTransportFolder>
+      <SQSTransportFolder>..\ServiceControl.Transports.SQS\$(OutputPath)\</SQSTransportFolder>
+      <LearningTransportFolder>..\ServiceControl.Transports.Learning\$(OutputPath)\</LearningTransportFolder>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <FilesToExclude Include="NServiceBus.Core.dll;NServiceBus.Raw.dll;ServiceControl.Transports.dll;ServiceControl.Transports.pdb" />
+
+      <ServiceControlMonitoring Include="$(ServiceControlMonitoringFolder)*.*" Exclude="$(ServiceControlMonitoringFolder)*.config" />
+      <MonitoringSqlTransport Include="$(SqlTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SqlTransportFolder)%(identity)')" />
+      <MonitoringASQTransport Include="$(ASQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASQTransportFolder)%(identity)')" />
+      <MonitoringASBTransport Include="$(ASBTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBTransportFolder)%(identity)')" />
+      <MonitoringASBSTransport Include="$(ASBSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBSTransportFolder)%(identity)')" />
+      <MonitoringRabbitMQTransport Include="$(RabbitMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(RabbitMQTransportFolder)%(identity)')" />
+      <MonitoringMSMQTransport Include="$(MSMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(MSMQTransportFolder)%(identity)')" />
+      <MonitoringSQSTransport Include="$(SQSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SQSTransportFolder)%(identity)')" />
+      <MonitoringLearningTransport Include="$(LearningTransportFolder)*.*" Exclude="@(FilesToExclude->'$(LearningTransportFolder)%(identity)')" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(ServiceControlMonitoring)" DestinationFolder="$(StagingFolder)ServiceControl.Monitoring\" />
+    <Copy SourceFiles="@(MonitoringSqlTransport)" DestinationFolder="$(StagingFolder)Transports\SQLServer" />
+    <Copy SourceFiles="@(MonitoringASQTransport)" DestinationFolder="$(StagingFolder)Transports\AzureStorageQueue" />
+    <Copy SourceFiles="@(MonitoringASBTransport)" DestinationFolder="$(StagingFolder)Transports\AzureServiceBus" />
+    <Copy SourceFiles="@(MonitoringASBSTransport)" DestinationFolder="$(StagingFolder)Transports\NetStandardAzureServiceBus" />
+    <Copy SourceFiles="@(MonitoringRabbitMQTransport)" DestinationFolder="$(StagingFolder)Transports\RabbitMQ" />
+    <Copy SourceFiles="@(MonitoringMSMQTransport)" DestinationFolder="$(StagingFolder)Transports\MSMQ" />
+    <Copy SourceFiles="@(MonitoringSQSTransport)" DestinationFolder="$(StagingFolder)Transports\AmazonSQS" />
+    <Copy SourceFiles="@(MonitoringLearningTransport)" DestinationFolder="$(StagingFolder)Transports\LearningTransport" />
+
+  </Target>
+
+  <!--
   <Target Name="CreateServiceControlMonitoringZip" AfterTargets="CreateServiceControlAuditZip">
     <PropertyGroup>
       <ZipTargetFolder>..\..\zip\</ZipTargetFolder>
@@ -192,4 +351,5 @@
     <ZipDirectory SourceDirectory="$(StagingFolder)" DestinationFile="$(ZipToCreate)" />
     <RemoveDir Directories="$(StagingFolder)" />
   </Target>
+  -->
 </Project>

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -22,23 +22,6 @@
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb5\ServiceControl.Audit.Persistence.RavenDb5.csproj" ReferenceOutputAssembly="false" Private="false"/>
   </ItemGroup>
 
-  <!--
-  <Target Name="CleanStaging" AfterTargets="Build">
-    <PropertyGroup>
-      <ZipTargetFolder>..\..\zip\</ZipTargetFolder>
-      <ZipToCreate>$(ZipTargetFolder)Particular.ServiceControl-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
-      <StagingFolder>$(ZipTargetFolder)Staging\</StagingFolder>
-    </PropertyGroup>
-    <MakeDir Directories="$(ZipTargetFolder)" />
-    <RemoveDir Directories="$(StagingFolder)" />
-    <MakeDir Directories="$(StagingFolder)" />
-    <ItemGroup>
-      <OldZips Include="$(ZipTargetFolder)*.*" />
-    </ItemGroup>
-    <Delete Files="@(OldZips)" />
-  </Target>
-  -->
-
   <PropertyGroup>
     <DeployFolder>..\..\deploy\</DeployFolder>
   </PropertyGroup>
@@ -97,61 +80,6 @@
 
   </Target>
   
-  
-  
-  <!--
-  <Target Name="CreateServiceControlZip" AfterTargets="CleanStaging">
-    <PropertyGroup>
-      <ZipTargetFolder>..\..\zip\</ZipTargetFolder>
-      <ZipToCreate>$(ZipTargetFolder)Particular.ServiceControl-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
-      <StagingFolder>$(ZipTargetFolder)Staging\</StagingFolder>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <ServiceControlFolder>..\ServiceControl\$(OutputPath)\</ServiceControlFolder>
-      <SqlTransportFolder>..\ServiceControl.Transports.SqlServer\$(OutputPath)\</SqlTransportFolder>
-      <ASQTransportFolder>..\ServiceControl.Transports.ASQ\$(OutputPath)\</ASQTransportFolder>
-      <ASBTransportFolder>..\ServiceControl.Transports.ASB\$(OutputPath)\</ASBTransportFolder>
-      <ASBSTransportFolder>..\ServiceControl.Transports.ASBS\$(OutputPath)\</ASBSTransportFolder>
-      <RabbitMQTransportFolder>..\ServiceControl.Transports.RabbitMQ\$(OutputPath)\</RabbitMQTransportFolder>
-      <MSMQTransportFolder>..\ServiceControl.Transports.Msmq\$(OutputPath)\</MSMQTransportFolder>
-      <SQSTransportFolder>..\ServiceControl.Transports.SQS\$(OutputPath)\</SQSTransportFolder>
-      <LearningTransportFolder>..\ServiceControl.Transports.Learning\$(OutputPath)\</LearningTransportFolder>
-      <RavenDB35PersistenceFolder>..\ServiceControl.Persistence.RavenDb\$(OutputPath)\</RavenDB35PersistenceFolder>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <FilesToExclude Include="NServiceBus.Core.dll;NServiceBus.Raw.dll;ServiceControl.Transports.dll;ServiceControl.Transports.pdb;Newtonsoft.Json.dll;System.Runtime.CompilerServices.Unsafe.dll" />
-
-      <ServiceControl Include="$(ServiceControlFolder)*.*" Exclude="$(ServiceControlFolder)*.config" />
-      <RavenDB35Persister Include="$(RavenDB35PersistenceFolder)*.dll" Exclude="@(FilesToExclude->'$(RavenDB35PersistenceFolder)%(identity)')" />
-
-      <SqlTransport Include="$(SqlTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SqlTransportFolder)%(identity)')" />
-      <ASQTransport Include="$(ASQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASQTransportFolder)%(identity)')" />
-      <ASBTransport Include="$(ASBTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBTransportFolder)%(identity)')" />
-      <ASBSTransport Include="$(ASBSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBSTransportFolder)%(identity)')" />
-      <RabbitMQTransport Include="$(RabbitMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(RabbitMQTransportFolder)%(identity)')" />
-      <MSMQTransport Include="$(MSMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(MSMQTransportFolder)%(identity)')" />
-      <SQSTransport Include="$(SQSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SQSTransportFolder)%(identity)')" />
-      <LearningTransport Include="$(LearningTransportFolder)*.*" Exclude="@(FilesToExclude->'$(LearningTransportFolder)%(identity)')" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(ServiceControl)" DestinationFolder="$(StagingFolder)ServiceControl\" />
-    <Copy SourceFiles="@(RavenDB35Persister)" DestinationFolder="$(StagingFolder)ServiceControl\" />
-    <Copy SourceFiles="@(SqlTransport)" DestinationFolder="$(StagingFolder)Transports\SQLServer" />
-    <Copy SourceFiles="@(ASQTransport)" DestinationFolder="$(StagingFolder)Transports\AzureStorageQueue" />
-    <Copy SourceFiles="@(ASBTransport)" DestinationFolder="$(StagingFolder)Transports\AzureServiceBus" />
-    <Copy SourceFiles="@(ASBSTransport)" DestinationFolder="$(StagingFolder)Transports\NetStandardAzureServiceBus" />
-    <Copy SourceFiles="@(RabbitMQTransport)" DestinationFolder="$(StagingFolder)Transports\RabbitMQ" />
-    <Copy SourceFiles="@(MSMQTransport)" DestinationFolder="$(StagingFolder)Transports\MSMQ" />
-    <Copy SourceFiles="@(SQSTransport)" DestinationFolder="$(StagingFolder)Transports\AmazonSQS" />
-    <Copy SourceFiles="@(LearningTransport)" DestinationFolder="$(StagingFolder)Transports\LearningTransport" />
-
-    <ZipDirectory SourceDirectory="$(StagingFolder)" DestinationFile="$(ZipToCreate)" />
-    <RemoveDir Directories="$(StagingFolder)" />
-  </Target>
-  -->
-
   <Target Name="PrepareServiceControlAudit" AfterTargets="CleanDeployFolder">
     <PropertyGroup>
       <StagingFolder>$(DeployFolder)Particular.ServiceControl.Audit\</StagingFolder>
@@ -203,64 +131,6 @@
     <Copy SourceFiles="@(AuditRavenDb5Persistence)" DestinationFolder="$(StagingFolder)Persisters\RavenDB5\%(RecursiveDir)" />
   </Target>
 
-  <!--
-  <Target Name="CreateServiceControlAuditZip" AfterTargets="CreateServiceControlZip">
-    <PropertyGroup>
-      <ZipTargetFolder>..\..\zip\</ZipTargetFolder>
-      <ZipToCreate>$(ZipTargetFolder)Particular.ServiceControl.Audit-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
-      <StagingFolder>$(ZipTargetFolder)Staging\</StagingFolder>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <ServiceControlAuditFolder>..\ServiceControl.Audit\$(OutputPath)\</ServiceControlAuditFolder>
-      <SqlTransportFolder>..\ServiceControl.Transports.SqlServer\$(OutputPath)\</SqlTransportFolder>
-      <ASQTransportFolder>..\ServiceControl.Transports.ASQ\$(OutputPath)\</ASQTransportFolder>
-      <ASBTransportFolder>..\ServiceControl.Transports.ASB\$(OutputPath)\</ASBTransportFolder>
-      <ASBSTransportFolder>..\ServiceControl.Transports.ASBS\$(OutputPath)\</ASBSTransportFolder>
-      <RabbitMQTransportFolder>..\ServiceControl.Transports.RabbitMQ\$(OutputPath)\</RabbitMQTransportFolder>
-      <MSMQTransportFolder>..\ServiceControl.Transports.Msmq\$(OutputPath)\</MSMQTransportFolder>
-      <SQSTransportFolder>..\ServiceControl.Transports.SQS\$(OutputPath)\</SQSTransportFolder>
-      <LearningTransportFolder>..\ServiceControl.Transports.Learning\$(OutputPath)\</LearningTransportFolder>
-      <InMemoryPersistenceFolder>..\ServiceControl.Audit.Persistence.InMemory\$(OutputPath)\</InMemoryPersistenceFolder>
-      <RavenDbPersistenceFolder>..\ServiceControl.Audit.Persistence.RavenDb\$(OutputPath)\</RavenDbPersistenceFolder>
-      <RavenDb5PersistenceFolder>..\ServiceControl.Audit.Persistence.RavenDb5\$(OutputPath)\</RavenDb5PersistenceFolder>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <FilesToExclude Include="NServiceBus.Core.dll;NServiceBus.Raw.dll;ServiceControl.Transports.dll;ServiceControl.Transports.pdb;ServiceControl.Audit.Persistence.dll;ServiceControl.Audit.Persistence.pdb;ServiceControl.Audit.Persistence.SagaAudit.dll;ServiceControl.Audit.Persistence.SagaAudit.pdb;System.Runtime.CompilerServices.Unsafe.dll" />
-
-      <ServiceControlAudit Include="$(ServiceControlAuditFolder)*.*" Exclude="$(ServiceControlAuditFolder)*.config" />
-      <AuditSqlTransport Include="$(SqlTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SqlTransportFolder)%(identity)')" />
-      <AuditASQTransport Include="$(ASQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASQTransportFolder)%(identity)')" />
-      <AuditASBTransport Include="$(ASBTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBTransportFolder)%(identity)')" />
-      <AuditASBSTransport Include="$(ASBSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBSTransportFolder)%(identity)')" />
-      <AuditRabbitMQTransport Include="$(RabbitMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(RabbitMQTransportFolder)%(identity)')" />
-      <AuditMSMQTransport Include="$(MSMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(MSMQTransportFolder)%(identity)')" />
-      <AuditSQSTransport Include="$(SQSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SQSTransportFolder)%(identity)')" />
-      <AuditLearningTransport Include="$(LearningTransportFolder)*.*" Exclude="@(FilesToExclude->'$(LearningTransportFolder)%(identity)')" />
-      <AuditInMemoryPersistence Include="$(InMemoryPersistenceFolder)*.*" Exclude="@(FilesToExclude->'$(InMemoryPersistenceFolder)%(identity)')" />
-      <AuditRavenDbPersistence Include="$(RavenDbPersistenceFolder)*.*" Exclude="@(FilesToExclude->'$(RavenDbPersistenceFolder)%(identity)')" />
-      <AuditRavenDb5Persistence Include="$(RavenDb5PersistenceFolder)\**\*.*" Exclude="@(FilesToExclude->'$(RavenDb5PersistenceFolder)%(identity)')" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(ServiceControlAudit)" DestinationFolder="$(StagingFolder)ServiceControl.Audit\" />
-    <Copy SourceFiles="@(AuditSqlTransport)" DestinationFolder="$(StagingFolder)Transports\SQLServer" />
-    <Copy SourceFiles="@(AuditASQTransport)" DestinationFolder="$(StagingFolder)Transports\AzureStorageQueue" />
-    <Copy SourceFiles="@(AuditASBTransport)" DestinationFolder="$(StagingFolder)Transports\AzureServiceBus" />
-    <Copy SourceFiles="@(AuditASBSTransport)" DestinationFolder="$(StagingFolder)Transports\NetStandardAzureServiceBus" />
-    <Copy SourceFiles="@(AuditRabbitMQTransport)" DestinationFolder="$(StagingFolder)Transports\RabbitMQ" />
-    <Copy SourceFiles="@(AuditMSMQTransport)" DestinationFolder="$(StagingFolder)Transports\MSMQ" />
-    <Copy SourceFiles="@(AuditSQSTransport)" DestinationFolder="$(StagingFolder)Transports\AmazonSQS" />
-    <Copy SourceFiles="@(AuditLearningTransport)" DestinationFolder="$(StagingFolder)Transports\LearningTransport" />
-    <Copy SourceFiles="@(AuditInMemoryPersistence)" DestinationFolder="$(StagingFolder)Persisters\InMemory" />
-    <Copy SourceFiles="@(AuditRavenDbPersistence)" DestinationFolder="$(StagingFolder)Persisters\RavenDB35" />
-    <Copy SourceFiles="@(AuditRavenDb5Persistence)" DestinationFolder="$(StagingFolder)Persisters\RavenDB5\%(RecursiveDir)" />
-
-    <ZipDirectory SourceDirectory="$(StagingFolder)" DestinationFile="$(ZipToCreate)" />
-    <RemoveDir Directories="$(StagingFolder)" />
-  </Target>
-  -->
-
   <Target Name="PrepareServiceControlMonitoring" AfterTargets="CleanDeployFolder">
     <PropertyGroup>
       <StagingFolder>$(DeployFolder)Particular.ServiceControl.Monitoring\</StagingFolder>
@@ -304,52 +174,4 @@
 
   </Target>
 
-  <!--
-  <Target Name="CreateServiceControlMonitoringZip" AfterTargets="CreateServiceControlAuditZip">
-    <PropertyGroup>
-      <ZipTargetFolder>..\..\zip\</ZipTargetFolder>
-      <ZipToCreate>$(ZipTargetFolder)Particular.ServiceControl.Monitoring-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
-      <StagingFolder>$(ZipTargetFolder)Staging\</StagingFolder>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <ServiceControlMonitoringFolder>..\ServiceControl.Monitoring\$(OutputPath)\</ServiceControlMonitoringFolder>
-      <SqlTransportFolder>..\ServiceControl.Transports.SqlServer\$(OutputPath)\</SqlTransportFolder>
-      <ASQTransportFolder>..\ServiceControl.Transports.ASQ\$(OutputPath)\</ASQTransportFolder>
-      <ASBTransportFolder>..\ServiceControl.Transports.ASB\$(OutputPath)\</ASBTransportFolder>
-      <ASBSTransportFolder>..\ServiceControl.Transports.ASBS\$(OutputPath)\</ASBSTransportFolder>
-      <RabbitMQTransportFolder>..\ServiceControl.Transports.RabbitMQ\$(OutputPath)\</RabbitMQTransportFolder>
-      <MSMQTransportFolder>..\ServiceControl.Transports.Msmq\$(OutputPath)\</MSMQTransportFolder>
-      <SQSTransportFolder>..\ServiceControl.Transports.SQS\$(OutputPath)\</SQSTransportFolder>
-      <LearningTransportFolder>..\ServiceControl.Transports.Learning\$(OutputPath)\</LearningTransportFolder>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <FilesToExclude Include="NServiceBus.Core.dll;NServiceBus.Raw.dll;ServiceControl.Transports.dll;ServiceControl.Transports.pdb" />
-
-      <ServiceControlMonitoring Include="$(ServiceControlMonitoringFolder)*.*" Exclude="$(ServiceControlMonitoringFolder)*.config" />
-      <MonitoringSqlTransport Include="$(SqlTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SqlTransportFolder)%(identity)')" />
-      <MonitoringASQTransport Include="$(ASQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASQTransportFolder)%(identity)')" />
-      <MonitoringASBTransport Include="$(ASBTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBTransportFolder)%(identity)')" />
-      <MonitoringASBSTransport Include="$(ASBSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBSTransportFolder)%(identity)')" />
-      <MonitoringRabbitMQTransport Include="$(RabbitMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(RabbitMQTransportFolder)%(identity)')" />
-      <MonitoringMSMQTransport Include="$(MSMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(MSMQTransportFolder)%(identity)')" />
-      <MonitoringSQSTransport Include="$(SQSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SQSTransportFolder)%(identity)')" />
-      <MonitoringLearningTransport Include="$(LearningTransportFolder)*.*" Exclude="@(FilesToExclude->'$(LearningTransportFolder)%(identity)')" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(ServiceControlMonitoring)" DestinationFolder="$(StagingFolder)ServiceControl.Monitoring\" />
-    <Copy SourceFiles="@(MonitoringSqlTransport)" DestinationFolder="$(StagingFolder)Transports\SQLServer" />
-    <Copy SourceFiles="@(MonitoringASQTransport)" DestinationFolder="$(StagingFolder)Transports\AzureStorageQueue" />
-    <Copy SourceFiles="@(MonitoringASBTransport)" DestinationFolder="$(StagingFolder)Transports\AzureServiceBus" />
-    <Copy SourceFiles="@(MonitoringASBSTransport)" DestinationFolder="$(StagingFolder)Transports\NetStandardAzureServiceBus" />
-    <Copy SourceFiles="@(MonitoringRabbitMQTransport)" DestinationFolder="$(StagingFolder)Transports\RabbitMQ" />
-    <Copy SourceFiles="@(MonitoringMSMQTransport)" DestinationFolder="$(StagingFolder)Transports\MSMQ" />
-    <Copy SourceFiles="@(MonitoringSQSTransport)" DestinationFolder="$(StagingFolder)Transports\AmazonSQS" />
-    <Copy SourceFiles="@(MonitoringLearningTransport)" DestinationFolder="$(StagingFolder)Transports\LearningTransport" />
-
-    <ZipDirectory SourceDirectory="$(StagingFolder)" DestinationFile="$(ZipToCreate)" />
-    <RemoveDir Directories="$(StagingFolder)" />
-  </Target>
-  -->
 </Project>


### PR DESCRIPTION
https://github.com/Particular/ServiceControl/pull/3187 made ServiceControl unreleasable. The issue is a race condition in creating the zip files in Packaging and the need for them in the Platform Sample NuGet project.

This PR reworks the Packaging, the Engine, and the Platform sample projects to make the responsibilities cleaner.
Packaging is now responsible for _only_ outputting deployable artifacts to a deploy folder in the root. The engine is the one that needs the zip files, and it'll create them in the zip folder. Finally, the Platform sample won't rely anymore on the zip files; instead, it'll use the artifacts created by Packaging in the deploy folder.

- [ ] Update the Readme in Packaging
- [ ] Fix Docker dockerfiles
