### PR TITLE
📦 Bump Azure.Message.ServiceBus to 7.11.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -85,6 +85,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="Azure.Message.ServiceBus" Version="7.11.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump Azure.Message.ServiceBus to 7.11.1, previously a transitive dependency and using 7.4.0