### PR TITLE
Update the PowerShell module IconUri

### DIFF
--- a/src/ServiceControl.Management.PowerShell/Particular.ServiceControl.Management.psd1
+++ b/src/ServiceControl.Management.PowerShell/Particular.ServiceControl.Management.psd1
@@ -103,7 +103,7 @@ PrivateData = @{
         ProjectUri = 'https://github.com/Particular/ServiceControl'
 
         # A URL to an icon representing this module.
-        IconUri = 'https://particular.net/images/common/sc.svg'
+        IconUri = 'https://s3.amazonaws.com/particular.downloads/icons/servicecontrol.svg'
 
         # ReleaseNotes of this module
         # ReleaseNotes = ''


### PR DESCRIPTION
This PR switches the icon referenced in the PowerShell module definition to an S3 location that is going to be more stable than the original location.