### PR TITLE
Include PowerShell module in Octopus package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,21 @@ jobs:
           tenant-id: ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}
           client-secret: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
           certificate-name: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
+      - name: Create PowerShell module catalog
+        run: New-FileCatalog -Path assets\PowerShellModules\Particular.ServiceControl.Management -CatalogFilePath assets\PowerShellModules\Particular.ServiceControl.Management\Particular.ServiceControl.Management.cat -CatalogVersion 2.0
+      - name: Install AzureSignTool
+        run: dotnet tool install --global azuresigntool
+      - name: Sign PowerShell module
+        run: |
+          AzureSignTool sign `
+          --file-digest sha256 `
+          --timestamp-rfc3161 http://timestamp.digicert.com `
+          --azure-key-vault-url https://particularcodesigning.vault.azure.net `
+          --azure-key-vault-client-id ${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }} `
+          --azure-key-vault-tenant-id ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }} `
+          --azure-key-vault-client-secret ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }} `
+          --azure-key-vault-certificate ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }} `
+          assets\PowerShellModules\Particular.ServiceControl.Management\Particular.ServiceControl.Management.cat
       - name: Setup Advanced Installer
         run: |
           $version = "20.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
 
           $serviceControlMetadata | ConvertTo-Json | Out-File -Path ServiceControlMetadata.json
       - name: Deploy
-        uses: Particular/push-octopus-package-action@v1.0.0
+        uses: Particular/push-octopus-package-action@v1.1.0
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
           additional-metadata-paths: ServiceControlMetadata.json

--- a/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
+++ b/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
@@ -5,7 +5,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>10.0</LangVersion>
     <ModuleName>Particular.ServiceControl.Management</ModuleName>
-    <ModuleArtifactsPath>$(ArtifactsPath)PowerShellModule\$(ModuleName)\</ModuleArtifactsPath>
+    <ModuleArtifactsPath>$(MSBuildThisFileDirectory)..\..\assets\PowerShellModules\$(ModuleName)\</ModuleArtifactsPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR moves the PowerShell module files into the `assets` folder, which means it will get included in the Octopus deploy package that is built in the release workflow.

A catalog file is created and signed as well, which means the module on the Gallery will be signed.