### PR TITLE
Resolves NRE on settings during ResolveAssembly by postponing AssemblyResolve subscription

### DIFF
--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -18,7 +18,6 @@
 
         static async Task Main(string[] args)
         {
-            AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
             AppDomain.CurrentDomain.UnhandledException += (s, e) => LogException(e.ExceptionObject as Exception);
 
             var arguments = new HostArguments(args);
@@ -33,6 +32,8 @@
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             settings = Settings.FromConfiguration(arguments.ServiceName);
+
+            AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
 
             await new CommandRunner(arguments.Commands).Execute(arguments, settings)
                 .ConfigureAwait(false);

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -16,7 +16,6 @@
 
         static async Task Main(string[] args)
         {
-            AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
             AppDomain.CurrentDomain.UnhandledException += (s, e) => LogException(e.ExceptionObject as Exception);
 
             var arguments = new HostArguments(args);
@@ -31,6 +30,8 @@
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             settings = new Settings(arguments.ServiceName);
+
+            AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
 
             await new CommandRunner(arguments.Commands).Execute(arguments, settings)
                 .ConfigureAwait(false);


### PR DESCRIPTION
Resolves NRE on settings during ResolveAssembly by postponing subscribing to AssemblyResolve after settings are initialized

Alternative:

- https://github.com/Particular/ServiceControl/pull/3568