### PR TITLE
Add workaround for .NET 8 SDK artifacts conflict

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -24,4 +24,9 @@
     <InstanceName Include="Particular.ServiceControl.Monitoring" />
   </ItemGroup>
 
+  <!-- workaround for https://github.com/microsoft/MSBuildSdks/issues/477 -->
+  <PropertyGroup>
+    <UseArtifactsOutput>false</UseArtifactsOutput>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
The .NET 8 SDK has added a "simplified outputs" feature, but it conflicts with `Microsoft.Build.Artifacts` because they both use the same `ArtifactsPath` property.

The .NET SDK is supposed to detect `Microsoft.Build.Artifacts` being used and disable its feature, but it appears it's not working yet for the way `Microsoft.Build.Artifacts` is being used in this repo.

For now, I've added a workaround to force the SDK feature off.

See https://github.com/microsoft/MSBuildSdks/issues/477 for more info.