### PR TITLE
Test to ensure license is valid for RavenDB version

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -96,6 +96,8 @@ dotnet_diagnostic.IDE0082.severity = error
 dotnet_diagnostic.IDE0029.severity = error
 dotnet_diagnostic.IDE0030.severity = error
 dotnet_style_coalesce_expression = true:error
+# IDE0270: Use coalesce expression when throwing exceptions
+dotnet_diagnostic.IDE0270.severity = suggestion
 
 dotnet_diagnostic.IDE0031.severity = error
 dotnet_style_null_propagation = true:error

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/LicenseTest.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/LicenseTest.cs
@@ -1,0 +1,41 @@
+﻿namespace ServiceControl.Audit.Persistence.Tests.RavenDb5
+{
+    using System;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    class LicenseTest : PersistenceTestFixture
+    {
+        [Test]
+        public async Task EnsureLicenseIsValid()
+        {
+            using (var http = new HttpClient())
+            using (var response = await http.GetAsync(configuration.DocumentStore.Urls.First() + "/license/status"))
+            {
+                response.EnsureSuccessStatusCode();
+
+                var jsonText = await response.Content.ReadAsStringAsync();
+                var details = System.Text.Json.JsonSerializer.Deserialize<LicenseDetails>(jsonText);
+
+                Assert.That(details.Id, Is.EqualTo("64c6a174-3f3a-4e7d-ac5d-b3eedd801460"));
+                Assert.That(details.LicensedTo, Is.EqualTo("ParticularNservicebus (Israel)"));
+                Assert.That(details.Status, Is.EqualTo("Commercial"));
+                Assert.That(details.Expired, Is.False);
+                Assert.That(details.Type, Is.EqualTo("Professional"));
+                Assert.That(DateTime.UtcNow.AddDays(14) < details.Expiration, "The RavenDB license expires in less than 2 weeks. Contact RavenDB for the new license.");
+            }
+        }
+
+        class LicenseDetails
+        {
+            public string Id { get; set; }
+            public string LicensedTo { get; set; }
+            public string Status { get; set; }
+            public bool Expired { get; set; }
+            public string Type { get; set; }
+            public DateTime Expiration { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
@@ -36,8 +36,9 @@
                     {
                         using (await embeddedDatabase.Connect(cancellationToken).ConfigureAwait(false))
                         {
-                            // no-op
+                            //no-op
                         }
+
                         return embeddedDatabase;
                     }
                     catch (Exception)

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/SharedEmbeddedServer.cs
@@ -3,10 +3,7 @@
     using System;
     using System.IO;
     using System.Linq;
-    using System.Net.Http;
     using System.Net.NetworkInformation;
-    using System.Text;
-    using System.Text.Json.Nodes;
     using System.Threading;
     using System.Threading.Tasks;
     using NUnit.Framework;
@@ -30,12 +27,6 @@
                 var logsMode = "Operations";
                 var serverUrl = $"http://localhost:{FindAvailablePort(33334)}";
 
-                var licenseFileName = "RavenLicense.json";
-                var localRavenLicense = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, licenseFileName);
-                var licenseText = File.ReadAllText(localRavenLicense);
-                var licenseJsonNode = JsonNode.Parse(licenseText);
-                var licenseContent = new StringContent(licenseJsonNode.ToJsonString(), Encoding.UTF8, "application/json");
-
                 embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, 5, new ServerConfiguration(dbPath, serverUrl, logPath, logsMode)));
 
                 //make sure that the database is up
@@ -45,24 +36,14 @@
                     {
                         using (await embeddedDatabase.Connect(cancellationToken).ConfigureAwait(false))
                         {
-                            // no-op - just to wait until server is available for requests
+                            // no-op
                         }
+                        return embeddedDatabase;
                     }
                     catch (Exception)
                     {
                         await Task.Delay(500, cancellationToken).ConfigureAwait(false);
                     }
-
-                    using (var store = await embeddedDatabase.Connect(cancellationToken).ConfigureAwait(false))
-                    {
-                        var executor = store.GetRequestExecutor();
-                        var activateUrl = embeddedDatabase.ServerUrl + "/admin/license/activate";
-                        var res = await executor.HttpClient.PostAsync(activateUrl, licenseContent, cancellationToken).ConfigureAwait(false);
-                        var resContent = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        res.EnsureSuccessStatusCode();
-                    }
-
-                    return embeddedDatabase;
                 }
             }
             finally


### PR DESCRIPTION
Server ignores --License.Path parameter on startup so the test infrastructure will forcibly apply the license.