### PR TITLE
Use attributes to ignore tests instead of filtering by category

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,14 @@ jobs:
           # Cleanup of queues starting with `GHA-` handled by https://github.com/Particular/NServiceBus.AmazonSQS/blob/master/.github/workflows/tests-cleanup.yml
           $connectString = "AccessKeyId=${{ secrets.AWS_ACCESS_KEY_ID }};SecretAccessKey=${{ secrets.AWS_SECRET_ACCESS_KEY }};Region=${{ secrets.AWS_REGION }};QueueNamePrefix=GHA-${{ github.run_id }}"
           echo "ServiceControl.TransportTests.SQS.ConnectionString=$connectString" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-      - name: Set test category filter
+      - name: Set test filter
         shell: pwsh
         run: |
           if('${{ matrix.test-category }}' -eq 'Default'){
-            echo "TEST_FILTER=TestCategory!~Transports." | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+            echo "TEST_FILTER=${{ matrix.test-category }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
           else{
-            echo "TEST_FILTER=TestCategory=Transports.${{ matrix.test-category }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+            echo "TEST_FILTER=Transports.${{ matrix.test-category }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
       - name: Run tests
         uses: Particular/run-tests-action@v1.5.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Run tests
         uses: Particular/run-tests-action@v1.5.0
         env:
-          TEST_FILTER: ${{ matrix.test-category }}
+          ServiceControl_TESTS_FILTER: ${{ matrix.test-category }}
           ServiceControl/LicenseText: ${{ secrets.LICENSETEXT }}
           ServiceControl.Audit/LicenseText: ${{ secrets.LICENSETEXT }}
           Monitoring/LicenseText: ${{ secrets.LICENSETEXT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,18 +95,10 @@ jobs:
           # Cleanup of queues starting with `GHA-` handled by https://github.com/Particular/NServiceBus.AmazonSQS/blob/master/.github/workflows/tests-cleanup.yml
           $connectString = "AccessKeyId=${{ secrets.AWS_ACCESS_KEY_ID }};SecretAccessKey=${{ secrets.AWS_SECRET_ACCESS_KEY }};Region=${{ secrets.AWS_REGION }};QueueNamePrefix=GHA-${{ github.run_id }}"
           echo "ServiceControl.TransportTests.SQS.ConnectionString=$connectString" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-      - name: Set test filter
-        shell: pwsh
-        run: |
-          if('${{ matrix.test-category }}' -eq 'Default'){
-            echo "TEST_FILTER=${{ matrix.test-category }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          }
-          else{
-            echo "TEST_FILTER=Transports.${{ matrix.test-category }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          }
       - name: Run tests
         uses: Particular/run-tests-action@v1.5.0
         env:
+          TEST_FILTER: ${{ matrix.test-category }}
           ServiceControl/LicenseText: ${{ secrets.LICENSETEXT }}
           ServiceControl.Audit/LicenseText: ${{ secrets.LICENSETEXT }}
           Monitoring/LicenseText: ${{ secrets.LICENSETEXT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,6 @@ jobs:
           }
       - name: Run tests
         uses: Particular/run-tests-action@v1.5.0
-        with:
-          filter: ${{ env.TEST_FILTER }}
         env:
           ServiceControl/LicenseText: ${{ secrets.LICENSETEXT }}
           ServiceControl.Audit/LicenseText: ${{ secrets.LICENSETEXT }}

--- a/README.md
+++ b/README.md
@@ -59,12 +59,27 @@ Testing using the [CI workflow](/.github/workflows/ci.yml) depends on the follow
 * `AWS_REGION`: For testing SQS
 
 ## Running the Tests
+
+Running all tests all the times takes a lot of resources. Tests are filtered based on the `TEST_FILTER` environment variable. If no variable is defined no tests will be run. To run a transport tests, e.g., SQS, define the variable as `TEST_FILTER=Transports.SQS`. The `TEST_FILTER` variable supports multiple values, semi-colon separated. For example, to run SQS tests and all default tests not transport specific define the variable as `TEST_FILTER=Transports.SQS;Default`. Using the same approach to run SQS and ASB tests define the variable as `TEST_FILTER=Transports.SQS;Transports.AzureServiceBus`. The following list contains all the possible `TEST_FILTER` values:
+
+- `All` - runs all tests
+- `Default` - runs only non-transport-specific tests
+- `Transports.AzureServiceBus`
+- `Transports.AzureStorageQueues`
+- `Transports.MSMQ`
+- `Transports.RabbitMQ`
+- `Transports.SqlServer`
+- `Transports.SQS`
+
+### Use the x64 test agent
+
 The tests need to be run in x64 otherwise an exception about RavenDB (Voron) not being supported in 32bit mode will be thrown.
 The ServiceControl.runsettings file in each test project should automatically ensure that tests are run in 64 bit mode.  For reference, there is also a setting in Visual Studio that can be used to ensure test execution is using x64 only: 
 
 ![image](https://user-images.githubusercontent.com/4316196/177248330-c7357e85-b7a1-4cec-992f-535b1e9a0cb4.png)
 
 ### Integration Tests
+
 ًBy default integration tests use `MSMQ` transport to run. This can be overridden by renaming the `_connection.txt` file in the root of the solution to `connection.txt` and updating the transport type and connection string.
 Only the first 3 lines of this file are read with the following information:
 - First line is the Transport name

--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ Testing using the [CI workflow](/.github/workflows/ci.yml) depends on the follow
 
 ## Running the Tests
 
-Running all tests all the times takes a lot of resources. Tests are filtered based on the `ServiceControl_TESTS_FILTER` environment variable. If no variable is defined no tests will be run. To run a transport tests, e.g., SQS, define the variable as `ServiceControl_TESTS_FILTER=SQS`. The following list contains all the possible `ServiceControl_TESTS_FILTER` values:
+Running all tests all the times takes a lot of resources. Tests are filtered based on the `ServiceControl_TESTS_FILTER` environment variable. To run only a subset, e.g., SQS transport tests, define the variable as `ServiceControl_TESTS_FILTER=SQS`. The following list contains all the possible `ServiceControl_TESTS_FILTER` values:
 
-- `All` - runs all tests
 - `Default` - runs only non-transport-specific tests
 - `AzureServiceBus`
 - `AzureStorageQueues`
@@ -70,6 +69,8 @@ Running all tests all the times takes a lot of resources. Tests are filtered bas
 - `RabbitMQ`
 - `SqlServer`
 - `SQS`
+
+NOTE: If no variable is defined all tests will be executed.
 
 ### Use the x64 test agent
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ Testing using the [CI workflow](/.github/workflows/ci.yml) depends on the follow
 
 ## Running the Tests
 
-Running all tests all the times takes a lot of resources. Tests are filtered based on the `TEST_FILTER` environment variable. If no variable is defined no tests will be run. To run a transport tests, e.g., SQS, define the variable as `TEST_FILTER=SQS`. The following list contains all the possible `TEST_FILTER` values:
+Running all tests all the times takes a lot of resources. Tests are filtered based on the `ServiceControl_TESTS_FILTER` environment variable. If no variable is defined no tests will be run. To run a transport tests, e.g., SQS, define the variable as `ServiceControl_TESTS_FILTER=SQS`. The following list contains all the possible `ServiceControl_TESTS_FILTER` values:
 
 - `All` - runs all tests
 - `Default` - runs only non-transport-specific tests
-- `Transports.AzureServiceBus`
-- `Transports.AzureStorageQueues`
-- `Transports.MSMQ`
-- `Transports.RabbitMQ`
-- `Transports.SqlServer`
-- `Transports.SQS`
+- `AzureServiceBus`
+- `AzureStorageQueues`
+- `MSMQ`
+- `RabbitMQ`
+- `SqlServer`
+- `SQS`
 
 ### Use the x64 test agent
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Testing using the [CI workflow](/.github/workflows/ci.yml) depends on the follow
 
 ## Running the Tests
 
-Running all tests all the times takes a lot of resources. Tests are filtered based on the `TEST_FILTER` environment variable. If no variable is defined no tests will be run. To run a transport tests, e.g., SQS, define the variable as `TEST_FILTER=Transports.SQS`. The `TEST_FILTER` variable supports multiple values, semi-colon separated. For example, to run SQS tests and all default tests not transport specific define the variable as `TEST_FILTER=Transports.SQS;Default`. Using the same approach to run SQS and ASB tests define the variable as `TEST_FILTER=Transports.SQS;Transports.AzureServiceBus`. The following list contains all the possible `TEST_FILTER` values:
+Running all tests all the times takes a lot of resources. Tests are filtered based on the `TEST_FILTER` environment variable. If no variable is defined no tests will be run. To run a transport tests, e.g., SQS, define the variable as `TEST_FILTER=SQS`. The following list contains all the possible `TEST_FILTER` values:
 
 - `All` - runs all tests
 - `Default` - runs only non-transport-specific tests

--- a/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
+++ b/src/ServiceControl.AcceptanceTests/ServiceControl.AcceptanceTests.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\ServiceControl.Persistence.SqlServer\ServiceControl.Persistence.SqlServer.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.AcceptanceTests/TestsFilter.cs
+++ b/src/ServiceControl.AcceptanceTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.AcceptanceTests/TestsFilter.cs
+++ b/src/ServiceControl.AcceptanceTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/ServiceControl.Audit.AcceptanceTests.RavenDB.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/ServiceControl.Audit.AcceptanceTests.RavenDB.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <Compile Include="..\ServiceControl.Audit.AcceptanceTests\**\*.cs" Exclude="..\ServiceControl.Audit.AcceptanceTests\AcceptanceTestStorageConfiguration.cs;..\ServiceControl.Audit.AcceptanceTests\obj\**\*.*;..\ServiceControl.Audit.AcceptanceTests\bin\**\*.*" />
+    <Compile Remove="..\ServiceControl.Audit.AcceptanceTests\TestsFilter.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/ServiceControl.Audit.AcceptanceTests.RavenDB.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/ServiceControl.Audit.AcceptanceTests.RavenDB.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb\ServiceControl.Audit.Persistence.RavenDb.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/TestsFilter.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/TestsFilter.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/ServiceControl.Audit.AcceptanceTests.RavenDB5.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/ServiceControl.Audit.AcceptanceTests.RavenDB5.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb5\ServiceControl.Audit.Persistence.RavenDb5.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/ServiceControl.Audit.AcceptanceTests.RavenDB5.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/ServiceControl.Audit.AcceptanceTests.RavenDB5.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Audit.AcceptanceTests\**\*.cs" Exclude="..\ServiceControl.Audit.AcceptanceTests\AcceptanceTestStorageConfiguration.cs;..\ServiceControl.Audit.AcceptanceTests\obj\**\*.*;..\ServiceControl.Audit.AcceptanceTests\bin\**\*.*" />
     <Compile Include="..\ServiceControl.Audit.Persistence.Tests.RavenDb5\SharedEmbeddedServer.cs" />
+    <Compile Remove="..\ServiceControl.Audit.AcceptanceTests\TestsFilter.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/TestsFilter.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/TestsFilter.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB5/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Audit.AcceptanceTests/ServiceControl.Audit.AcceptanceTests.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests/ServiceControl.Audit.AcceptanceTests.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.AcceptanceTests/TestsFilter.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Audit.AcceptanceTests/TestsFilter.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/ServiceControl.Audit.Persistence.Tests.RavenDB.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/ServiceControl.Audit.Persistence.Tests.RavenDB.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Audit.Persistence.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Audit.Persistence.Tests\PersistenceManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Audit.Persistence.Tests\TestsFilter.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/ServiceControl.Audit.Persistence.Tests.RavenDB.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/ServiceControl.Audit.Persistence.Tests.RavenDB.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb\ServiceControl.Audit.Persistence.RavenDb.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/TestsFilter.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/TestsFilter.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ServiceControl.Audit.Persistence.Tests.RavenDb5.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ServiceControl.Audit.Persistence.Tests.RavenDb5.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Audit.Persistence.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Audit.Persistence.Tests\PersistenceManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Audit.Persistence.Tests\TestsFilter.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ServiceControl.Audit.Persistence.Tests.RavenDb5.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/ServiceControl.Audit.Persistence.Tests.RavenDb5.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb5\ServiceControl.Audit.Persistence.RavenDb5.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/TestsFilter.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/TestsFilter.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDb5/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
+++ b/src/ServiceControl.Audit.Persistence.Tests/ServiceControl.Audit.Persistence.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Audit.Persistence\ServiceControl.Audit.Persistence.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.Persistence.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Audit.Persistence.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Audit.UnitTests/ServiceControl.Audit.UnitTests.csproj
+++ b/src/ServiceControl.Audit.UnitTests/ServiceControl.Audit.UnitTests.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\ServiceControl.Audit.Persistence.RavenDb\ServiceControl.Audit.Persistence.RavenDb.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControl.Audit\ServiceControl.Audit.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.UnitTests/TestsFilter.cs
+++ b/src/ServiceControl.Audit.UnitTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Audit.UnitTests/TestsFilter.cs
+++ b/src/ServiceControl.Audit.UnitTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
+++ b/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Config\ServiceControl.Config.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Config.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Config.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Config.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Config.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Monitoring.AcceptanceTests/ServiceControl.Monitoring.AcceptanceTests.csproj
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/ServiceControl.Monitoring.AcceptanceTests.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\ServiceControl.Monitoring\ServiceControl.Monitoring.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Monitoring.AcceptanceTests/TestsFilter.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Monitoring.AcceptanceTests/TestsFilter.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Monitoring.UnitTests/ServiceControl.Monitoring.UnitTests.csproj
+++ b/src/ServiceControl.Monitoring.UnitTests/ServiceControl.Monitoring.UnitTests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Monitoring\ServiceControl.Monitoring.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Monitoring.UnitTests/TestsFilter.cs
+++ b/src/ServiceControl.Monitoring.UnitTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Monitoring.UnitTests/TestsFilter.cs
+++ b/src/ServiceControl.Monitoring.UnitTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\ServiceControl.Persistence.SqlServer\ServiceControl.Persistence.SqlServer.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/TestsFilter.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/TestsFilter.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.PersistenceTests/ServiceControl.PersistenceTests.csproj
+++ b/src/ServiceControl.PersistenceTests/ServiceControl.PersistenceTests.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" />
     <ProjectReference Include="..\ServiceControl.Persistence.SqlServer\ServiceControl.Persistence.SqlServer.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.PersistenceTests/TestsFilter.cs
+++ b/src/ServiceControl.PersistenceTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.PersistenceTests/TestsFilter.cs
+++ b/src/ServiceControl.PersistenceTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.Transports.ASBEndpointTopology.Tests/ServiceControl.Transports.ASBEndpointTopology.Tests.csproj
+++ b/src/ServiceControl.Transports.ASBEndpointTopology.Tests/ServiceControl.Transports.ASBEndpointTopology.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.ASBEndpointTopology.Tests/ServiceControl.Transports.ASBEndpointTopology.Tests.csproj
+++ b/src/ServiceControl.Transports.ASBEndpointTopology.Tests/ServiceControl.Transports.ASBEndpointTopology.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 

--- a/src/ServiceControl.Transports.ASBEndpointTopology.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.ASBEndpointTopology.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.AzureServiceBus")]

--- a/src/ServiceControl.Transports.ASBEndpointTopology.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.ASBEndpointTopology.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: AzureServiceBusTest()]

--- a/src/ServiceControl.Transports.ASBEndpointTopology.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.ASBEndpointTopology.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: AzureServiceBusTest()]
+﻿[assembly: IncludeInAzureServiceBusTests()]

--- a/src/ServiceControl.Transports.ASBForwardingTopology.Tests/ServiceControl.Transports.ASBForwardingTopology.Tests.csproj
+++ b/src/ServiceControl.Transports.ASBForwardingTopology.Tests/ServiceControl.Transports.ASBForwardingTopology.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.ASBForwardingTopology.Tests/ServiceControl.Transports.ASBForwardingTopology.Tests.csproj
+++ b/src/ServiceControl.Transports.ASBForwardingTopology.Tests/ServiceControl.Transports.ASBForwardingTopology.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 

--- a/src/ServiceControl.Transports.ASBForwardingTopology.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.ASBForwardingTopology.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.AzureServiceBus")]

--- a/src/ServiceControl.Transports.ASBForwardingTopology.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.ASBForwardingTopology.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: AzureServiceBusTest()]

--- a/src/ServiceControl.Transports.ASBForwardingTopology.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.ASBForwardingTopology.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: AzureServiceBusTest()]
+﻿[assembly: IncludeInAzureServiceBusTests()]

--- a/src/ServiceControl.Transports.ASBS.Tests/ServiceControl.Transports.ASBS.Tests.csproj
+++ b/src/ServiceControl.Transports.ASBS.Tests/ServiceControl.Transports.ASBS.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.ASBS.Tests/ServiceControl.Transports.ASBS.Tests.csproj
+++ b/src/ServiceControl.Transports.ASBS.Tests/ServiceControl.Transports.ASBS.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 

--- a/src/ServiceControl.Transports.ASBS.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.ASBS.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.AzureServiceBus")]

--- a/src/ServiceControl.Transports.ASBS.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.ASBS.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: AzureServiceBusTest()]

--- a/src/ServiceControl.Transports.ASBS.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.ASBS.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: AzureServiceBusTest()]
+﻿[assembly: IncludeInAzureServiceBusTests()]

--- a/src/ServiceControl.Transports.ASQ.Tests/ServiceControl.Transports.ASQ.Tests.csproj
+++ b/src/ServiceControl.Transports.ASQ.Tests/ServiceControl.Transports.ASQ.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.ASQ.Tests/ServiceControl.Transports.ASQ.Tests.csproj
+++ b/src/ServiceControl.Transports.ASQ.Tests/ServiceControl.Transports.ASQ.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 

--- a/src/ServiceControl.Transports.ASQ.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.ASQ.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.AzureStorageQueues")]

--- a/src/ServiceControl.Transports.ASQ.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.ASQ.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: AzureStorageQueuesTest()]

--- a/src/ServiceControl.Transports.ASQ.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.ASQ.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: AzureStorageQueuesTest()]
+﻿[assembly: IncludeInAzureStorageQueuesTests()]

--- a/src/ServiceControl.Transports.Msmq.Tests/ServiceControl.Transports.Msmq.Tests.csproj
+++ b/src/ServiceControl.Transports.Msmq.Tests/ServiceControl.Transports.Msmq.Tests.csproj
@@ -24,6 +24,7 @@
     <!-- MSMQ can't be queried across machines and uses https://github.com/Particular/NServiceBus.Metrics.ServiceControl.Msmq installed into each endpoint to collect metrics instead-->
     <Compile Remove="..\ServiceControl.Transports.Tests\QueueLengthMonitoringTests.cs" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 </Project>

--- a/src/ServiceControl.Transports.Msmq.Tests/ServiceControl.Transports.Msmq.Tests.csproj
+++ b/src/ServiceControl.Transports.Msmq.Tests/ServiceControl.Transports.Msmq.Tests.csproj
@@ -24,5 +24,6 @@
     <!-- MSMQ can't be queried across machines and uses https://github.com/Particular/NServiceBus.Metrics.ServiceControl.Msmq installed into each endpoint to collect metrics instead-->
     <Compile Remove="..\ServiceControl.Transports.Tests\QueueLengthMonitoringTests.cs" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 </Project>

--- a/src/ServiceControl.Transports.Msmq.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.Msmq.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.MSMQ")]

--- a/src/ServiceControl.Transports.Msmq.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.Msmq.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: MsmqTest()]

