### PR TITLE
Set EventAggregator in LicenseViewModel

### DIFF
--- a/src/ServiceControl.Config/UI/License/LicenseViewModel.cs
+++ b/src/ServiceControl.Config/UI/License/LicenseViewModel.cs
@@ -13,6 +13,11 @@
 
     class LicenseViewModel : RxScreen
     {
+        public LicenseViewModel(IEventAggregator eventAggregator)
+        {
+            EventAggregator = eventAggregator;
+        }
+
         public string ApplyLicenseError { get; set; }
 
         public string ApplyLicenseSuccess { get; set; }
@@ -51,7 +56,9 @@
                 ApplyLicenseError = null;
                 RefreshLicenseInfo();
                 ApplyLicenseSuccess = "License imported successfully";
+
                 await EventAggregator.PublishOnUIThreadAsync(new LicenseUpdated());
+
             }
             else
             {


### PR DESCRIPTION
When updating the license file in SCMU a Null Reference Exception is thrown due to the EventAggregator being null.  This PR reverts part of a [prior change](https://github.com/Particular/ServiceControl/pull/3013) where the constructor was removed.