### PR TITLE
Saga audit data isn't cleaned up

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/UnitOfWork/RavenDbAuditIngestionUnitOfWork.cs
@@ -64,7 +64,7 @@
         }
 
         public Task RecordSagaSnapshot(SagaSnapshot sagaSnapshot)
-            => bulkInsert.StoreAsync(sagaSnapshot);
+            => bulkInsert.StoreAsync(sagaSnapshot, GetExpirationMetadata());
 
         public Task RecordKnownEndpoint(KnownEndpoint knownEndpoint)
             => bulkInsert.StoreAsync(knownEndpoint, GetExpirationMetadata());


### PR DESCRIPTION
Ensuring sagaSnapshot gets expiration metadata in order for retention cleanup to work