### PR TITLE
Spike RavenDB 6

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+	<add key="raven-nightly" value="https://www.myget.org/F/ravendb/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="particular packages" value="https://f.feedz.io/particular-software/packages/nuget/index.json" />
   </packageSources>
   <packageSourceMapping>
+	<packageSource key="raven-nightly">
+		<package pattern="RavenDB.*" />
+	</packageSource>
     <packageSource key="nuget.org">
         <package pattern="*" />
     </packageSource>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -61,7 +61,7 @@
     <PackageVersion Include="PropertyChanged.Fody" Version="4.1.0" />
     <PackageVersion Include="PropertyChanging.Fody" Version="1.30.3" />
     <PackageVersion Include="PublicApiGenerator" Version="11.0.0" />
-    <PackageVersion Include="RavenDB.Embedded" Version="5.4.109" />
+    <PackageVersion Include="RavenDB.Embedded" Version="6.0.1-nightly-20231020-1100" />
     <PackageVersion Include="ReactiveUI.WPF" Version="19.4.1" />
     <PackageVersion Include="Rx-Linq" Version="2.2.5" />
     <PackageVersion Include="ServiceControl.Contracts" Version="4.0.0" />

--- a/src/ServiceControl.AcceptanceTests.RavenDB5/Recoverability/MessageFailures/FailedMessageRetriesController.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB5/Recoverability/MessageFailures/FailedMessageRetriesController.cs
@@ -10,7 +10,7 @@
 
     public class FailedMessageRetriesCountReponse
     {
-        public int Count { get; set; }
+        public long Count { get; set; }
     }
 
     class FailedMessageRetriesController : ApiController

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -66,7 +66,9 @@
                     $"--Logs.Mode={databaseConfiguration.ServerConfiguration.LogsMode}",
                     // HINT: If this is not set, then Raven will pick a default location relative to the server binaries
                     // See https://github.com/ravendb/ravendb/issues/15694
-                    $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\""
+                    $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\"",
+                    "--Indexing.Auto.SearchEngineType=Corax",
+                    "--Indexing.Static.SearchEngineType=Corax"
                 },
                 AcceptEula = true,
                 DataDirectory = databaseConfiguration.ServerConfiguration.DbPath,

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenDbAuditDataStore.cs
@@ -202,9 +202,9 @@
                             .Take(0)
                             .ToArrayAsync();
 
-                        if (stats.LongTotalResults > 0)
+                        if (stats.TotalResults > 0)
                         {
-                            results.Add(new AuditCount { UtcDate = date, Count = stats.LongTotalResults });
+                            results.Add(new AuditCount { UtcDate = date, Count = stats.TotalResults });
                         }
                     }
                 }

--- a/src/ServiceControl.Audit.Persistence.RavenDb5/RavenLicense.json
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/RavenLicense.json
@@ -2,15 +2,18 @@
   "Id": "64c6a174-3f3a-4e7d-ac5d-b3eedd801460",
   "Name": "ParticularNservicebus (Israel)",
   "Keys": [
-    "kWznr3iTRWkzuYjFJH8IvS1LY",
-    "t5GJId7H/h5i4YjW2Z7YPgUoR",
-    "igl/wrjx4y6pmXcChQRnTu1TK",
-    "Q1scjkLMB2aaH9VZ5G2s4E0gz",
-    "08GaHnSOHpRVz6SgjFGcAqnEb",
-    "c0ZhNNOGsBcrOVx+KOq7+ggHs",
-    "MtKI8e8mCRcgiaTOkPURpAAyU",
+    "NKhWkUrAnwvE+M6VmSxK7J6am",
+    "D2JME/+XVMQq9xh18W4lClw+a",
+    "FDWF3ZqgA89/tIgwUyc8BZ09f",
+    "wSsdi8WzL/w01TOB00HuGQE4r",
+    "jAkg7BKr7LWIRfbg02KLhiU4M",
+    "Y1FQx8IA4BOBK0XP+X+aaWE48",
+    "fLmwuqGsSc0kg0rzFdYs9AAyU",
     "GKEkFCisMLQ4vMAcREjM0NRYX",
-    "GhufAh8AnwIgAJ8CIwBBMkMMR",
-    "AY4OTw9Pp8CISBiP1g="
+    "GhufAh8AnwIgAJ8CIwCfAiQgn",
+    "wIlIJ8CJiCfAicgnwIoIJ8CKS",
+    "CfAiognwIrIJ8CLACfAi0AnwI",
+    "uIJ8CLwCfAjAggQM2LjBDMEQG",
+    "ODk8PT6fAiEgYoFY"
   ]
 }