--- a/src/ServiceControl.Transports.Msmq.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.Msmq.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: MsmqTest()]
+﻿[assembly: IncludeInMsmqTests()]

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/ServiceControl.Transports.RabbitMQClassicConventionalRoutingTests.csproj
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/ServiceControl.Transports.RabbitMQClassicConventionalRoutingTests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/ServiceControl.Transports.RabbitMQClassicConventionalRoutingTests.csproj
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/ServiceControl.Transports.RabbitMQClassicConventionalRoutingTests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.RabbitMQ")]

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: RabbitMQTest()]

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: RabbitMQTest()]
+﻿[assembly: IncludeInRabbitMQTests()]

--- a/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests.csproj
+++ b/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests.csproj
+++ b/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 

--- a/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.RabbitMQ")]

--- a/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: RabbitMQTest()]

--- a/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: RabbitMQTest()]
+﻿[assembly: IncludeInRabbitMQTests()]

--- a/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests.csproj
+++ b/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests.csproj
+++ b/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 

--- a/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.RabbitMQ")]

--- a/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: RabbitMQTest()]

--- a/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: RabbitMQTest()]
+﻿[assembly: IncludeInRabbitMQTests()]

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests.csproj
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests.csproj
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.RabbitMQ")]

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: RabbitMQTest()]

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: RabbitMQTest()]
+﻿[assembly: IncludeInRabbitMQTests()]

