### PR TITLE
Fix ASBS QueueLengthProvider to process duplicate QueueRuntimeProperties

### DIFF
--- a/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
@@ -85,7 +85,7 @@ namespace ServiceControl.Transports.ASBS
                 while (await enumerator.MoveNextAsync().ConfigureAwait(false))
                 {
                     var queueRuntimeProperties = enumerator.Current;
-                    queuePathToRuntimeInfo.Add(queueRuntimeProperties.Name, queueRuntimeProperties);
+                    queuePathToRuntimeInfo[queueRuntimeProperties.Name] = queueRuntimeProperties;
                 }
             }
             finally

--- a/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
@@ -85,6 +85,14 @@ namespace ServiceControl.Transports.ASBS
                 while (await enumerator.MoveNextAsync().ConfigureAwait(false))
                 {
                     var queueRuntimeProperties = enumerator.Current;
+                    if (queuePathToRuntimeInfo.ContainsKey(queueRuntimeProperties.Name))
+                    {
+                        var existingItem = queuePathToRuntimeInfo[queueRuntimeProperties.Name];
+                        if(existingItem.Count!=queueRuntimeProperties.Count)
+                        {
+                            Logger.WarnFormat("Queue <{0}> already processed with different length (length {1} vs {2})", queueRuntimeProperties.Name, queuePathToRuntimeInfo.Count, existingItem.Count);
+                        }
+                    }
                     queuePathToRuntimeInfo[queueRuntimeProperties.Name] = queueRuntimeProperties;
                 }
             }

--- a/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
@@ -93,7 +93,7 @@ namespace ServiceControl.Transports.ASBS
                             Logger.WarnFormat("Queue <{0}> already processed with different length (length {1} vs {2})", queueRuntimeProperties.Name, queuePathToRuntimeInfo.Count, existingItem.Count);
                         }
                     }
-                    queuePathToRuntimeInfo[queueRuntimeProperties.Name] = queueRuntimeProperties;
+                    queuePathToRuntimeInfo[queueRuntimeProperties.Name] = queueRuntimeProperties; // Assuming last write is most up to date
                 }
             }
             finally

--- a/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
@@ -85,19 +85,6 @@ namespace ServiceControl.Transports.ASBS
                 while (await enumerator.MoveNextAsync().ConfigureAwait(false))
                 {
                     var queueRuntimeProperties = enumerator.Current;
-                    if (queuePathToRuntimeInfo.ContainsKey(queueRuntimeProperties.Name))
-                    {
-                        var existingItem = queuePathToRuntimeInfo[queueRuntimeProperties.Name];
-                        if(existingItem.ActiveMessageCount != queueRuntimeProperties.ActiveMessageCount)
-                        {
-                            Logger.WarnFormat(
-                                "Queue <{0}> already processed with different length (length {1} vs {2})",
-                                queueRuntimeProperties.Name,
-                                queuePathToRuntimeInfo.ActiveMessageCount,
-                                existingItem.ActiveMessageCount
-                                );
-                        }
-                    }
                     queuePathToRuntimeInfo[queueRuntimeProperties.Name] = queueRuntimeProperties; // Assuming last write is most up to date
                 }
             }

--- a/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
@@ -88,9 +88,14 @@ namespace ServiceControl.Transports.ASBS
                     if (queuePathToRuntimeInfo.ContainsKey(queueRuntimeProperties.Name))
                     {
                         var existingItem = queuePathToRuntimeInfo[queueRuntimeProperties.Name];
-                        if(existingItem.Count!=queueRuntimeProperties.Count)
+                        if(existingItem.ActiveMessageCount != queueRuntimeProperties.ActiveMessageCount)
                         {
-                            Logger.WarnFormat("Queue <{0}> already processed with different length (length {1} vs {2})", queueRuntimeProperties.Name, queuePathToRuntimeInfo.Count, existingItem.Count);
+                            Logger.WarnFormat(
+                                "Queue <{0}> already processed with different length (length {1} vs {2})",
+                                queueRuntimeProperties.Name,
+                                queuePathToRuntimeInfo.ActiveMessageCount,
+                                existingItem.ActiveMessageCount
+                                );
                         }
                     }
                     queuePathToRuntimeInfo[queueRuntimeProperties.Name] = queueRuntimeProperties; // Assuming last write is most up to date


### PR DESCRIPTION
Based on a support cases
It seems `GetQueuesRuntimePropertiesAsync` can return the same items multiple times which will cause a `System.ArgumentException: An item with the same key has already been added.` as it uses `.Add` instead of `[]`

