### PR TITLE
Update installer prerequisite check versions

### DIFF
--- a/src/Setup/ServiceControl.aip
+++ b/src/Setup/ServiceControl.aip
@@ -635,8 +635,8 @@
   <COMPONENT cid="caphyon.advinst.msicomp.PreReqSearchComponent">
     <ROW SearchKey="C4FE6FD5B7C4D07B3A313E754A9A6A8Vers" Prereq="C4FE6FD5B7C4D07B3A313E754A9A6A8" SearchType="2" SearchString="HKLM\SOFTWARE\Microsoft\DevDiv\VC\Servicing\14.0\RuntimeMinimum\Version" VerMin="14.26.28720" Order="1" Property="PreReqSearch_C4FE6FD5B7C4D07B3A313E"/>
     <ROW SearchKey="C676C2BD547E7A6181C255B343B7AReleas" Prereq="C676C2BD547E7A6181C255B343B7A" SearchType="9" SearchString="HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\Release" RefContent="G461813" Order="1" Property="PreReqSearch_C676C2BD547E7A6181C255"/>
-    <ROW SearchKey="C6F7BF650B714DC58735D62C12F214E4M_1" Prereq="C6F7BF650B714DC58735D62C12F214E4" SearchType="12" SearchString="HKLM\SOFTWARE\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App" VerMin="6.0.10" Order="2" Property="PreReqSearch_1"/>
-    <ROW SearchKey="E25D6A62194038942640BDE651049CASP.N" Prereq="E25D6A62194038942640BDE651049C" SearchType="1" SearchString="HKLM\SOFTWARE\Microsoft\ASP.NET Core\Shared Framework\v6.0" VerMin="6.0.10" Order="1" Property="PreReqSearch_E25D6A62194038942640BD"/>
+    <ROW SearchKey="C6F7BF650B714DC58735D62C12F214E4M_1" Prereq="C6F7BF650B714DC58735D62C12F214E4" SearchType="12" SearchString="HKLM\SOFTWARE\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App" VerMin="6.0.12" VerMax="6.0.100" Order="2" Property="PreReqSearch_1"/>
+    <ROW SearchKey="E25D6A62194038942640BDE651049CASP.N" Prereq="E25D6A62194038942640BDE651049C" SearchType="1" SearchString="HKLM\SOFTWARE\Microsoft\ASP.NET Core\Shared Framework\v6.0" VerMin="6.0.12" Order="1" Property="PreReqSearch_E25D6A62194038942640BD"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.SynchronizedFolderComponent">
     <ROW Directory_="APPDIR" SourcePath="&lt;WPF_PATH&gt;" Feature="ServiceControlManagment" ExcludePattern="*~|#*#|%*%|._|CVS|.cvsignore|SCCS|vssver.scc|mssccprj.scc|vssver2.scc|.svn|.DS_Store|\*|*.vshost.*" ExcludeFlags="6" FileAddOptions="4"/>


### PR DESCRIPTION
While the minimum versions were updated in #3332, the actual checks used by the installer were not.

This makes the following changes:
- .NET 6 runtime
   - Minimum version updated to 6.0.12
   - Due to how the registry entries are structured, added a maximum version of 6.0.100 to prevent any installed .NET 7 runtimes from causing the installer to skip installing a .NET 6 runtime. 
- .NET ASP.NET Core 6.0 runtime
   - Minimum version updated to 6.0.12
   - Maximum version not needed here because the registry structure is different, so any installed 7.0 versions won't interfere