--- a/src/ServiceControl.Transports.SQS.Tests/ServiceControl.Transports.SQS.Tests.csproj
+++ b/src/ServiceControl.Transports.SQS.Tests/ServiceControl.Transports.SQS.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.SQS.Tests/ServiceControl.Transports.SQS.Tests.csproj
+++ b/src/ServiceControl.Transports.SQS.Tests/ServiceControl.Transports.SQS.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Transports.SQS\ServiceControl.Transports.SQS.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Transports.SQS.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.SQS.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.SQS")]

--- a/src/ServiceControl.Transports.SQS.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.SQS.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: AmazonSqsTest()]
+﻿[assembly: IncludeInAmazonSqsTests()]

--- a/src/ServiceControl.Transports.SQS.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.SQS.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: AmazonSqsTest()]

--- a/src/ServiceControl.Transports.SqlServer.Tests/ServiceControl.Transports.SqlServer.Tests.csproj
+++ b/src/ServiceControl.Transports.SqlServer.Tests/ServiceControl.Transports.SqlServer.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.SqlServer.Tests/ServiceControl.Transports.SqlServer.Tests.csproj
+++ b/src/ServiceControl.Transports.SqlServer.Tests/ServiceControl.Transports.SqlServer.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\ServiceControl.Transports.Tests\*.cs" Link="Shared\%(RecursiveDir)%(FileName)%(Extension)" />
     <Compile Remove="..\ServiceControl.Transports.Tests\TransportManifestLibraryTests.cs" />
