### PR TITLE
Configure embedded RavenDB 5 to use the configured log directory of the audit instance

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -34,7 +34,7 @@
             {
                 CommandLineArgs = new List<string>
                 {
-                    $"--License.Path=\"{localRavenLicense}\" --Logs.Mode={databaseConfiguration.ServerConfiguration.LogsMode}"
+                    $"--License.Path=\"{localRavenLicense}\" --Logs.Mode={databaseConfiguration.ServerConfiguration.LogsMode} --Indexing.NuGetPackagesPath=\"c:\\bleble\""
                 },
                 AcceptEula = true,
                 DataDirectory = databaseConfiguration.ServerConfiguration.DbPath,

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -38,7 +38,8 @@
                 },
                 AcceptEula = true,
                 DataDirectory = databaseConfiguration.ServerConfiguration.DbPath,
-                ServerUrl = databaseConfiguration.ServerConfiguration.ServerUrl
+                ServerUrl = databaseConfiguration.ServerConfiguration.ServerUrl,
+                LogsPath = databaseConfiguration.ServerConfiguration.LogPath
             };
 
             EmbeddedServer.Instance.StartServer(serverOptions);

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -29,12 +29,18 @@
                 throw new Exception($"RavenDB license not found. Make sure the RavenDB license file, '{licenseFileName}', is stored in the '{AppDomain.CurrentDomain.BaseDirectory}' folder.");
             }
 
+            var nugetPackagesPath = Path.Combine(databaseConfiguration.ServerConfiguration.DbPath, "Packages", "NuGet");
+
             logger.InfoFormat("Loading RavenDB license from {0}", localRavenLicense);
             var serverOptions = new ServerOptions
             {
                 CommandLineArgs = new List<string>
                 {
-                    $"--License.Path=\"{localRavenLicense}\" --Logs.Mode={databaseConfiguration.ServerConfiguration.LogsMode} --Indexing.NuGetPackagesPath=\"c:\\bleble\""
+                    $"--License.Path=\"{localRavenLicense}\"",
+                    $"--Logs.Mode={databaseConfiguration.ServerConfiguration.LogsMode}",
+                    // HINT: If this is not set, then Raven will pick a default location relative to the server binaries
+                    // See https://github.com/ravendb/ravendb/issues/15694
+                    $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\""
                 },
                 AcceptEula = true,
                 DataDirectory = databaseConfiguration.ServerConfiguration.DbPath,

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -34,7 +34,7 @@
             {
                 CommandLineArgs = new List<string>
                 {
-                    $"--License.Path=\"{localRavenLicense}\""
+                    $"--License.Path=\"{localRavenLicense}\" --Logs.Mode={databaseConfiguration.ServerConfiguration.LogsMode}"
                 },
                 AcceptEula = true,
                 DataDirectory = databaseConfiguration.ServerConfiguration.DbPath,

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbPersistenceConfiguration.cs
@@ -18,7 +18,8 @@
             DatabasePathKey,
             ConnectionStringKey,
             DatabaseMaintenancePortKey,
-            ExpirationProcessTimerInSecondsKey
+            ExpirationProcessTimerInSecondsKey,
+            LogPathKey
         };
 
         public string Name => "RavenDB5";

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbPersistenceConfiguration.cs
@@ -11,6 +11,7 @@
         public const string ConnectionStringKey = "RavenDB5/ConnectionString";
         public const string DatabaseMaintenancePortKey = "DatabaseMaintenancePort";
         public const string ExpirationProcessTimerInSecondsKey = "ExpirationProcessTimerInSeconds";
+        public const string LogPathKey = "LogPath";
 
         public IEnumerable<string> ConfigurationKeys => new string[]{
             DatabaseNameKey,
@@ -58,7 +59,12 @@
 
                 var serverUrl = $"http://localhost:{databaseMaintenancePort}";
 
-                serverConfiguration = new ServerConfiguration(dbPath, serverUrl);
+                if (!settings.PersisterSpecificSettings.TryGetValue(LogPathKey, out var logPath))
+                {
+                    throw new InvalidOperationException($"{LogPathKey}  must be specified when using embedded server.");
+                }
+
+                serverConfiguration = new ServerConfiguration(dbPath, serverUrl, logPath);
             }
             else if (settings.PersisterSpecificSettings.TryGetValue(ConnectionStringKey, out var connectionString))
             {

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/ServerConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/ServerConfiguration.cs
@@ -7,17 +7,19 @@
             UseEmbeddedServer = false;
             ConnectionString = connectionString;
         }
-        public ServerConfiguration(string dbPath, string serverUrl)
+
+        public ServerConfiguration(string dbPath, string serverUrl, string logPath)
         {
             UseEmbeddedServer = true;
             DbPath = dbPath;
-
             ServerUrl = serverUrl;
+            LogPath = logPath;
         }
 
         public string ConnectionString { get; }
         public bool UseEmbeddedServer { get; }
         public string DbPath { get; }
         public string ServerUrl { get; }
+        public string LogPath { get; }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/ServerConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/ServerConfiguration.cs
@@ -8,12 +8,13 @@
             ConnectionString = connectionString;
         }
 
-        public ServerConfiguration(string dbPath, string serverUrl, string logPath)
+        public ServerConfiguration(string dbPath, string serverUrl, string logPath, string logsMode)
         {
             UseEmbeddedServer = true;
             DbPath = dbPath;
             ServerUrl = serverUrl;
             LogPath = logPath;
+            LogsMode = logsMode;
         }
 
         public string ConnectionString { get; }
