### PR TITLE
Disable docker images build and publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,6 @@ jobs:
         env:
           AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
         run: dotnet build src/Setup --configuration Release
-      - name: Build Docker images
-        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
-        run: dotnet build src/ServiceControl.DockerImages --configuration Release
-      - name: List Docker images
-        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
-        shell: pwsh
-        run: docker images
       - name: Publish assets
         uses: actions/upload-artifact@v3.1.3
         with:
@@ -146,20 +139,3 @@ jobs:
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
           additional-metadata-paths: ServiceControlMetadata.json
-      - name: Login to Docker Hub
-        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
-        uses: docker/login-action@v3.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Push Docker images
-        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
-        shell: pwsh
-        run: |
-          Get-ChildItem -Path dockerfiles -Filter *.dockerfile | ForEach-Object {
-              $dockerImageName = $_.Name.SubString(0, $_.Name.Length - ".dockerfile".Length);
-              
-              $dockerpushcmd = "docker push particular/" + $dockerImageName +":${{ env.MinVerVersion }}"
-              echo "Docker Push Command: $dockerpushcmd"
-              Invoke-Expression $dockerpushcmd.ToLower()
-          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,13 @@ jobs:
         env:
           AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
         run: dotnet build src/Setup --configuration Release
+      # - name: Build Docker images
+      #   if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+      #   run: dotnet build src/ServiceControl.DockerImages --configuration Release
+      # - name: List Docker images
+      #   if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+      #   shell: pwsh
+      #   run: docker images
       - name: Publish assets
         uses: actions/upload-artifact@v3.1.3
         with:
@@ -139,3 +146,20 @@ jobs:
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
           additional-metadata-paths: ServiceControlMetadata.json
+      # - name: Login to Docker Hub
+      #   if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+      #   uses: docker/login-action@v3.0.0
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # - name: Push Docker images
+      #   if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+      #   shell: pwsh
+      #   run: |
+      #     Get-ChildItem -Path dockerfiles -Filter *.dockerfile | ForEach-Object {
+      #         $dockerImageName = $_.Name.SubString(0, $_.Name.Length - ".dockerfile".Length);
+      #
+      #         $dockerpushcmd = "docker push particular/" + $dockerImageName +":${{ env.MinVerVersion }}"
+      #         echo "Docker Push Command: $dockerpushcmd"
+      #         Invoke-Expression $dockerpushcmd.ToLower()
+      #     }

--- a/src/ServiceControl.DockerImages/ServiceControl.DockerImages.csproj
+++ b/src/ServiceControl.DockerImages/ServiceControl.DockerImages.csproj
@@ -74,7 +74,9 @@
 
   </ItemGroup>
 
-  <Target Name="CleanGeneratedDockerfiles" AfterTargets="Build">
+  <!-- NOTE: this should be re-enabled after ServiceControl can be run on Linux -->
+  <!--<Target Name="CleanGeneratedDockerfiles" AfterTargets="Build">-->
+  <Target Name="CleanGeneratedDockerfiles">
     <ItemGroup>
       <Dockerfiles Include="$(DockerfilesFolder)*.dockerfile" />
     </ItemGroup>


### PR DESCRIPTION
This PR removes docker image building and publishing. The workflow steps have been removed, and the target in the project file that builds the images locally has been disabled. 