### PR TITLE
Enable CORS for HEAD requests

### DIFF
--- a/src/ServiceControl/Infrastructure/WebApi/Cors.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/Cors.cs
@@ -42,8 +42,7 @@
 
             policy.ExposedHeaders.AddRange(new[] { "ETag", "Last-Modified", "Link", "Total-Count", "X-Particular-Version" });
             policy.Headers.AddRange(new[] { "Origin", "X-Requested-With", "Content-Type", "Accept" });
-            policy.Methods.AddRange(new[] { "POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH" });
-
+            policy.Methods.AddRange(new[] { "POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD" });
             return policy;
         }
 


### PR DESCRIPTION
For some reason, `HEAD` requests were not included on the allowed methods. However, the [errors API supports `HEAD` operations](https://github.com/Particular/ServiceControl/blob/master/src/ServiceControl/MessageFailures/Api/GetAllErrorsController.cs#L47) which can be used by ServicePulse. When running in scenarios where the CORS settings are relevant, these requests since the CORS checks/preflight requests fail. Adding `HEAD` to the allowed methods resolves the issue.