### PR TITLE
Streamline artifacts dependencies by coping transports and persisters binaries from the artifacts folder and not from the various output folders

### DIFF
--- a/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
@@ -14,9 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="..\ServiceControl.Audit.Persistence.InMemory\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Persisters\InMemory\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Audit.Persistence.RavenDb\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Persisters\RavenDB35\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Audit.Persistence.RavenDb5\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Persisters\RavenDB5\%(RecursiveDir)" />
+    <Artifact Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters" DestinationFolder="$(OutputPath)\Persisters\%(RecursiveDir)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports.Tests/ServiceControl.Transports.Tests.csproj
+++ b/src/ServiceControl.Transports.Tests/ServiceControl.Transports.Tests.csproj
@@ -20,14 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="..\ServiceControl.Transports.ASBS\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\NetStandardAzureServiceBus\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Transports.ASQ\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\AzureStorageQueue\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Transports.Learning\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\LearningTransport\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Transports.Msmq\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\MSMQ\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Transports.RabbitMQ\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\RabbitMQ\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Transports.SqlServer\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\SQLServer\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Transports.SQS\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\AmazonSQS\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Transports.ASB\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\AzureServiceBus\%(RecursiveDir)" />
+    <!-- The following assumes transports are the same for every instance type. Coping the transports binaries from the primary instance artifacts folder -->
+    <Artifact Include="$(ArtifactsPath)Particular.ServiceControl\Transports" DestinationFolder="$(OutputPath)\Transports\%(RecursiveDir)" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Replaces https://github.com/Particular/ServiceControl/pull/3541