### PR TITLE
Allow valid service names

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModel.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Runtime.InteropServices.WindowsRuntime;
     using System.Windows.Input;
     using Framework.Rx;
     using PropertyChanged;

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedServiceControlEditorViewModel.cs
@@ -155,18 +155,9 @@
 
             instanceName += !string.IsNullOrEmpty(suggestedName) ? validServiceName : serviceBaseName;
 
-            instanceName = instanceName.Trim();
-
-            instanceName = RemoveIllegalCharacters(instanceName);
-
-            instanceName = RemoveInvalidFileNameCharacters(instanceName);
+            instanceName = SanitizeServiceName(instanceName);
 
             return instanceName;
-        }
-
-        protected string RemoveIllegalCharacters(string name)
-        {
-            return name?.Replace(' ', '.');
         }
 
         protected int GetInstalledInstancesCount()
@@ -186,6 +177,11 @@
                     return i;
                 }
             }
+        }
+
+        static string RemoveIllegalCharacters(string name)
+        {
+            return name?.Replace(' ', '.');
         }
 
         //Valid service names use only ascii characters between 32-127 and not / or \ 
@@ -236,6 +232,17 @@
             name = name.TrimEnd('.');
 
             return name;
+        }
+
+        static string SanitizeServiceName(string serviceName)
+        {
+            serviceName = serviceName.Trim();
+
+            serviceName = RemoveIllegalCharacters(serviceName);
+
+            serviceName = RemoveInvalidFileNameCharacters(serviceName);
+
+            return serviceName;
         }
 
         string hostName;


### PR DESCRIPTION
Fixes 
- #1767 

This PR does a few things. 
- It allows for the user's specified casing to be used. 
- Removes any characters not valid in service names
- Removes characters not valid in file names and paths. 