### PR TITLE
Handle prerelease versions in the module manifest

### DIFF
--- a/src/ServiceControl.Management.PowerShell/Particular.ServiceControl.Management.psd1
+++ b/src/ServiceControl.Management.PowerShell/Particular.ServiceControl.Management.psd1
@@ -109,7 +109,7 @@ PrivateData = @{
         # ReleaseNotes = ''
 
         # Prerelease string of this module
-        # Prerelease = ''
+        Prerelease = '{{Prerelease}}'
 
         # Flag to indicate whether the module requires explicit user acceptance for install/update/save
         # RequireLicenseAcceptance = $false

--- a/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
+++ b/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
@@ -28,7 +28,7 @@
     <ParameterGroup>
       <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
       <Pattern ParameterType="System.String" Required="true" />
-      <ReplacementText ParameterType="System.String" Required="true" />
+      <ReplacementText ParameterType="System.String" />
     </ParameterGroup>
     <Task>
       <Using Namespace="System.Text.RegularExpressions" />
@@ -38,9 +38,16 @@
              RegexOptions options = RegexOptions.Multiline | RegexOptions.IgnoreCase;
              if (Files.Length > 0)
              {
+                  ReplacementText ??= string.Empty;
+                  if (Pattern == "{{Prerelease}}" && !string.IsNullOrEmpty(ReplacementText))
+                  {
+                      var parts = ReplacementText.Split('.');
+                      var result = int.Parse(parts[1]);
+                      ReplacementText = $"{parts[0]}{result:D4}";
+                  }
                   for (int i = 0; i < Files.Length; i++)
                   {
-                      string path = Files[i].GetMetadata("FullPath");
+                      var path = Files[i].GetMetadata("FullPath");
                       File.WriteAllText(path, Regex.Replace(File.ReadAllText(path), Pattern, ReplacementText, options));
                   }
               }
@@ -54,6 +61,7 @@
       <ModuleFile Include="$(ModuleArtifactsPath)$(ModuleName).psd1" />
     </ItemGroup>
     <FileUpdate Files="@(ModuleFile)" Pattern="{{Version}}" ReplacementText="$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)" />
+    <FileUpdate Files="@(ModuleFile)" Pattern="{{Prerelease}}" ReplacementText="$(MinVerPrerelease)" />
     <FileUpdate Files="@(ModuleFile)" Pattern="{{Date}}" ReplacementText="$([System.DateTime]::UtcNow.ToString(yyyy))" />
   </Target>
 


### PR DESCRIPTION
Backport of #3374 for the `release-4.27` branch.