@@ -21,5 +22,6 @@
         public string DbPath { get; }
         public string ServerUrl { get; }
         public string LogPath { get; }
+        public string LogsMode { get; set; }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/persistence.manifest
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/persistence.manifest
@@ -10,6 +10,10 @@
       "Mandatory": true
     },
     {
+      "Name": "ServiceControl.Audit/LogPath",
+      "Mandatory": true
+    },
+    {
       "Name": "ServiceControl.Audit/DatabaseMaintenancePort",
       "Mandatory": true
     }

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ConfigurationValidationTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ConfigurationValidationTests.cs
@@ -39,15 +39,17 @@
         public void Should_support_embedded_server()
         {
             var settings = BuildSettings();
-            var dpPath = "c://some-path";
+            var dpPath = "c://db-path";
+            var logPath = "c://log-path";
 
             settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabasePathKey] = dpPath;
             settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabaseMaintenancePortKey] = "11111";
-
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.LogPathKey] = logPath;
             var configuration = RavenDbPersistenceConfiguration.GetDatabaseConfiguration(settings);
 
             Assert.True(configuration.ServerConfiguration.UseEmbeddedServer);
             Assert.AreEqual(dpPath, configuration.ServerConfiguration.DbPath);
+            Assert.AreEqual(logPath, configuration.ServerConfiguration.LogPath);
             Assert.AreEqual("http://localhost:11111", configuration.ServerConfiguration.ServerUrl);
         }
 

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/EmbeddedLifecycleTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/EmbeddedLifecycleTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Audit.Persistence.Tests
 {
+    using System;
     using System.IO;
     using System.Linq;
     using System.Net.NetworkInformation;
@@ -10,14 +11,19 @@
     [TestFixture]
     class EmbeddedLifecycleTests : PersistenceTestFixture
     {
+        string logPath;
+        string dbPath;
+
         public override async Task Setup()
         {
             SetSettings = s =>
             {
-                var dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "Embedded");
+                dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "Embedded");
+                logPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
                 var databaseMaintenancePort = FindAvailablePort(33335);
 
                 s.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabasePathKey] = dbPath;
+                s.PersisterSpecificSettings[RavenDbPersistenceConfiguration.LogPathKey] = logPath;
                 s.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabaseMaintenancePortKey] = databaseMaintenancePort.ToString();
             };
 
@@ -28,9 +34,12 @@
         }
 
         [Test]
-        public async Task CheckDataStoreAvailable()
+        public async Task Verify_embedded_database()
         {
             await DataStore.QueryKnownEndpoints();
+
+            DirectoryAssert.Exists(dbPath);
+            DirectoryAssert.Exists(logPath);
         }
 
         static int FindAvailablePort(int startPort)

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/PersistenceTestsConfiguration.cs
@@ -28,13 +28,16 @@
 
             setSettings(settings);
 
-            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.LogPathKey] = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Logs");
-
             if (!settings.PersisterSpecificSettings.ContainsKey(RavenDbPersistenceConfiguration.DatabasePathKey))
             {
                 var instance = await SharedEmbeddedServer.GetInstance();
 
                 settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.ConnectionStringKey] = instance.ServerUrl;
+            }
+
+            if (!settings.PersisterSpecificSettings.ContainsKey(RavenDbPersistenceConfiguration.LogPathKey))
+            {
+                settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.LogPathKey] = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Logs");
             }
 
             if (settings.PersisterSpecificSettings.TryGetValue(RavenDbPersistenceConfiguration.DatabaseNameKey, out var configuredDatabaseName))

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/PersistenceTestsConfiguration.cs
@@ -1,8 +1,10 @@
 ﻿namespace ServiceControl.Audit.Persistence.Tests
 {
     using System;
+    using System.IO;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
     using Raven.Client.Documents;
     using Raven.Client.Documents.BulkInsert;
     using Raven.Client.ServerWide.Operations;
@@ -25,6 +27,8 @@
             var settings = new PersistenceSettings(TimeSpan.FromHours(1), true, 100000);
 
             setSettings(settings);
+
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.LogPathKey] = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Logs");
 
             if (!settings.PersisterSpecificSettings.ContainsKey(RavenDbPersistenceConfiguration.DatabasePathKey))
             {

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
@@ -25,7 +25,7 @@
                 var dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "AuditData");
                 var serverUrl = $"http://localhost:{FindAvailablePort(33334)}";
 
-                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl)));
+                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl, TestContext.CurrentContext.WorkDirectory)));
 
                 //make sure that the database is up
                 while (true)

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
@@ -23,9 +23,10 @@
                 }
 
                 var dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "AuditData");
+                var logPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Logs");
                 var serverUrl = $"http://localhost:{FindAvailablePort(33334)}";
 
-                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl, TestContext.CurrentContext.WorkDirectory)));
+                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl, logPath)));
 
                 //make sure that the database is up
                 while (true)

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
@@ -24,9 +24,10 @@
 
                 var dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "AuditData");
                 var logPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Logs");
+                var logsMode = "Operations";
                 var serverUrl = $"http://localhost:{FindAvailablePort(33334)}";
 
-                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl, logPath)));
+                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl, logPath, logsMode)));
 
                 //make sure that the database is up
                 while (true)


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceControl/issues/3364