### PR TITLE
Restart RavenDB Server process

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -73,8 +73,19 @@
             }
 
             EmbeddedServer.Instance.StartServer(serverOptions);
-
+            EmbeddedServer.Instance.ServerProcessExited += Instance_ServerProcessExited;
             return new EmbeddedDatabase(databaseConfiguration);
+        }
+
+        static void Instance_ServerProcessExited(object sender, ServerProcessExitedEventArgs e)
+        {
+            logger.Warn($"RavenDB process exited - attempting to restart...");
+
+            //TODO should this be tried a few times, and if doesn't work shutdown audit instance?
+            //OR should we stop the audit instance altogether
+            EmbeddedServer.Instance.RestartServerAsync().GetAwaiter().GetResult();
+
+            logger.Info("RavenDB process restarted");
         }
 
         public async Task<IDocumentStore> Connect(CancellationToken cancellationToken)

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -79,13 +79,22 @@
 
         static void Instance_ServerProcessExited(object sender, ServerProcessExitedEventArgs e)
         {
-            logger.Warn($"RavenDB process exited - attempting to restart...");
+            if (((System.Diagnostics.Process)sender).HasExited && ((System.Diagnostics.Process)sender).ExitCode != 0)
+            {
+                logger.Warn($"RavenDB process exited - attempting to restart...");
 
-            //TODO should this be tried a few times, and if doesn't work shutdown audit instance?
-            //OR should we stop the audit instance altogether
-            EmbeddedServer.Instance.RestartServerAsync().GetAwaiter().GetResult();
-
-            logger.Info("RavenDB process restarted");
+                //TODO should this be tried a few times, and if doesn't work shutdown audit instance?
+                //OR should we stop the audit instance altogether
+                try
+                {
+                    EmbeddedServer.Instance.RestartServerAsync().GetAwaiter().GetResult();
+                    logger.Info("RavenDB process restarted");
+                }
+                catch (Exception ex)
+                {
+                    logger.Error("Failed to restart RavenDB process", ex);
+                }
+            }
         }
 
         public async Task<IDocumentStore> Connect(CancellationToken cancellationToken)


### PR DESCRIPTION
Attempts to resolve https://github.com/Particular/ServiceControl/issues/3522

Restarting the RavenDB5 server process if it stops.

To discuss: should this be something that we try a few times in a loop and then exit, or should we not bother restarting at all and exit straight away?