### PR TITLE
Remove unused DisableRavenDBPerformanceCounters setting

### DIFF
--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -7,7 +7,6 @@
   "ValidateConfiguration": true,
   "ExternalIntegrationsDispatchingBatchSize": 100,
   "DisableExternalIntegrationsPublishing": false,
-  "DisableRavenDBPerformanceCounters": false,
   "SkipQueueCreation": false,
   "RunCleanupBundle": false,
   "RootUrl": "http://localhost:8888/",

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClr.approved.txt
@@ -72,7 +72,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public string DbPath { get; set; }
         public bool DisableExternalIntegrationsPublishing { get; set; }
         public bool DisableHealthChecks { get; set; }
-        public bool DisableRavenDBPerformanceCounters { get; set; }
         public string EmailDropFolder { get; set; }
         public bool EnableFullTextSearchOnBodies { get; set; }
         public string ErrorLogQueue { get; set; }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClrHosting.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PublicClrHosting.approved.txt
@@ -29,7 +29,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public string DbPath { get; set; }
         public bool DisableExternalIntegrationsPublishing { get; set; }
         public bool DisableHealthChecks { get; set; }
-        public bool DisableRavenDBPerformanceCounters { get; set; }
         public string EmailDropFolder { get; set; }
         public bool EnableFullTextSearchOnBodies { get; set; }
         public string ErrorLogQueue { get; set; }

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -74,8 +74,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
         public bool DisableExternalIntegrationsPublishing { get; set; }
 
-        public bool DisableRavenDBPerformanceCounters { get; set; }
-
         public bool SkipQueueCreation { get; set; }
 
         public bool RunCleanupBundle { get; set; }


### PR DESCRIPTION
Remove unused DisableRavenDBPerformanceCounters setting

ref: [ServiceControl audit instance missing documentation DisableRavenDBPerformanceCounters setting #5618](https://Particular/docs.particular.net/issues/5618)