--- a/src/ServiceControl.Audit.Persistence/Infrastructure/QueryStatsInfo.cs
+++ b/src/ServiceControl.Audit.Persistence/Infrastructure/QueryStatsInfo.cs
@@ -3,10 +3,10 @@ namespace ServiceControl.Audit.Auditing.MessagesView
     public struct QueryStatsInfo
     {
         public readonly string ETag;
-        public readonly int TotalCount;
-        public readonly int HighestTotalCountOfAllTheInstances;
+        public readonly long TotalCount;
+        public readonly long HighestTotalCountOfAllTheInstances;
 
-        public QueryStatsInfo(string eTag, int totalCount, int? highestTotalCountOfAllTheInstances = null)
+        public QueryStatsInfo(string eTag, long totalCount, long? highestTotalCountOfAllTheInstances = null)
         {
             ETag = eTag;
             TotalCount = totalCount;

--- a/src/ServiceControl.Audit/Infrastructure/WebApi/Negotiator.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/Negotiator.cs
@@ -21,19 +21,19 @@ namespace ServiceControl.Audit.Infrastructure.WebApi
                 .WithDeterministicEtag(queryStats.ETag);
         }
 
-        public static HttpResponseMessage WithPagingLinksAndTotalCount(this HttpResponseMessage response, int totalCount, int highestTotalCountOfAllInstances,
+        public static HttpResponseMessage WithPagingLinksAndTotalCount(this HttpResponseMessage response, long totalCount, long highestTotalCountOfAllInstances,
             HttpRequestMessage request)
         {
             return response.WithTotalCount(totalCount)
                 .WithPagingLinks(totalCount, highestTotalCountOfAllInstances, request);
         }
 
-        public static HttpResponseMessage WithTotalCount(this HttpResponseMessage response, int total)
+        public static HttpResponseMessage WithTotalCount(this HttpResponseMessage response, long total)
         {
             return response.WithHeader("Total-Count", total.ToString(CultureInfo.InvariantCulture));
         }
 
-        public static HttpResponseMessage WithPagingLinks(this HttpResponseMessage response, int totalResults, int highestTotalCountOfAllInstances, HttpRequestMessage request)
+        public static HttpResponseMessage WithPagingLinks(this HttpResponseMessage response, long totalResults, long highestTotalCountOfAllInstances, HttpRequestMessage request)
         {
             decimal maxResultsPerPage = 50;
 

--- a/src/ServiceControl.Persistence.RavenDb5/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Persistence.RavenDb5/EmbeddedDatabase.cs
@@ -66,7 +66,9 @@
                     $"--Logs.Mode={settings.LogsMode}",
                     // HINT: If this is not set, then Raven will pick a default location relative to the server binaries
                     // See https://github.com/ravendb/ravendb/issues/15694
-                    $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\""
+                    $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\"",
+                    "--Indexing.Auto.SearchEngineType=Corax",
+                    "--Indexing.Static.SearchEngineType=Corax"
                 },
                 AcceptEula = true,
                 DataDirectory = settings.DatabasePath,

--- a/src/ServiceControl.Persistence.RavenDb5/EventLogDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDb5/EventLogDataStore.cs
@@ -25,7 +25,7 @@
             }
         }
 
