### PR TITLE
Installer: Validate if the storage engine is RavenDB5 compatible

### DIFF
--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -51,7 +51,7 @@
             var instance = InstanceFinder.FindInstanceByName<ServiceControlAuditInstance>(model.Name);
             instance.Service.Refresh();
 
-            var compatibleStorageEngine = instance.PersistenceManifest.Name == "RavenDB5";
+            var compatibleStorageEngine = instance.PersistenceManifest.Name == StorageEngineNames.RavenDB5;
 
             if (!compatibleStorageEngine)
             {

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -58,8 +58,8 @@
                 var upgradeGuide4to5url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
 
                 var openUpgradeGuide = await windowManager.ShowYesNoDialog("STORAGE ENGINE INCOMPATIBLE",
-                    $@"Please note that the storage format has changed. Upgrading requires a manual side-by-side deployment of both versions. Guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}",
-                    "Open upgrade guide in system default browser?",
+                    $"Please note that the storage format has changed and the {instance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}",
+                    "Open online ServiceControl 4 to 5 upgrade guide in system default browser?",
                     "Yes",
                     "No"
                 );

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -68,8 +68,8 @@
                 var upgradeGuide4to5url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
 
                 var openUpgradeGuide = await windowManager.ShowYesNoDialog("STORAGE ENGINE INCOMPATIBLE",
-                    $@"Please note that the storage format has changed. Upgrading requires a manual side-by-side deployment of both versions. Guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}",
-                    "Open upgrade guide in system default browser?",
+                    $"Please note that the storage format has changed and the {instance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}",
+                    "Open online ServiceControl 4 to 5 upgrade guide in system default browser?",
                     "Yes",
                     "No"
                 );

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -61,7 +61,7 @@
 
             instance.Service.Refresh();
 
-            var compatibleStorageEngine = instance.PersistenceManifest.Name == "RavenDB5";
+            var compatibleStorageEngine = instance.PersistenceManifest.Name == StorageEngineNames.RavenDB5;
 
             if (!compatibleStorageEngine)
             {

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
@@ -36,10 +36,9 @@ namespace ServiceControl.Management.PowerShell
 
             foreach (var name in Name)
             {
-                var instance = InstanceFinder.FindServiceControlInstance(name);
-                if (instance == null)
+                if (InstanceFinder.FindServiceControlInstance(name) is not ServiceControlAuditInstance instance)
                 {
-                    WriteWarning($"No action taken. An instance called {name} was not found");
+                    WriteWarning($"No action taken. An audit instance called {name} was not found");
                     break;
                 }
 

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditNewInstance.cs
@@ -21,7 +21,7 @@
 
         public static ServiceControlAuditNewInstance CreateWithDefaultPersistence(string deploymentCachePath)
         {
-            const string persisterToUseForBrandNewInstances = "RavenDB5";
+            const string persisterToUseForBrandNewInstances = StorageEngineNames.RavenDB5;
             return CreateWithPersistence(deploymentCachePath, persisterToUseForBrandNewInstances);
         }
 

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlNewInstance.cs
@@ -22,7 +22,7 @@ namespace ServiceControlInstaller.Engine.Instances
 
         public static ServiceControlNewInstance CreateWithDefaultPersistence(string deploymentCachePath)
         {
-            const string persisterUsedForBrandNewInstances = "RavenDB5";
+            const string persisterUsedForBrandNewInstances = StorageEngineNames.RavenDB5;
             return CreateWithPersistence(deploymentCachePath, persisterUsedForBrandNewInstances);
         }
 

--- a/src/ServiceControlInstaller.Engine/Instances/StorageEngineNames.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/StorageEngineNames.cs
@@ -1,0 +1,7 @@
+﻿namespace ServiceControlInstaller.Engine.Instances
+{
+    public static class StorageEngineNames
+    {
+        public const string RavenDB5 = "RavenDB5";
+    }
+}

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
@@ -104,8 +104,17 @@
             return true;
         }
 
-        public bool Upgrade(ServiceControlBaseService instance)
+        public bool Upgrade(ServiceControlAuditInstance instance)
         {
+            var compatibleStorageEngine = instance.PersistenceManifest.Name == StorageEngineNames.RavenDB5;
+
+            if (!compatibleStorageEngine)
+            {
+                var upgradeGuide4to5url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
+                logger.Error($"Upgrade aborted. Please note that the storage format has changed and the {instance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}");
+                return false;
+            }
+
             ZipInfo.ValidateZip();
 
             var checkLicenseResult = CheckLicenseIsValid();

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
@@ -102,6 +102,15 @@
 
         public bool Upgrade(ServiceControlInstance instance, ServiceControlUpgradeOptions options)
         {
+            var compatibleStorageEngine = instance.PersistenceManifest.Name == StorageEngineNames.RavenDB5;
+
+            if (!compatibleStorageEngine)
+            {
+                var upgradeGuide4to5url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
+                logger.Error($"Upgrade aborted. Please note that the storage format has changed and the {instance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}");
+                return false;
+            }
+
             if (instance.Version < options.UpgradeInfo.CurrentMinimumVersion)
             {
                 logger.Error($"Upgrade aborted. An interim upgrade to version {options.UpgradeInfo.RecommendedUpgradeVersion} is required before upgrading to version {ZipInfo.Version}. Download available at https://github.com/Particular/ServiceControl/releases/tag/{options.UpgradeInfo.RecommendedUpgradeVersion}");


### PR DESCRIPTION
Validate if the storage engine is RavenDB5 compatible. If not, do not allow the upgrade and provide guidance to the online upgrade guide.

## Powershell

```
   Ramon@ZOLDER  S:\ServiceControl\src  installer-storage-engine-check  sc-upgrade -Name Particular.V4.25
Upgrade aborted. Please note that the storage format has changed and the RavenDB 3.5 storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at https://docs.particular.net/servicecontrol/upgrades/4to5/
Invoke-ServiceControlInstanceUpgrade: Upgrade of Particular.V4.25 failed
   Ramon@ZOLDER  S:\ServiceControl\src  installer-storage-engine-check    audit-upgrade -Name  Particular.V4.25.Audit
Upgrade aborted. Please note that the storage format has changed and the RavenDB 3.5 storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at https://docs.particular.net/servicecontrol/upgrades/4to5/
Invoke-ServiceControlAuditInstanceUpgrade: Upgrade of Particular.V4.25.Audit failed
   Ramon@ZOLDER  S:\ServiceControl\src  installer-storage-engine-check   
```

## SCMU

![image](https://github.com/Particular/ServiceControl/assets/152998/55cb2b1d-cdff-43de-b705-1de7884d5e6e)



