### PR TITLE
Also add support for envvar expanding of config file settings in audit instance

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Settings/ConfigFileSettingsReader.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/ConfigFileSettingsReader.cs
@@ -24,9 +24,11 @@ namespace ServiceControl.Audit.Infrastructure.Settings
         {
             var fullKey = $"{root}/{name}";
 
-            if (ConfigurationManager.AppSettings[fullKey] != null)
+            var appSettingValue = ConfigurationManager.AppSettings[fullKey];
+            if (appSettingValue != null)
             {
-                value = (T)Convert.ChangeType(ConfigurationManager.AppSettings[fullKey], typeof(T));
+                appSettingValue = Environment.ExpandEnvironmentVariables(appSettingValue);
+                value = (T)Convert.ChangeType(appSettingValue, typeof(T));
                 return true;
             }
 


### PR DESCRIPTION
Primary already supports expanding envvar's in config file. This allows for example using `%TEMP%` in paths for paths for database or logs or any other useful envvar.