### PR TITLE
Update advanced installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           Compress-Archive -Path deploy\PowerShellModules\Particular.ServiceControl.Management\* -DestinationPath assets\PowerShellModules\Particular.ServiceControl.Management.zip
       - name: Setup Advanced Installer
         run: |
-          $version = "20.0"
+          $version = "20.2.1"
           choco install advanced-installer --version=$version
           & "C:\Program Files (x86)\Caphyon\Advanced Installer $version\bin\x86\AdvancedInstaller.com" /register ${{ secrets.ADVANCED_INSTALLER_LICENSE_KEY }}
       - name: Prepare AIP file


### PR DESCRIPTION
This [version](https://www.advancedinstaller.com/release-20.2.1.html) included a bug fix which is impacting the build server's ability to create release builds.

> The command line build randomly failed with error -1073740940 / FFFFFFFFC0000374 in projects with a KeyVault hosted certificate

