### PR TITLE
Zip PowerShell module in assets folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,12 @@ jobs:
       - name: Build
         run: msbuild src -p:Configuration=Release -restore -m -verbosity:minimal
       - name: Zip PowerShell module
-        if: matrix.transport == 'Msmq' && matrix.storage == 'RavenDB35'
+        if: matrix.transport == 'LearningTransport' && matrix.storage == 'SqlDb'
         run: |
           New-Item assets\PowerShellModules -ItemType Directory
           Compress-Archive -Path deploy\PowerShellModules\Particular.ServiceControl.Management\* -DestinationPath assets\PowerShellModules\Particular.ServiceControl.Management.zip
       - name: Upload assets
-        if: matrix.transport == 'Msmq' && matrix.storage == 'RavenDB35'
+        if: matrix.transport == 'LearningTransport' && matrix.storage == 'SqlDb'
         uses: actions/upload-artifact@v3.1.1
         with:
           name: assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,12 @@ jobs:
         uses: microsoft/setup-msbuild@v1.3
       - name: Build
         run: msbuild src -p:Configuration=Release -restore -m -verbosity:minimal
-      - name: Upload packages
+      - name: Zip PowerShell module
+        if: matrix.transport == 'Msmq' && matrix.storage == 'RavenDB35'
+        run: |
+          New-Item assets\PowerShellModules -ItemType Directory
+          Compress-Archive -Path deploy\PowerShellModules\Particular.ServiceControl.Management\* -DestinationPath assets\PowerShellModules\Particular.ServiceControl.Management.zip
+      - name: Upload assets
         if: matrix.transport == 'Msmq' && matrix.storage == 'RavenDB35'
         uses: actions/upload-artifact@v3.1.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           client-secret: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
           certificate-name: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
       - name: Create PowerShell module catalog
-        run: New-FileCatalog -Path assets\PowerShellModules\Particular.ServiceControl.Management -CatalogFilePath assets\PowerShellModules\Particular.ServiceControl.Management\Particular.ServiceControl.Management.cat -CatalogVersion 2.0
+        run: New-FileCatalog -Path deploy\PowerShellModules\Particular.ServiceControl.Management -CatalogFilePath deploy\PowerShellModules\Particular.ServiceControl.Management\Particular.ServiceControl.Management.cat -CatalogVersion 2.0
       - name: Install AzureSignTool
         run: dotnet tool install --global azuresigntool
       - name: Sign PowerShell module
@@ -43,7 +43,11 @@ jobs:
           --azure-key-vault-tenant-id ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }} `
           --azure-key-vault-client-secret ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }} `
           --azure-key-vault-certificate ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }} `
-          assets\PowerShellModules\Particular.ServiceControl.Management\Particular.ServiceControl.Management.cat
+          deploy\PowerShellModules\Particular.ServiceControl.Management\Particular.ServiceControl.Management.cat
+      - name: Zip PowerShell module
+        run: |
+          New-Item assets\PowerShellModules -ItemType Directory
+          Compress-Archive -Path deploy\PowerShellModules\Particular.ServiceControl.Management\* -DestinationPath assets\PowerShellModules\Particular.ServiceControl.Management.zip
       - name: Setup Advanced Installer
         run: |
           $version = "20.0"
@@ -60,10 +64,10 @@ jobs:
         run: dotnet build src/Setup --configuration Release
       - name: Build Docker images
         run: dotnet build src/ServiceControl.DockerImages --configuration Release
-      - name: Publish installer
+      - name: Publish assets
         uses: actions/upload-artifact@v3.1.1
         with:
-          name: installer
+          name: assets
           path: assets/*
           retention-days: 1
       - name: Publish NuGet packages

--- a/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
+++ b/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
@@ -5,7 +5,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>10.0</LangVersion>
     <ModuleName>Particular.ServiceControl.Management</ModuleName>
-    <ModuleArtifactsPath>$(MSBuildThisFileDirectory)..\..\assets\PowerShellModules\$(ModuleName)\</ModuleArtifactsPath>
+    <ModuleArtifactsPath>$(ArtifactsPath)PowerShellModules\$(ModuleName)\</ModuleArtifactsPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.Packaging.UnitTests/DeploymentPackage.cs
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/DeploymentPackage.cs
@@ -37,7 +37,7 @@ namespace Tests
 
         public static IEnumerable<DeploymentPackage> All => GetDeployDirectory()
                 .EnumerateDirectories()
-                .Where(d => d.Name != "PowerShellModule")
+                .Where(d => d.Name != "PowerShellModules")
                 .Select(d => new DeploymentPackage(d));
 
         public static DirectoryInfo GetDeployDirectory()


### PR DESCRIPTION
Follow-up to #3354 

The module needs to be zipped in the `assets` folder to better integrate with the existing Octopus workflows.

This also adds the zip step to the CI workflow so that the module continues to be available in those runs as well.