### PR TITLE
Update to WiX Toolset v4

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,10 @@
 <Project>
+
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
+
   <ItemGroup Label="Versions for direct package references">
     <PackageVersion Include="Autofac" Version="6.5.0" />
     <PackageVersion Include="Azure.Identity" Version="1.8.2" />
@@ -39,7 +41,7 @@
     <PackageVersion Include="NServiceBus.Extensions.DependencyInjection" Version="1.1.0" />
     <PackageVersion Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
     <PackageVersion Include="NServiceBus.Extensions.Logging" Version="1.0.0" />
-    <PackageVersion Include="NServiceBus.Heartbeat" Version="3.0.1" />    
+    <PackageVersion Include="NServiceBus.Heartbeat" Version="3.0.1" />
     <PackageVersion Include="NServiceBus.Metrics" Version="3.1.0" />
     <PackageVersion Include="NServiceBus.Metrics.ServiceControl" Version="3.0.6" />
     <PackageVersion Include="NServiceBus.Metrics.ServiceControl.Msmq" Version="3.0.1" />
@@ -75,8 +77,9 @@
     <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
     <PackageVersion Include="Validar.Fody" Version="1.9.0" />
     <PackageVersion Include="Windows7APICodePack-Shell" Version="1.1.0" />
-    <PackageVersion Include="WiX" Version="3.11.2" />
+    <PackageVersion Include="WixToolset.Dtf.CustomAction" Version="4.0.0" />
   </ItemGroup>
+
   <ItemGroup Label="Versions to pin transitive references">
     <PackageVersion Include="Microsoft.Owin.Hosting" Version="4.2.2" />
     <PackageVersion Include="NServiceBus.Newtonsoft.Json" Version="2.4.0" />
@@ -85,8 +88,10 @@
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
+
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="4.2.0" />
     <GlobalPackageReference Include="Particular.Packaging" Version="2.3.0" />
   </ItemGroup>
+
 </Project>

--- a/src/ServiceControlInstaller.CustomActions/CustomActionsInstall.cs
+++ b/src/ServiceControlInstaller.CustomActions/CustomActionsInstall.cs
@@ -8,9 +8,9 @@
     using Engine.Configuration.ServiceControl;
     using Engine.FileSystem;
     using Engine.Instances;
-    using ServiceControl.LicenseManagement;
     using Engine.Unattended;
-    using Microsoft.Deployment.WindowsInstaller;
+    using ServiceControl.LicenseManagement;
+    using WixToolset.Dtf.WindowsInstaller;
 
     public class CustomActionsInstall
     {

--- a/src/ServiceControlInstaller.CustomActions/CustomActionsMigration.cs
+++ b/src/ServiceControlInstaller.CustomActions/CustomActionsMigration.cs
@@ -5,8 +5,8 @@
     using System.Linq;
     using Engine;
     using Extensions;
-    using Microsoft.Deployment.WindowsInstaller;
     using Microsoft.Win32;
+    using WixToolset.Dtf.WindowsInstaller;
 
     public class CustomActionsMigrations
     {
@@ -141,9 +141,9 @@
 
         // This list does not need to be updated beyond version 1.6.3
         // After 1.6.3 a new MSI product code was used. This was done at the introduction of the management app.
-        // The older versions of the MSI handled install and uninstall of a single service, if we'd used the same MSI product code then the 
+        // The older versions of the MSI handled install and uninstall of a single service, if we'd used the same MSI product code then the
         // installation of the management app would have also uninstalled existing ServiceControl instances.
-        // Instead this custom action removes the registry entries that indicate the old MSI was installed.  
+        // Instead this custom action removes the registry entries that indicate the old MSI was installed.
         // Add/Remove/Upgrade of the services is all done by the app now.
         static readonly Dictionary<string, string> oldProducts = new Dictionary<string, string>
         {

--- a/src/ServiceControlInstaller.CustomActions/CustomActionsPowerShell.cs
+++ b/src/ServiceControlInstaller.CustomActions/CustomActionsPowerShell.cs
@@ -3,7 +3,7 @@ namespace ServiceControlInstaller.CustomActions
     using System;
     using System.Linq;
     using System.Runtime.InteropServices;
-    using Microsoft.Deployment.WindowsInstaller;
+    using WixToolset.Dtf.WindowsInstaller;
 
     public class CustomActionsPowerShell
     {

--- a/src/ServiceControlInstaller.CustomActions/CustomActionsUninstall.cs
+++ b/src/ServiceControlInstaller.CustomActions/CustomActionsUninstall.cs
@@ -3,7 +3,7 @@
     using System;
     using Engine.Instances;
     using Engine.Unattended;
-    using Microsoft.Deployment.WindowsInstaller;
+    using WixToolset.Dtf.WindowsInstaller;
 
     public class CustomActionsUninstall
     {

--- a/src/ServiceControlInstaller.CustomActions/MSILogger.cs
+++ b/src/ServiceControlInstaller.CustomActions/MSILogger.cs
@@ -1,7 +1,7 @@
 ﻿namespace ServiceControlInstaller.CustomActions
 {
     using Engine;
-    using Microsoft.Deployment.WindowsInstaller;
+    using WixToolset.Dtf.WindowsInstaller;
 
     public class MSILogger : ILogging
     {

--- a/src/ServiceControlInstaller.CustomActions/ServiceControlInstaller.CustomActions.csproj
+++ b/src/ServiceControlInstaller.CustomActions/ServiceControlInstaller.CustomActions.csproj
@@ -9,30 +9,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Deployment.WindowsInstaller" HintPath="$(WixSdkPath)Microsoft.Deployment.WindowsInstaller.dll" />
+    <PackageReference Include="WixToolset.Dtf.CustomAction" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WiX" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove=".editorconfig" />
     <None Remove="CustomAction.config" />
     <Content Include="CustomAction.config" />
   </ItemGroup>
-
-  <!-- Workaround needed because importing WiX targets file below is too early for $(TargetName) and $(TargetExt) to be defined -->
-  <PropertyGroup>
-    <TargetCAFileName>ServiceControlInstaller.CustomActions.CA.dll</TargetCAFileName>
-  </PropertyGroup>
-  <!-- End workaround -->
-
-  <Import Project="$(WixCATargetsPath)" Condition="Exists('$(WixCATargetsPath)')" />
-
-  <!-- Workaround needed because WiX targets don't currently work with SDK projects -->
-  <Target Name="CleanCAFile" DependsOnTargets="CleanCustomAction" BeforeTargets="CoreClean" Condition="'$(DesignTimeBuild)' != 'true'" />
-  <Target Name="CreateCAFile" DependsOnTargets="PackCustomAction" AfterTargets="CoreCompile" Condition="'$(DesignTimeBuild)' != 'true'" />
-  <!-- End workaround -->
 
 </Project>


### PR DESCRIPTION
This PR updates the ServiceControlInstaller.CustomActions project to use WiX Toolset v4, which finally supports SDK projects and no longer requires .NET Framework 3.5 to build.

