### PR TITLE
Exclude the changes and sagatype properties from indexing

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDb5/Indexes/SagaDetailsIndex.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/Indexes/SagaDetailsIndex.cs
@@ -15,17 +15,17 @@ namespace ServiceControl.SagaAudit
                                              doc.SagaType,
                                              Changes = new[]
                                              {
-                        new SagaStateChange
-                        {
-                            Endpoint = doc.Endpoint,
-                            FinishTime = doc.FinishTime,
-                            InitiatingMessage = doc.InitiatingMessage,
-                            OutgoingMessages = doc.OutgoingMessages,
-                            StartTime = doc.StartTime,
-                            StateAfterChange = doc.StateAfterChange,
-                            Status = doc.Status
-                        }
-                    }
+                                                new SagaStateChange
+                                                {
+                                                    Endpoint = doc.Endpoint,
+                                                    FinishTime = doc.FinishTime,
+                                                    InitiatingMessage = doc.InitiatingMessage,
+                                                    OutgoingMessages = doc.OutgoingMessages,
+                                                    StartTime = doc.StartTime,
+                                                    StateAfterChange = doc.StateAfterChange,
+                                                    Status = doc.Status
+                                                }
+                                             }
                                          });
 
             //Legacy so we still scan old sagahistories
@@ -52,6 +52,9 @@ namespace ServiceControl.SagaAudit
                                         .OrderByDescending(x => x.FinishTime)
                                         .ToList()
                                 };
+
+            Index(x => x.SagaType, FieldIndexing.No);
+            Index(x => x.Changes, FieldIndexing.No);
         }
     }
 }


### PR DESCRIPTION
We are not querying them so this will speed up indexing

See https://ravendb.net/docs/article-page/5.4/java/indexes/using-analyzers#manipulating-field-indexing-behavior for more details

This was also recommended by the RavenDB team as a workaround for https://issues.hibernatingrhinos.com/issue/RavenDB-19762/Failed-to-index-a-large-reduce-result