### PR TITLE
Fix problems with installer Setup project build ordering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,6 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-*'
 env:
   DOTNET_NOLOGO: true
-  # Signals build to create the installer
-  RELEASE_WORKFLOW: true
 jobs:
   release:
     runs-on: windows-2022
@@ -22,6 +20,15 @@ jobs:
           dotnet-version: 6.0.x
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
+      - name: Build
+        run: msbuild src -p:Configuration=Release -restore -m -verbosity:minimal
+      - name: Sign NuGet packages
+        uses: Particular/sign-nuget-packages-action@v1.0.0
+        with:
+          client-id: ${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}
+          client-secret: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
+          certificate-name: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
       - name: Setup Advanced Installer
         run: |
           $version = "20.0"
@@ -32,17 +39,10 @@ jobs:
           $content = Get-Content -Raw -Path src/Setup/ServiceControl.aip
           $content = $content -replace "replace-tenant-id", "${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}" -replace "replace-app-id", "${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }}" -replace "replace-cert-name", "${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}"
           Set-Content src/Setup/ServiceControl.aip $content
-      - name: Build
+      - name: Build Windows installer
         env:
           AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
-        run: msbuild src -p:Configuration=Release -restore -m -verbosity:minimal
-      - name: Sign NuGet packages
-        uses: Particular/sign-nuget-packages-action@v1.0.0
-        with:
-          client-id: ${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}
-          client-secret: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
-          certificate-name: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
+        run: dotnet build src/Setup --configuration Release
       - name: Build Docker images
         run: dotnet build src/ServiceControl.DockerImages --configuration Release
       - name: Publish installer

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -147,7 +147,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Audit.Persis
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.DockerImages", "ServiceControl.DockerImages\ServiceControl.DockerImages.csproj", "{1C648E04-F9E3-433F-86D9-E99344275613}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Management.PowerShell", "ServiceControl.Management.PowerShell\ServiceControl.Management.PowerShell.csproj", "{31CF8050-9A87-4569-A750-3171B2A892C0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Management.PowerShell", "ServiceControl.Management.PowerShell\ServiceControl.Management.PowerShell.csproj", "{31CF8050-9A87-4569-A750-3171B2A892C0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -188,9 +188,7 @@ Global
 		{C0EEF6D1-5DF7-4A26-9964-6376F465B085}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C0EEF6D1-5DF7-4A26-9964-6376F465B085}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F6473A7A-01B7-4A9A-B30C-4D200BFFFE4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F6473A7A-01B7-4A9A-B30C-4D200BFFFE4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6473A7A-01B7-4A9A-B30C-4D200BFFFE4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F6473A7A-01B7-4A9A-B30C-4D200BFFFE4D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C7EC4072-F74C-410D-B0C3-4C05B7C9CFB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C7EC4072-F74C-410D-B0C3-4C05B7C9CFB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C7EC4072-F74C-410D-B0C3-4C05B7C9CFB7}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -1,18 +1,22 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+
+  <!--
+
+  WARNING
+  This project is not automatically built when building the solution.
+  To build the Windows installer, explicitly build this project after having built the solution.
+
+  -->
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup Label="Needed for build ordering">
-    <ProjectReference Include="..\ServiceControl.Config\ServiceControl.Config.csproj" ReferenceOutputAssembly="false" Private="false" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="Prerequisites\**\*.*" />
   </ItemGroup>
 
-  <Target Name="CreateInstaller" AfterTargets="Build" Condition="'$(CI)' == 'true' AND '$(RELEASE_WORKFLOW)' == 'true'">
+  <Target Name="CreateInstaller" AfterTargets="Build">
     <ItemGroup>
       <BuiltFiles Include="$(OutputPath)\*.*" />
     </ItemGroup>
@@ -28,9 +32,9 @@
       <Prerequisites Include="Prerequisites\**\*.*" />
     </ItemGroup>
     <PropertyGroup>
-      <SetupExeOutputFolder>$(SolutionDir)..\assets\</SetupExeOutputFolder>
+      <RepoRootDir>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)\..\..\))</RepoRootDir>
+      <SetupExeOutputFolder>$(RepoRootDir)assets\</SetupExeOutputFolder>
       <SetupExeName>Particular.ServiceControl-$(MinVerVersion).exe</SetupExeName>
-      <ZipFolder>$([System.IO.Path]::GetFullPath($(SolutionDir)..\zip))</ZipFolder>
     </PropertyGroup>
     <MakeDir Directories="$(SetupExeOutputFolder)" />
     <ItemGroup>
@@ -41,11 +45,11 @@
     <Copy SourceFiles="$(CommandFile)" DestinationFolder="$(IntermediateOutputPath)" />
     <Copy SourceFiles="@(ResourceFiles)" DestinationFolder="$(IntermediateOutputPath)Res\%(RecursiveDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(Prerequisites)" DestinationFolder="$(IntermediateOutputPath)Prerequisites\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name PROJECT_PATH -value $(SolutionDir)Setup -valuetype Folder" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name WPF_PATH -value $(SolutionDir)ServiceControl.Config\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name ZIP_PATH -value $(ZipFolder) -valuetype Folder" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name POSH_PATH -value $(SolutionDir)ServiceControlInstaller.PowerShell\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name CUSTOMACTIONS_PATH -value $(SolutionDir)ServiceControlInstaller.CustomActions\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name PROJECT_PATH -value $(RepoRootDir)src\Setup -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name WPF_PATH -value $(RepoRootDir)src\ServiceControl.Config\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name ZIP_PATH -value $(RepoRootDir)zip -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name POSH_PATH -value $(RepoRootDir)src\ServiceControlInstaller.PowerShell\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name CUSTOMACTIONS_PATH -value $(RepoRootDir)src\ServiceControlInstaller.CustomActions\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /SetVersion $(MinVerMajor).$(MinVerMinor).$(MinVerPatch)" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /SetPackageName $(SetupExeOutputFolder)$(SetupExeName) -buildname DefaultBuild" />
     <Exec Command="$(AdvancedInstallerExe) /execute $(IntermediateOutputPath)$(AIPFile) $(IntermediateOutputPath)$(CommandFile)" />


### PR DESCRIPTION
This PR changes how the `Setup` project that creates the Windows Installer is built.

Previously, the project was always built, but the `CreateInstaller` target in the project file had a condition to ensure it only ran during the release workflow. For this to work correctly, the project would need to the proper build ordering to ensure it was built after all of the artifacts that go into the installer are on disk.

Despite everything indicating that the build ordering should be correct, MSBuild was scheduling it to run too soon.

Now, the `Setup` project is never built when building the solution. Instead, you need to build the project specifically.

The release workflow has been updated to do this after the solution has been built.