### PR TITLE
Backporting "Configure embedded RavenDB 5 to use the configured log directory" to 4.27

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -29,16 +29,23 @@
                 throw new Exception($"RavenDB license not found. Make sure the RavenDB license file, '{licenseFileName}', is stored in the '{AppDomain.CurrentDomain.BaseDirectory}' folder.");
             }
 
+            var nugetPackagesPath = Path.Combine(databaseConfiguration.ServerConfiguration.DbPath, "Packages", "NuGet");
+
             logger.InfoFormat("Loading RavenDB license from {0}", localRavenLicense);
             var serverOptions = new ServerOptions
             {
                 CommandLineArgs = new List<string>
                 {
-                    $"--License.Path=\"{localRavenLicense}\""
+                    $"--License.Path=\"{localRavenLicense}\"",
+                    $"--Logs.Mode={databaseConfiguration.ServerConfiguration.LogsMode}",
+                    // HINT: If this is not set, then Raven will pick a default location relative to the server binaries
+                    // See https://github.com/ravendb/ravendb/issues/15694
+                    $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\""
                 },
                 AcceptEula = true,
                 DataDirectory = databaseConfiguration.ServerConfiguration.DbPath,
-                ServerUrl = databaseConfiguration.ServerConfiguration.ServerUrl
+                ServerUrl = databaseConfiguration.ServerConfiguration.ServerUrl,
+                LogsPath = databaseConfiguration.ServerConfiguration.LogPath
             };
 
             EmbeddedServer.Instance.StartServer(serverOptions);

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/ServerConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/ServerConfiguration.cs
@@ -7,17 +7,21 @@
             UseEmbeddedServer = false;
             ConnectionString = connectionString;
         }
-        public ServerConfiguration(string dbPath, string serverUrl)
+
+        public ServerConfiguration(string dbPath, string serverUrl, string logPath, string logsMode)
         {
             UseEmbeddedServer = true;
             DbPath = dbPath;
-
             ServerUrl = serverUrl;
+            LogPath = logPath;
+            LogsMode = logsMode;
         }
 
         public string ConnectionString { get; }
         public bool UseEmbeddedServer { get; }
         public string DbPath { get; }
         public string ServerUrl { get; }
+        public string LogPath { get; }
+        public string LogsMode { get; set; }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/persistence.manifest
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/persistence.manifest
@@ -10,6 +10,10 @@
       "Mandatory": true
     },
     {
+      "Name": "ServiceControl.Audit/LogPath",
+      "Mandatory": true
+    },
+    {
       "Name": "ServiceControl.Audit/DatabaseMaintenancePort",
       "Mandatory": true
     }

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ConfigurationValidationTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ConfigurationValidationTests.cs
@@ -39,15 +39,17 @@
         public void Should_support_embedded_server()
         {
             var settings = BuildSettings();
-            var dpPath = "c://some-path";
+            var dpPath = "c://db-path";
+            var logPath = "c://log-path";
 
             settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabasePathKey] = dpPath;
             settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabaseMaintenancePortKey] = "11111";
-
+            settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.LogPathKey] = logPath;
             var configuration = RavenDbPersistenceConfiguration.GetDatabaseConfiguration(settings);
 
             Assert.True(configuration.ServerConfiguration.UseEmbeddedServer);
             Assert.AreEqual(dpPath, configuration.ServerConfiguration.DbPath);
+            Assert.AreEqual(logPath, configuration.ServerConfiguration.LogPath);
             Assert.AreEqual("http://localhost:11111", configuration.ServerConfiguration.ServerUrl);
         }
 

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/EmbeddedLifecycleTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/EmbeddedLifecycleTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Audit.Persistence.Tests
 {
+    using System;
     using System.IO;
     using System.Linq;
     using System.Net.NetworkInformation;
@@ -10,14 +11,19 @@
     [TestFixture]
     class EmbeddedLifecycleTests : PersistenceTestFixture
     {
+        string logPath;
+        string dbPath;
+
         public override async Task Setup()
         {
             SetSettings = s =>
             {
-                var dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "Embedded");
+                dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "Embedded");
+                logPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
                 var databaseMaintenancePort = FindAvailablePort(33335);
 
                 s.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabasePathKey] = dbPath;
+                s.PersisterSpecificSettings[RavenDbPersistenceConfiguration.LogPathKey] = logPath;
                 s.PersisterSpecificSettings[RavenDbPersistenceConfiguration.DatabaseMaintenancePortKey] = databaseMaintenancePort.ToString();
             };
 
@@ -28,9 +34,12 @@
         }
 
         [Test]
-        public async Task CheckDataStoreAvailable()
+        public async Task Verify_embedded_database()
         {
             await DataStore.QueryKnownEndpoints();
+
+            DirectoryAssert.Exists(dbPath);
+            DirectoryAssert.Exists(logPath);
         }
 
         static int FindAvailablePort(int startPort)

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/PersistenceTestsConfiguration.cs
@@ -1,8 +1,10 @@
 ﻿namespace ServiceControl.Audit.Persistence.Tests
 {
     using System;
+    using System.IO;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
     using Raven.Client.Documents;
     using Raven.Client.Documents.BulkInsert;
     using Raven.Client.ServerWide.Operations;
@@ -31,6 +33,11 @@
                 var instance = await SharedEmbeddedServer.GetInstance();
 
                 settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.ConnectionStringKey] = instance.ServerUrl;
+            }
+
+            if (!settings.PersisterSpecificSettings.ContainsKey(RavenDbPersistenceConfiguration.LogPathKey))
+            {
+                settings.PersisterSpecificSettings[RavenDbPersistenceConfiguration.LogPathKey] = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Logs");
             }
 
             if (settings.PersisterSpecificSettings.TryGetValue(RavenDbPersistenceConfiguration.DatabaseNameKey, out var configuredDatabaseName))

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
@@ -23,9 +23,11 @@
                 }
 
                 var dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "AuditData");
+                var logPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Logs");
+                var logsMode = "Operations";
                 var serverUrl = $"http://localhost:{FindAvailablePort(33334)}";
 
-                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl)));
+                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, new ServerConfiguration(dbPath, serverUrl, logPath, logsMode)));
 
                 //make sure that the database is up
                 while (true)


### PR DESCRIPTION
Backporting https://github.com/Particular/ServiceControl/pull/3367 to version 4.27