### PR TITLE
Added SuppressPropertyChangedWarnings to remove warning

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModel.cs
@@ -31,6 +31,7 @@
             ApplyConventionalServiceNameToAuditInstance(ConventionName);
         }
 
+        [SuppressPropertyChangedWarnings]
         public virtual void OnSelectedTransportChanged()
         {
             ServiceControl?.SelectedTransportChanged();


### PR DESCRIPTION
The warnings states to add the `SuppressPropertyChangedWarnings` attribute. Not sure if that is the right fix but I'm fed up with the warning :-)