### PR TITLE
Update Microsoft.Build.Artifacts

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -89,6 +89,7 @@
 
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.0.3" />
+    <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.273" />
     <GlobalPackageReference Include="Particular.Packaging" Version="3.0.0" />
   </ItemGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -88,7 +88,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.0.0" />
+    <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.0.3" />
     <GlobalPackageReference Include="Particular.Packaging" Version="3.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates Microsoft.Build.Artifacts to 6.0.3, which removes the dependency on System.Threading.Tasks.Dataflow. 

The PR also adds the [Microsoft.Build.CopyOnWrite](https://github.com/microsoft/MSBuildSdks/tree/main/src/CopyOnWrite) package to further improve the build performance when used with a [Dev Drive](https://learn.microsoft.com/en-us/windows/dev-drive/).