### PR TITLE
Streamline project references

### DIFF
--- a/src/Persisters.Audit.Artifacts.Includes.props
+++ b/src/Persisters.Audit.Artifacts.Includes.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup Label="Persisters">
+	<Artifact Include="..\ServiceControl.Audit.Persistence.InMemory\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Persisters\InMemory\%(RecursiveDir)" />
+	<Artifact Include="..\ServiceControl.Audit.Persistence.RavenDb\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Persisters\RavenDB35\%(RecursiveDir)" />
+	<Artifact Include="..\ServiceControl.Audit.Persistence.RavenDb5\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Persisters\RavenDB5\%(RecursiveDir)" />
+  </ItemGroup>
+</Project>

--- a/src/Persisters.Audit.Includes.props
+++ b/src/Persisters.Audit.Includes.props
@@ -1,15 +1,7 @@
 <Project>
-
-    <!--NOTE: Changes to this file should be reflected in ServiceControl.Audit.Persistence.Tests -->
-	<ItemGroup Label="Persisters">
+  <ItemGroup Label="Persisters">
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.InMemory\ServiceControl.Audit.Persistence.InMemory.csproj" ReferenceOutputAssembly="false" Private="false" />
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb\ServiceControl.Audit.Persistence.RavenDb.csproj" ReferenceOutputAssembly="false" Private="false" />
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb5\ServiceControl.Audit.Persistence.RavenDb5.csproj" ReferenceOutputAssembly="false" Private="false" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Artifact Include="..\ServiceControl.Audit.Persistence.InMemory\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Persisters\InMemory\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Audit.Persistence.RavenDb\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Persisters\RavenDB35\%(RecursiveDir)" />
-    <Artifact Include="..\ServiceControl.Audit.Persistence.RavenDb5\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Persisters\RavenDB5\%(RecursiveDir)" />
   </ItemGroup>
 </Project>

--- a/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
@@ -9,8 +9,6 @@
   <ItemGroup Label="Persisters">
     <!--NOTE: We need a direct reference to InMemory for test configuration -->
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.InMemory\ServiceControl.Audit.Persistence.InMemory.csproj" ReferenceOutputAssembly="true" Private="true" />
-    <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb\ServiceControl.Audit.Persistence.RavenDb.csproj" ReferenceOutputAssembly="false" Private="false" />
-    <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb5\ServiceControl.Audit.Persistence.RavenDb5.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.InMemory\ServiceControl.Audit.Persistence.InMemory.csproj" ReferenceOutputAssembly="true" Private="true" />
   </ItemGroup>
 
+  <!-- NOTE: Not using Persisters.Audit.Artifacts.Includes.props to avoid race conditions-->
   <ItemGroup>
     <Artifact Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters" DestinationFolder="$(OutputPath)\Persisters\%(RecursiveDir)" />
   </ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
-  <!-- NOTE: cannot rely on import because we need a direct reference to InMemory -->
-  <!--<Import Project="..\Persisters.Audit.Includes.props" />-->
+  
+  <Import Project="..\Persisters.Audit.Includes.props" />
 
   <ItemGroup Label="Persisters">
     <!--NOTE: We need a direct reference to InMemory for test configuration -->

--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <Import Project="..\Transports.Includes.props" />
+  <Import Project="..\Transports.Artifacts.Includes.props" />
   <Import Project="..\Persisters.Audit.Includes.props" />
+  <Import Project="..\Persisters.Audit.Artifacts.Includes.props" />  
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit.Persistence\ServiceControl.Audit.Persistence.csproj" />

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <Import Project="..\Transports.Includes.props" />
+  <Import Project="..\Transports.Artifacts.Includes.props" />  
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj" />

--- a/src/ServiceControl.Transports.Tests/ServiceControl.Transports.Tests.csproj
+++ b/src/ServiceControl.Transports.Tests/ServiceControl.Transports.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
@@ -7,15 +7,8 @@
   <Import Project="..\Transports.Includes.props" />
 
   <ItemGroup Label="Transports">
-    <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" ReferenceOutputAssembly="false" Private="false" />
-    <ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" ReferenceOutputAssembly="false" Private="false" />
-    <ProjectReference Include="..\ServiceControl.Transports.ASQ\ServiceControl.Transports.ASQ.csproj" ReferenceOutputAssembly="false" Private="false" />
     <!--NOTE: We need a direct reference to Learning transport for test configuration -->
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" ReferenceOutputAssembly="true" Private="true" />
-    <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" ReferenceOutputAssembly="false" Private="false" />
-    <ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" ReferenceOutputAssembly="false" Private="false" />
-    <ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" ReferenceOutputAssembly="false" Private="false" />
-    <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports.Tests/ServiceControl.Transports.Tests.csproj
+++ b/src/ServiceControl.Transports.Tests/ServiceControl.Transports.Tests.csproj
@@ -1,11 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
-  <!-- NOTE: cannot rely on import because we need a direct reference to Learning transport -->
-  <!--<Import Project="..\Transports.Includes.props" />-->
+  <Import Project="..\Transports.Includes.props" />
 
   <ItemGroup Label="Transports">
     <ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" ReferenceOutputAssembly="false" Private="false" />

--- a/src/ServiceControl.Transports.Tests/ServiceControl.Transports.Tests.csproj
+++ b/src/ServiceControl.Transports.Tests/ServiceControl.Transports.Tests.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" ReferenceOutputAssembly="true" Private="true" />
   </ItemGroup>
 
