### PR TITLE
Packaging revamp

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,8 +1,8 @@
 # Deployment
 
-All ServiceControl deployment options listed below rely on the zip files produced by [packaging](packaging.md).
+All ServiceControl deployment options listed below rely on the files produced by [packaging](packaging.md).
 
-## ServiceControll installer
+## ServiceControl installer
 
 A [windows installer is provided for download](https://docs.particular.net/servicecontrol/installation) containing both ServiceControl Management Utility (SCMU) and [Powershell commands](https://docs.particular.net/servicecontrol/powershell).
 
@@ -11,11 +11,11 @@ When installing an instance using one of the above method instance files, persis
 A configuration file generated based on:
 
 - User input (and defaults)
-- Contents of the `persister.manifest` file of the selected persiser
+- Contents of the `persister.manifest` file of the selected persister
 
 ## NuGet package
 
-The binaries are shipped to the [PlatformSample](https://github.com/Particular/Particular.PlatformSample) via the `Particular.PlatformSample.ServiceControl` NuGet package with transport hardcoded to `LearningTransport` and persister hardcoded to `RavenDB 3.5`.
+The binaries are shipped to the [PlatformSample](https://github.com/Particular/Particular.PlatformSample) via the `Particular.PlatformSample.ServiceControl` NuGet package with transport hardcoded to `LearningTransport` and persister hardcoded to `In Memory`.
 
 NOTE: The platform sample runs all instance in the same process the same transport and persister has to be used.
 
@@ -23,10 +23,8 @@ NOTE: The platform sample runs all instance in the same process the same transpo
 
 NOTE: Docker isn't currently officially supported but we do have [a sample showing how to use it](https://docs.particular.net/samples/platformtools-docker-compose/).
 
-Multiple docker images, windows only, are generated using the following matrix [{InstanceType}, {TransportType}, {Init|NoInit}] where `Init` means that the instance is started in setup mode and then shutdown to support creating queues, database artefacts etc. All images are pushed to [DockerHub](https://hub.docker.com/) during deployment.
+Multiple docker images, windows only, are generated using the following matrix [{InstanceType}, {TransportType}, {Init|NoInit}] where `Init` means that the instance is started in setup mode and then shutdown to support creating queues, database artifacts etc. All images are pushed to [DockerHub](https://hub.docker.com/) during deployment.
 
-All required configuration values are defaulted in the `dockerfile` but can be overrided via environment variables. To simulate an instance running in docker the `{instance}.exe` passing in the `--portable` option.
+All required configuration values are defaulted in the `dockerfile` but can be overridden via environment variables. To simulate an instance running in docker the `{instance}.exe` passing in the `--portable` option.
 
 NOTE: Persister is hardcoded to `RavenDB 3.5`.
-
-NOTE: In CI the binaries for the docker files are extracted from the zipfile produced by packaging while locally they are pulled from the bin folders. https://github.com/Particular/ServiceControl/issues/3184 tracks fixing this.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -16,7 +16,7 @@ Each zip has the following folder structure:
 The [Microsoft.Build.Artifacts](https://github.com/microsoft/MSBuildSdks/tree/main/src/Artifacts) package is used to define artifacts that are placed into the `deploy` folder when the solution is built. Each project that contributes artifacts has an `Artifact` definition in its project file.
 To ensure proper build ordering, the `ServiceControlInstaller.Packaging` project needs to have a `ProjectReference` to every project that has an artifact definition.
 
-Every project that uses the artifacts then has to have a build ordering `ProjectReference` the `ServiceControlInstaller.Packaging` project. The projects that use the artifacts are:
+Every project that uses the artifacts then has to have a build ordering `ProjectReference` to the `ServiceControlInstaller.Packaging` project. The projects that use the artifacts are:
 
 - The `ServiceControlInstaller.Engine` project to create the above-mentioned required zip files
 - The `Particular.PlatformSample.ServiceControl` project to create the Platform sample required NuGet package

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,11 +1,11 @@
 # Packaging
 
-Each product (ServiceControl, ServiceControl.Monitoring and ServiceControl.Audit),  is packaged into its own versioned zip file in the `./zip` folder. These zip files are included in the installation package. 
+Each product (ServiceControl, ServiceControl.Monitoring and ServiceControl.Audit), is packaged into its own versioned zip file in the `zip` folder. These zip files are included in the installation package.
 
 Each zip has the following folder structure:
 
 - `/Transports` contains a folder for each supported transport
-- `/Persistence` contains a folder for each supported persister (Only the Audit instance use this currently)
+- `/Persisters` contains a folder for each supported persister (Only the Audit instance use this currently)
 - `/<product>` contains the instance files specific to the type of instance
   - `/ServiceControl`
   - `/ServiceControl.Audit`
@@ -13,34 +13,27 @@ Each zip has the following folder structure:
 
 ## The mechanics
 
-The `ServiceControlInstaller.Packaging` project is responsible to output to a `deploy` folder in the root all the required artifacts for `ServiceControl`, `ServiceControl.Audit`, and `ServiceControl.Monitoring`. Those artifacts are later needed by:
+The [Microsoft.Build.Artifacts](https://github.com/microsoft/MSBuildSdks/tree/main/src/Artifacts) package is used to define artifacts that are placed into the `deploy` folder when the solution is built. Each project that contributes artifacts has an `Artifact` definition in its project file.
+To ensure proper build ordering, the `ServiceControlInstaller.Packaging` project needs to have a `ProjectReference` to every project that has an artifact definition.
 
-- the `ServiceControlInstaller.Engine` project to create the above-mentioned required zip files
-- the `Particular.PlatformSample.ServiceControl` project to create the Platform sample required NuGet package
-- The Docker `dockerfile`(s) to build the Docker container images
+Every project that uses the artifacts then has to have a build ordering `ProjectReference` the `ServiceControlInstaller.Packaging` project. The projects that use the artifacts are:
+
+- The `ServiceControlInstaller.Engine` project to create the above-mentioned required zip files
+- The `Particular.PlatformSample.ServiceControl` project to create the Platform sample required NuGet package
+- The `ServiceControl.DockerImages` project to build the Docker container images
 
 ## Assembly version mismatches
 
-There can be an issue when the main instance folder and the selected transport each have a copy of the same assembly. This can happen when the transport/persistence package and the instance each reference the same dependency, but select different versions. At install time, one version or the other will be copied into the instance binary folder and things may break unexpectedly at runtime.
+There can be an issue when the main instance folder and the selected transport/persister component each have a copy of the same assembly but reference different versions. At install time, one version or the other will be copied into the instance binary folder and things may break unexpectedly at runtime.
 
 To prevent this, the unit test `DeploymentPackageTests.DuplicateAssemblyShouldHaveMatchingVersions` tests if duplicated assemblies might be deployed. If their versions match, then the test passes. If not then the test will fail with:
 
 ```
- Component assembly version mismatch detected
-    Expected: <empty>
-    But was:  < "Microsoft.Bcl.AsyncInterfaces.dll has a different version in Instance/ServiceControl.Audit compared to Transports/AzureServiceBus: 7.0.22.51805 | 4.700.19.56404", "System.Memory.dll has a different version in Instance/ServiceControl.Audit compared to Transports/AzureServiceBus: 4.6.31308.01 | 4.6.28619.01", "System.Text.Encodings.Web.dll has a different version in Instance/ServiceControl.Audit compared to Transports/AzureServiceBus: 7.0.22.51805 | 4.700.20.21406", "System.Text.Json.dll has a different version in Instance/ServiceControl.Audit compared to Transports/AzureServiceBus: 7.0.22.51805 | 4.700.20.21406", "Microsoft.Bcl.AsyncInterfaces.dll has a different version in Persisters/InMemory compared to Transports/AzureServiceBus: 7.0.22.51805 | 4.700.19.56404", "System.Memory.dll has a different version in Persisters/InMemory compared to Transports/AzureServiceBus: 4.6.31308.01 | 4.6.28619.01", "Microsoft.Bcl.AsyncInterfaces.dll has a different version in Persisters/RavenDB35 compared to Transports/AzureServiceBus: 7.0.22.51805 | 4.700.19.56404", "System.Memory.dll has a different version in Persisters/RavenDB35 compared to Transports/AzureServiceBus: 4.6.31308.01 | 4.6.28619.01", "Microsoft.Bcl.AsyncInterfaces.dll has a different version in Persisters/RavenDB5 compared to Transports/AzureServiceBus: 7.0.22.51805 | 4.700.19.56404", "System.Memory.dll has a different version in Persisters/RavenDB5 compared to Transports/AzureServiceBus: 4.6.31308.01 | 4.6.28619.01"... >
+  Component assembly version mismatch detected
+  Expected: <empty>
+  But was:  < "System.Memory.dll has a different version in Instance/ServiceControl compared to Transports/RabbitMQ. Add the package to Directory.Packages.props to ensure the same version is used everywhere: 4.6.31308.01 | 4.6.28619.01", "System.Memory.dll has a different version in Transports/RabbitMQ compared to Instance/ServiceControl. Add the package to Directory.Packages.props to ensure the same version is used everywhere: 4.6.28619.01 | 4.6.31308.01" >
 ```
-
-> Microsoft.Bcl.AsyncInterfaces.dll has a different version in Instance/ServiceControl.Audit compared to Transports/AzureServiceBus
-
-This tells that the mismatch is happening in ServiceControl.Audit and that the instance itself is clashing with the Azure ServiceBus transport and RavenDB 5 persister.
 
 ### How to resolve
 
-When a mismatch occurs, we need to make sure that the versions of the dependencies match between the transport/persistence package and the ServiceControl package. 
-
-There are two mechanisms for doing that:
-
-1. Add an explicit version of the package as a dependency on the transport/persistence package that matches the version being used by ServiceControl. This is the preferred option, as Dependabot will pick up when a new version of the dependency has been released and raise a PR for us to test and review.
-2. [Exclude a specific assembly from being included in any transport folder during the packaging process](https://github.com/Particular/ServiceControl/pull/1735/files#diff-181a8bea53d298736c8183d4d5821665e2ec3c854e5f7a4f7e8694b4cddc4b3f). This is a legacy option and should only be used for packages that most transports rely on. This will cause a mismatch between what is automatically tested and what goes into the deployment package.
-3. [Exclude the specific assembly from the check](https://github.com/Particular/ServiceControl/blob/master/src/ServiceControlInstaller.Packaging.UnitTests/DeploymentPackageTests.cs#L125) if its confirmed that the version mismatch is ok
+The repo uses [NuGet central package management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) to ensure that the same version of dependencies are used in each project. When a test fails with a version mismatch, add the package that provides the assembly to the `Versions to pin transitive references` ItemGroup in the `Directory.packages.props` file.

--- a/nuget.config
+++ b/nuget.config
@@ -4,4 +4,12 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="particular myget.org" value="https://www.myget.org/F/particular/api/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+        <package pattern="*" />
+    </packageSource>
+    <packageSource key="particular myget.org">
+        <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)../artifacts/</ArtifactsPath>
+    <EnableDefaultArtifacts>false</EnableDefaultArtifacts>
     <!-- Remove after upgrading to NServiceBus 8.x -->
     <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>
   </PropertyGroup>
@@ -13,11 +15,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Artifacts" Version="4.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>
     <WriteMinVerProperties>false</WriteMinVerProperties>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Product Include="Particular.ServiceControl" />
+    <Product Include="Particular.ServiceControl.Audit" />
+    <Product Include="Particular.ServiceControl.Monitoring" />
+  </ItemGroup>
 
 </Project>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <ArtifactsPath>$(MSBuildThisFileDirectory)../deploy/</ArtifactsPath>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)..\deploy\</ArtifactsPath>
     <EnableDefaultArtifacts>false</EnableDefaultArtifacts>
     <!-- Remove after upgrading to NServiceBus 8.x -->
     <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Product Include="Particular.ServiceControl" />
-    <Product Include="Particular.ServiceControl.Audit" />
-    <Product Include="Particular.ServiceControl.Monitoring" />
+    <InstanceName Include="Particular.ServiceControl" />
+    <InstanceName Include="Particular.ServiceControl.Audit" />
+    <InstanceName Include="Particular.ServiceControl.Monitoring" />
   </ItemGroup>
 
 </Project>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -14,11 +14,6 @@
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Artifacts" Version="4.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
-  </ItemGroup>
-
   <PropertyGroup>
     <WriteMinVerProperties>false</WriteMinVerProperties>
   </PropertyGroup>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <ArtifactsPath>$(MSBuildThisFileDirectory)../artifacts/</ArtifactsPath>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)../deploy/</ArtifactsPath>
     <EnableDefaultArtifacts>false</EnableDefaultArtifacts>
     <!-- Remove after upgrading to NServiceBus 8.x -->
     <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,9 +17,13 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Particular.Analyzers" Version="$(ParticularAnalyzersVersion)" PrivateAssets="All" />
+  <!--<ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
+    <GlobalPackageReference Include="Particular.Analyzers" Version="$(ParticularAnalyzersVersion)" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
+    <PackageReference Include="Particular.Analyzers" Version="$(ParticularAnalyzersVersion)" PrivateAssets="All" />
+  </ItemGroup>-->
 
   <ItemGroup>
     <SourceRoot Include="$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)..\))" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,13 +17,13 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <!--<ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
+  <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
     <GlobalPackageReference Include="Particular.Analyzers" Version="$(ParticularAnalyzersVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
     <PackageReference Include="Particular.Analyzers" Version="$(ParticularAnalyzersVersion)" PrivateAssets="All" />
-  </ItemGroup>-->
+  </ItemGroup>
 
   <ItemGroup>
     <SourceRoot Include="$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)..\))" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -89,7 +89,6 @@
 
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="4.2.0" />
-    <!--<GlobalPackageReference Include="Particular.Analyzers" Version="0.9.0" />-->
     <GlobalPackageReference Include="Particular.Packaging" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +17,7 @@
     <PackageVersion Include="HdrHistogram" Version="2.5.0" />
     <PackageVersion Include="Lucene.Net" Version="3.0.3" />
     <PackageVersion Include="Metrics.NET" Version="0.5.5" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.AspNet.SignalR" Version="2.4.3" />
     <PackageVersion Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
     <PackageVersion Include="Microsoft.AspNet.SignalR.Owin" Version="1.2.2" />
@@ -70,18 +72,19 @@
     <PackageVersion Include="ReactiveUI.WPF" Version="17.1.50" />
     <PackageVersion Include="Rx-Linq" Version="2.2.5" />
     <PackageVersion Include="ServiceControl.Contracts" Version="3.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Validar.Fody" Version="1.9.0" />
     <PackageVersion Include="Windows7APICodePack-Shell" Version="1.1.0" />
     <PackageVersion Include="WiX" Version="3.11.2" />
-
-
-
- 
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,93 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Autofac" Version="6.5.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.8.0" />
+    <PackageVersion Include="ByteSize" Version="2.1.1" />
+    <PackageVersion Include="Caliburn.Micro" Version="4.0.212" />
+    <PackageVersion Include="Dapper" Version="2.0.123" />
+    <PackageVersion Include="DotNetZip" Version="1.16.0" />
+    <PackageVersion Include="FluentValidation" Version="11.4.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageVersion Include="HdrHistogram" Version="2.5.0" />
+    <PackageVersion Include="Lucene.Net" Version="3.0.3" />
+    <PackageVersion Include="Metrics.NET" Version="0.5.5" />
+    <PackageVersion Include="Microsoft.AspNet.SignalR" Version="2.4.3" />
+    <PackageVersion Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
+    <PackageVersion Include="Microsoft.AspNet.SignalR.Owin" Version="1.2.2" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi" Version="5.2.9" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.9" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageVersion Include="Microsoft.Owin.Cors" Version="4.2.2" />
+    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
+    <PackageVersion Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
+    <PackageVersion Include="Mindscape.Raygun4Net" Version="5.13.0" />
+    <PackageVersion Include="Moq" Version="4.18.2" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="1.7.4" />
+    <PackageVersion Include="NServiceBus" Version="7.8.0" />
+    <PackageVersion Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
+    <PackageVersion Include="NServiceBus.AmazonSQS" Version="5.6.1" />
+    <PackageVersion Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="10.1.0" />
+    <PackageVersion Include="NServiceBus.CustomChecks" Version="3.0.1" />
+    <PackageVersion Include="NServiceBus.Extensions.DependencyInjection" Version="1.1.0" />
+    <PackageVersion Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
+    <PackageVersion Include="NServiceBus.Extensions.Logging" Version="1.0.0" />
+    <PackageVersion Include="NServiceBus.Heartbeat" Version="3.0.1" />
+    <PackageVersion Include="NServiceBus.Newtonsoft.Json" Version="2.4.0" />
+    <PackageVersion Include="NServiceBus.NLog" Version="3.0.0" />
+    <PackageVersion Include="NServiceBus.Metrics" Version="3.1.0" />
+    <PackageVersion Include="NServiceBus.Metrics.ServiceControl" Version="3.0.6" />
+    <PackageVersion Include="NServiceBus.Metrics.ServiceControl.Msmq" Version="3.0.1" />
+    <PackageVersion Include="NServiceBus.RabbitMQ" Version="7.0.3" />
+    <PackageVersion Include="NServiceBus.SagaAudit" Version="3.0.1" />
+    <PackageVersion Include="NServiceBus.Testing" Version="7.4.1" />
+    <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="2.0.3" />
+    <PackageVersion Include="NServiceBus.Transport.AzureStorageQueues" Version="10.0.4" />
+    <PackageVersion Include="NServiceBus.Transport.Msmq" Version="1.2.1" />
+    <PackageVersion Include="NServiceBus.Transport.SqlServer" Version="6.3.4" />
+    <PackageVersion Include="NServiceBus.Raw" Version="3.2.5" />
+    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageVersion Include="OwinHttpMessageHandler" Version="2.0.2" />
+    <PackageVersion Include="Particular.Approvals" Version="0.3.0" />
+    <PackageVersion Include="Particular.Licensing.Sources" Version="5.0.1" />
+    <PackageVersion Include="PropertyChanged.Fody" Version="4.1.0" />
+    <PackageVersion Include="PropertyChanging.Fody" Version="1.30.3" />
+    <PackageVersion Include="PublicApiGenerator" Version="10.3.0" />
+    <PackageVersion Include="RavenDB.Database" Version="3.5.10-patch-35312" />
+    <PackageVersion Include="RavenDB.Embedded" Version="5.4.4" />
+    <PackageVersion Include="RavenDB.Tests.Helpers" Version="3.5.10-patch-35312" />
+    <PackageVersion Include="ReactiveUI.WPF" Version="17.1.50" />
+    <PackageVersion Include="Rx-Linq" Version="2.2.5" />
+    <PackageVersion Include="ServiceControl.Contracts" Version="3.0.0" />
+    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
+    <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
+    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
+    <PackageVersion Include="Validar.Fody" Version="1.9.0" />
+    <PackageVersion Include="Windows7APICodePack-Shell" Version="1.1.0" />
+    <PackageVersion Include="WiX" Version="3.11.2" />
+
+
+
+ 
+  </ItemGroup>
+
+  <ItemGroup>
+    <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="4.2.0" />
+    <!--<GlobalPackageReference Include="Particular.Analyzers" Version="0.9.0" />-->
+    <GlobalPackageReference Include="Particular.Packaging" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="Microsoft.AspNet.WebApi" Version="5.2.9" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.9" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Versions for direct package references">
     <PackageVersion Include="Autofac" Version="6.5.0" />
     <PackageVersion Include="Azure.Identity" Version="1.8.0" />
     <PackageVersion Include="ByteSize" Version="2.1.1" />
@@ -17,10 +17,8 @@
     <PackageVersion Include="HdrHistogram" Version="2.5.0" />
     <PackageVersion Include="Lucene.Net" Version="3.0.3" />
     <PackageVersion Include="Metrics.NET" Version="0.5.5" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.AspNet.SignalR" Version="2.4.3" />
     <PackageVersion Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
-    <PackageVersion Include="Microsoft.AspNet.SignalR.Owin" Version="1.2.2" />
     <PackageVersion Include="Microsoft.AspNet.WebApi" Version="5.2.9" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.9" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.2" />
@@ -31,7 +29,6 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageVersion Include="Microsoft.Owin.Cors" Version="4.2.2" />
-    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
     <PackageVersion Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
     <PackageVersion Include="Mindscape.Raygun4Net" Version="5.13.0" />
     <PackageVersion Include="Moq" Version="4.18.2" />
@@ -46,7 +43,6 @@
     <PackageVersion Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
     <PackageVersion Include="NServiceBus.Extensions.Logging" Version="1.0.0" />
     <PackageVersion Include="NServiceBus.Heartbeat" Version="3.0.1" />
-    <PackageVersion Include="NServiceBus.Newtonsoft.Json" Version="2.4.0" />
     <PackageVersion Include="NServiceBus.NLog" Version="3.0.0" />
     <PackageVersion Include="NServiceBus.Metrics" Version="3.1.0" />
     <PackageVersion Include="NServiceBus.Metrics.ServiceControl" Version="3.0.6" />
@@ -73,19 +69,22 @@
     <PackageVersion Include="ReactiveUI.WPF" Version="17.1.50" />
     <PackageVersion Include="Rx-Linq" Version="2.2.5" />
     <PackageVersion Include="ServiceControl.Contracts" Version="3.0.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-    <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />
     <PackageVersion Include="System.Text.Json" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
-    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Validar.Fody" Version="1.9.0" />
     <PackageVersion Include="Windows7APICodePack-Shell" Version="1.1.0" />
     <PackageVersion Include="WiX" Version="3.11.2" />
+  </ItemGroup>
+
+  <ItemGroup Label="Versions to pin transitive references">
+    <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
+    <PackageVersion Include="NServiceBus.Newtonsoft.Json" Version="2.4.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" /> <!--Needed for build ordering-->
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -11,14 +11,14 @@
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PreparePrimaryInstance;PrepareAuditInstance;PrepareMonitoringInstance;AddFilesToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <ItemGroup>  
+  <ItemGroup>
     <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
   <PropertyGroup>
     <DeployFolder>..\..\deploy\</DeployFolder>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <None Remove="buildProps\**\*" />
     <Content Include="buildProps\**\*" PackagePath="" />
@@ -59,7 +59,7 @@
     <Copy SourceFiles="@(AuditRavenPersistence)" DestinationFolder="$(AuditWithPersistenceFolder)" />
     <Copy SourceFiles="@(LearningTransport)" DestinationFolder="$(AuditWithPersistenceFolder)" />
   </Target>
-  
+
   <Target Name="PrepareMonitoringInstance">
     <PropertyGroup>
       <MonitoringFolder>.\$(OutputPath)\monitoring-persistence\</MonitoringFolder>

--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -11,8 +11,8 @@
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddFilesToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" /> <!--Needed for build ordering-->
+  <ItemGroup Label="Needed for build ordering">
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -6,82 +6,31 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <Description>Particular ServiceControl binaries for use by Particular.PlatformSample. Not intended for use outside of Particular.PlatformSample.</Description>
     <PackageProjectUrl>https://docs.particular.net/servicecontrol/</PackageProjectUrl>
-    <NoWarn>$(NoWarn);NU5100</NoWarn>
+    <NoWarn>$(NoWarn);NU5100;NU5118</NoWarn>
     <IsPackable>true</IsPackable>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PreparePrimaryInstance;PrepareAuditInstance;PrepareMonitoringInstance;AddFilesToPackage</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddFilesToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" /> <!--Needed for build ordering-->
   </ItemGroup>
 
-  <PropertyGroup>
-    <DeployFolder>..\..\deploy\</DeployFolder>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Remove="buildProps\**\*" />
     <Content Include="buildProps\**\*" PackagePath="" />
   </ItemGroup>
 
-  <Target Name="PreparePrimaryInstance">
-    <PropertyGroup>
-      <PrimaryWithPersistenceFolder>.\$(OutputPath)\primary-with-persistence\</PrimaryWithPersistenceFolder>
-      <PrimaryStagingFolder>$(OutputPath)\primary-staging\</PrimaryStagingFolder>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <ServiceControl Include="$(DeployFolder)\Particular.ServiceControl\ServiceControl\**\*.*" Exclude="**\*.config;**\*.pdb" />
-      <LearningTransport Include="$(DeployFolder)\Particular.ServiceControl\Transports\LearningTransport\**\*.*" Exclude="**\*.config;**\*.pdb" />
-    </ItemGroup>
-
-    <RemoveDir Directories="$(PrimaryWithPersistenceFolder)" />
-    <MakeDir Directories="$(PrimaryWithPersistenceFolder)" />
-    <Copy SourceFiles="@(ServiceControl)" DestinationFolder="$(PrimaryWithPersistenceFolder)" />
-    <Copy SourceFiles="@(LearningTransport)" DestinationFolder="$(PrimaryWithPersistenceFolder)" />
-  </Target>
-
-  <Target Name="PrepareAuditInstance">
-    <PropertyGroup>
-      <AuditWithPersistenceFolder>.\$(OutputPath)\audit-with-persistence\</AuditWithPersistenceFolder>
-      <AuditStagingFolder>$(OutputPath)\audit-staging\</AuditStagingFolder>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <ServiceControlAudit Include="$(DeployFolder)\Particular.ServiceControl.Audit\ServiceControl.Audit\**\*.*" Exclude="**\*.config;**\*.pdb" />
-      <AuditRavenPersistence Include="$(DeployFolder)\Particular.ServiceControl.Audit\Persisters\RavenDB35\**\*.*" Exclude="**\*.config;**\*.pdb" />
-      <LearningTransport Include="$(DeployFolder)\Particular.ServiceControl.Audit\Transports\LearningTransport\**\*.*" Exclude="**\*.config;**\*.pdb" />
-    </ItemGroup>
-
-    <RemoveDir Directories="$(AuditWithPersistenceFolder)" />
-    <MakeDir Directories="$(AuditWithPersistenceFolder)" />
-    <Copy SourceFiles="@(ServiceControlAudit)" DestinationFolder="$(AuditWithPersistenceFolder)" />
-    <Copy SourceFiles="@(AuditRavenPersistence)" DestinationFolder="$(AuditWithPersistenceFolder)" />
-    <Copy SourceFiles="@(LearningTransport)" DestinationFolder="$(AuditWithPersistenceFolder)" />
-  </Target>
-
-  <Target Name="PrepareMonitoringInstance">
-    <PropertyGroup>
-      <MonitoringFolder>.\$(OutputPath)\monitoring-persistence\</MonitoringFolder>
-      <MonitoringStagingFolder>$(OutputPath)\monitoring-staging\</MonitoringStagingFolder>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <ServiceControlMonitoring Include="$(DeployFolder)\Particular.ServiceControl.Monitoring\ServiceControl.Monitoring\**\*.*" Exclude="**\*.config;**\*.pdb" />
-      <LearningTransport Include="$(DeployFolder)\Particular.ServiceControl.Monitoring\Transports\LearningTransport\**\*.*" Exclude="**\*.config;**\*.pdb" />
-    </ItemGroup>
-
-    <RemoveDir Directories="$(MonitoringFolder)" />
-    <MakeDir Directories="$(MonitoringFolder)" />
-    <Copy SourceFiles="@(ServiceControlMonitoring)" DestinationFolder="$(MonitoringFolder)" />
-    <Copy SourceFiles="@(LearningTransport)" DestinationFolder="$(MonitoringFolder)" />
-  </Target>
-
   <Target Name="AddFilesToPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(PrimaryWithPersistenceFolder)" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\servicecontrol-instance" />
-      <TfmSpecificPackageFile Include="$(AuditWithPersistenceFolder)" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
-      <TfmSpecificPackageFile Include="$(MonitoringFolder)" Exclude="**\*.config;**\*.pdb" PackagePath="platform\servicecontrol\monitoring-instance" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\ServiceControl\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance" />
+
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\ServiceControl.Audit\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\InMemory\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
+
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Monitoring\ServiceControl.Monitoring\**\*" PackagePath="platform\servicecontrol\monitoring-instance" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Monitoring\Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\monitoring-instance" />
     </ItemGroup>
   </Target>
 

--- a/src/ServiceControl.AcceptanceTesting/ServiceControl.AcceptanceTesting.csproj
+++ b/src/ServiceControl.AcceptanceTesting/ServiceControl.AcceptanceTesting.csproj
@@ -20,8 +20,11 @@
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" />
     <PackageReference Include="NServiceBus.NLog" />
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Aliases="TransportASBS" /> <!--Needed for extern alias -->
     <PackageReference Include="OwinHttpMessageHandler" />
+  </ItemGroup>
+
+  <ItemGroup Label="Needed for extern alias">
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Aliases="TransportASBS" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.AcceptanceTesting/ServiceControl.AcceptanceTesting.csproj
+++ b/src/ServiceControl.AcceptanceTesting/ServiceControl.AcceptanceTesting.csproj
@@ -5,37 +5,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
-    <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASQ\ServiceControl.Transports.ASQ.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" />
-  </ItemGroup>
-
-  <!-- Workaround. See: https://github.com/NuGet/Home/issues/4989 -->
-  <Target Name="ChangeAliasesOfNugetRefs" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'NServiceBus.Transport.AzureServiceBus'">
-        <Aliases>TransportASBS</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
-
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
+    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
+    <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" />
-    <PackageReference Include="NServiceBus.Heartbeat" />
-    <PackageReference Include="NServiceBus.SagaAudit" />
     <PackageReference Include="NServiceBus.NLog" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Aliases="TransportASBS" /> <!--Needed for extern alias -->
     <PackageReference Include="OwinHttpMessageHandler" />
   </ItemGroup>
 

--- a/src/ServiceControl.AcceptanceTesting/ServiceControl.AcceptanceTesting.csproj
+++ b/src/ServiceControl.AcceptanceTesting/ServiceControl.AcceptanceTesting.csproj
@@ -31,12 +31,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />
-    <PackageReference Include="NServiceBus.SagaAudit" Version="3.0.1" />
-    <PackageReference Include="NServiceBus.NLog" Version="3.0.0" />
-    <PackageReference Include="OwinHttpMessageHandler" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" />
+    <PackageReference Include="NServiceBus.Heartbeat" />
+    <PackageReference Include="NServiceBus.SagaAudit" />
+    <PackageReference Include="NServiceBus.NLog" />
+    <PackageReference Include="OwinHttpMessageHandler" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -37,16 +37,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />
-    <PackageReference Include="NServiceBus.SagaAudit" Version="3.0.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="OwinHttpMessageHandler" Version="2.0.2" />
-    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" />
+    <PackageReference Include="NServiceBus.Heartbeat" />
+    <PackageReference Include="NServiceBus.SagaAudit" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="OwinHttpMessageHandler" />
+    <PackageReference Include="Dapper" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -6,47 +6,29 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
     <ProjectReference Include="..\ServiceControl.AcceptanceTesting\ServiceControl.AcceptanceTesting.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.InMemory\ServiceControl.Persistence.InMemory.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.SqlServer\ServiceControl.Persistence.SqlServer.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
-    <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
-    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASQ\ServiceControl.Transports.ASQ.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" />
-  </ItemGroup>
-
-  <!-- Workaround. See: https://github.com/NuGet/Home/issues/4989 -->
-  <Target Name="ChangeAliasesOfNugetRefs" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'NServiceBus.Transport.AzureServiceBus'">
-        <Aliases>TransportASBS</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
-
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
+    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
+    <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" />
     <PackageReference Include="NServiceBus.Heartbeat" />
     <PackageReference Include="NServiceBus.SagaAudit" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="OwinHttpMessageHandler" />
-    <PackageReference Include="Dapper" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/ServiceControl.Audit.AcceptanceTests.RavenDB.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/ServiceControl.Audit.AcceptanceTests.RavenDB.csproj
@@ -25,11 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/ServiceControl.Audit.AcceptanceTests.RavenDB.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/ServiceControl.Audit.AcceptanceTests.RavenDB.csproj
@@ -6,30 +6,29 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="../ServiceControl.Audit.AcceptanceTests/**/*.cs"
-             Exclude="../ServiceControl.Audit.AcceptanceTests/AcceptanceTestStorageConfiguration.cs;../ServiceControl.Audit.AcceptanceTests/obj/**/*.*;../ServiceControl.Audit.AcceptanceTests/bin/**/*.*"  />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\ServiceControl.AcceptanceTesting\ServiceControl.AcceptanceTesting.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb\ServiceControl.Audit.Persistence.RavenDb.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASQ\ServiceControl.Transports.ASQ.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NServiceBus.SagaAudit" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ServiceControl.Audit.AcceptanceTests\**\*.cs" Exclude="..\ServiceControl.Audit.AcceptanceTests\AcceptanceTestStorageConfiguration.cs;..\ServiceControl.Audit.AcceptanceTests\obj\**\*.*;..\ServiceControl.Audit.AcceptanceTests\bin\**\*.*" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/ServiceControl.Audit.AcceptanceTests.RavenDB5.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/ServiceControl.Audit.AcceptanceTests.RavenDB5.csproj
@@ -28,12 +28,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="System.Text.Json" Version="7.0.0" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/ServiceControl.Audit.AcceptanceTests.RavenDB5.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/ServiceControl.Audit.AcceptanceTests.RavenDB5.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
@@ -6,33 +6,30 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="../ServiceControl.Audit.AcceptanceTests/**/*.cs" Exclude="../ServiceControl.Audit.AcceptanceTests/AcceptanceTestStorageConfiguration.cs;../ServiceControl.Audit.AcceptanceTests/obj/**/*.*;../ServiceControl.Audit.AcceptanceTests/bin/**/*.*" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="..\ServiceControl.Audit.Persistence.Tests.RavenDb5\SharedEmbeddedServer.cs" Link="SharedEmbeddedServer.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
     <ProjectReference Include="..\ServiceControl.AcceptanceTesting\ServiceControl.AcceptanceTesting.csproj" />
+    <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb5\ServiceControl.Audit.Persistence.RavenDb5.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASQ\ServiceControl.Transports.ASQ.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NServiceBus.SagaAudit" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ServiceControl.Audit.AcceptanceTests\**\*.cs" Exclude="..\ServiceControl.Audit.AcceptanceTests\AcceptanceTestStorageConfiguration.cs;..\ServiceControl.Audit.AcceptanceTests\obj\**\*.*;..\ServiceControl.Audit.AcceptanceTests\bin\**\*.*" />
+    <Compile Include="..\ServiceControl.Audit.Persistence.Tests.RavenDb5\SharedEmbeddedServer.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.AcceptanceTests/ServiceControl.Audit.AcceptanceTests.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests/ServiceControl.Audit.AcceptanceTests.csproj
@@ -9,41 +9,23 @@
     <ProjectReference Include="..\ServiceControl.AcceptanceTesting\ServiceControl.AcceptanceTesting.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.InMemory\ServiceControl.Audit.Persistence.InMemory.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
-    <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASQ\ServiceControl.Transports.ASQ.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" />
-  </ItemGroup>
-
-  <!-- Workaround. See: https://github.com/NuGet/Home/issues/4989 -->
-  <Target Name="ChangeAliasesOfNugetRefs" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'NServiceBus.Transport.AzureServiceBus'">
-        <Aliases>TransportASBS</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
-
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
+    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
+    <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" />
-    <PackageReference Include="NServiceBus.Heartbeat" />
     <PackageReference Include="NServiceBus.SagaAudit" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="OwinHttpMessageHandler" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.AcceptanceTests/ServiceControl.Audit.AcceptanceTests.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests/ServiceControl.Audit.AcceptanceTests.csproj
@@ -35,15 +35,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />
-    <PackageReference Include="NServiceBus.SagaAudit" Version="3.0.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="OwinHttpMessageHandler" Version="2.0.2" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" />
+    <PackageReference Include="NServiceBus.Heartbeat" />
+    <PackageReference Include="NServiceBus.SagaAudit" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="OwinHttpMessageHandler" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.Persistence.InMemory/ServiceControl.Audit.Persistence.InMemory.csproj
+++ b/src/ServiceControl.Audit.Persistence.InMemory/ServiceControl.Audit.Persistence.InMemory.csproj
@@ -22,4 +22,8 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\InMemory" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Audit.Persistence.InMemory/ServiceControl.Audit.Persistence.InMemory.csproj
+++ b/src/ServiceControl.Audit.Persistence.InMemory/ServiceControl.Audit.Persistence.InMemory.csproj
@@ -5,17 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="persistence.manifest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit.Persistence\ServiceControl.Audit.Persistence.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="persistence.manifest" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.InMemory/ServiceControl.Audit.Persistence.InMemory.csproj
+++ b/src/ServiceControl.Audit.Persistence.InMemory/ServiceControl.Audit.Persistence.InMemory.csproj
@@ -10,10 +10,6 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Label="ServiceControl compatibility transient dependencies">
-    <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit.Persistence\ServiceControl.Audit.Persistence.csproj" />
   </ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.RavenDb/ServiceControl.Audit.Persistence.RavenDb.csproj
+++ b/src/ServiceControl.Audit.Persistence.RavenDb/ServiceControl.Audit.Persistence.RavenDb.csproj
@@ -15,13 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RavenDB.Database" Version="3.5.10-patch-35312" GeneratePathProperty="true" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
-    <PackageReference Include="Lucene.Net" Version="3.0.3" />
-  </ItemGroup>
-
-  <ItemGroup Label="ServiceControl compatibility transient dependencies">
-    <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
+    <PackageReference Include="RavenDB.Database" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.CustomChecks"  />
+    <PackageReference Include="Lucene.Net" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.RavenDb/ServiceControl.Audit.Persistence.RavenDb.csproj
+++ b/src/ServiceControl.Audit.Persistence.RavenDb/ServiceControl.Audit.Persistence.RavenDb.csproj
@@ -36,4 +36,8 @@
     <None Include="$(PkgRavenDB_Database)\tools\Raven.Studio.Html5.zip" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\RavenDB35" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Audit.Persistence.RavenDb/ServiceControl.Audit.Persistence.RavenDb.csproj
+++ b/src/ServiceControl.Audit.Persistence.RavenDb/ServiceControl.Audit.Persistence.RavenDb.csproj
@@ -5,19 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="persistence.manifest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="RavenLicense.xml" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="RavenDB.Database" GeneratePathProperty="true" />
-    <PackageReference Include="NServiceBus.CustomChecks"  />
-    <PackageReference Include="Lucene.Net" />
+    <ProjectReference Include="..\ServiceControl.Audit.Persistence\ServiceControl.Audit.Persistence.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,7 +13,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ServiceControl.Audit.Persistence\ServiceControl.Audit.Persistence.csproj" />
+    <PackageReference Include="Lucene.Net" />
+    <PackageReference Include="NServiceBus.CustomChecks"  />
+    <PackageReference Include="RavenDB.Database" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="persistence.manifest" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="RavenLicense.xml" />
+    <EmbeddedResource Include="RavenLicense.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/ServiceControl.Audit.Persistence.RavenDb5.csproj
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/ServiceControl.Audit.Persistence.RavenDb5.csproj
@@ -31,4 +31,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\RavenDB5" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/ServiceControl.Audit.Persistence.RavenDb5.csproj
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/ServiceControl.Audit.Persistence.RavenDb5.csproj
@@ -11,14 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RavenDB.Embedded" Version="5.4.4" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
-    <PackageReference Include="Lucene.Net" Version="3.0.3" />
-  </ItemGroup>
-
-  <ItemGroup Label="ServiceControl compatibility transient dependencies">
-    <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" TreatAsUsed="true"/>
+    <PackageReference Include="RavenDB.Embedded" />
+    <PackageReference Include="NServiceBus.CustomChecks" />
+    <PackageReference Include="Lucene.Net" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/ServiceControl.Audit.Persistence.RavenDb5.csproj
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/ServiceControl.Audit.Persistence.RavenDb5.csproj
@@ -5,25 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="persistence.manifest">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="RavenDB.Embedded" />
-    <PackageReference Include="NServiceBus.CustomChecks" />
-    <PackageReference Include="Lucene.Net" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit.Persistence\ServiceControl.Audit.Persistence.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="RavenLicense.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <PackageReference Include="Lucene.Net" />
+    <PackageReference Include="NServiceBus.CustomChecks" />
+    <PackageReference Include="RavenDB.Embedded" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="persistence.manifest" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="RavenLicense.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/ServiceControl.Audit.Persistence.Tests.RavenDB.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/ServiceControl.Audit.Persistence.Tests.RavenDB.csproj
@@ -5,22 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove=".editorconfig" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="GitHubActionsTestLogger" />
-    <PackageReference Include="Particular.Approvals"/>
-    <PackageReference Include="System.IO.Compression" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb\ServiceControl.Audit.Persistence.RavenDb.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Particular.Approvals"/>
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/ServiceControl.Audit.Persistence.Tests.RavenDB.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/ServiceControl.Audit.Persistence.Tests.RavenDB.csproj
@@ -9,13 +9,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Particular.Approvals"/>
+    <PackageReference Include="System.IO.Compression" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ServiceControl.Audit.Persistence.Tests.RavenDb5.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ServiceControl.Audit.Persistence.Tests.RavenDb5.csproj
@@ -5,22 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove=".editorconfig" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="GitHubActionsTestLogger" />
-    <PackageReference Include="Particular.Approvals" />
-    <PackageReference Include="System.IO.Compression" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb5\ServiceControl.Audit.Persistence.RavenDb5.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Particular.Approvals" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ServiceControl.Audit.Persistence.Tests.RavenDb5.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ServiceControl.Audit.Persistence.Tests.RavenDb5.csproj
@@ -9,13 +9,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Particular.Approvals" />
+    <PackageReference Include="System.IO.Compression" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Particular.Approvals" />
+    <PackageReference Include="System.IO.Compression" />
+    <PackageReference Include="NServiceBus.CustomChecks" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
@@ -5,20 +5,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="GitHubActionsTestLogger" />
-    <PackageReference Include="Particular.Approvals" />
-    <PackageReference Include="System.IO.Compression" />
-    <PackageReference Include="NServiceBus.CustomChecks" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit.Persistence\ServiceControl.Audit.Persistence.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.InMemory\ServiceControl.Audit.Persistence.InMemory.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NServiceBus.CustomChecks" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Particular.Approvals" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.Persistence/ServiceControl.Audit.Persistence.csproj
+++ b/src/ServiceControl.Audit.Persistence/ServiceControl.Audit.Persistence.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" />
-    <PackageReference Include="Microsoft.AspNet.WebApi" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <ProjectReference Include="..\ServiceControl.Audit.Persistence.SagaAudit\ServiceControl.Audit.Persistence.SagaAudit.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ServiceControl.Audit.Persistence.SagaAudit\ServiceControl.Audit.Persistence.SagaAudit.csproj" />
+    <PackageReference Include="Microsoft.AspNet.WebApi" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
+    <PackageReference Include="NServiceBus" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.Persistence/ServiceControl.Audit.Persistence.csproj
+++ b/src/ServiceControl.Audit.Persistence/ServiceControl.Audit.Persistence.csproj
@@ -1,15 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.8.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.9" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageReference Include="NServiceBus" />
+    <PackageReference Include="Microsoft.AspNet.WebApi" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.UnitTests/ServiceControl.Audit.UnitTests.csproj
+++ b/src/ServiceControl.Audit.UnitTests/ServiceControl.Audit.UnitTests.csproj
@@ -13,12 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
-    <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Particular.Approvals" />
+    <PackageReference Include="PublicApiGenerator" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -14,19 +14,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ByteSize" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.9" />
-    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.1.0" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
-    <PackageReference Include="NServiceBus.NLog" Version="3.0.0" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
-    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Owin.Cors" Version="4.2.2" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="5.0.1" PrivateAssets="All" TreatAsUsed="true" />
-    <PackageReference Include="System.Threading.Channels" Version="7.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
+    <PackageReference Include="ByteSize" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
+    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" />
+    <PackageReference Include="NServiceBus.CustomChecks" />
+    <PackageReference Include="NServiceBus.NLog" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" />
+    <PackageReference Include="NLog.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Owin.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+    <PackageReference Include="Microsoft.Owin.Cors" />
+    <PackageReference Include="Particular.Licensing.Sources" />
+    <PackageReference Include="System.Threading.Channels" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -16,17 +16,14 @@
   <ItemGroup>
     <PackageReference Include="ByteSize" />
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
-    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" />
-    <PackageReference Include="NServiceBus.CustomChecks" />
-    <PackageReference Include="NServiceBus.NLog" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" />
-    <PackageReference Include="NLog.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Owin.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
     <PackageReference Include="Microsoft.Owin.Cors" />
-    <PackageReference Include="Particular.Licensing.Sources" />
+    <PackageReference Include="NLog.Extensions.Logging" />
+    <PackageReference Include="NServiceBus.NLog" />
+    <PackageReference Include="NServiceBus.CustomChecks" />
+    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" />
     <PackageReference Include="System.Threading.Channels" />
-    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="NServiceBus.NLog" Version="3.0.0" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
-    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />    
+    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
     <PackageReference Include="Microsoft.Owin.Cors" Version="4.2.2" />
     <PackageReference Include="Particular.Licensing.Sources" Version="5.0.1" PrivateAssets="All" TreatAsUsed="true" />
@@ -32,6 +32,10 @@
   <ItemGroup>
     <None Remove="Infrastructure\Hosting\Help.txt" />
     <EmbeddedResource Include="Infrastructure\Hosting\Help.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.Audit.exe.config" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl.Audit\ServiceControl.Audit" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
+++ b/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
@@ -11,11 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
+++ b/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.Config\ServiceControl.Config.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.Messaging" />
     <Reference Include="System.ServiceProcess" />
@@ -16,10 +20,6 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceControl.Config\ServiceControl.Config.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -33,7 +33,6 @@
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Mindscape.Raygun4Net" />
     <PackageReference Include="ReactiveUI.WPF" />
-    <PackageReference Include="System.ValueTuple" />
     <PackageReference Include="Windows7APICodePack-Shell" />
   </ItemGroup>
 

--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -22,19 +22,19 @@
 
   <!-- Fody and friends -->
   <ItemGroup>
-    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
-    <PackageReference Include="PropertyChanging.Fody" Version="1.30.3" PrivateAssets="All" />
-    <PackageReference Include="Validar.Fody" Version="1.9.0" PrivateAssets="All" />
+    <PackageReference Include="PropertyChanged.Fody" PrivateAssets="All" />
+    <PackageReference Include="PropertyChanging.Fody" PrivateAssets="All" />
+    <PackageReference Include="Validar.Fody" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.5.0" />
-    <PackageReference Include="Caliburn.Micro" Version="4.0.212" />
-    <PackageReference Include="FluentValidation" Version="11.4.0" />
-    <PackageReference Include="Mindscape.Raygun4Net" Version="5.13.0" />
-    <PackageReference Include="ReactiveUI.WPF" Version="17.1.50" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" />
+    <PackageReference Include="Autofac" />
+    <PackageReference Include="Caliburn.Micro" />
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="Mindscape.Raygun4Net" />
+    <PackageReference Include="ReactiveUI.WPF" />
+    <PackageReference Include="System.ValueTuple" />
+    <PackageReference Include="Windows7APICodePack-Shell" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.DockerImages/ServiceControl.DockerImages.csproj
+++ b/src/ServiceControl.DockerImages/ServiceControl.DockerImages.csproj
@@ -12,8 +12,8 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" /> <!--Needed for build ordering-->
+  <ItemGroup Label="Needed for build ordering">
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/ServiceControl.DockerImages/ServiceControl.DockerImages.csproj
+++ b/src/ServiceControl.DockerImages/ServiceControl.DockerImages.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />  <!--Needed for build ordering-->
   </ItemGroup>
 
   <Target Name="CleanGeneratedDockerfiles" AfterTargets="Build">

--- a/src/ServiceControl.DockerImages/ServiceControl.DockerImages.csproj
+++ b/src/ServiceControl.DockerImages/ServiceControl.DockerImages.csproj
@@ -1,11 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.6.0">
 
   <!--
 
   WARNING
-  This project is not automatically built when building the solution
-  to keep the overall build time under control.
-  To build Docker images explicitly build this project.
+  This project is not automatically built when building the solution to keep the overall build time under control.
+  To build Docker images, explicitly build this project.
 
   -->
 
@@ -13,56 +12,65 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" /> <!--Needed for build ordering-->
+  </ItemGroup>
+
   <PropertyGroup>
     <DockerfilesFolder>..\..\dockerfiles\</DockerfilesFolder>
   </PropertyGroup>
 
   <ItemGroup Label="Supported transports">
     <!-- property values containing spaces or any command line special character must be quoted -->
+
     <SupportedTransport Include="Azure Service Bus">
       <TransportName>NetStandardAzureServiceBus</TransportName>
       <DockerfileCustomization>azureservicebus</DockerfileCustomization>
       <TransportCustomizationType>"ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS"</TransportCustomizationType>
     </SupportedTransport>
+
     <SupportedTransport Include="Azure Storage Queues">
       <TransportName>AzureStorageQueue</TransportName>
       <DockerfileCustomization>azurestoragequeues</DockerfileCustomization>
       <TransportCustomizationType>"ServiceControl.Transports.ASQ.ASQTransportCustomization, ServiceControl.Transports.ASQ"</TransportCustomizationType>
     </SupportedTransport>
-    <SupportedTransport Include="SQL Server">
-      <DockerfileCustomization>sqlserver</DockerfileCustomization>
-      <TransportName>SQLServer</TransportName>
-      <TransportCustomizationType>"ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"</TransportCustomizationType>
-    </SupportedTransport>
-    <SupportedTransport Include="SQS">
-      <DockerfileCustomization>amazonsqs</DockerfileCustomization>
-      <TransportName>AmazonSQS</TransportName>
-      <TransportCustomizationType>"ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"</TransportCustomizationType>
-    </SupportedTransport>
+
     <SupportedTransport Include="RabbitMQ Classic Conventional Routing">
       <TransportName>RabbitMQ</TransportName>
       <DockerfileCustomization>rabbitmq.classic.conventional</DockerfileCustomization>
       <TransportCustomizationType>"ServiceControl.Transports.RabbitMQ.RabbitMQClassicConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"</TransportCustomizationType>
     </SupportedTransport>
+
     <SupportedTransport Include="RabbitMQ Classic Direct Routing">
       <TransportName>RabbitMQ</TransportName>
       <DockerfileCustomization>rabbitmq.classic.direct</DockerfileCustomization>
       <TransportCustomizationType>"ServiceControl.Transports.RabbitMQ.RabbitMQClassicDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"</TransportCustomizationType>
     </SupportedTransport>
+
     <SupportedTransport Include="RabbitMQ Quorum Queues Conventional Routing">
       <TransportName>RabbitMQ</TransportName>
       <DockerfileCustomization>rabbitmq.quorum.conventional</DockerfileCustomization>
       <TransportCustomizationType>"ServiceControl.Transports.RabbitMQ.RabbitMQQuorumConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"</TransportCustomizationType>
     </SupportedTransport>
+
     <SupportedTransport Include="RabbitMQ Quorum Queues Direct Routing">
       <TransportName>RabbitMQ</TransportName>
       <DockerfileCustomization>rabbitmq.quorum.direct</DockerfileCustomization>
       <TransportCustomizationType>"ServiceControl.Transports.RabbitMQ.RabbitMQQuorumDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ"</TransportCustomizationType>
     </SupportedTransport>
-  </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />  <!--Needed for build ordering-->
+    <SupportedTransport Include="SQL Server">
+      <DockerfileCustomization>sqlserver</DockerfileCustomization>
+      <TransportName>SQLServer</TransportName>
+      <TransportCustomizationType>"ServiceControl.Transports.SqlServer.SqlServerTransportCustomization, ServiceControl.Transports.SqlServer"</TransportCustomizationType>
+    </SupportedTransport>
+
+    <SupportedTransport Include="SQS">
+      <DockerfileCustomization>amazonsqs</DockerfileCustomization>
+      <TransportName>AmazonSQS</TransportName>
+      <TransportCustomizationType>"ServiceControl.Transports.SQS.SQSTransportCustomization, ServiceControl.Transports.SQS"</TransportCustomizationType>
+    </SupportedTransport>
+
   </ItemGroup>
 
   <Target Name="CleanGeneratedDockerfiles" AfterTargets="Build">
@@ -72,23 +80,27 @@
 
   <Target Name="ExpandDockerfileTemplates" AfterTargets="CleanGeneratedDockerfiles">
     <!-- primary instance and sidecar dockerfiles -->
-    <Exec Command="copy .\servicecontrol.transport.init-windows.dockerfile-template $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).init-windows.dockerfile" />
-    <Exec Command="copy .\servicecontrol.transport-windows.dockerfile-template $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization)-windows.dockerfile" />
+    <Copy SourceFiles="servicecontrol.transport.init-windows.dockerfile-template" DestinationFiles="$(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).init-windows.dockerfile" />
+    <Copy SourceFiles="servicecontrol.transport-windows.dockerfile-template" DestinationFiles="$(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization)-windows.dockerfile" />
+
     <!-- audit instance and sidecar dockerfiles -->
-    <Exec Command="copy .\servicecontrol.transport.audit.init-windows.dockerfile-template $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).audit.init-windows.dockerfile" />
-    <Exec Command="copy .\servicecontrol.transport.audit-windows.dockerfile-template $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).audit-windows.dockerfile" />
+    <Copy SourceFiles="servicecontrol.transport.audit.init-windows.dockerfile-template" DestinationFiles="$(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).audit.init-windows.dockerfile" />
+    <Copy SourceFiles="servicecontrol.transport.audit-windows.dockerfile-template" DestinationFiles="$(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).audit-windows.dockerfile" />
+
     <!-- monitoring instance and sidecar dockerfiles -->
-    <Exec Command="copy .\servicecontrol.transport.monitoring.init-windows.dockerfile-template $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).monitoring.init-windows.dockerfile" />
-    <Exec Command="copy .\servicecontrol.transport.monitoring-windows.dockerfile-template $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).monitoring-windows.dockerfile" />
+    <Copy SourceFiles="servicecontrol.transport.monitoring.init-windows.dockerfile-template" DestinationFiles="$(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).monitoring.init-windows.dockerfile" />
+    <Copy SourceFiles="servicecontrol.transport.monitoring-windows.dockerfile-template" DestinationFiles="$(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).monitoring-windows.dockerfile" />
   </Target>
 
   <Target Name="BuildDockerImages" AfterTargets="ExpandDockerfileTemplates">
     <!-- Build primary instance and sidecar images -->
     <Exec Command="docker build -f $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).init-windows.dockerfile -t particular/servicecontrol.%(SupportedTransport.DockerfileCustomization).init-windows --build-arg TRANSPORT=%(SupportedTransport.TransportName) --build-arg TRANSPORT_CUSTOMIZATION_TYPE=%(SupportedTransport.TransportCustomizationType) ./../../" />
     <Exec Command="docker build -f $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization)-windows.dockerfile -t particular/servicecontrol.%(SupportedTransport.DockerfileCustomization)-windows --build-arg TRANSPORT=%(SupportedTransport.TransportName) --build-arg TRANSPORT_CUSTOMIZATION_TYPE=%(SupportedTransport.TransportCustomizationType) ./../../" />
+
     <!-- Build audit instance and sidecar images -->
     <Exec Command="docker build -f $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).audit.init-windows.dockerfile -t particular/servicecontrol.%(SupportedTransport.DockerfileCustomization).audit.init-windows --build-arg TRANSPORT=%(SupportedTransport.TransportName) --build-arg TRANSPORT_CUSTOMIZATION_TYPE=%(SupportedTransport.TransportCustomizationType) ./../../" />
     <Exec Command="docker build -f $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).audit-windows.dockerfile -t particular/servicecontrol.%(SupportedTransport.DockerfileCustomization).audit-windows --build-arg TRANSPORT=%(SupportedTransport.TransportName) --build-arg TRANSPORT_CUSTOMIZATION_TYPE=%(SupportedTransport.TransportCustomizationType) ./../../" />
+
     <!-- Build monitoring instance and sidecar images -->
     <Exec Command="docker build -f $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).monitoring.init-windows.dockerfile -t particular/servicecontrol.%(SupportedTransport.DockerfileCustomization).monitoring.init-windows --build-arg TRANSPORT=%(SupportedTransport.TransportName) --build-arg TRANSPORT_CUSTOMIZATION_TYPE=%(SupportedTransport.TransportCustomizationType) ./../../" />
     <Exec Command="docker build -f $(DockerfilesFolder)servicecontrol.%(SupportedTransport.DockerfileCustomization).monitoring-windows.dockerfile -t particular/servicecontrol.%(SupportedTransport.DockerfileCustomization).monitoring-windows --build-arg TRANSPORT=%(SupportedTransport.TransportName) --build-arg TRANSPORT_CUSTOMIZATION_TYPE=%(SupportedTransport.TransportCustomizationType) ./../../" />

--- a/src/ServiceControl.DockerImages/ServiceControl.DockerImages.csproj
+++ b/src/ServiceControl.DockerImages/ServiceControl.DockerImages.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <!-- 
-  
+  <!--
+
   WARNING
   This project is not automatically built when building the solution
   to keep the overall build time under control.
   To build Docker images explicitly build this project.
-  
+
   -->
-  
+
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <DockerfilesFolder>..\..\dockerfiles\</DockerfilesFolder>
   </PropertyGroup>

--- a/src/ServiceControl.Infrastructure.RavenDB/ServiceControl.Infrastructure.RavenDB.csproj
+++ b/src/ServiceControl.Infrastructure.RavenDB/ServiceControl.Infrastructure.RavenDB.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RavenDB.Database" Version="3.5.10-patch-35312" />
+    <PackageReference Include="RavenDB.Database" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Infrastructure.RavenDB/ServiceControl.Infrastructure.RavenDB.csproj
+++ b/src/ServiceControl.Infrastructure.RavenDB/ServiceControl.Infrastructure.RavenDB.csproj
@@ -8,4 +8,8 @@
     <PackageReference Include="RavenDB.Database" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="$(PkgRavenDB_Database)\tools\Raven.Studio.Html5.zip" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.LicenseManagement/ServiceControl.LicenseManagement.csproj
+++ b/src/ServiceControl.LicenseManagement/ServiceControl.LicenseManagement.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Particular.Licensing.Sources" Version="5.0.1" TreatAsUsed="true" />
+    <PackageReference Include="Particular.Licensing.Sources" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.LoadTests.AuditGenerator/ServiceControl.LoadTests.AuditGenerator.csproj
+++ b/src/ServiceControl.LoadTests.AuditGenerator/ServiceControl.LoadTests.AuditGenerator.csproj
@@ -11,10 +11,6 @@
     <ProjectReference Include="..\ServiceControl.Infrastructure.Metrics\ServiceControl.Infrastructure.Metrics.csproj" />
     <ProjectReference Include="..\ServiceControl.LoadTests.Messages\ServiceControl.LoadTests.Messages.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
-
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" />
-    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.LoadTests.AuditGenerator/ServiceControl.LoadTests.AuditGenerator.csproj
+++ b/src/ServiceControl.LoadTests.AuditGenerator/ServiceControl.LoadTests.AuditGenerator.csproj
@@ -13,8 +13,8 @@
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
 
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.4.0" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.LoadTests.Messages/ServiceControl.LoadTests.Messages.csproj
+++ b/src/ServiceControl.LoadTests.Messages/ServiceControl.LoadTests.Messages.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.8.0" />
+    <PackageReference Include="NServiceBus" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.LoadTests.Reporter/ServiceControl.LoadTests.Reporter.csproj
+++ b/src/ServiceControl.LoadTests.Reporter/ServiceControl.LoadTests.Reporter.csproj
@@ -5,14 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Metrics.NET" />
-    <PackageReference Include="NServiceBus" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
     <ProjectReference Include="..\ServiceControl.LoadTests.Messages\ServiceControl.LoadTests.Messages.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Metrics.NET" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.LoadTests.Reporter/ServiceControl.LoadTests.Reporter.csproj
+++ b/src/ServiceControl.LoadTests.Reporter/ServiceControl.LoadTests.Reporter.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Metrics.NET" Version="0.5.5" />
-    <PackageReference Include="NServiceBus" Version="7.8.0" />
+    <PackageReference Include="Metrics.NET" />
+    <PackageReference Include="NServiceBus" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Monitoring.AcceptanceTests/ServiceControl.Monitoring.AcceptanceTests.csproj
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/ServiceControl.Monitoring.AcceptanceTests.csproj
@@ -33,17 +33,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
-    <PackageReference Include="NServiceBus.Metrics" Version="3.1.0" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.6" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl.Msmq" Version="3.0.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="HdrHistogram" Version="2.5.0" />
-    <PackageReference Include="OwinHttpMessageHandler" Version="2.0.2" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="NServiceBus.Transport.Msmq" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="NServiceBus.AcceptanceTesting" />
+    <PackageReference Include="NServiceBus.Metrics" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl.Msmq" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="HdrHistogram" />
+    <PackageReference Include="OwinHttpMessageHandler" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Monitoring.UnitTests/ServiceControl.Monitoring.UnitTests.csproj
+++ b/src/ServiceControl.Monitoring.UnitTests/ServiceControl.Monitoring.UnitTests.csproj
@@ -9,11 +9,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Particular.Approvals" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.9" />
-    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
-    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
-    <PackageReference Include="Microsoft.Owin.Cors" Version="4.2.2" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
-    <PackageReference Include="NServiceBus.Extensions.Logging" Version="1.0.0" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="5.0.1" PrivateAssets="All" TreatAsUsed="true" />
-    <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
+    <PackageReference Include="Microsoft.AspNet.WebApi" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Owin.Hosting" />
+    <PackageReference Include="Microsoft.Owin.Cors" />
+    <PackageReference Include="NLog.Extensions.Logging" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" />
+    <PackageReference Include="NServiceBus.Extensions.Logging" />
+    <PackageReference Include="Particular.Licensing.Sources" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -25,4 +25,8 @@
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.Monitoring.exe.config" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl.Monitoring\ServiceControl.Monitoring" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -7,22 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
-    <PackageReference Include="Microsoft.AspNet.WebApi" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
-    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Owin.Hosting" />
-    <PackageReference Include="Microsoft.Owin.Cors" />
-    <PackageReference Include="NLog.Extensions.Logging" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" />
-    <PackageReference Include="NServiceBus.Extensions.Logging" />
-    <PackageReference Include="Particular.Licensing.Sources" />
-    <PackageReference Include="System.Memory" />
+    <ProjectReference Include="..\ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+    <PackageReference Include="Microsoft.Owin.Cors" />
+    <PackageReference Include="NLog.Extensions.Logging" />
+    <PackageReference Include="NServiceBus.Extensions.DependencyInjection" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" />
+    <PackageReference Include="NServiceBus.Extensions.Logging" />
+    <PackageReference Include="Particular.Licensing.Sources" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
     <ProjectReference Include="..\ServiceControl.AcceptanceTesting\ServiceControl.AcceptanceTesting.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.InMemory\ServiceControl.Audit.Persistence.InMemory.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
@@ -14,24 +15,15 @@
     <ProjectReference Include="..\ServiceControl.Persistence.SqlServer\ServiceControl.Persistence.SqlServer.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
-    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" />
-    <PackageReference Include="NServiceBus.Heartbeat"/>
     <PackageReference Include="NServiceBus.SagaAudit" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="OwinHttpMessageHandler" />
     <PackageReference Include="Particular.Approvals" />
   </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
@@ -23,15 +23,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />
-    <PackageReference Include="NServiceBus.SagaAudit" Version="3.0.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="OwinHttpMessageHandler" Version="2.0.2" />
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Client" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" />
+    <PackageReference Include="NServiceBus.Heartbeat"/>
+    <PackageReference Include="NServiceBus.SagaAudit" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="OwinHttpMessageHandler" />
+    <PackageReference Include="Particular.Approvals" />
   </ItemGroup>
 </Project>

--- a/src/ServiceControl.Persistence.RavenDb/ServiceControl.Persistence.RavenDb.csproj
+++ b/src/ServiceControl.Persistence.RavenDb/ServiceControl.Persistence.RavenDb.csproj
@@ -8,4 +8,8 @@
     <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.exe.config" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl\ServiceControl" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Persistence.RavenDb/ServiceControl.Persistence.RavenDb.csproj
+++ b/src/ServiceControl.Persistence.RavenDb/ServiceControl.Persistence.RavenDb.csproj
@@ -8,6 +8,8 @@
     <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
   </ItemGroup>
 
+  <!--Artifacts for the primary instance are currently defined here because we only ship this persister option right now.
+  This definition should be moved to ServiceControl.csproj once we have multiple persister options for the primary instance. -->
   <ItemGroup>
     <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.exe.config" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl\ServiceControl" />
   </ItemGroup>

--- a/src/ServiceControl.Persistence.SqlServer/ServiceControl.Persistence.SqlServer.csproj
+++ b/src/ServiceControl.Persistence.SqlServer/ServiceControl.Persistence.SqlServer.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" />
+    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
+    <PackageReference Include="Dapper" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Persistence.SqlServer/ServiceControl.Persistence.SqlServer.csproj
+++ b/src/ServiceControl.Persistence.SqlServer/ServiceControl.Persistence.SqlServer.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Dapper" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.PersistenceTests/ServiceControl.PersistenceTests.csproj
+++ b/src/ServiceControl.PersistenceTests/ServiceControl.PersistenceTests.csproj
@@ -10,11 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />    
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageReference Include="Dapper" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="GitHubActionsTestLogger" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\ServiceControl.Persistence.SqlServer\ServiceControl.Persistence.SqlServer.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
-    
+
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.PersistenceTests/ServiceControl.PersistenceTests.csproj
+++ b/src/ServiceControl.PersistenceTests/ServiceControl.PersistenceTests.csproj
@@ -6,24 +6,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove=".editorconfig" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Dapper" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="GitHubActionsTestLogger" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.InMemory\ServiceControl.Persistence.InMemory.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.SqlServer\ServiceControl.Persistence.SqlServer.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
-    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.SagaAudit/ServiceControl.SagaAudit.csproj
+++ b/src/ServiceControl.SagaAudit/ServiceControl.SagaAudit.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.8.0" />
+    <PackageReference Include="NServiceBus" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.SagaAudit/ServiceControl.SagaAudit.csproj
+++ b/src/ServiceControl.SagaAudit/ServiceControl.SagaAudit.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" />
+    <ProjectReference Include="..\ServiceControl.Audit.Persistence.SagaAudit\ServiceControl.Audit.Persistence.SagaAudit.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ServiceControl.Audit.Persistence.SagaAudit\ServiceControl.Audit.Persistence.SagaAudit.csproj" />
+    <PackageReference Include="NServiceBus" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.ASB/ServiceControl.Transports.ASB.csproj
+++ b/src/ServiceControl.Transports.ASB/ServiceControl.Transports.ASB.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\AzureServiceBus')" />
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(InstanceName->'$(ArtifactsPath)%(identity)\Transports\AzureServiceBus')" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.ASB/ServiceControl.Transports.ASB.csproj
+++ b/src/ServiceControl.Transports.ASB/ServiceControl.Transports.ASB.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.21.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\AzureServiceBus')" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Transports.ASB/ServiceControl.Transports.ASB.csproj
+++ b/src/ServiceControl.Transports.ASB/ServiceControl.Transports.ASB.csproj
@@ -9,9 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="10.1.0" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.21.0" />
+    <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" />
+    <PackageReference Include="NServiceBus.CustomChecks" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports.ASBS/ServiceControl.Transports.ASBS.csproj
+++ b/src/ServiceControl.Transports.ASBS/ServiceControl.Transports.ASBS.csproj
@@ -9,16 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.8.0" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="2.0.3" />
-  </ItemGroup>
-
-  <ItemGroup Label="ServiceControl compatibility transient dependencies">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" TreatAsUsed="true" />
-    <PackageReference Include="System.Text.Json" Version="7.0.0" TreatAsUsed="true" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" TreatAsUsed="true" />
-    <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="NServiceBus.CustomChecks" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports.ASBS/ServiceControl.Transports.ASBS.csproj
+++ b/src/ServiceControl.Transports.ASBS/ServiceControl.Transports.ASBS.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\NetStandardAzureServiceBus')" />
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(InstanceName->'$(ArtifactsPath)%(identity)\Transports\NetStandardAzureServiceBus')" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.ASBS/ServiceControl.Transports.ASBS.csproj
+++ b/src/ServiceControl.Transports.ASBS/ServiceControl.Transports.ASBS.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\NetStandardAzureServiceBus')" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Transports.ASQ/ServiceControl.Transports.ASQ.csproj
+++ b/src/ServiceControl.Transports.ASQ/ServiceControl.Transports.ASQ.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\AzureStorageQueue')" />
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(InstanceName->'$(ArtifactsPath)%(identity)\Transports\AzureStorageQueue')" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.ASQ/ServiceControl.Transports.ASQ.csproj
+++ b/src/ServiceControl.Transports.ASQ/ServiceControl.Transports.ASQ.csproj
@@ -9,15 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" Version="10.0.4" />
-    <PackageReference Include="System.Text.Json" Version="7.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Label="ServiceControl compatibility transient dependencies">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" TreatAsUsed="true" />
-    <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" TreatAsUsed="true"/>
+    <PackageReference Include="NServiceBus.Transport.AzureStorageQueues" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports.ASQ/ServiceControl.Transports.ASQ.csproj
+++ b/src/ServiceControl.Transports.ASQ/ServiceControl.Transports.ASQ.csproj
@@ -20,4 +20,8 @@
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" TreatAsUsed="true"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\AzureStorageQueue')" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Transports.Learning/ServiceControl.Transports.Learning.csproj
+++ b/src/ServiceControl.Transports.Learning/ServiceControl.Transports.Learning.csproj
@@ -7,4 +7,9 @@
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\LearningTransport')" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Transports.Learning/ServiceControl.Transports.Learning.csproj
+++ b/src/ServiceControl.Transports.Learning/ServiceControl.Transports.Learning.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\LearningTransport')" />
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(InstanceName->'$(ArtifactsPath)%(identity)\Transports\LearningTransport')" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.Msmq/ServiceControl.Transports.Msmq.csproj
+++ b/src/ServiceControl.Transports.Msmq/ServiceControl.Transports.Msmq.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\MSMQ')" />
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(InstanceName->'$(ArtifactsPath)%(identity)\Transports\MSMQ')" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.Msmq/ServiceControl.Transports.Msmq.csproj
+++ b/src/ServiceControl.Transports.Msmq/ServiceControl.Transports.Msmq.csproj
@@ -10,7 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.2.1" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />    
+    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\MSMQ')" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.Msmq/ServiceControl.Transports.Msmq.csproj
+++ b/src/ServiceControl.Transports.Msmq/ServiceControl.Transports.Msmq.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.2.1" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
+    <PackageReference Include="NServiceBus.Transport.Msmq" />
+    <PackageReference Include="NServiceBus.CustomChecks" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports.RabbitMQ/ServiceControl.Transports.RabbitMQ.csproj
+++ b/src/ServiceControl.Transports.RabbitMQ/ServiceControl.Transports.RabbitMQ.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\RabbitMQ')" />
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(InstanceName->'$(ArtifactsPath)%(identity)\Transports\RabbitMQ')" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.RabbitMQ/ServiceControl.Transports.RabbitMQ.csproj
+++ b/src/ServiceControl.Transports.RabbitMQ/ServiceControl.Transports.RabbitMQ.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\RabbitMQ')" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Transports.RabbitMQ/ServiceControl.Transports.RabbitMQ.csproj
+++ b/src/ServiceControl.Transports.RabbitMQ/ServiceControl.Transports.RabbitMQ.csproj
@@ -9,12 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.3" />
-    <PackageReference Include="System.Threading.Channels" Version="7.0.0" TreatAsUsed="true" />
-  </ItemGroup>
-
-  <ItemGroup Label="ServiceControl compatibility transient dependencies">
-    <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
+    <PackageReference Include="NServiceBus.RabbitMQ" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports.SQS/ServiceControl.Transports.SQS.csproj
+++ b/src/ServiceControl.Transports.SQS/ServiceControl.Transports.SQS.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="NServiceBus.AmazonSQS" Version="5.6.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\AmazonSQS')" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Transports.SQS/ServiceControl.Transports.SQS.csproj
+++ b/src/ServiceControl.Transports.SQS/ServiceControl.Transports.SQS.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\AmazonSQS')" />
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(InstanceName->'$(ArtifactsPath)%(identity)\Transports\AmazonSQS')" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.SQS/ServiceControl.Transports.SQS.csproj
+++ b/src/ServiceControl.Transports.SQS/ServiceControl.Transports.SQS.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AmazonSQS" Version="5.6.1" />
+    <PackageReference Include="NServiceBus.AmazonSQS" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports.SqlServer/ServiceControl.Transports.SqlServer.csproj
+++ b/src/ServiceControl.Transports.SqlServer/ServiceControl.Transports.SqlServer.csproj
@@ -11,7 +11,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.2" TreatAsUsed="true" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI" Version="4.0.0" />
-    <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.3.4" />    
+    <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.3.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\SQLServer')" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.SqlServer/ServiceControl.Transports.SqlServer.csproj
+++ b/src/ServiceControl.Transports.SqlServer/ServiceControl.Transports.SqlServer.csproj
@@ -9,9 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.2" TreatAsUsed="true" />
-    <PackageReference Include="Microsoft.Data.SqlClient.SNI" Version="4.0.0" />
-    <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.3.4" />
+    <PackageReference Include="NServiceBus.Transport.SqlServer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports.SqlServer/ServiceControl.Transports.SqlServer.csproj
+++ b/src/ServiceControl.Transports.SqlServer/ServiceControl.Transports.SqlServer.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" DestinationFolder="@(Product->'$(ArtifactsPath)%(identity)\Transports\SQLServer')" />
+    <Artifact Include="$(OutputPath)" DestinationFolder="@(InstanceName->'$(ArtifactsPath)%(identity)\Transports\SQLServer')" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.UnitTests/ServiceControl.Transports.UnitTests.csproj
+++ b/src/ServiceControl.Transports.UnitTests/ServiceControl.Transports.UnitTests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports/ServiceControl.Transports.csproj
+++ b/src/ServiceControl.Transports/ServiceControl.Transports.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus.Raw" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports/ServiceControl.Transports.csproj
+++ b/src/ServiceControl.Transports/ServiceControl.Transports.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Raw" Version="3.2.5" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.4.0" />
+    <PackageReference Include="NServiceBus.Raw" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -6,17 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.InMemory\ServiceControl.Persistence.InMemory.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.SqlServer\ServiceControl.Persistence.SqlServer.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
-    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,7 +24,6 @@
     <PackageReference Include="Particular.Approvals" />
     <PackageReference Include="PublicApiGenerator" />
     <PackageReference Include="RavenDB.Tests.Helpers" />
-    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -20,15 +20,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NServiceBus.Testing" Version="7.4.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
-    <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
-    <PackageReference Include="RavenDB.Tests.Helpers" Version="3.5.10-patch-35312" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NServiceBus.Testing" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Particular.Approvals" />
+    <PackageReference Include="PublicApiGenerator" />
+    <PackageReference Include="RavenDB.Tests.Helpers" />
+    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -19,14 +19,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControlInstaller.Packaging", "ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj", "{15F811B7-314C-4E9E-B5E9-35596045BBC4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Config", "ServiceControl.Config\ServiceControl.Config.csproj", "{C0EEF6D1-5DF7-4A26-9964-6376F465B085}"
-	ProjectSection(ProjectDependencies) = postProject
-		{15F811B7-314C-4E9E-B5E9-35596045BBC4} = {15F811B7-314C-4E9E-B5E9-35596045BBC4}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Setup", "Setup\Setup.csproj", "{F6473A7A-01B7-4A9A-B30C-4D200BFFFE4D}"
-	ProjectSection(ProjectDependencies) = postProject
-		{C0EEF6D1-5DF7-4A26-9964-6376F465B085} = {C0EEF6D1-5DF7-4A26-9964-6376F465B085}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControlInstaller.Engine.UnitTests", "ServiceControlInstaller.Engine.UnitTests\ServiceControlInstaller.Engine.UnitTests.csproj", "{C7EC4072-F74C-410D-B0C3-4C05B7C9CFB7}"
 EndProject
@@ -137,9 +131,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.SagaAudit.Persistence.RavenDb", "ServiceControl.SagaAudit.Persistence.RavenDb\ServiceControl.SagaAudit.Persistence.RavenDb.csproj", "{6C4077F7-7507-487B-9E93-66BF8768343A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Audit.Persistence.Tests.RavenDB", "ServiceControl.Audit.Persistence.Tests.RavenDB\ServiceControl.Audit.Persistence.Tests.RavenDB.csproj", "{04359CC6-170E-4AB7-8291-FA58AAA9C441}"
-	ProjectSection(ProjectDependencies) = postProject
-		{DEDC8155-F9EF-4A8D-9476-B44610AABCA1} = {DEDC8155-F9EF-4A8D-9476-B44610AABCA1}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Audit.AcceptanceTests.RavenDB", "ServiceControl.Audit.AcceptanceTests.RavenDB\ServiceControl.Audit.AcceptanceTests.RavenDB.csproj", "{7274653C-5E5E-4AA7-A565-5B89F488E1D0}"
 EndProject

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -48,6 +48,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		..\.github\workflows\ci.yml = ..\.github\workflows\ci.yml
 		Custom.Build.props = Custom.Build.props
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Transports", "ServiceControl.Transports\ServiceControl.Transports.csproj", "{3D9E3A53-164F-4430-A6A4-D35551F5DC88}"

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -15,25 +15,25 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ByteSize" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.9" />
-    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
-    <PackageReference Include="NServiceBus.CustomChecks" Version="3.0.1" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
-    <PackageReference Include="NServiceBus.NLog" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.2.2" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
-    <PackageReference Include="ServiceControl.Contracts" Version="3.0.0" />
-    <PackageReference Include="Lucene.Net" Version="3.0.3" />
-    <PackageReference Include="Rx-Linq" Version="2.2.5" />
-    <PackageReference Include="Microsoft.AspNet.SignalR" Version="2.4.3" TreatAsUsed="true" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Owin" Version="1.2.2" />
-    <PackageReference Include="Microsoft.Owin.Cors" Version="4.2.2" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="5.0.1" />
-    <PackageReference Include="System.Threading.Channels" Version="7.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
+    <PackageReference Include="ByteSize" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
+    <PackageReference Include="Microsoft.AspNet.WebApi" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices"/>
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
+    <PackageReference Include="NServiceBus.CustomChecks" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" />
+    <PackageReference Include="NServiceBus.NLog" />
+    <PackageReference Include="Microsoft.Owin.Hosting" />
+    <PackageReference Include="NLog.Extensions.Logging"/>
+    <PackageReference Include="ServiceControl.Contracts" />
+    <PackageReference Include="Lucene.Net" />
+    <PackageReference Include="Rx-Linq" />
+    <PackageReference Include="Microsoft.AspNet.SignalR" />
+    <PackageReference Include="Microsoft.AspNet.SignalR.Owin" />
+    <PackageReference Include="Microsoft.Owin.Cors"/>
+    <PackageReference Include="Particular.Licensing.Sources" />
+    <PackageReference Include="System.Threading.Channels" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.AspNet.SignalR" Version="2.4.3" TreatAsUsed="true" />
     <PackageReference Include="Microsoft.AspNet.SignalR.Owin" Version="1.2.2" />
     <PackageReference Include="Microsoft.Owin.Cors" Version="4.2.2" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="5.0.1" PrivateAssets="All" TreatAsUsed="true" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="5.0.1" />
     <PackageReference Include="System.Threading.Channels" Version="7.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" TreatAsUsed="true" />
   </ItemGroup>

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -16,24 +16,20 @@
 
   <ItemGroup>
     <PackageReference Include="ByteSize" />
+    <PackageReference Include="Lucene.Net" />
+    <PackageReference Include="Microsoft.AspNet.SignalR" />
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" />
-    <PackageReference Include="Microsoft.AspNet.WebApi" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices"/>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
+    <PackageReference Include="Microsoft.Owin.Cors"/>
+    <PackageReference Include="NLog.Extensions.Logging"/>
     <PackageReference Include="NServiceBus.CustomChecks" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" />
     <PackageReference Include="NServiceBus.NLog" />
-    <PackageReference Include="Microsoft.Owin.Hosting" />
-    <PackageReference Include="NLog.Extensions.Logging"/>
-    <PackageReference Include="ServiceControl.Contracts" />
-    <PackageReference Include="Lucene.Net" />
-    <PackageReference Include="Rx-Linq" />
-    <PackageReference Include="Microsoft.AspNet.SignalR" />
-    <PackageReference Include="Microsoft.AspNet.SignalR.Owin" />
-    <PackageReference Include="Microsoft.Owin.Cors"/>
     <PackageReference Include="Particular.Licensing.Sources" />
+    <PackageReference Include="Rx-Linq" />
+    <PackageReference Include="ServiceControl.Contracts" />
     <PackageReference Include="System.Threading.Channels" />
-    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,10 +40,6 @@
   <ItemGroup>
     <None Remove="Infrastructure\RavenDB\RavenLicense.xml" />
     <EmbeddedResource Include="Infrastructure\RavenDB\RavenLicense.xml" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="$(PkgRavenDB_Database)\tools\Raven.Studio.Html5.zip" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -42,4 +42,7 @@
     <EmbeddedResource Include="Infrastructure\RavenDB\RavenLicense.xml" />
   </ItemGroup>
 
+  <!-- Artifacts for the primary instance are not currently defined here because we don't yet have selectable persister options.
+  They are defined on the ServiceControl.Persistence.RavenDb project instead. -->
+
 </Project>

--- a/src/ServiceControlInstaller.CustomActions.UnitTests/ServiceControlInstaller.CustomActions.UnitTests.csproj
+++ b/src/ServiceControlInstaller.CustomActions.UnitTests/ServiceControlInstaller.CustomActions.UnitTests.csproj
@@ -9,10 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControlInstaller.CustomActions/ServiceControlInstaller.CustomActions.csproj
+++ b/src/ServiceControlInstaller.CustomActions/ServiceControlInstaller.CustomActions.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WiX" Version="3.11.2" />
+    <PackageReference Include="WiX" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Particular.Approvals" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj" />
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" /> <!--Needed for build ordering-->
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -5,6 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Label="Needed for build ordering">
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="System.Configuration" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.Management" />
@@ -19,43 +27,12 @@
     <PackageReference Include="System.Reflection.MetadataLoadContext" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj" />
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" /> <!--Needed for build ordering-->
-  </ItemGroup>
-
-  <PropertyGroup>
-    <DeployFolder>..\..\deploy\</DeployFolder>
-    <ZipFolder>..\..\zip\</ZipFolder>
-  </PropertyGroup>
-
-  <Target Name="CleanZipFolder" AfterTargets="Build">
-    <RemoveDir Directories="$(ZipFolder)" />
+  <Target Name="CreateZipFiles" AfterTargets="Build">
+    <PropertyGroup>
+      <ZipFolder>..\..\zip\</ZipFolder>
+    </PropertyGroup>
     <MakeDir Directories="$(ZipFolder)" />
-  </Target>
-
-  <Target Name="ZipServiceControl" AfterTargets="CleanZipFolder">
-    <PropertyGroup>
-      <InstanceName>Particular.ServiceControl</InstanceName>
-      <ZipToCreate>$(ZipFolder)$(InstanceName)-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
-    </PropertyGroup>
-    <ZipDirectory SourceDirectory="$(DeployFolder)$(InstanceName)" DestinationFile="$(ZipToCreate)" />
-  </Target>
-
-  <Target Name="ZipServiceControlAudit" AfterTargets="CleanZipFolder">
-    <PropertyGroup>
-      <InstanceName>Particular.ServiceControl.Audit</InstanceName>
-      <ZipToCreate>$(ZipFolder)$(InstanceName)-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
-    </PropertyGroup>
-    <ZipDirectory SourceDirectory="$(DeployFolder)$(InstanceName)" DestinationFile="$(ZipToCreate)" />
-  </Target>
-
-  <Target Name="ZipServiceControlMonitoring" AfterTargets="CleanZipFolder">
-    <PropertyGroup>
-      <InstanceName>Particular.ServiceControl.Monitoring</InstanceName>
-      <ZipToCreate>$(ZipFolder)$(InstanceName)-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip</ZipToCreate>
-    </PropertyGroup>
-    <ZipDirectory SourceDirectory="$(DeployFolder)$(InstanceName)" DestinationFile="$(ZipToCreate)" />
+    <ZipDirectory SourceDirectory="$(ArtifactsPath)%(InstanceName.identity)" DestinationFile="$(ZipFolder)%(InstanceName.identity)-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).zip" Overwrite="true" />
   </Target>
 
 </Project>

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -12,11 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.16.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
+    <PackageReference Include="DotNetZip" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.IO.Compression" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" />
   </ItemGroup>
 
   <ItemGroup>
@@ -57,5 +57,5 @@
     </PropertyGroup>
     <ZipDirectory SourceDirectory="$(DeployFolder)$(InstanceName)" DestinationFile="$(ZipToCreate)" />
   </Target>
-  
+
 </Project>

--- a/src/ServiceControlInstaller.Packaging.UnitTests/AuditDeploymentPackageTests.cs
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/AuditDeploymentPackageTests.cs
@@ -26,7 +26,6 @@ namespace Tests
             foreach (var persister in persisters)
             {
                 Assert.IsFalse(persister.Files.Any(f => f.Name.EndsWith(".config")), $"{persister.Name} contains a config file");
-                Assert.IsFalse(persister.Files.Any(f => f.Name == "ServiceControl.Audit.Persistence.dll"), $"{persister.Name} contains the transport seam assembly");
                 Assert.IsTrue(persister.Files.Any(f => f.Name == "persistence.manifest"), $"{persister.Name} doesn't contain a persistence.manifest file");
             }
         }

--- a/src/ServiceControlInstaller.Packaging.UnitTests/DeploymentPackageTests.cs
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/DeploymentPackageTests.cs
@@ -74,16 +74,10 @@ namespace Tests
                     continue;
                 }
 
-                var mismatch = $"{leftAssembly.Name} has a different version in {leftDeploymentUnit.FullName} compared to {rightDeploymentUnit.FullName}: {leftVersion} | {rightVersion}";
+                var mismatch = $"{leftAssembly.Name} has a different version in {leftDeploymentUnit.FullName} compared to {rightDeploymentUnit.FullName}. Add the package to Directory.Packages.props to ensure the same version is used everywhere: {leftVersion} | {rightVersion}";
 
                 var leftAssemblyFullname = $"{leftDeploymentUnit.FullName}/{leftAssembly.Name}";
                 var rightAssemblyFullname = $"{rightDeploymentUnit.FullName}/{rightAssembly.Name}";
-
-                if (IgnoreList.Contains(leftAssemblyFullname) || IgnoreList.Contains(rightAssemblyFullname))
-                {
-                    TestContext.Out.WriteLine($"IGNORED: {mismatch}");
-                    continue;
-                }
 
                 detectedMismatches.Add(mismatch);
             }
@@ -110,20 +104,6 @@ namespace Tests
                 .Select(u => u.Name);
 
             CollectionAssert.AreEquivalent(allTransports, transports, $"Expected transports folder to contain {string.Join(",", allTransports)}");
-        }
-
-        static IEnumerable<string> IgnoreList
-        {
-            get
-            {
-                // NServiceBus.Transport.Msmq references V5.0.0 of this assembly,
-                // but only for the native delayed delivery codepath so is not used by ServiceControl.
-                // Updating the reference will in turn break NServiceBus.Transport.RabbitMQ
-                // as that package references V4.7.1.
-                // It should therefore be safe to explicitly exclude this assembly mismatch from
-                // the test.
-                yield return "Transports/MSMQ/System.Threading.Channels.dll";
-            }
         }
 
         readonly DeploymentPackage deploymentPackage;

--- a/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" />
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" /> <!--Needed for build ordering-->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
@@ -2,18 +2,17 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
@@ -9,10 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" /> <!--Needed for build ordering-->
+  <ItemGroup Label="Needed for build ordering">
+    <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -1,177 +1,34 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.6.0">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceControl.Monitoring\ServiceControl.Monitoring.csproj" ReferenceOutputAssembly="false" Private="false" />
-    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Transports.ASQ\ServiceControl.Transports.ASQ.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Audit.Persistence.InMemory\ServiceControl.Audit.Persistence.InMemory.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb\ServiceControl.Audit.Persistence.RavenDb.csproj" ReferenceOutputAssembly="false" Private="false"/>
-    <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb5\ServiceControl.Audit.Persistence.RavenDb5.csproj" ReferenceOutputAssembly="false" Private="false"/>
+  <ItemGroup Label="Instances">
+    <ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" />  <!--Deploy artifacts come from this project-->
+    <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
+    <ProjectReference Include="..\ServiceControl.Monitoring\ServiceControl.Monitoring.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <DeployFolder>..\..\deploy\</DeployFolder>
-  </PropertyGroup>
+  <ItemGroup Label="Audit persisters">
+    <ProjectReference Include="..\ServiceControl.Audit.Persistence.InMemory\ServiceControl.Audit.Persistence.InMemory.csproj" />
+    <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb\ServiceControl.Audit.Persistence.RavenDb.csproj" />
+    <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb5\ServiceControl.Audit.Persistence.RavenDb5.csproj" />
+  </ItemGroup>
 
+  <ItemGroup Label="Transports">
+    <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.ASQ\ServiceControl.Transports.ASQ.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj"/>
+    <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" />
+    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
+  </ItemGroup>
 
-  <Target Name="CleanDeployFolder" AfterTargets="Build">
-    <!-- Ensure Folder Exists  -->
-    <RemoveDir Directories="$(DeployFolder)" />
-    <MakeDir Directories="$(DeployFolder)" />
-  </Target>
-
-  <Target Name="PrepareServiceControl" AfterTargets="CleanDeployFolder">
-    <PropertyGroup>
-      <StagingFolder>$(DeployFolder)Particular.ServiceControl\</StagingFolder>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <ServiceControlFolder>..\ServiceControl\$(OutputPath)\</ServiceControlFolder>
-      <SqlTransportFolder>..\ServiceControl.Transports.SqlServer\$(OutputPath)\</SqlTransportFolder>
-      <ASQTransportFolder>..\ServiceControl.Transports.ASQ\$(OutputPath)\</ASQTransportFolder>
-      <ASBTransportFolder>..\ServiceControl.Transports.ASB\$(OutputPath)\</ASBTransportFolder>
-      <ASBSTransportFolder>..\ServiceControl.Transports.ASBS\$(OutputPath)\</ASBSTransportFolder>
-      <RabbitMQTransportFolder>..\ServiceControl.Transports.RabbitMQ\$(OutputPath)\</RabbitMQTransportFolder>
-      <MSMQTransportFolder>..\ServiceControl.Transports.Msmq\$(OutputPath)\</MSMQTransportFolder>
-      <SQSTransportFolder>..\ServiceControl.Transports.SQS\$(OutputPath)\</SQSTransportFolder>
-      <LearningTransportFolder>..\ServiceControl.Transports.Learning\$(OutputPath)\</LearningTransportFolder>
-      <RavenDB35PersistenceFolder>..\ServiceControl.Persistence.RavenDb\$(OutputPath)\</RavenDB35PersistenceFolder>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <FilesToExclude Include="NServiceBus.Core.dll;NServiceBus.Raw.dll;ServiceControl.Transports.dll;ServiceControl.Transports.pdb;Newtonsoft.Json.dll;System.Runtime.CompilerServices.Unsafe.dll" />
-
-      <ServiceControl Include="$(ServiceControlFolder)*.*" Exclude="$(ServiceControlFolder)*.config" />
-      <RavenDB35Persister Include="$(RavenDB35PersistenceFolder)*.dll" Exclude="@(FilesToExclude->'$(RavenDB35PersistenceFolder)%(identity)')" />
-
-      <SqlTransport Include="$(SqlTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SqlTransportFolder)%(identity)')" />
-      <ASQTransport Include="$(ASQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASQTransportFolder)%(identity)')" />
-      <ASBTransport Include="$(ASBTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBTransportFolder)%(identity)')" />
-      <ASBSTransport Include="$(ASBSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBSTransportFolder)%(identity)')" />
-      <RabbitMQTransport Include="$(RabbitMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(RabbitMQTransportFolder)%(identity)')" />
-      <MSMQTransport Include="$(MSMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(MSMQTransportFolder)%(identity)')" />
-      <SQSTransport Include="$(SQSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SQSTransportFolder)%(identity)')" />
-      <LearningTransport Include="$(LearningTransportFolder)*.*" Exclude="@(FilesToExclude->'$(LearningTransportFolder)%(identity)')" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(ServiceControl)" DestinationFolder="$(StagingFolder)ServiceControl\" />
-    <Copy SourceFiles="@(RavenDB35Persister)" DestinationFolder="$(StagingFolder)ServiceControl\" />
-    <Copy SourceFiles="@(SqlTransport)" DestinationFolder="$(StagingFolder)Transports\SQLServer" />
-    <Copy SourceFiles="@(ASQTransport)" DestinationFolder="$(StagingFolder)Transports\AzureStorageQueue" />
-    <Copy SourceFiles="@(ASBTransport)" DestinationFolder="$(StagingFolder)Transports\AzureServiceBus" />
-    <Copy SourceFiles="@(ASBSTransport)" DestinationFolder="$(StagingFolder)Transports\NetStandardAzureServiceBus" />
-    <Copy SourceFiles="@(RabbitMQTransport)" DestinationFolder="$(StagingFolder)Transports\RabbitMQ" />
-    <Copy SourceFiles="@(MSMQTransport)" DestinationFolder="$(StagingFolder)Transports\MSMQ" />
-    <Copy SourceFiles="@(SQSTransport)" DestinationFolder="$(StagingFolder)Transports\AmazonSQS" />
-    <Copy SourceFiles="@(LearningTransport)" DestinationFolder="$(StagingFolder)Transports\LearningTransport" />
-
-  </Target>
-  
-  <Target Name="PrepareServiceControlAudit" AfterTargets="CleanDeployFolder">
-    <PropertyGroup>
-      <StagingFolder>$(DeployFolder)Particular.ServiceControl.Audit\</StagingFolder>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <ServiceControlAuditFolder>..\ServiceControl.Audit\$(OutputPath)\</ServiceControlAuditFolder>
-      <SqlTransportFolder>..\ServiceControl.Transports.SqlServer\$(OutputPath)\</SqlTransportFolder>
-      <ASQTransportFolder>..\ServiceControl.Transports.ASQ\$(OutputPath)\</ASQTransportFolder>
-      <ASBTransportFolder>..\ServiceControl.Transports.ASB\$(OutputPath)\</ASBTransportFolder>
-      <ASBSTransportFolder>..\ServiceControl.Transports.ASBS\$(OutputPath)\</ASBSTransportFolder>
-      <RabbitMQTransportFolder>..\ServiceControl.Transports.RabbitMQ\$(OutputPath)\</RabbitMQTransportFolder>
-      <MSMQTransportFolder>..\ServiceControl.Transports.Msmq\$(OutputPath)\</MSMQTransportFolder>
-      <SQSTransportFolder>..\ServiceControl.Transports.SQS\$(OutputPath)\</SQSTransportFolder>
-      <LearningTransportFolder>..\ServiceControl.Transports.Learning\$(OutputPath)\</LearningTransportFolder>
-      <InMemoryPersistenceFolder>..\ServiceControl.Audit.Persistence.InMemory\$(OutputPath)\</InMemoryPersistenceFolder>
-      <RavenDbPersistenceFolder>..\ServiceControl.Audit.Persistence.RavenDb\$(OutputPath)\</RavenDbPersistenceFolder>
-      <RavenDb5PersistenceFolder>..\ServiceControl.Audit.Persistence.RavenDb5\$(OutputPath)\</RavenDb5PersistenceFolder>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <FilesToExclude Include="NServiceBus.Core.dll;NServiceBus.Raw.dll;ServiceControl.Transports.dll;ServiceControl.Transports.pdb;ServiceControl.Audit.Persistence.dll;ServiceControl.Audit.Persistence.pdb;ServiceControl.Audit.Persistence.SagaAudit.dll;ServiceControl.Audit.Persistence.SagaAudit.pdb;System.Runtime.CompilerServices.Unsafe.dll" />
-
-      <ServiceControlAudit Include="$(ServiceControlAuditFolder)*.*" Exclude="$(ServiceControlAuditFolder)*.config" />
-      <AuditSqlTransport Include="$(SqlTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SqlTransportFolder)%(identity)')" />
-      <AuditASQTransport Include="$(ASQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASQTransportFolder)%(identity)')" />
-      <AuditASBTransport Include="$(ASBTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBTransportFolder)%(identity)')" />
-      <AuditASBSTransport Include="$(ASBSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBSTransportFolder)%(identity)')" />
-      <AuditRabbitMQTransport Include="$(RabbitMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(RabbitMQTransportFolder)%(identity)')" />
-      <AuditMSMQTransport Include="$(MSMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(MSMQTransportFolder)%(identity)')" />
-      <AuditSQSTransport Include="$(SQSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SQSTransportFolder)%(identity)')" />
-      <AuditLearningTransport Include="$(LearningTransportFolder)*.*" Exclude="@(FilesToExclude->'$(LearningTransportFolder)%(identity)')" />
-      <AuditInMemoryPersistence Include="$(InMemoryPersistenceFolder)*.*" Exclude="@(FilesToExclude->'$(InMemoryPersistenceFolder)%(identity)')" />
-      <AuditRavenDbPersistence Include="$(RavenDbPersistenceFolder)*.*" Exclude="@(FilesToExclude->'$(RavenDbPersistenceFolder)%(identity)')" />
-      <AuditRavenDb5Persistence Include="$(RavenDb5PersistenceFolder)\**\*.*" Exclude="@(FilesToExclude->'$(RavenDb5PersistenceFolder)%(identity)')" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(ServiceControlAudit)" DestinationFolder="$(StagingFolder)ServiceControl.Audit\" />
-    <Copy SourceFiles="@(AuditSqlTransport)" DestinationFolder="$(StagingFolder)Transports\SQLServer" />
-    <Copy SourceFiles="@(AuditASQTransport)" DestinationFolder="$(StagingFolder)Transports\AzureStorageQueue" />
-    <Copy SourceFiles="@(AuditASBTransport)" DestinationFolder="$(StagingFolder)Transports\AzureServiceBus" />
-    <Copy SourceFiles="@(AuditASBSTransport)" DestinationFolder="$(StagingFolder)Transports\NetStandardAzureServiceBus" />
-    <Copy SourceFiles="@(AuditRabbitMQTransport)" DestinationFolder="$(StagingFolder)Transports\RabbitMQ" />
-    <Copy SourceFiles="@(AuditMSMQTransport)" DestinationFolder="$(StagingFolder)Transports\MSMQ" />
-    <Copy SourceFiles="@(AuditSQSTransport)" DestinationFolder="$(StagingFolder)Transports\AmazonSQS" />
-    <Copy SourceFiles="@(AuditLearningTransport)" DestinationFolder="$(StagingFolder)Transports\LearningTransport" />
-    <Copy SourceFiles="@(AuditInMemoryPersistence)" DestinationFolder="$(StagingFolder)Persisters\InMemory" />
-    <Copy SourceFiles="@(AuditRavenDbPersistence)" DestinationFolder="$(StagingFolder)Persisters\RavenDB35" />
-    <Copy SourceFiles="@(AuditRavenDb5Persistence)" DestinationFolder="$(StagingFolder)Persisters\RavenDB5\%(RecursiveDir)" />
-  </Target>
-
-  <Target Name="PrepareServiceControlMonitoring" AfterTargets="CleanDeployFolder">
-    <PropertyGroup>
-      <StagingFolder>$(DeployFolder)Particular.ServiceControl.Monitoring\</StagingFolder>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <ServiceControlMonitoringFolder>..\ServiceControl.Monitoring\$(OutputPath)\</ServiceControlMonitoringFolder>
-      <SqlTransportFolder>..\ServiceControl.Transports.SqlServer\$(OutputPath)\</SqlTransportFolder>
-      <ASQTransportFolder>..\ServiceControl.Transports.ASQ\$(OutputPath)\</ASQTransportFolder>
-      <ASBTransportFolder>..\ServiceControl.Transports.ASB\$(OutputPath)\</ASBTransportFolder>
-      <ASBSTransportFolder>..\ServiceControl.Transports.ASBS\$(OutputPath)\</ASBSTransportFolder>
-      <RabbitMQTransportFolder>..\ServiceControl.Transports.RabbitMQ\$(OutputPath)\</RabbitMQTransportFolder>
-      <MSMQTransportFolder>..\ServiceControl.Transports.Msmq\$(OutputPath)\</MSMQTransportFolder>
-      <SQSTransportFolder>..\ServiceControl.Transports.SQS\$(OutputPath)\</SQSTransportFolder>
-      <LearningTransportFolder>..\ServiceControl.Transports.Learning\$(OutputPath)\</LearningTransportFolder>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <FilesToExclude Include="NServiceBus.Core.dll;NServiceBus.Raw.dll;ServiceControl.Transports.dll;ServiceControl.Transports.pdb" />
-
-      <ServiceControlMonitoring Include="$(ServiceControlMonitoringFolder)*.*" Exclude="$(ServiceControlMonitoringFolder)*.config" />
-      <MonitoringSqlTransport Include="$(SqlTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SqlTransportFolder)%(identity)')" />
-      <MonitoringASQTransport Include="$(ASQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASQTransportFolder)%(identity)')" />
-      <MonitoringASBTransport Include="$(ASBTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBTransportFolder)%(identity)')" />
-      <MonitoringASBSTransport Include="$(ASBSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(ASBSTransportFolder)%(identity)')" />
-      <MonitoringRabbitMQTransport Include="$(RabbitMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(RabbitMQTransportFolder)%(identity)')" />
-      <MonitoringMSMQTransport Include="$(MSMQTransportFolder)*.*" Exclude="@(FilesToExclude->'$(MSMQTransportFolder)%(identity)')" />
-      <MonitoringSQSTransport Include="$(SQSTransportFolder)*.*" Exclude="@(FilesToExclude->'$(SQSTransportFolder)%(identity)')" />
-      <MonitoringLearningTransport Include="$(LearningTransportFolder)*.*" Exclude="@(FilesToExclude->'$(LearningTransportFolder)%(identity)')" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(ServiceControlMonitoring)" DestinationFolder="$(StagingFolder)ServiceControl.Monitoring\" />
-    <Copy SourceFiles="@(MonitoringSqlTransport)" DestinationFolder="$(StagingFolder)Transports\SQLServer" />
-    <Copy SourceFiles="@(MonitoringASQTransport)" DestinationFolder="$(StagingFolder)Transports\AzureStorageQueue" />
-    <Copy SourceFiles="@(MonitoringASBTransport)" DestinationFolder="$(StagingFolder)Transports\AzureServiceBus" />
-    <Copy SourceFiles="@(MonitoringASBSTransport)" DestinationFolder="$(StagingFolder)Transports\NetStandardAzureServiceBus" />
-    <Copy SourceFiles="@(MonitoringRabbitMQTransport)" DestinationFolder="$(StagingFolder)Transports\RabbitMQ" />
-    <Copy SourceFiles="@(MonitoringMSMQTransport)" DestinationFolder="$(StagingFolder)Transports\MSMQ" />
-    <Copy SourceFiles="@(MonitoringSQSTransport)" DestinationFolder="$(StagingFolder)Transports\AmazonSQS" />
-    <Copy SourceFiles="@(MonitoringLearningTransport)" DestinationFolder="$(StagingFolder)Transports\LearningTransport" />
-
-  </Target>
+<ItemGroup>
+  <ProjectReference Update="..\**\*" ReferenceOutputAssembly="false" Private="false" />
+</ItemGroup>
 
 </Project>

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup Label="Instances">
-    <ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" />  <!--Deploy artifacts come from this project-->
+    <!-- Primary instance artifacts come from this project. See project files for details -->
+    <ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
     <ProjectReference Include="..\ServiceControl.Monitoring\ServiceControl.Monitoring.csproj" />
   </ItemGroup>
@@ -20,15 +21,15 @@
     <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.ASQ\ServiceControl.Transports.ASQ.csproj" />
-    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj"/>
+    <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
   </ItemGroup>
 
-<ItemGroup>
-  <ProjectReference Update="..\**\*" ReferenceOutputAssembly="false" Private="false" />
-</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Update="..\**\*" ReferenceOutputAssembly="false" Private="false" />
+  </ItemGroup>
 
 </Project>

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -29,6 +29,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- This ensures that all the project references listed above are configured to be build ordering references only.
+    No assemblies or content are copied when these are set -->
     <ProjectReference Update="..\**\*" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 

--- a/src/ServiceControlInstaller.PowerShell/ServiceControlInstaller.PowerShell.csproj
+++ b/src/ServiceControlInstaller.PowerShell/ServiceControlInstaller.PowerShell.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
+    <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.Config\ServiceControl.Config.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="Prerequisites\**\*.*" />
   </ItemGroup>
 

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Needed for build ordering">
     <ProjectReference Include="..\ServiceControl.Config\ServiceControl.Config.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ServiceControl.Config\ServiceControl.Config.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ServiceControl.Config\ServiceControl.Config.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR makes some big changes in how dependencies are managed in the repo and how deployment artifacts are defined and managed:

- Package references use [central package management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) to make it easy to ensure the same package version is referenced, including transitive references.
- [Microsoft.Build.Artifacts](https://github.com/microsoft/MSBuildSdks/tree/main/src/Artifacts) is used to define the `deploy` artifacts in each project that contributes artifacts instead of there being a single massive list of things in the `ServiceControlInstaller.Packaging` project.
- The `ServiceControlInstaller.Packaging` project is now used to control build ordering only. Every project that produces artifacts needs to be listed in this project, and every project that uses `deploy` artifacts needs a build ordering dependency on `ServiceControlInstaller.Packaging`. 

Some general project file cleanup and simplification has also been included.

