### PR TITLE
Include NServiceBus version when listing endpoints

### DIFF
--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditDataStore.cs
@@ -175,7 +175,8 @@
                     {
                         Host = x.Host,
                         HostId = x.HostId,
-                        Name = x.Name
+                        Name = x.Name,
+                        NServiceBusVersion = x.NServiceBusVersion
                     },
                     HostDisplayName = x.Host
                 })

--- a/src/ServiceControl.Audit.Persistence.RavenDb/RavenDbAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb/RavenDbAuditDataStore.cs
@@ -210,7 +210,8 @@
                         {
                             Host = x.Host,
                             HostId = x.HostId,
-                            Name = x.Name
+                            Name = x.Name,
+                            NServiceBusVersion = x.NServiceBusVersion
                         },
                         HostDisplayName = x.Host
                     })

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
@@ -165,7 +165,8 @@
                         {
                             Host = x.Host,
                             HostId = x.HostId,
-                            Name = x.Name
+                            Name = x.Name,
+                            NServiceBusVersion = x.NServiceBusVersion
                         },
                         HostDisplayName = x.Host
                     })

--- a/src/ServiceControl.Audit.Persistence.Tests/KnownEndpointsTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/KnownEndpointsTests.cs
@@ -17,7 +17,8 @@
                 Host = "HostName",
                 HostId = Guid.NewGuid(),
                 LastSeen = DateTime.UtcNow,
-                Name = "Endpoint"
+                Name = "Endpoint",
+                NServiceBusVersion = "1.2.3"
             };
 
             await IngestKnownEndpoints(ingestedEndpoint);
@@ -30,6 +31,7 @@
             Assert.That(endpoint.EndpointDetails.Host, Is.EqualTo(ingestedEndpoint.Host));
             Assert.That(endpoint.EndpointDetails.HostId, Is.EqualTo(ingestedEndpoint.HostId));
             Assert.That(endpoint.EndpointDetails.Name, Is.EqualTo(ingestedEndpoint.Name));
+            Assert.That(endpoint.EndpointDetails.NServiceBusVersion, Is.EqualTo(ingestedEndpoint.NServiceBusVersion));
         }
 
         [Test]

--- a/src/ServiceControl.Audit.Persistence/Monitoring/EndpointDetails.cs
+++ b/src/ServiceControl.Audit.Persistence/Monitoring/EndpointDetails.cs
@@ -9,5 +9,7 @@ namespace ServiceControl.Audit.Monitoring
         public Guid HostId { get; set; }
 
         public string Host { get; set; }
+
+        public string NServiceBusVersion { get; set; }
     }
 }

--- a/src/ServiceControl.Audit.Persistence/Monitoring/KnownEndpoint.cs
+++ b/src/ServiceControl.Audit.Persistence/Monitoring/KnownEndpoint.cs
@@ -15,6 +15,8 @@
 
         public DateTime LastSeen { get; set; }
 
+        public string NServiceBusVersion { get; set; }
+
         public static string MakeDocumentId(string endpointName, Guid endpointHostId)
         {
             return $"{CollectionName}/{DeterministicGuid.MakeId(endpointName, endpointHostId.ToString())}";

--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -182,6 +182,7 @@
                     HostId = observedEndpoint.HostId,
                     LastSeen = processedMessage.ProcessedAt,
                     Name = observedEndpoint.Name,
+                    NServiceBusVersion = observedEndpoint.NServiceBusVersion,
                     Id = KnownEndpoint.MakeDocumentId(observedEndpoint.Name, observedEndpoint.HostId),
                 };
                 observedEndpoints.Add(uniqueEndpointId, knownEndpoint);

--- a/src/ServiceControl.Audit/Monitoring/EndpointDetailsParser.cs
+++ b/src/ServiceControl.Audit/Monitoring/EndpointDetailsParser.cs
@@ -14,6 +14,7 @@ namespace ServiceControl.Audit.Monitoring
             DictionaryExtensions.CheckIfKeyExists(Headers.OriginatingEndpoint, headers, s => endpointDetails.Name = s);
             DictionaryExtensions.CheckIfKeyExists("NServiceBus.OriginatingMachine", headers, s => endpointDetails.Host = s);
             DictionaryExtensions.CheckIfKeyExists(Headers.OriginatingHostId, headers, s => endpointDetails.HostId = Guid.Parse(s));
+            DictionaryExtensions.CheckIfKeyExists(Headers.NServiceBusVersion, headers, s => endpointDetails.NServiceBusVersion = s);
 
             if (!string.IsNullOrEmpty(endpointDetails.Name) && !string.IsNullOrEmpty(endpointDetails.Host))
             {
@@ -53,6 +54,7 @@ namespace ServiceControl.Audit.Monitoring
             }
 
             DictionaryExtensions.CheckIfKeyExists(Headers.ProcessingEndpoint, headers, s => endpoint.Name = s);
