### PR TITLE
Fix audit storage size at startup reporting

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDb5/ServiceControl.Audit.Persistence.RavenDb5.csproj
+++ b/src/ServiceControl.Audit.Persistence.RavenDb5/ServiceControl.Audit.Persistence.RavenDb5.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="ByteSize" />
     <PackageReference Include="Lucene.Net" />
     <PackageReference Include="NServiceBus.CustomChecks" />
     <PackageReference Include="RavenDB.Embedded" />


### PR DESCRIPTION
Audit storage size numbers were incorrect. Ported storage size startup reporting behavior from primary instance to audit instance.