### PR TITLE
Removal of ServiceControl.Persistence.InMemory.csproj was not complete in #3683

### DIFF
--- a/src/Persisters.Primary.Includes.props
+++ b/src/Persisters.Primary.Includes.props
@@ -1,6 +1,5 @@
 <Project>
-  <ItemGroup Label="Persisters">
-    <ProjectReference Include="..\ServiceControl.Persistence.InMemory\ServiceControl.Persistence.InMemory.csproj" ReferenceOutputAssembly="false" Private="false" />
-    <ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" ReferenceOutputAssembly="false" Private="false" />
-  </ItemGroup>
+	<ItemGroup Label="Persisters">
+		<ProjectReference Include="..\ServiceControl.Persistence.RavenDb\ServiceControl.Persistence.RavenDb.csproj" ReferenceOutputAssembly="false" Private="false" />
+	</ItemGroup>
 </Project>

--- a/src/ServiceControl.Configuration/InternalsVisibleTo.cs
+++ b/src/ServiceControl.Configuration/InternalsVisibleTo.cs
@@ -6,5 +6,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("ServiceControl.AcceptanceTesting")]
 [assembly: InternalsVisibleTo("ServiceControl.PersistenceTests")]
 [assembly: InternalsVisibleTo("ServiceControl.MultiInstance.AcceptanceTests")]
-[assembly: InternalsVisibleTo("ServiceControl.Persistence.InMemory")]
 [assembly: InternalsVisibleTo("ServiceControl.Persistence.RavenDb")]

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ServiceControl\ServiceControl.csproj" />
-    <ProjectReference Include="..\ServiceControl.Persistence.InMemory\ServiceControl.Persistence.InMemory.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Learning\ServiceControl.Transports.Learning.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports.Msmq\ServiceControl.Transports.Msmq.csproj" />
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />

--- a/src/ServiceControl/InternalsVisibleTo.cs
+++ b/src/ServiceControl/InternalsVisibleTo.cs
@@ -7,5 +7,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("ServiceControl.PersistenceTests")]
 [assembly: InternalsVisibleTo("ServiceControl.Persistence.Tests.RavenDB")]
 [assembly: InternalsVisibleTo("ServiceControl.MultiInstance.AcceptanceTests")]
-[assembly: InternalsVisibleTo("ServiceControl.Persistence.InMemory")]
 [assembly: InternalsVisibleTo("ServiceControl.Persistence.RavenDb")]


### PR DESCRIPTION
Removal of ServiceControl.Persistence.InMemory.csproj was not complete in #3683 as references to ServiceControl.Persistence.InMemory.csproj still existed but it didn't result in a compiler error and also removed obsolete InternalsVisibleTo for this assembly