+            DictionaryExtensions.CheckIfKeyExists(Headers.NServiceBusVersion, headers, s => endpoint.NServiceBusVersion = s);
 
             if (!string.IsNullOrEmpty(endpoint.Name) && !string.IsNullOrEmpty(endpoint.Host))
             {

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_endpoint_known_to_audit_instance.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_endpoint_known_to_audit_instance.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.MultiInstance.AcceptanceTests.Auditing
 {
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -39,7 +40,9 @@
             var knownEndpoint = knownEndpoints.FirstOrDefault(x => x.EndpointDetails.Name == Conventions.EndpointNamingConvention(typeof(Sender)));
 
             Assert.IsNotNull(knownEndpoint);
-            Assert.AreEqual("1.0.0", knownEndpoint.EndpointDetails.NServiceBusVersion);
+
+            var nsbFileVersion = FileVersionInfo.GetVersionInfo(typeof(IMessageHandlerContext).Assembly.Location);
+            Assert.AreEqual($"{nsbFileVersion.FileMajorPart}.{nsbFileVersion.FileMinorPart}.{nsbFileVersion.FileBuildPart}", knownEndpoint.EndpointDetails.NServiceBusVersion);
         }
 
         class SomeMessage : IMessage

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_endpoint_known_to_audit_instance.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_endpoint_known_to_audit_instance.cs
@@ -33,9 +33,13 @@
                     return result.HasResult;
                 })
                 .Run();
+
             Assert.AreEqual(1, knownEndpoints.Count);
+
             var knownEndpoint = knownEndpoints.FirstOrDefault(x => x.EndpointDetails.Name == Conventions.EndpointNamingConvention(typeof(Sender)));
+
             Assert.IsNotNull(knownEndpoint);
+            Assert.AreEqual("1.0.0", knownEndpoint.EndpointDetails.NServiceBusVersion);
         }
 
         class SomeMessage : IMessage

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -437,6 +437,7 @@ namespace ServiceControl.Contracts.Operations
         public EndpointDetails() { }
         public string Host { get; set; }
         public System.Guid HostId { get; set; }
+        public string NServiceBusVersion { get; set; }
         public string Name { get; set; }
         public System.Guid GetDeterministicId() { }
     }

--- a/src/ServiceControl/Contracts/Operations/EndpointDetails.cs
+++ b/src/ServiceControl/Contracts/Operations/EndpointDetails.cs
@@ -11,6 +11,8 @@ namespace ServiceControl.Contracts.Operations
 
         public string Host { get; set; }
 
+        public string NServiceBusVersion { get; set; }
+
         public Guid GetDeterministicId() => DeterministicGuid.MakeId(Name, HostId.ToString());
     }
 }

--- a/src/ServiceControl/CustomChecks/InternalCustomChecks/InternalCustomChecksHostedService.cs
+++ b/src/ServiceControl/CustomChecks/InternalCustomChecks/InternalCustomChecksHostedService.cs
@@ -6,7 +6,6 @@
     using System.Threading.Tasks;
     using Contracts.Operations;
     using Infrastructure.BackgroundTasks;
-    using Infrastructure.DomainEvents;
     using Microsoft.Extensions.Hosting;
     using NServiceBus.CustomChecks;
     using NServiceBus.Hosting;

--- a/src/ServiceControl/Monitoring/KnownEndpointIndex.cs
+++ b/src/ServiceControl/Monitoring/KnownEndpointIndex.cs
@@ -9,14 +9,14 @@ namespace ServiceControl.Audit.Monitoring
         public KnownEndpointIndex()
         {
             Map = knownEndpoints => from knownEndpoint in knownEndpoints
-                              select new
-                              {
-                                  EndpointDetails_Name = knownEndpoint.EndpointDetails.Name,
-                                  EndpointDetails_Host = knownEndpoint.EndpointDetails.Host,
-                                  knownEndpoint.HostDisplayName,
-                                  knownEndpoint.Monitored,
-                                  knownEndpoint.HasTemporaryId
-                              };
+                                    select new
+                                    {
+                                        EndpointDetails_Name = knownEndpoint.EndpointDetails.Name,
+                                        EndpointDetails_Host = knownEndpoint.EndpointDetails.Host,
+                                        knownEndpoint.HostDisplayName,
+                                        knownEndpoint.Monitored,
+                                        knownEndpoint.HasTemporaryId
+                                    };
 
             DisableInMemoryIndexing = true;
         }

--- a/src/ServiceControl/Monitoring/KnownEndpointIndex.cs
+++ b/src/ServiceControl/Monitoring/KnownEndpointIndex.cs
@@ -8,14 +8,14 @@ namespace ServiceControl.Audit.Monitoring
     {
         public KnownEndpointIndex()
         {
-            Map = messages => from message in messages
+            Map = knownEndpoints => from knownEndpoint in knownEndpoints
                               select new
                               {
-                                  EndpointDetails_Name = message.EndpointDetails.Name,
-                                  EndpointDetails_Host = message.EndpointDetails.Host,
-                                  message.HostDisplayName,
-                                  message.Monitored,
-                                  message.HasTemporaryId
+                                  EndpointDetails_Name = knownEndpoint.EndpointDetails.Name,
+                                  EndpointDetails_Host = knownEndpoint.EndpointDetails.Host,
+                                  knownEndpoint.HostDisplayName,
+                                  knownEndpoint.Monitored,
+                                  knownEndpoint.HasTemporaryId
                               };
 
             DisableInMemoryIndexing = true;


### PR DESCRIPTION
Just a spike to demo how to extract nsb versions of endpoints from the audit stream.

Other sources: Errors, heartbeats and custom checks