### PR TITLE
Make Windows service dependent to HTTP service (kernel driver)

### DIFF
--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
@@ -111,7 +111,11 @@
                 ImagePath = $"\"{Path.Combine(InstallPath, Constants.MonitoringExe)}\" --serviceName={Name}",
                 ServiceDescription = ServiceDescription
             };
-            var dependencies = new List<string>();
+            var dependencies = new List<string>
+            {
+                "HTTP"
+            };
+
             if (TransportPackage.ZipName.Equals("MSMQ", StringComparison.OrdinalIgnoreCase))
             {
                 dependencies.Add("MSMQ");

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstallableBase.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstallableBase.cs
@@ -160,7 +160,11 @@
 
         protected List<string> GetServiceDependencies()
         {
-            var dependencies = new List<string>();
+            var dependencies = new List<string>()
+            {
+                "HTTP"
+            };
+
             if (TransportPackage.ZipName.Equals("MSMQ", StringComparison.OrdinalIgnoreCase))
             {
                 dependencies.Add("MSMQ");


### PR DESCRIPTION
Make Windows service dependent to HTTP service (kernel driver). When the HTTP service is disabled SC cannot mount the port(s) and fails startup.


## Service dependent to HTTP after creation

![Service dependencies shown in Windows services console](https://github.com/Particular/ServiceControl/assets/152998/04f3f6c4-98fa-4309-aa89-a45c778e7db9)
