### PR TITLE
Fix flooding the logs with "Error parsing message type:" for metrics from polymorphic messages 

### DIFF
--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_queue_length_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_queue_length_data.cs
@@ -125,7 +125,11 @@
             }
         }
 
-        class SampleMessage : IMessage
+        class SampleMessage : SampleBaseMessage
+        {
+        }
+
+        class SampleBaseMessage : IMessage
         {
         }
 

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_retries_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_retries_data.cs
@@ -77,7 +77,11 @@
             public bool ShuttingDown { get; set; }
         }
 
-        class SampleMessage : IMessage
+        class SampleMessage : SampleBaseMessage
+        {
+        }
+
+        class SampleBaseMessage : IMessage
         {
         }
     }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_timings_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_timings_data.cs
@@ -63,7 +63,11 @@
         {
         }
 
-        class SampleMessage : IMessage
+        class SampleMessage : SampleBaseMessage
+        {
+        }
+
+        class SampleBaseMessage : IMessage
         {
         }
     }

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointMessageType.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointMessageType.cs
@@ -4,10 +4,16 @@
 
     public readonly struct EndpointMessageType
     {
-        public EndpointMessageType(string endpointName, string messageType)
+        public EndpointMessageType(string endpointName, string enclosedMessageTypes)
         {
+            var index = enclosedMessageTypes.IndexOf(';');
+
+            var firstType = index != -1
+                ? enclosedMessageTypes.Substring(0, index)
+                : enclosedMessageTypes;
+
             EndpointName = endpointName;
-            MessageType = messageType;
+            MessageType = firstType;
         }
 
         public string EndpointName { get; }

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointMessageType.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointMessageType.cs
@@ -6,12 +6,6 @@
     {
         public EndpointMessageType(string endpointName, string messageType)
         {
-            if (!string.IsNullOrEmpty(messageType))
-            {
-                // Validate messageType format, will still throw if the format is invalid.
-                _ = Type.GetType(messageType, throwOnError: false);
-            }
-
             EndpointName = endpointName;
             MessageType = messageType;
         }

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointMessageType.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointMessageType.cs
@@ -1,9 +1,17 @@
 ﻿namespace ServiceControl.Monitoring.Infrastructure
 {
+    using System;
+
     public readonly struct EndpointMessageType
     {
         public EndpointMessageType(string endpointName, string messageType)
         {
+            if (!string.IsNullOrEmpty(messageType))
+            {
+                // Validate messageType format, will still throw if the format is invalid.
+                _ = Type.GetType(messageType, throwOnError: false);
+            }
+
             EndpointName = endpointName;
             MessageType = messageType;
         }

--- a/src/ServiceControl.Monitoring/Infrastructure/MessageTypeTracker.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/MessageTypeTracker.cs
@@ -15,7 +15,15 @@
         {
             var endpointName = context.MessageHeaders[Headers.OriginatingEndpoint];
 
-            registry.Record(new EndpointMessageType(endpointName, message.TagValue));
+            var enclosedMessageTypes = message.TagValue;
+
+            var index = enclosedMessageTypes.IndexOf(';');
+
+            var firstType = index != -1
+                ? enclosedMessageTypes.Substring(0, index)
+                : enclosedMessageTypes;
+
+            registry.Record(new EndpointMessageType(endpointName, firstType));
 
             return Task.CompletedTask;
         }

--- a/src/ServiceControl.Monitoring/Infrastructure/MessageTypeTracker.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/MessageTypeTracker.cs
@@ -15,15 +15,7 @@
         {
             var endpointName = context.MessageHeaders[Headers.OriginatingEndpoint];
 
-            var enclosedMessageTypes = message.TagValue;
-
-            var index = enclosedMessageTypes.IndexOf(';');
-
-            var firstType = index != -1
-                ? enclosedMessageTypes.Substring(0, index)
-                : enclosedMessageTypes;
-
-            registry.Record(new EndpointMessageType(endpointName, firstType));
+            registry.Record(new EndpointMessageType(endpointName, enclosedMessageTypes: message.TagValue));
 
             return Task.CompletedTask;
         }

--- a/src/ServiceControl.Monitoring/Retries/TaggedLongValueOccurrenceHandler.cs
+++ b/src/ServiceControl.Monitoring/Retries/TaggedLongValueOccurrenceHandler.cs
@@ -19,15 +19,7 @@
 
             if (messageType == RetriesMessageType)
             {
-                var enclosedMessageTypes = message.TagValue;
-
-                var index = enclosedMessageTypes.IndexOf(';');
-
-                var firstType = index != -1
-                    ? enclosedMessageTypes.Substring(0, index)
-                    : enclosedMessageTypes;
-
-                store.Store(message.Entries, instanceId, new EndpointMessageType(instanceId.EndpointName, firstType));
+                store.Store(message.Entries, instanceId, new EndpointMessageType(instanceId.EndpointName, enclosedMessageTypes: message.TagValue));
             }
 
             return Task.CompletedTask;

--- a/src/ServiceControl.Monitoring/Retries/TaggedLongValueOccurrenceHandler.cs
+++ b/src/ServiceControl.Monitoring/Retries/TaggedLongValueOccurrenceHandler.cs
@@ -19,7 +19,15 @@
 
             if (messageType == RetriesMessageType)
             {
-                store.Store(message.Entries, instanceId, new EndpointMessageType(instanceId.EndpointName, message.TagValue));
+                var enclosedMessageTypes = message.TagValue;
+
+                var index = enclosedMessageTypes.IndexOf(';');
+
+                var firstType = index != -1
+                    ? enclosedMessageTypes.Substring(0, index)
+                    : enclosedMessageTypes;
+
+                store.Store(message.Entries, instanceId, new EndpointMessageType(instanceId.EndpointName, firstType));
             }
 
             return Task.CompletedTask;

--- a/src/ServiceControl.Monitoring/Timings/TaggedLongValueOccurrenceHandler.cs
+++ b/src/ServiceControl.Monitoring/Timings/TaggedLongValueOccurrenceHandler.cs
@@ -16,18 +16,9 @@
         public Task Handle(TaggedLongValueOccurrence message, IMessageHandlerContext context)
         {
             var instanceId = EndpointInstanceId.From(context.MessageHeaders);
+            var messageType = new EndpointMessageType(instanceId.EndpointName, enclosedMessageTypes: message.TagValue);
 
             var metricType = context.MessageHeaders[MetricHeaders.MetricType];
-
-            var enclosedMessageTypes = message.TagValue;
-
-            var index = enclosedMessageTypes.IndexOf(';');
-
-            var firstType = index != -1
-                ? enclosedMessageTypes.Substring(0, index)
-                : enclosedMessageTypes;
-
-            var messageType = new EndpointMessageType(instanceId.EndpointName, firstType);
 
             switch (metricType)
             {

--- a/src/ServiceControl.Monitoring/Timings/TaggedLongValueOccurrenceHandler.cs
+++ b/src/ServiceControl.Monitoring/Timings/TaggedLongValueOccurrenceHandler.cs
@@ -16,9 +16,18 @@
         public Task Handle(TaggedLongValueOccurrence message, IMessageHandlerContext context)
         {
             var instanceId = EndpointInstanceId.From(context.MessageHeaders);
-            var messageType = new EndpointMessageType(instanceId.EndpointName, message.TagValue);
 
             var metricType = context.MessageHeaders[MetricHeaders.MetricType];
+
+            var enclosedMessageTypes = message.TagValue;
+
+            var index = enclosedMessageTypes.IndexOf(';');
+
+            var firstType = index != -1
+                ? enclosedMessageTypes.Substring(0, index)
+                : enclosedMessageTypes;
+
+            var messageType = new EndpointMessageType(instanceId.EndpointName, firstType);
 
             switch (metricType)
             {


### PR DESCRIPTION
The received value is the value from NServiceBus.EnclosedMessageTypes which can contain multiple types.

This should resolve the issue that `MonitoredEndpointMessageTypeParser.Parse` receives the value with all types and results in the following log entry:

```txt
2023-08-14 10:19:48.5594|8|Warn|ServiceControl.Monitoring.Http.Diagrams.MonitoredEndpointMessageTypeParser|Error parsing message type: XXXX, YYY, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null;ZZZZ, YYY, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null.
System.IO.FileLoadException: The given assembly name or codebase was invalid. (Exception from HRESULT: 0x80131047)
   at System.Reflection.AssemblyName.nInit(RuntimeAssembly& assembly, Boolean forIntrospection, Boolean raiseResolveEvent)
   at System.Reflection.AssemblyName..ctor(String assemblyName)
   at ServiceControl.Monitoring.Http.Diagrams.MonitoredEndpointMessageTypeParser.Parse(String typeName) in /_/src/ServiceControl.Monitoring/Http/Diagrams/MonitoredEndpointMessageTypeParser.cs:line 31
```

Not sure if the behavior should only add the first (top) type or all. This is only taking the first type