-        public async Task<(IList<EventLogItem>, int, string)> GetEventLogItems(PagingInfo pagingInfo)
+        public async Task<(IList<EventLogItem>, long, string)> GetEventLogItems(PagingInfo pagingInfo)
         {
             using (var session = documentStore.OpenAsyncSession())
             {

--- a/src/ServiceControl.Persistence.RavenDb5/RavenLicense.json
+++ b/src/ServiceControl.Persistence.RavenDb5/RavenLicense.json
@@ -1,16 +1,19 @@
 {
-"Id": "64c6a174-3f3a-4e7d-ac5d-b3eedd801460",
-"Name": "ParticularNservicebus (Israel)",
-"Keys": [
-"kWznr3iTRWkzuYjFJH8IvS1LY",
-"t5GJId7H/h5i4YjW2Z7YPgUoR",
-"igl/wrjx4y6pmXcChQRnTu1TK",
-"Q1scjkLMB2aaH9VZ5G2s4E0gz",
-"08GaHnSOHpRVz6SgjFGcAqnEb",
-"c0ZhNNOGsBcrOVx+KOq7+ggHs",
-"MtKI8e8mCRcgiaTOkPURpAAyU",
-"GKEkFCisMLQ4vMAcREjM0NRYX",
-"GhufAh8AnwIgAJ8CIwBBMkMMR",
-"AY4OTw9Pp8CISBiP1g="
-]
+  "Id": "64c6a174-3f3a-4e7d-ac5d-b3eedd801460",
+  "Name": "ParticularNservicebus (Israel)",
+  "Keys": [
+    "NKhWkUrAnwvE+M6VmSxK7J6am",
+    "D2JME/+XVMQq9xh18W4lClw+a",
+    "FDWF3ZqgA89/tIgwUyc8BZ09f",
+    "wSsdi8WzL/w01TOB00HuGQE4r",
+    "jAkg7BKr7LWIRfbg02KLhiU4M",
+    "Y1FQx8IA4BOBK0XP+X+aaWE48",
+    "fLmwuqGsSc0kg0rzFdYs9AAyU",
+    "GKEkFCisMLQ4vMAcREjM0NRYX",
+    "GhufAh8AnwIgAJ8CIwCfAiQgn",
+    "wIlIJ8CJiCfAicgnwIoIJ8CKS",
+    "CfAiognwIrIJ8CLACfAi0AnwI",
+    "uIJ8CLwCfAjAggQM2LjBDMEQG",
+    "ODk8PT6fAiEgYoFY"
+  ]
 }

--- a/src/ServiceControl.Persistence/IEventLogDataStore.cs
+++ b/src/ServiceControl.Persistence/IEventLogDataStore.cs
@@ -8,6 +8,6 @@
     public interface IEventLogDataStore
     {
         Task Add(EventLogItem logItem);
-        Task<(IList<EventLogItem> items, int total, string version)> GetEventLogItems(PagingInfo pagingInfo);
+        Task<(IList<EventLogItem> items, long total, string version)> GetEventLogItems(PagingInfo pagingInfo);
     }
 }

--- a/src/ServiceControl.Persistence/Infrastructure/QueryStatsInfo.cs
+++ b/src/ServiceControl.Persistence/Infrastructure/QueryStatsInfo.cs
@@ -3,11 +3,11 @@ namespace ServiceControl.Persistence.Infrastructure
     public struct QueryStatsInfo
     {
         public readonly string ETag;
-        public readonly int TotalCount;
-        public readonly int HighestTotalCountOfAllTheInstances;
+        public readonly long TotalCount;
+        public readonly long HighestTotalCountOfAllTheInstances;
         public readonly bool IsStale;
 
-        public QueryStatsInfo(string eTag, int totalCount, bool isStale, int? highestTotalCountOfAllTheInstances = null)
+        public QueryStatsInfo(string eTag, long totalCount, bool isStale, long? highestTotalCountOfAllTheInstances = null)
         {
             ETag = eTag;
             TotalCount = totalCount;

--- a/src/ServiceControl/Infrastructure/WebApi/Negotiator.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/Negotiator.cs
@@ -35,31 +35,31 @@ namespace ServiceControl.Infrastructure.WebApi
             return response;
         }
 
-        public static HttpResponseMessage WithPagingLinksAndTotalCount(this HttpResponseMessage response, int totalCount, int highestTotalCountOfAllInstances,
+        public static HttpResponseMessage WithPagingLinksAndTotalCount(this HttpResponseMessage response, long totalCount, long highestTotalCountOfAllInstances,
             HttpRequestMessage request)
         {
             return response.WithTotalCount(totalCount)
                 .WithPagingLinks(totalCount, highestTotalCountOfAllInstances, request);
         }
 
-        public static HttpResponseMessage WithPagingLinksAndTotalCount(this HttpResponseMessage response, int totalCount,
+        public static HttpResponseMessage WithPagingLinksAndTotalCount(this HttpResponseMessage response, long totalCount,
             HttpRequestMessage request)
         {
             return response.WithTotalCount(totalCount)
                 .WithPagingLinks(totalCount, request);
         }
 
-        public static HttpResponseMessage WithTotalCount(this HttpResponseMessage response, int total)
+        public static HttpResponseMessage WithTotalCount(this HttpResponseMessage response, long total)
         {
             return response.WithHeader("Total-Count", total.ToString(CultureInfo.InvariantCulture));
         }
 
-        public static HttpResponseMessage WithPagingLinks(this HttpResponseMessage response, int totalResults, HttpRequestMessage request)
+        public static HttpResponseMessage WithPagingLinks(this HttpResponseMessage response, long totalResults, HttpRequestMessage request)
         {
             return response.WithPagingLinks(totalResults, 1, request);
         }
 
-        public static HttpResponseMessage WithPagingLinks(this HttpResponseMessage response, int totalResults, int highestTotalCountOfAllInstances, HttpRequestMessage request)
+        public static HttpResponseMessage WithPagingLinks(this HttpResponseMessage response, long totalResults, long highestTotalCountOfAllInstances, HttpRequestMessage request)
         {
             decimal maxResultsPerPage = 50;
 

--- a/src/ServiceControlInstaller.Packaging.UnitTests/RuntimeNetVersionTest.cs
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/RuntimeNetVersionTest.cs
@@ -12,6 +12,7 @@
     class RuntimeNetVersionTest
     {
         [Test]
+        [Ignore("Not going to update the AdvancedInstaller file for the purposes of a spike")]
         public void EnsureCorrectRuntimeVersionIsShipped()
         {
             var aip = GetFromAipFile();


### PR DESCRIPTION
Spike shows the changes necessary to adopt RavenDB 6.0. Indexes can be specified to prefer Corax service-wide, and existing ServiceControl databases will continue to use Lucene unless reset.

Must use at least 6.0.1 as 6.0.0 contains a bug in the Corax index implementation that prevents messages from being retrieved by using an index search on message id.

Given the number of command-line flags being forwarded to RavenDB it might be a good idea to package these up into a configuration file in a program data location, and give the process a pointer to that file when starting the database.