### PR TITLE
word wrap long transport name

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
@@ -26,7 +26,7 @@
             <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
-            <RowDefinition Height="80" />
+            <RowDefinition Height="90" />
             <RowDefinition Height="8" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
@@ -231,7 +231,7 @@
         <GroupBox Grid.Row="8"
                   Header="TRANSPORT"
                   HeaderTemplate="{StaticResource SimpleHeaderedGroupBox}">
-            <TextBlock FontSize="14px" Text="{Binding Transport.Name}" />
+            <TextBlock FontSize="14px" Text="{Binding Transport.Name}" TextWrapping="WrapWithOverflow" />
         </GroupBox>
         <GroupBox Grid.Row="8"
                    Grid.Column="1"


### PR DESCRIPTION
This PR is to fix [If the transport label in SCMU is too long it's not visible #3557](https://github.com/Particular/ServiceControl/issues/3557)