### PR TITLE
add diagnostics file when new monitoring instance is created

### DIFF
--- a/src/ServiceControl.Monitoring/Bootstrapper.cs
+++ b/src/ServiceControl.Monitoring/Bootstrapper.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Monitoring
 {
     using System;
+    using System.Configuration;
     using System.Linq;
     using System.Threading.Tasks;
     using Audit.Infrastructure.WebApi;
@@ -102,7 +103,7 @@
             });
 
             config.GetSettings().Set(settings);
-
+            config.SetDiagnosticsPath(settings.LogPath);
             config.LimitMessageProcessingConcurrencyTo(settings.MaximumConcurrencyLevel);
 
             config.UseSerialization<NewtonsoftJsonSerializer>();

--- a/src/ServiceControl.Monitoring/Bootstrapper.cs
+++ b/src/ServiceControl.Monitoring/Bootstrapper.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.Monitoring
 {
     using System;
-    using System.Configuration;
     using System.Linq;
     using System.Threading.Tasks;
     using Audit.Infrastructure.WebApi;


### PR DESCRIPTION
This PR is a fix for [Monitoring instance "Failed to write startup diagnostics"   #2021](https://github.com/Particular/ServiceControl/issues/2021)