### PR TITLE
Logging improvements

### DIFF
--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -78,7 +78,7 @@
 
         Task OnCriticalError(string failure, Exception exception)
         {
-            logger.Warn($"OnCriticalError. '{failure}'", exception);
+            logger.Fatal($"OnCriticalError. '{failure}'", exception);
             return watchdog.OnFailure(failure);
         }
 

--- a/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
@@ -25,7 +25,7 @@ namespace ServiceControl.Audit.Infrastructure
 
             var version = FileVersionInfo.GetVersionInfo(typeof(Bootstrapper).Assembly.Location).ProductVersion;
             var nlogConfig = new LoggingConfiguration();
-            var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}");
+            var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:|${exception:format=tostring}}");
             var header = $@"-------------------------------------------------------------
 ServiceControl Audit Version:				{version}
 -------------------------------------------------------------";

--- a/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
@@ -25,7 +25,7 @@
 
             var version = FileVersionInfo.GetVersionInfo(typeof(Bootstrapper).Assembly.Location).ProductVersion;
             var nlogConfig = new LoggingConfiguration();
-            var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}");
+            var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:|${exception:format=tostring}}");
             var header = $@"-------------------------------------------------------------
 ServiceControl Monitoring Version:				{version}
 Selected Transport:					{settings.TransportType}

--- a/src/ServiceControl/LoggingConfigurator.cs
+++ b/src/ServiceControl/LoggingConfigurator.cs
@@ -26,7 +26,7 @@ namespace Particular.ServiceControl
 
             var version = FileVersionInfo.GetVersionInfo(typeof(Bootstrapper).Assembly.Location).ProductVersion;
             var nlogConfig = new LoggingConfiguration();
-            var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:${newline}${exception:format=tostring}}");
+            var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:|${exception:format=tostring}}");
             var header = $@"-------------------------------------------------------------
 ServiceControl Version:				{version}
 -------------------------------------------------------------";

--- a/src/ServiceControl/Operations/ErrorIngestion.cs
+++ b/src/ServiceControl/Operations/ErrorIngestion.cs
@@ -194,7 +194,7 @@
 
         Task OnCriticalError(string failure, Exception exception)
         {
-            logger.Warn($"OnCriticalError. '{failure}'", exception);
+            logger.Fatal($"OnCriticalError. '{failure}'", exception);
             return watchdog.OnFailure(failure);
         }
 


### PR DESCRIPTION
- Log exceptions on the same line as log entry
- Log level for critical errors changed from WARN to FATAL as critical errors indicate a broken state


Before:
```
2023-08-22 14:28:04.5672|87|Error|NServiceBus.Transport.AzureServiceBus.MessagePump|Failed to execute recoverability.
Azure.Messaging.ServiceBus.ServiceBusException: The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue, or was received by a different receiver instance. (MessageLockLost). For troubleshooting information, see https://aka.ms/azsdk/net/servicebus/exceptions/troubleshoot.
   at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.ThrowLockLostException()
   at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.<DisposeMessageAsync>d__45.MoveNext()
```

After:
```
2023-08-22 14:28:04.5672|87|Error|NServiceBus.Transport.AzureServiceBus.MessagePump|Failed to execute recoverability.|Azure.Messaging.ServiceBus.ServiceBusException: The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue, or was received by a different receiver instance. (MessageLockLost). For troubleshooting information, see https://aka.ms/azsdk/net/servicebus/exceptions/troubleshoot.
   at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.ThrowLockLostException()
   at Azure.Messaging.ServiceBus.Amqp.AmqpReceiver.<DisposeMessageAsync>d__45.MoveNext()
```

This way log parsing returns more useful results. Currently, the results look like the following making it impossible to distinguish lines:

![image](https://github.com/Particular/ServiceControl/assets/152998/956e2ccf-bf47-4465-8b42-b42f96490cf7)
