### PR TITLE
Run non-deploy portions of release workflow when CI workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
   release:
     runs-on: windows-2022
     steps:
+      - name: Check for secrets
+        env:
+          SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
+        shell: pwsh
+        run: exit $(If ($env:SECRETS_AVAILABLE -eq 'true') { 0 } Else { 1 })
       - name: Checkout
         uses: actions/checkout@v3.5.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: Release
 on:
   push:
+    branches:
+      - master
+      - release-*
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-*'
+  pull_request:
+  workflow_dispatch:
 env:
   DOTNET_NOLOGO: true
 jobs:
@@ -64,6 +69,11 @@ jobs:
         run: dotnet build src/Setup --configuration Release
       - name: Build Docker images
         run: dotnet build src/ServiceControl.DockerImages --configuration Release
+      - name: Docker Diagnostics
+        shell: pwsh
+        run: |
+          # List out the docker images on the system
+          docker images
       - name: Publish assets
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -96,21 +106,19 @@ jobs:
 
           $serviceControlMetadata | ConvertTo-Json | Out-File -Path ServiceControlMetadata.json
       - name: Deploy
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         uses: Particular/push-octopus-package-action@v1.1.0
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
           additional-metadata-paths: ServiceControlMetadata.json
       - name: Login to Docker Hub
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Diagnostics
-        shell: pwsh
-        run: |
-          # List out the docker images on the system
-          docker images
       - name: Push Docker images
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         shell: pwsh
         run: |
           Get-ChildItem -Path dockerfiles -Filter *.dockerfile | ForEach-Object {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,34 @@ jobs:
           name: zips
           path: zip/*
           retention-days: 1
+      - name : Verify release artifact counts
+        shell: pwsh
+        run: |
+          $assetsCount = (Get-ChildItem -Recurse -File assets).Count
+          $nugetsCount =  (Get-ChildItem -Recurse -File nugets).Count
+          $zipCount = (Get-ChildItem -Recurse -File zip).Count
+
+          $expectedAssetsCount = 2
+          $expectedNugetsCount = 1
+          $expectedZipCount = 3
+
+          if ($assetsCount -ne $expectedAssetsCount)
+          {
+              Write-Host Assets: Expected $expectedAssetsCount but found $assetsCount
+              exit -1
+          }
+
+          if ($nugetsCount -ne $expectedNugetsCount)
+          {
+              Write-Host Nugets: Expected $expectedNugetsCount but found $nugetsCount
+              exit -1
+          }
+
+          if ($expectedZipCount -ne $zipCount)
+          {
+              Write-Host Zips: Expected $expectedZipCount but found $zipCount
+              exit -1
+          }
       - name: Prepare ServiceControl metadata
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
   DOTNET_NOLOGO: true
 jobs:
   release:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: windows-2022
     steps:
       - name: Check for secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,12 @@ jobs:
           AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
         run: dotnet build src/Setup --configuration Release
       - name: Build Docker images
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         run: dotnet build src/ServiceControl.DockerImages --configuration Release
-      - name: Docker Diagnostics
+      - name: List Docker images
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         shell: pwsh
-        run: |
-          # List out the docker images on the system
-          docker images
+        run: docker images
       - name: Publish assets
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -93,6 +93,7 @@ jobs:
           path: zip/*
           retention-days: 1
       - name: Prepare ServiceControl metadata
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         shell: pwsh
         run: |
           #List of Docker image names used to control re-tagging during push to production


### PR DESCRIPTION
This PR makes the following changes:
- The release workflow now has all the same triggers as the CI workflow, meaning it will run whenever the CI workflow runs.
  - The steps that actually deploy the release artifacts are skipped unless the workflow is triggered from a tag. This means that nothing changes in our release process because of this PR.
  - The release workflow is skipped when Dependabot opens a PR because it would otherwise fail due to the code signing secrets not being available to Dependabot.
- A step to verify the expected number of release artifacts has been added. This means that if something causes the number of artifacts to change, the release workflow will fail. The counts need to be manually adjusted if there is an intentional change to the expected number of artifacts for a release.
- Building the docker images is because [they currently take way too long](https://github.com/Particular/ServiceControl/issues/3338) to include as part of every PR.

The end result of this PR is that you'll see the release workflow running on every PR, making it easy to access release artifacts, like the Windows installer, for testing. This also means that it is easier to prevent the release workflow from being broken accidentally.