### PR TITLE
Update to zip target to allow for incremental builds

### DIFF
--- a/src/ServiceControl.Audit/ServiceControl.Audit.csproj
+++ b/src/ServiceControl.Audit/ServiceControl.Audit.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.Audit.exe.config;logfile.*.txt;nsb_log_*.txt" DirExclude="Transports;Persisters;.diagnostics" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl.Audit\ServiceControl.Audit" />
+    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.Audit.exe.config;logfile.*.txt;nsb_log_*.txt;*-configuration.txt" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl.Audit\ServiceControl.Audit" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.Monitoring.exe.config;logfile.*.txt;nsb_log_*.txt" DirExclude="Transports;.diagnostics" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl.Monitoring\ServiceControl.Monitoring" />
+    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.Monitoring.exe.config;logfile.*.txt;nsb_log_*.txt;*-configuration.txt" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl.Monitoring\ServiceControl.Monitoring" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.exe.config;logfile.*.txt;nsb_log_*.txt" DirExclude="Transports;Persisters;.diagnostics" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl\ServiceControl" />
+    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.exe.config;logfile.*.txt;nsb_log_*.txt;*-configuration.txt" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl\ServiceControl" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -20,20 +20,48 @@
     <ProjectReference Update="..\**\*" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ZipFile Include="Particular.ServiceControl" />
-    <ZipFile Include="Particular.ServiceControl.Audit" />
-    <ZipFile Include="Particular.ServiceControl.Monitoring" />
-    <ZipFile Include="Transports" />
-    <ZipFile Include="RavenDBServer" />
-  </ItemGroup>
+  <PropertyGroup>
+    <ZipFolder>..\..\zip\</ZipFolder>
+    <Primary>Particular.ServiceControl</Primary>
+    <Audit>Particular.ServiceControl.Audit</Audit>
+    <Monitoring>Particular.ServiceControl.Monitoring</Monitoring>
+    <Transports>Transports</Transports>
+    <RavenDBServer>RavenDBServer</RavenDBServer>
+  </PropertyGroup>
 
-  <Target Name="CreateZipFiles" AfterTargets="CopyArtifacts">
-    <PropertyGroup>
-      <ZipFolder>..\..\zip\</ZipFolder>
-    </PropertyGroup>
+  <Target Name="PrepareCreateZipFiles">
+    <ItemGroup>
+      <PrimaryFilesToZip Include="$(ArtifactsPath)$(Primary)\**\*" />
+      <AuditFilesToZip Include="$(ArtifactsPath)$(Audit)\**\*" />
+      <MonitoringFilesToZip Include="$(ArtifactsPath)$(Monitoring)\**\*" />
+      <TransportsFilesToZip Include="$(ArtifactsPath)$(Transports)\**\*" />
+      <RavenDBServerFilesToZip Include="$(ArtifactsPath)$(RavenDBServer)\**\*" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CreatePrimaryZipFile" AfterTargets="CopyArtifacts" DependsOnTargets="PrepareCreateZipFiles" Inputs="@(PrimaryFilesToZip)" Outputs="$(ZipFolder)$(Primary).zip">
     <MakeDir Directories="$(ZipFolder)" />
-    <ZipDirectory SourceDirectory="$(ArtifactsPath)%(ZipFile.identity)" DestinationFile="$(ZipFolder)%(ZipFile.identity).zip" Overwrite="true" />
+    <ZipDirectory SourceDirectory="$(ArtifactsPath)$(Primary)" DestinationFile="$(ZipFolder)$(Primary).zip" Overwrite="true" />
+  </Target>
+
+  <Target Name="CreateAuditZipFile" AfterTargets="CopyArtifacts" DependsOnTargets="PrepareCreateZipFiles" Inputs="@(AuditFilesToZip)" Outputs="$(ZipFolder)$(Audit).zip">
+    <MakeDir Directories="$(ZipFolder)" />
+    <ZipDirectory SourceDirectory="$(ArtifactsPath)$(Audit)" DestinationFile="$(ZipFolder)$(Audit).zip" Overwrite="true" />
+  </Target>
+
+  <Target Name="CreateMonitoringZipFile" AfterTargets="CopyArtifacts" DependsOnTargets="PrepareCreateZipFiles" Inputs="@(MonitoringFilesToZip)" Outputs="$(ZipFolder)$(Monitoring).zip">
+    <MakeDir Directories="$(ZipFolder)" />
+    <ZipDirectory SourceDirectory="$(ArtifactsPath)$(Monitoring)" DestinationFile="$(ZipFolder)$(Monitoring).zip" Overwrite="true" />
+  </Target>
+
+  <Target Name="CreateTransportsZipFile" AfterTargets="CopyArtifacts" DependsOnTargets="PrepareCreateZipFiles" Inputs="@(TransportsFilesToZip)" Outputs="$(ZipFolder)$(Transports).zip">
+    <MakeDir Directories="$(ZipFolder)" />
+    <ZipDirectory SourceDirectory="$(ArtifactsPath)$(Transports)" DestinationFile="$(ZipFolder)$(Transports).zip" Overwrite="true" />
+  </Target>
+
+  <Target Name="CreateRavenDBServerZipFile" AfterTargets="CopyArtifacts" DependsOnTargets="PrepareCreateZipFiles" Inputs="@(RavenDBServerFilesToZip)" Outputs="$(ZipFolder)$(RavenDBServer).zip">
+    <MakeDir Directories="$(ZipFolder)" />
+    <ZipDirectory SourceDirectory="$(ArtifactsPath)$(RavenDBServer)" DestinationFile="$(ZipFolder)$(RavenDBServer).zip" Overwrite="true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
With this change, the zip targets will properly support incremental builds, so the zip files won't be recreated every time you build.

Instead, they'll only build when there is newer content than what the previous zip file contains.

Also, I included some cleanup to the instance artifact definitions that I've been meaning to do after all the recent changes.