### PR TITLE
Remove trailing spaces from instance names

### DIFF
--- a/src/ServiceControl.Config.Tests/AddInstance/AddMonitoringInstance/InstanceName.cs
+++ b/src/ServiceControl.Config.Tests/AddInstance/AddMonitoringInstance/InstanceName.cs
@@ -7,10 +7,10 @@
     {
         [Test]
         [TestCase("Foo/*", "Foo")]
-        [TestCase("Foo     ", "Foo.")]
+        [TestCase("Foo     ", "Foo")]
         [TestCase("  Foo/*", "Foo")]
-        [TestCase("  Foo     ", "Foo.")]
-        [TestCase("  Foo a     ", "Foo.a.")]
+        [TestCase("  Foo     ", "Foo")]
+        [TestCase("  Foo a     ", "Foo.a")]
         [TestCase(@"<foo", "foo")]
         [TestCase(@">  foo", "foo")]
         [TestCase(@"foo | foo", "foo.foo")]

--- a/src/ServiceControl.Config.Tests/AddInstance/InstanceName.cs
+++ b/src/ServiceControl.Config.Tests/AddInstance/InstanceName.cs
@@ -27,10 +27,10 @@
 
         [Test]
         [TestCase("Foo/*", "Foo")]
-        [TestCase("Foo     ", "Foo.")]
+        [TestCase("Foo     ", "Foo")]
         [TestCase("  Foo/*", "Foo")]
-        [TestCase("  Foo     ", "Foo.")]
-        [TestCase("  Foo a     ", "Foo.a.")]
+        [TestCase("  Foo     ", "Foo")]
+        [TestCase("  Foo a     ", "Foo.a")]
         [TestCase(@"<foo", "foo")]
         [TestCase(@">  foo", "foo")]
         [TestCase(@"foo | foo", "foo.foo")]

--- a/src/ServiceControl.Config/Extensions/InstanceNameExtensions.cs
+++ b/src/ServiceControl.Config/Extensions/InstanceNameExtensions.cs
@@ -36,7 +36,7 @@
 
             instanceName = serviceNameBuilder.ToString();
 
-            instanceName = instanceName.TrimStart();
+            instanceName = instanceName.Trim();
 
             instanceName = ReplaceSpacesWithPeriods(instanceName);
 


### PR DESCRIPTION
PR to fix [Trailing spaces in "Name" can result in hang or otherwise result in trailing period characters in name / window service name for error and audit instances name #1971](https://github.com/Particular/ServiceControl/issues/1971)