+  <!-- NOTE: Not using Transports.Artifacts.Includes.props to avoid race conditions-->
   <ItemGroup>
     <!-- The following assumes transports are the same for every instance type. Coping the transports binaries from the primary instance artifacts folder -->
     <Artifact Include="$(ArtifactsPath)Particular.ServiceControl\Transports" DestinationFolder="$(OutputPath)\Transports\%(RecursiveDir)" />

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -48,9 +48,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		..\.github\workflows\ci.yml = ..\.github\workflows\ci.yml
 		Custom.Build.props = Custom.Build.props
-		Directory.Packages.props = Directory.Packages.props
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
+		Persisters.Audit.Artifacts.Includes.props = Persisters.Audit.Artifacts.Includes.props
 		Persisters.Audit.Includes.props = Persisters.Audit.Includes.props
+		Transports.Artifacts.Includes.props = Transports.Artifacts.Includes.props
 		Transports.Includes.props = Transports.Includes.props
 	EndProjectSection
 EndProject

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <Import Project="..\Transports.Includes.props" />
-
+  <Import Project="..\Transports.Artifacts.Includes.props" />  
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Configuration\ServiceControl.Configuration.csproj" />

--- a/src/Transports.Artifacts.Includes.props
+++ b/src/Transports.Artifacts.Includes.props
@@ -1,0 +1,12 @@
+<Project>
+	<ItemGroup Label="Transports">
+		<Artifact Include="..\ServiceControl.Transports.ASBS\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\NetStandardAzureServiceBus\%(RecursiveDir)" />
+		<Artifact Include="..\ServiceControl.Transports.ASQ\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\AzureStorageQueue\%(RecursiveDir)" />
+		<Artifact Include="..\ServiceControl.Transports.Learning\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\LearningTransport\%(RecursiveDir)" />
+		<Artifact Include="..\ServiceControl.Transports.Msmq\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\MSMQ\%(RecursiveDir)" />
+		<Artifact Include="..\ServiceControl.Transports.RabbitMQ\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\RabbitMQ\%(RecursiveDir)" />
+		<Artifact Include="..\ServiceControl.Transports.SqlServer\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\SQLServer\%(RecursiveDir)" />
+		<Artifact Include="..\ServiceControl.Transports.SQS\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\AmazonSQS\%(RecursiveDir)" />
+		<Artifact Include="..\ServiceControl.Transports.ASB\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\AzureServiceBus\%(RecursiveDir)" />
+	</ItemGroup>
+</Project>

--- a/src/Transports.Includes.props
+++ b/src/Transports.Includes.props
@@ -1,6 +1,4 @@
 <Project>
-	<!--NOTE: Changes to this file should be reflected in ServiceControl.Transports.Tests -->
-
 	<ItemGroup Label="Transports">
 		<ProjectReference Include="..\ServiceControl.Transports.ASB\ServiceControl.Transports.ASB.csproj" ReferenceOutputAssembly="false" Private="false" />
 		<ProjectReference Include="..\ServiceControl.Transports.ASBS\ServiceControl.Transports.ASBS.csproj" ReferenceOutputAssembly="false" Private="false" />
@@ -10,16 +8,5 @@
 		<ProjectReference Include="..\ServiceControl.Transports.RabbitMQ\ServiceControl.Transports.RabbitMQ.csproj" ReferenceOutputAssembly="false" Private="false" />
 		<ProjectReference Include="..\ServiceControl.Transports.SqlServer\ServiceControl.Transports.SqlServer.csproj" ReferenceOutputAssembly="false" Private="false" />
 		<ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" ReferenceOutputAssembly="false" Private="false" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Artifact Include="..\ServiceControl.Transports.ASBS\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\NetStandardAzureServiceBus\%(RecursiveDir)" />
-		<Artifact Include="..\ServiceControl.Transports.ASQ\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\AzureStorageQueue\%(RecursiveDir)" />
-		<Artifact Include="..\ServiceControl.Transports.Learning\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\LearningTransport\%(RecursiveDir)" />
-		<Artifact Include="..\ServiceControl.Transports.Msmq\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\MSMQ\%(RecursiveDir)" />
-		<Artifact Include="..\ServiceControl.Transports.RabbitMQ\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\RabbitMQ\%(RecursiveDir)" />
-		<Artifact Include="..\ServiceControl.Transports.SqlServer\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\SQLServer\%(RecursiveDir)" />
-		<Artifact Include="..\ServiceControl.Transports.SQS\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\AmazonSQS\%(RecursiveDir)" />
-		<Artifact Include="..\ServiceControl.Transports.ASB\bin\$(Configuration)\$(TargetFramework)\**\*.*" DestinationFolder="$(OutputPath)\Transports\AzureServiceBus\%(RecursiveDir)" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This PR reduces to the minimum required dependencies between `Audit.Persister.Tests` and the various persisters, and `Transports.Tests` and the various transports.

The reasoning is that:

- Persisters and transports, each time they are built, copy their artifacts to the `deploy` folder in the repo root
- The mentioned tests projects copy the required artifacts from the `deploy` folder
- The only requirements are:
  - Transports are built _before_ the `Transports.Tests` -> satisfied by the `Transports.Includes.props` referenced by the test project
  - Persisters are built _before_ `Audit.Persister.Tests` -> satisfied by the `Persisters.Includes.props` referenced by the test project