+    <Compile Remove="..\ServiceControl.Transports.Tests\TestsFilter.cs" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 

--- a/src/ServiceControl.Transports.SqlServer.Tests/TestCategory.cs
+++ b/src/ServiceControl.Transports.SqlServer.Tests/TestCategory.cs
@@ -1,3 +1,0 @@
-﻿using NUnit.Framework;
-
-[assembly: Category("Transports.SqlServer")]

--- a/src/ServiceControl.Transports.SqlServer.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.SqlServer.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: SqlServerTest()]
+﻿[assembly: IncludeInSqlServerTests()]

--- a/src/ServiceControl.Transports.SqlServer.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.SqlServer.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: SqlServerTest()]

--- a/src/ServiceControl.Transports.Tests/ServiceControl.Transports.Tests.csproj
+++ b/src/ServiceControl.Transports.Tests/ServiceControl.Transports.Tests.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Transports.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.Tests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.Transports.Tests/TestsFilter.cs
+++ b/src/ServiceControl.Transports.Tests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.UnitTests/TestsFilter.cs
+++ b/src/ServiceControl.UnitTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControl.UnitTests/TestsFilter.cs
+++ b/src/ServiceControl.UnitTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -176,6 +176,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Persistence"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Configuration", "ServiceControl.Configuration\ServiceControl.Configuration.csproj", "{B75EEFBA-FAE9-4DEE-9227-7ECF3C7B5F6A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestHelper", "TestHelper\TestHelper.csproj", "{AD692C6B-D99B-4EAF-B473-BA68AA151ED2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -446,6 +448,10 @@ Global
 		{B75EEFBA-FAE9-4DEE-9227-7ECF3C7B5F6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B75EEFBA-FAE9-4DEE-9227-7ECF3C7B5F6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B75EEFBA-FAE9-4DEE-9227-7ECF3C7B5F6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD692C6B-D99B-4EAF-B473-BA68AA151ED2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD692C6B-D99B-4EAF-B473-BA68AA151ED2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD692C6B-D99B-4EAF-B473-BA68AA151ED2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD692C6B-D99B-4EAF-B473-BA68AA151ED2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ServiceControlInstaller.CustomActions.UnitTests/ServiceControlInstaller.CustomActions.UnitTests.csproj
+++ b/src/ServiceControlInstaller.CustomActions.UnitTests/ServiceControlInstaller.CustomActions.UnitTests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControlInstaller.CustomActions\ServiceControlInstaller.CustomActions.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.CustomActions.UnitTests/TestsFilter.cs
+++ b/src/ServiceControlInstaller.CustomActions.UnitTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControlInstaller.CustomActions.UnitTests/TestsFilter.cs
+++ b/src/ServiceControlInstaller.CustomActions.UnitTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControlInstaller.Engine.UnitTests/TestsFilter.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControlInstaller.Engine.UnitTests/TestsFilter.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
@@ -9,6 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />

--- a/src/ServiceControlInstaller.Packaging.UnitTests/TestsFilter.cs
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/TestsFilter.cs
@@ -1,0 +1,1 @@
+﻿[assembly: DefaultTest()]

--- a/src/ServiceControlInstaller.Packaging.UnitTests/TestsFilter.cs
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/TestsFilter.cs
@@ -1,1 +1,1 @@
-﻿[assembly: DefaultTest()]
+﻿[assembly: IncludeInDefaultTests()]

--- a/src/TestHelper/AmazonSqsTestAttribute.cs
+++ b/src/TestHelper/AmazonSqsTestAttribute.cs
@@ -1,4 +1,0 @@
-﻿public class AmazonSqsTestAttribute : FilterTestAttribute
-{
-    protected override string Filter => "Transports.SQS";
-}

--- a/src/TestHelper/AmazonSqsTestAttribute.cs
+++ b/src/TestHelper/AmazonSqsTestAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class AmazonSqsTestAttribute : FilterTestAttribute
+{
+    protected override string Filter => "Transports.SQS";
+}

--- a/src/TestHelper/AzureServiceBusTestAttribute.cs
+++ b/src/TestHelper/AzureServiceBusTestAttribute.cs
@@ -1,4 +1,0 @@
-﻿public class AzureServiceBusTestAttribute : FilterTestAttribute
-{
-    protected override string Filter => "Transports.AzureServiceBus";
-}

--- a/src/TestHelper/AzureServiceBusTestAttribute.cs
+++ b/src/TestHelper/AzureServiceBusTestAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class AzureServiceBusTestAttribute : FilterTestAttribute
+{
+    protected override string Filter => "Transports.AzureServiceBus";
+}

--- a/src/TestHelper/AzureStorageQueuesTestAttribute.cs
+++ b/src/TestHelper/AzureStorageQueuesTestAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class AzureStorageQueuesTestAttribute : FilterTestAttribute
+{
+    protected override string Filter => "Transports.AzureStorageQueues";
+}

--- a/src/TestHelper/AzureStorageQueuesTestAttribute.cs
+++ b/src/TestHelper/AzureStorageQueuesTestAttribute.cs
@@ -1,4 +1,0 @@
-﻿public class AzureStorageQueuesTestAttribute : FilterTestAttribute
-{
-    protected override string Filter => "Transports.AzureStorageQueues";
-}

--- a/src/TestHelper/DefaultTestAttribute.cs
+++ b/src/TestHelper/DefaultTestAttribute.cs
@@ -1,4 +1,0 @@
-﻿public class DefaultTestAttribute : FilterTestAttribute
-{
-    protected override string Filter => "Default";
-}

--- a/src/TestHelper/DefaultTestAttribute.cs
+++ b/src/TestHelper/DefaultTestAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class DefaultTestAttribute : FilterTestAttribute
+{
+    protected override string Filter => "Default";
+}

--- a/src/TestHelper/FilterTestAttribute.cs
+++ b/src/TestHelper/FilterTestAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
+public abstract class FilterTestAttribute : Attribute, IApplyToContext
+{
+    public void ApplyToContext(TestExecutionContext context)
+    {
+        var currentFilters = Environment.GetEnvironmentVariable("TEST_FILTER")?.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+        if (!currentFilters.Contains(Filter))
+        {
+            Assert.Ignore("Ignoring because environment variable TEST_FILTER doesn't contain '{0}'.", Filter);
+        }
+    }
+
+    protected abstract string Filter { get; }
+}

--- a/src/TestHelper/FilterTestAttribute.cs
+++ b/src/TestHelper/FilterTestAttribute.cs
@@ -10,6 +10,11 @@ public abstract class FilterTestAttribute : Attribute, IApplyToContext
     public void ApplyToContext(TestExecutionContext context)
     {
         var currentFilters = Environment.GetEnvironmentVariable("TEST_FILTER")?.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+        if (currentFilters.Contains("All"))
+        {
+            return;
+        }
+
         if (!currentFilters.Contains(Filter))
         {
             Assert.Ignore("Ignoring because environment variable TEST_FILTER doesn't contain '{0}'.", Filter);

--- a/src/TestHelper/IncludeInAmazonSqsTestsAttribute.cs
+++ b/src/TestHelper/IncludeInAmazonSqsTestsAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class IncludeInAmazonSqsTestsAttribute : IncludeInTestsAttribute
+{
+    protected override string Filter => "Transports.SQS";
+}

--- a/src/TestHelper/IncludeInAmazonSqsTestsAttribute.cs
+++ b/src/TestHelper/IncludeInAmazonSqsTestsAttribute.cs
@@ -1,4 +1,4 @@
 ﻿public class IncludeInAmazonSqsTestsAttribute : IncludeInTestsAttribute
 {
-    protected override string Filter => "Transports.SQS";
+    protected override string Filter => "SQS";
 }

--- a/src/TestHelper/IncludeInAzureServiceBusTestsAttribute.cs
+++ b/src/TestHelper/IncludeInAzureServiceBusTestsAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class IncludeInAzureServiceBusTestsAttribute : IncludeInTestsAttribute
+{
+    protected override string Filter => "Transports.AzureServiceBus";
+}

--- a/src/TestHelper/IncludeInAzureServiceBusTestsAttribute.cs
+++ b/src/TestHelper/IncludeInAzureServiceBusTestsAttribute.cs
@@ -1,4 +1,4 @@
 ﻿public class IncludeInAzureServiceBusTestsAttribute : IncludeInTestsAttribute
 {
-    protected override string Filter => "Transports.AzureServiceBus";
+    protected override string Filter => "AzureServiceBus";
 }

--- a/src/TestHelper/IncludeInAzureStorageQueuesTestsAttribute.cs
+++ b/src/TestHelper/IncludeInAzureStorageQueuesTestsAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class IncludeInAzureStorageQueuesTestsAttribute : IncludeInTestsAttribute
+{
+    protected override string Filter => "Transports.AzureStorageQueues";
+}

--- a/src/TestHelper/IncludeInAzureStorageQueuesTestsAttribute.cs
+++ b/src/TestHelper/IncludeInAzureStorageQueuesTestsAttribute.cs
@@ -1,4 +1,4 @@
 ﻿public class IncludeInAzureStorageQueuesTestsAttribute : IncludeInTestsAttribute
 {
-    protected override string Filter => "Transports.AzureStorageQueues";
+    protected override string Filter => "AzureStorageQueues";
 }

--- a/src/TestHelper/IncludeInDefaultTestsAttribute.cs
+++ b/src/TestHelper/IncludeInDefaultTestsAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class IncludeInDefaultTestsAttribute : IncludeInTestsAttribute
+{
+    protected override string Filter => "Default";
+}

--- a/src/TestHelper/IncludeInMsmqTestsAttribute.cs
+++ b/src/TestHelper/IncludeInMsmqTestsAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class IncludeInMsmqTestsAttribute : IncludeInTestsAttribute
+{
+    protected override string Filter => "Transports.MSMQ";
+}

--- a/src/TestHelper/IncludeInMsmqTestsAttribute.cs
+++ b/src/TestHelper/IncludeInMsmqTestsAttribute.cs
@@ -1,4 +1,4 @@
 ﻿public class IncludeInMsmqTestsAttribute : IncludeInTestsAttribute
 {
-    protected override string Filter => "Transports.MSMQ";
+    protected override string Filter => "MSMQ";
 }

--- a/src/TestHelper/IncludeInRabbitMQTestsAttribute.cs
+++ b/src/TestHelper/IncludeInRabbitMQTestsAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class IncludeInRabbitMQTestsAttribute : IncludeInTestsAttribute
+{
+    protected override string Filter => "Transports.RabbitMQ";
+}

--- a/src/TestHelper/IncludeInRabbitMQTestsAttribute.cs
+++ b/src/TestHelper/IncludeInRabbitMQTestsAttribute.cs
@@ -1,4 +1,4 @@
 ﻿public class IncludeInRabbitMQTestsAttribute : IncludeInTestsAttribute
 {
-    protected override string Filter => "Transports.RabbitMQ";
+    protected override string Filter => "RabbitMQ";
 }

--- a/src/TestHelper/IncludeInSqlServerTestsAttribute.cs
+++ b/src/TestHelper/IncludeInSqlServerTestsAttribute.cs
@@ -1,4 +1,4 @@
 ﻿public class IncludeInSqlServerTestsAttribute : IncludeInTestsAttribute
 {
-    protected override string Filter => "Transports.SqlServer";
+    protected override string Filter => "SqlServer";
 }

--- a/src/TestHelper/IncludeInSqlServerTestsAttribute.cs
+++ b/src/TestHelper/IncludeInSqlServerTestsAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class IncludeInSqlServerTestsAttribute : IncludeInTestsAttribute
+{
+    protected override string Filter => "Transports.SqlServer";
+}

--- a/src/TestHelper/IncludeInTestsAttribute.cs
+++ b/src/TestHelper/IncludeInTestsAttribute.cs
@@ -9,8 +9,8 @@ public abstract class IncludeInTestsAttribute : Attribute, IApplyToContext
 {
     public void ApplyToContext(TestExecutionContext context)
     {
-        var currentFilter = Environment.GetEnvironmentVariable("TEST_FILTER");
-        context.OutWriter.WriteLine($"Environment variable TEST_FILTER is '{currentFilter ?? "null or not set"}'");
+        var currentFilter = Environment.GetEnvironmentVariable("ServiceControl_TESTS_FILTER");
+        context.OutWriter.WriteLine($"Environment variable ServiceControl_TESTS_FILTER is '{currentFilter ?? "null or not set"}'");
         if (currentFilter == "All")
         {
             return;
@@ -18,7 +18,7 @@ public abstract class IncludeInTestsAttribute : Attribute, IApplyToContext
 
         if (currentFilter != Filter)
         {
-            Assert.Ignore($"Ignoring because environment variable TEST_FILTER doesn't contain '{Filter}'.");
+            Assert.Ignore($"Ignoring because environment variable ServiceControl_TESTS_FILTER doesn't contain '{Filter}'.");
         }
     }
 

--- a/src/TestHelper/IncludeInTestsAttribute.cs
+++ b/src/TestHelper/IncludeInTestsAttribute.cs
@@ -5,13 +5,14 @@ using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
-public abstract class FilterTestAttribute : Attribute, IApplyToContext
+public abstract class IncludeInTestsAttribute : Attribute, IApplyToContext
 {
     public void ApplyToContext(TestExecutionContext context)
     {
         var currentFilters = Environment.GetEnvironmentVariable("TEST_FILTER")?.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
         if (currentFilters.Contains("All"))
         {
+            Console.WriteLine("Executing because environment variable TEST_FILTER contains 'All'");
             return;
         }
 

--- a/src/TestHelper/IncludeInTestsAttribute.cs
+++ b/src/TestHelper/IncludeInTestsAttribute.cs
@@ -10,9 +10,10 @@ public abstract class IncludeInTestsAttribute : Attribute, IApplyToContext
     public void ApplyToContext(TestExecutionContext context)
     {
         var currentFilter = Environment.GetEnvironmentVariable("ServiceControl_TESTS_FILTER");
-        context.OutWriter.WriteLine($"Environment variable ServiceControl_TESTS_FILTER is '{currentFilter ?? "null or not set"}'");
-        if (currentFilter == "All")
+        context.OutWriter.WriteLine($"Environment variable ServiceControl_TESTS_FILTER is '{currentFilter ?? "not set"}'");
+        if (currentFilter == null)
         {
+            //allows running them all
             return;
         }
 

--- a/src/TestHelper/IncludeInTestsAttribute.cs
+++ b/src/TestHelper/IncludeInTestsAttribute.cs
@@ -9,16 +9,16 @@ public abstract class IncludeInTestsAttribute : Attribute, IApplyToContext
 {
     public void ApplyToContext(TestExecutionContext context)
     {
-        var currentFilters = Environment.GetEnvironmentVariable("TEST_FILTER")?.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-        if (currentFilters.Contains("All"))
+        var currentFilter = Environment.GetEnvironmentVariable("TEST_FILTER");
+        context.OutWriter.WriteLine($"Environment variable TEST_FILTER is '{currentFilter ?? "null or not set"}'");
+        if (currentFilter == "All")
         {
-            Console.WriteLine("Executing because environment variable TEST_FILTER contains 'All'");
             return;
         }
 
-        if (!currentFilters.Contains(Filter))
+        if (currentFilter != Filter)
         {
-            Assert.Ignore("Ignoring because environment variable TEST_FILTER doesn't contain '{0}'.", Filter);
+            Assert.Ignore($"Ignoring because environment variable TEST_FILTER doesn't contain '{Filter}'.");
         }
     }
 

--- a/src/TestHelper/MsmqTestAttribute.cs
+++ b/src/TestHelper/MsmqTestAttribute.cs
@@ -1,4 +1,0 @@
-﻿public class MsmqTestAttribute : FilterTestAttribute
-{
-    protected override string Filter => "Transports.MSMQ";
-}

--- a/src/TestHelper/MsmqTestAttribute.cs
+++ b/src/TestHelper/MsmqTestAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class MsmqTestAttribute : FilterTestAttribute
+{
+    protected override string Filter => "Transports.MSMQ";
+}

--- a/src/TestHelper/RabbitMQTestAttribute.cs
+++ b/src/TestHelper/RabbitMQTestAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class RabbitMQTestAttribute : FilterTestAttribute
+{
+    protected override string Filter => "Transports.RabbitMQ";
+}

--- a/src/TestHelper/RabbitMQTestAttribute.cs
+++ b/src/TestHelper/RabbitMQTestAttribute.cs
@@ -1,4 +1,0 @@
-﻿public class RabbitMQTestAttribute : FilterTestAttribute
-{
-    protected override string Filter => "Transports.RabbitMQ";
-}

--- a/src/TestHelper/SqlServerTestAttribute.cs
+++ b/src/TestHelper/SqlServerTestAttribute.cs
@@ -1,4 +1,0 @@
-﻿public class SqlServerTestAttribute : FilterTestAttribute
-{
-    protected override string Filter => "Transports.SqlServer";
-}

--- a/src/TestHelper/SqlServerTestAttribute.cs
+++ b/src/TestHelper/SqlServerTestAttribute.cs
@@ -1,0 +1,4 @@
+﻿public class SqlServerTestAttribute : FilterTestAttribute
+{
+    protected override string Filter => "Transports.SqlServer";
+}

--- a/src/TestHelper/TestHelper.csproj
+++ b/src/TestHelper/TestHelper.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
NOTE: Before merging make sure tests run as expected!

This PR replaces the NUnit test categories with a set of custom attributes that use the `ServiceControl_TESTS_FILTER` environment variable to filter which tests to run. Fixes:

- #3471 

The downside of this approach is that ServiceControl has a set of tests that are transport agnostic (identified in the CI matrix as `Default`). To make sure those tests are not run for every transport permutation the filter attribute must be defined in every test project. Failing to do so results in the tests being executed for every transport, nothing concerning other than the build will take more time.