### PR TITLE
Update minimum error retention to 5 days everywhere

### DIFF
--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
@@ -86,7 +86,7 @@ namespace ServiceControl.Management.PowerShell
 
         [Parameter(Mandatory = true, HelpMessage = "Specify the timespan to keep Error Data")]
         [ValidateNotNull]
-        [ValidateTimeSpanRange(MinimumHours = 240, MaximumHours = 1080)] //10 to 45 days
+        [ValidateTimeSpanRange(MinimumHours = 120, MaximumHours = 1080)] //5 to 45 days
         public TimeSpan ErrorRetentionPeriod { get; set; }
 
         [Parameter(Mandatory = false, HelpMessage = "Do not automatically create queues")]

--- a/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.dll-help.xml
+++ b/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.dll-help.xml
@@ -1500,7 +1500,7 @@
           <maml:description>
             <maml:para>
               ErrorRetentionPeriod controls how long ServiceControl retains messages ingested from the Error queue in the database.  Only error messages that have been successfully retried or marked as resolved are purged.
-              The value must be a TimeSpan within the range 10 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
+              The value must be a TimeSpan within the range 5 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
             </maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="true">Nullable`1[TimeSpan]</command:parameterValue>
@@ -1556,7 +1556,7 @@
         <maml:description>
           <maml:para>
             ErrorRetentionPeriod controls how long ServiceControl retains messages ingested from the Error queue in the database.  Only error messages that have been successfully retried or marked as resolved are purged.
-            The value must be a TimeSpan within the range 10 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
+            The value must be a TimeSpan within the range 5 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
           </maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="true">Nullable`1[TimeSpan]</command:parameterValue>
@@ -2643,7 +2643,7 @@
             <maml:para>
               ErrorRetentionPeriod controls how long ServiceControl retains messages ingested from the Error queue in the database.
               The retention policy does not remove error messages that still in the unresolved state.
-              The value must be a TimeSpan within the range 10 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
+              The value must be a TimeSpan within the range 5 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
             </maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">TimeSpan</command:parameterValue>
@@ -2893,7 +2893,7 @@
           <maml:para>
             ErrorRetentionPeriod controls how long ServiceControl retains messages ingested from the Error queue in the database.
             The retention policy does not remove error messages that still in the unresolved state.
-            The value must be a TimeSpan within the range 10 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
+            The value must be a TimeSpan within the range 5 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
           </maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">TimeSpan</command:parameterValue>

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -382,9 +382,9 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
             if (TimeSpan.TryParse(valueRead, out var result))
             {
-                if (ValidateConfiguration && result < TimeSpan.FromDays(10))
+                if (ValidateConfiguration && result < TimeSpan.FromDays(5))
                 {
-                    message = "ErrorRetentionPeriod settings is invalid, value should be minimum 10 days.";
+                    message = "ErrorRetentionPeriod settings is invalid, value should be minimum 5 days.";
                     logger.Fatal(message);
                     throw new Exception(message);
                 }

--- a/src/ServiceControlInstaller.Engine.UnitTests/RunEngineTasksExplicitly.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/RunEngineTasksExplicitly.cs
@@ -64,7 +64,7 @@
                 AuditQueue = "audittest",
                 ForwardAuditMessages = false,
                 ForwardErrorMessages = false,
-                AuditRetentionPeriod = TimeSpan.FromHours(SettingConstants.AuditRetentionPeriodDefaultInDaysForUI),
+                AuditRetentionPeriod = TimeSpan.FromDays(SettingConstants.AuditRetentionPeriodDefaultInDaysForUI),
                 ErrorRetentionPeriod = TimeSpan.FromDays(SettingConstants.ErrorRetentionPeriodDefaultInDaysForUI),
                 ErrorQueue = "testerror",
                 TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.MSMQ),

--- a/src/ServiceControlInstaller.PowerShell/ServiceControlInstaller.Powershell.dll-help.xml
+++ b/src/ServiceControlInstaller.PowerShell/ServiceControlInstaller.Powershell.dll-help.xml
@@ -1500,7 +1500,7 @@
           <maml:description>
             <maml:para>
               ErrorRetentionPeriod controls how long ServiceControl retains messages ingested from the Error queue in the database.  Only error messages that have been successfully retried or marked as resolved are purged.
-              The value must be a TimeSpan within the range 10 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
+              The value must be a TimeSpan within the range 5 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
             </maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="true">Nullable`1[TimeSpan]</command:parameterValue>
@@ -1556,7 +1556,7 @@
         <maml:description>
           <maml:para>
             ErrorRetentionPeriod controls how long ServiceControl retains messages ingested from the Error queue in the database.  Only error messages that have been successfully retried or marked as resolved are purged.
-            The value must be a TimeSpan within the range 10 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
+            The value must be a TimeSpan within the range 5 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
           </maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="true">Nullable`1[TimeSpan]</command:parameterValue>
@@ -2643,7 +2643,7 @@
             <maml:para>
               ErrorRetentionPeriod controls how long ServiceControl retains messages ingested from the Error queue in the database.
               The retention policy does not remove error messages that still in the unresolved state.
-              The value must be a TimeSpan within the range 10 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
+              The value must be a TimeSpan within the range 5 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
             </maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">TimeSpan</command:parameterValue>
@@ -2893,7 +2893,7 @@
           <maml:para>
             ErrorRetentionPeriod controls how long ServiceControl retains messages ingested from the Error queue in the database.
             The retention policy does not remove error messages that still in the unresolved state.
-            The value must be a TimeSpan within the range 10 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
+            The value must be a TimeSpan within the range 5 days to 45 days.  Use the New-TimeSpan cmdlet to generate a TimeSpan value.
           </maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">TimeSpan</command:parameterValue>


### PR DESCRIPTION
Update minimum error retention to 5 days in PowerShell and ServiceControl