### PR TITLE
Force upgrade support for ver 4 of primary instances running on RavenDB 3.5

### DIFF
--- a/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
@@ -1,6 +1,5 @@
 namespace ServiceControl.Config.Commands;
 
-using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -35,7 +34,7 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
         var instance = InstanceFinder.ServiceControlInstances().FirstOrDefault(i => i.Name == model.Name);
 
         //HINT: Force upgrade is available only primary v4 instance, running on RavenDB 3.5
-        return instance != null && instance.Version.Major == 4 && instance.PersistenceManifest.Name == StorageEngineNames.RavenDB35;
+        return instance != null && instance.Version.Major == 4 && instance.PersistenceManifest.Name == "RavenDB35";
     }
     public override async Task ExecuteAsync(ServiceControlAdvancedViewModel model)
     {
@@ -100,7 +99,7 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
                 //HINT: we move the data directory to a backup location
                 Directory.Move(instance.DBPath, model.ForcedUpgradeBackupLocation);
 
-                instance.PersistenceManifest = ServiceControlPersisters.PrimaryPersistenceManifests.Single(pm => pm.Name == StorageEngineNames.RavenDB5);
+                instance.PersistenceManifest = ServiceControlPersisters.GetPrimaryPersistence(StorageEngineNames.RavenDB);
 
                 return serviceControlInstaller.Upgrade(instance, upgradeOptions, progress);
             });

--- a/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
@@ -48,10 +48,9 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
             }
         }
 
-        if (ForcedUpgradeAllowed(model) == false)
+        if (!ForcedUpgradeAllowed(model))
         {
-            await windowManager.ShowMessage("Cannot run the command",
-                "Only ver. 4.x primary instance that use RavenDB ver. 3.5 can be forced upgraded.");
+            await windowManager.ShowMessage("Cannot run the command", "Only ver. 4.x primary instance that use RavenDB ver. 3.5 can be forced upgraded.");
 
             return;
         }
@@ -98,7 +97,7 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
             reportCard = await Task.Run(() =>
             {
                 //HINT: we wipe out the database before we continue with the upgrade
-                FileUtils.DeleteDirectory(instance.DBPath, true, true);
+                FileUtils.DeleteDirectory(instance.DBPath, recursive: true, contentsOnly: true);
                 instance.PersistenceManifest = ServiceControlPersisters.PrimaryPersistenceManifests.Single(pm => pm.Name == StorageEngineNames.RavenDB5);
 
                 return serviceControlInstaller.Upgrade(instance, upgradeOptions, progress);

--- a/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
@@ -1,5 +1,7 @@
-﻿namespace ServiceControl.Config.Commands;
+namespace ServiceControl.Config.Commands;
 
+using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Caliburn.Micro;
@@ -8,7 +10,6 @@ using Events;
 using Framework.Modules;
 using Framework;
 using ServiceControlInstaller.Engine.Configuration.ServiceControl;
-using ServiceControlInstaller.Engine.FileSystem;
 using ServiceControlInstaller.Engine.Instances;
 using ServiceControlInstaller.Engine.ReportCard;
 using ServiceControlInstaller.Engine.Validation;
@@ -96,8 +97,9 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
 
             reportCard = await Task.Run(() =>
             {
-                //HINT: we wipe out the database before we continue with the upgrade
-                FileUtils.DeleteDirectory(instance.DBPath, recursive: true, contentsOnly: true);
+                //HINT: we move the data directory to a backup location
+                Directory.Move(instance.DBPath, model.ForcedUpgradeBackupLocation);
+
                 instance.PersistenceManifest = ServiceControlPersisters.PrimaryPersistenceManifests.Single(pm => pm.Name == StorageEngineNames.RavenDB5);
 
                 return serviceControlInstaller.Upgrade(instance, upgradeOptions, progress);

--- a/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
@@ -72,7 +72,7 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
 
         await UpgradeServiceControlInstance(model, instance, upgradeOptions);
 
-        await eventAggregator.PublishOnUIThreadAsync(new RefreshInstances());
+        await eventAggregator.PublishOnUIThreadAsync(new ResetInstances());
     }
 
     async Task UpgradeServiceControlInstance(ServiceControlAdvancedViewModel model, ServiceControlInstance instance, ServiceControlUpgradeOptions upgradeOptions)

--- a/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
@@ -1,0 +1,129 @@
+﻿namespace ServiceControl.Config.Commands;
+
+using System.Linq;
+using System.Threading.Tasks;
+using Caliburn.Micro;
+using Framework.Commands;
+using Events;
+using Framework.Modules;
+using Framework;
+using ServiceControlInstaller.Engine.Configuration.ServiceControl;
+using ServiceControlInstaller.Engine.FileSystem;
+using ServiceControlInstaller.Engine.Instances;
+using ServiceControlInstaller.Engine.ReportCard;
+using ServiceControlInstaller.Engine.Validation;
+using UI.AdvancedOptions;
+
+class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<ServiceControlAdvancedViewModel>
+{
+    public ForceUpgradeServiceControlInstanceCommand(
+        IServiceControlWindowManager windowManager,
+        IEventAggregator eventAggregator,
+        ServiceControlInstanceInstaller serviceControlInstaller) : base(ForcedUpgradeAllowed)
+    {
+        this.windowManager = windowManager;
+        this.eventAggregator = eventAggregator;
+        this.serviceControlInstaller = serviceControlInstaller;
+    }
+
+    [FeatureToggle(Feature.LicenseChecks)]
+    public bool LicenseChecks { get; set; }
+
+    static bool ForcedUpgradeAllowed(ServiceControlAdvancedViewModel model)
+    {
+        var instance = InstanceFinder.ServiceControlInstances().FirstOrDefault(i => i.Name == model.Name);
+
+        //HINT: Force upgrade is available only primary v4 instance, running on RavenDB 3.5
+        return instance != null && instance.Version.Major == 4 && instance.PersistenceManifest.Name == StorageEngineNames.RavenDB35;
+    }
+    public override async Task ExecuteAsync(ServiceControlAdvancedViewModel model)
+    {
+        if (LicenseChecks)
+        {
+            var licenseCheckResult = serviceControlInstaller.CheckLicenseIsValid();
+            if (!licenseCheckResult.Valid)
+            {
+                await windowManager.ShowMessage("LICENSE ERROR", $"Upgrade could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact contact@particular.net", hideCancel: true);
+                return;
+            }
+        }
+
+        if (ForcedUpgradeAllowed(model) == false)
+        {
+            await windowManager.ShowMessage("Cannot run the command",
+                "Only ver. 4.x primary instance that use RavenDB ver. 3.5 can be forced upgraded.");
+
+            return;
+        }
+
+        if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB: true, out var missingMessage))
+        {
+            await windowManager.ShowMessage("Missing prerequisites", missingMessage, acceptText: "Cancel", hideCancel: true);
+            return;
+        }
+
+        var instance = InstanceFinder.FindInstanceByName<ServiceControlInstance>(model.Name);
+
+        var upgradeInfo = UpgradeControl.GetUpgradeInfoForTargetVersion(serviceControlInstaller.ZipInfo.Version, instance.Version);
+        var upgradeOptions = new ServiceControlUpgradeOptions
+        {
+            UpgradeInfo = upgradeInfo,
+        };
+
+        await UpgradeServiceControlInstance(model, instance, upgradeOptions);
+
+        await eventAggregator.PublishOnUIThreadAsync(new RefreshInstances());
+    }
+
+    async Task UpgradeServiceControlInstance(ServiceControlAdvancedViewModel model, ServiceControlInstance instance, ServiceControlUpgradeOptions upgradeOptions)
+    {
+        using (var progress = model.GetProgressObject($"UPGRADING {model.Name}"))
+        {
+            var reportCard = new ReportCard();
+            var restartAgain = model.IsRunning;
+
+            var stopped = await model.StopService(progress);
+
+            if (!stopped)
+            {
+                await eventAggregator.PublishOnUIThreadAsync(new RefreshInstances());
+
+                reportCard.Errors.Add("Failed to stop the service");
+                reportCard.SetStatus();
+                await windowManager.ShowActionReport(reportCard, "ISSUES UPGRADING INSTANCE", "Could not upgrade instance because of the following errors:");
+
+                return;
+            }
+
+            reportCard = await Task.Run(() =>
+            {
+                //HINT: we wipe out the database before we continue with the upgrade
+                FileUtils.DeleteDirectory(instance.DBPath, true, true);
+                instance.PersistenceManifest = ServiceControlPersisters.PrimaryPersistenceManifests.Single(pm => pm.Name == StorageEngineNames.RavenDB5);
+
+                return serviceControlInstaller.Upgrade(instance, upgradeOptions, progress);
+            });
+
+            if (reportCard.HasErrors || reportCard.HasWarnings)
+            {
+                await windowManager.ShowActionReport(reportCard, "ISSUES UPGRADING INSTANCE", "Could not upgrade instance because of the following errors:", "There were some warnings while upgrading the instance:");
+            }
+            else
+            {
+                if (restartAgain)
+                {
+                    var serviceStarted = await model.StartService(progress, maintenanceMode: false);
+                    if (!serviceStarted)
+                    {
+                        reportCard.Errors.Add("The Service failed to start. Please consult the ServiceControl logs for this instance");
+                        await windowManager.ShowActionReport(reportCard, "UPGRADE FAILURE", "Instance reported this error after upgrade:");
+                    }
+                }
+            }
+        }
+    }
+
+    readonly IEventAggregator eventAggregator;
+    readonly IServiceControlWindowManager windowManager;
+    readonly ServiceControlInstanceInstaller serviceControlInstaller;
+}

--- a/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
@@ -38,6 +38,12 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
     }
     public override async Task ExecuteAsync(ServiceControlAdvancedViewModel model)
     {
+        if (await windowManager.ShowMessage("Forced migration",
+                "Do you want to proceed with forced migration to version 5?", "Yes") == false)
+        {
+            return;
+        }
+
         if (LicenseChecks)
         {
             var licenseCheckResult = serviceControlInstaller.CheckLicenseIsValid();

--- a/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
@@ -1,5 +1,7 @@
 namespace ServiceControl.Config.Commands;
 
+using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Caliburn.Micro;
@@ -8,7 +10,6 @@ using Events;
 using Framework.Modules;
 using Framework;
 using ServiceControlInstaller.Engine.Configuration.ServiceControl;
-using ServiceControlInstaller.Engine.FileSystem;
 using ServiceControlInstaller.Engine.Instances;
 using ServiceControlInstaller.Engine.ReportCard;
 using ServiceControlInstaller.Engine.Validation;
@@ -96,8 +97,9 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
 
             reportCard = await Task.Run(() =>
             {
-                //HINT: we wipe out the database before we continue with the upgrade
-                FileUtils.DeleteDirectory(instance.DBPath, recursive: true, contentsOnly: true);
+                //HINT: we move the data directory to a backup location
+                Directory.Move(instance.DBPath, model.ForcedUpgradeBackupLocation);
+
                 instance.PersistenceManifest = ServiceControlPersisters.PrimaryPersistenceManifests.Single(pm => pm.Name == StorageEngineNames.RavenDB5);
 
                 return serviceControlInstaller.Upgrade(instance, upgradeOptions, progress);

--- a/src/ServiceControl.Config/Commands/StartServiceControlInMaintenanceModeCommand.cs
+++ b/src/ServiceControl.Config/Commands/StartServiceControlInMaintenanceModeCommand.cs
@@ -39,7 +39,7 @@
                         return;
                     }
 
-                    var started = await model.StartServiceInMaintenanceMode(progress);
+                    var started = await model.StartService(progress, maintenanceMode: true);
 
                     if (!started)
                     {

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
@@ -112,35 +112,26 @@
                         Width="180"
                         />
 
-                <!-- Forced Upgrade to Version 5 Section-->
+                <!-- Forced Upgrade to RavenDB5 Section-->
                 <StackPanel Visibility="{Binding ForcedUpgradeAllowed, Converter={StaticResource boolToVis}}">
                     <Border Margin="0,25,0,0"
                             BorderBrush="{StaticResource Gray90Brush}"
                             BorderThickness="0,0,0,1">
                         <TextBlock FontSize="13px"
                                    FontWeight="Bold"
-                                   Text="FORCE UPGRADE TO VERSION 5"
+                                   Text="FORCE UPGRADE TO RAVENDB 5"  
                         />
                     </Border>
 
                     <TextBlock FontSize="12px" 
                                TextWrapping="Wrap" 
                                Margin="0,0,0,20">
-                        Forced upgrade to version 5 will not preserve any data stored by the instance. Before migration a backup of current data will be stored in 
-                        <TextBlock Text="{Binding ForcedUpgradeBackupLocation}" /> directory.
-                        
-
-                        <LineBreak/>
-                        <LineBreak/>
-                        If you want migrate the error data follow
-                        <Hyperlink Command="{Binding OpenUrl}" CommandParameter="https://docs.particular.net/servicecontrol/upgrades/4to5/">
-                            the version 4 to 5 upgrade guide
-                        </Hyperlink>.
+                        Forced upgrade to RavenDB 5 will delete any data stored by the instance.<LineBreak />The associated database and logs can be also removed via the confirmation dialog.
                     </TextBlock>
                     <Button
                         Command="{Binding ForceUpgradeCommand}"
                         CommandParameter="{Binding DataContext, ElementName=root}"
-                        Content="Upgrade instance"
+                        Content="Upgrade"
                         Style="{StaticResource ErrorButton}" 
                         HorizontalAlignment="Left"
                         Padding="10,10"

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
@@ -111,7 +111,33 @@
                         Padding="10,10"
                         Width="180"
                         />
-                
+
+                <!-- Forced Upgrade to RavenDB5 Section-->
+                <StackPanel Visibility="{Binding ForcedUpgradeAllowed, Converter={StaticResource boolToVis}}">
+                    <Border Margin="0,25,0,0"
+                            BorderBrush="{StaticResource Gray90Brush}"
+                            BorderThickness="0,0,0,1">
+                        <TextBlock FontSize="13px"
+                                   FontWeight="Bold"
+                                   Text="FORCE UPGRADE TO RAVENDB 5"  
+                        />
+                    </Border>
+
+                    <TextBlock FontSize="12px" 
+                               TextWrapping="Wrap" 
+                               Margin="0,0,0,20">
+                        Forced upgrade to RavenDB 5 will delete any data stored by the instance.<LineBreak />The associated database and logs can be also removed via the confirmation dialog.
+                    </TextBlock>
+                    <Button
+                        Command="{Binding ForceUpgradeCommand}"
+                        CommandParameter="{Binding DataContext, ElementName=root}"
+                        Content="Upgrade"
+                        Style="{StaticResource ErrorButton}" 
+                        HorizontalAlignment="Left"
+                        Padding="10,10"
+                        Width="180"
+                    />
+                </StackPanel>
             </StackPanel>
 
 

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="ServiceControl.Config.UI.AdvancedOptions.ServiceControlAdvancedView"
+<UserControl x:Class="ServiceControl.Config.UI.AdvancedOptions.ServiceControlAdvancedView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -126,8 +126,13 @@
                     <TextBlock FontSize="12px" 
                                TextWrapping="Wrap" 
                                Margin="0,0,0,20">
-                        Forced upgrade to version 5 deletes any data stored by the instance.<LineBreak /> 
-                        If you want to preserve the error data follow
+                        Forced upgrade to version 5 will not preserve any data stored by the instance. Before migration a backup of current data will be stored in 
+                        <TextBlock Text="{Binding ForcedUpgradeBackupLocation}" /> directory.
+                        
+
+                        <LineBreak/>
+                        <LineBreak/>
+                        If you want migrate the error data follow
                         <Hyperlink Command="{Binding OpenUrl}" CommandParameter="https://docs.particular.net/servicecontrol/upgrades/4to5/">
                             the version 4 to 5 upgrade guide
                         </Hyperlink>.
@@ -135,7 +140,7 @@
                     <Button
                         Command="{Binding ForceUpgradeCommand}"
                         CommandParameter="{Binding DataContext, ElementName=root}"
-                        Content="Delete all data and upgrade"
+                        Content="Upgrade instance"
                         Style="{StaticResource ErrorButton}" 
                         HorizontalAlignment="Left"
                         Padding="10,10"

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
@@ -135,7 +135,7 @@
                     <Button
                         Command="{Binding ForceUpgradeCommand}"
                         CommandParameter="{Binding DataContext, ElementName=root}"
-                        Content="Upgrade"
+                        Content="Delete all data and upgrade"
                         Style="{StaticResource ErrorButton}" 
                         HorizontalAlignment="Left"
                         Padding="10,10"

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
@@ -119,14 +119,14 @@
                             BorderThickness="0,0,0,1">
                         <TextBlock FontSize="13px"
                                    FontWeight="Bold"
-                                   Text="FORCE UPGRADE TO VERSION 5"  
+                                   Text="FORCE UPGRADE TO VERSION 5"
                         />
                     </Border>
 
                     <TextBlock FontSize="12px" 
                                TextWrapping="Wrap" 
                                Margin="0,0,0,20">
-                        Forced upgrade to version 5 will delete any data stored by the instance.<LineBreak /> 
+                        Forced upgrade to version 5 deletes any data stored by the instance.<LineBreak /> 
                         If you want to preserve the error data follow
                         <Hyperlink Command="{Binding OpenUrl}" CommandParameter="https://docs.particular.net/servicecontrol/upgrades/4to5/">
                             the version 4 to 5 upgrade guide

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
@@ -112,21 +112,25 @@
                         Width="180"
                         />
 
-                <!-- Forced Upgrade to RavenDB5 Section-->
+                <!-- Forced Upgrade to Version 5 Section-->
                 <StackPanel Visibility="{Binding ForcedUpgradeAllowed, Converter={StaticResource boolToVis}}">
                     <Border Margin="0,25,0,0"
                             BorderBrush="{StaticResource Gray90Brush}"
                             BorderThickness="0,0,0,1">
                         <TextBlock FontSize="13px"
                                    FontWeight="Bold"
-                                   Text="FORCE UPGRADE TO RAVENDB 5"  
+                                   Text="FORCE UPGRADE TO VERSION 5"  
                         />
                     </Border>
 
                     <TextBlock FontSize="12px" 
                                TextWrapping="Wrap" 
                                Margin="0,0,0,20">
-                        Forced upgrade to RavenDB 5 will delete any data stored by the instance.<LineBreak />The associated database and logs can be also removed via the confirmation dialog.
+                        Forced upgrade to version 5 will delete any data stored by the instance.<LineBreak /> 
+                        If you want to preserve the error data follow
+                        <Hyperlink Command="{Binding OpenUrl}" CommandParameter="https://docs.particular.net/servicecontrol/upgrades/4to5/">
+                            the version 4 to 5 upgrade guide
+                        </Hyperlink>.
                     </TextBlock>
                     <Button
                         Command="{Binding ForceUpgradeCommand}"

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
@@ -125,14 +125,13 @@
 
                     <TextBlock FontSize="12px" 
                                TextWrapping="Wrap" 
-                               Margin="0,0,0,20">
-                        Forced upgrade to version 5 will not preserve any data stored by the instance. Before migration a backup of current data will be stored in 
-                        <TextBlock Text="{Binding ForcedUpgradeBackupLocation}" /> directory.
-                        
-
+                               Margin="0,0,0,20"
+                               >
+                        Forced upgrade will not preserve data stored by the instance. Before the migration, the current, RavenDB 3.5 database will be moved to 
+                        <TextBlock FontSize="12px" FontWeight="Bold" Text="{Binding ForcedUpgradeBackupLocation}" /> directory.
                         <LineBreak/>
                         <LineBreak/>
-                        If you want migrate the error data follow
+                        If you want perform the migration preserving the error data follow
                         <Hyperlink Command="{Binding OpenUrl}" CommandParameter="https://docs.particular.net/servicecontrol/upgrades/4to5/">
                             the version 4 to 5 upgrade guide
                         </Hyperlink>.

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
@@ -126,8 +126,13 @@
                     <TextBlock FontSize="12px" 
                                TextWrapping="Wrap" 
                                Margin="0,0,0,20">
-                        Forced upgrade to version 5 deletes any data stored by the instance.<LineBreak /> 
-                        If you want to preserve the error data follow
+                        Forced upgrade to version 5 will not preserve any data stored by the instance. Before migration a backup of current data will be stored in 
+                        <TextBlock Text="{Binding ForcedUpgradeBackupLocation}" /> directory.
+                        
+
+                        <LineBreak/>
+                        <LineBreak/>
+                        If you want migrate the error data follow
                         <Hyperlink Command="{Binding OpenUrl}" CommandParameter="https://docs.particular.net/servicecontrol/upgrades/4to5/">
                             the version 4 to 5 upgrade guide
                         </Hyperlink>.
@@ -135,7 +140,7 @@
                     <Button
                         Command="{Binding ForceUpgradeCommand}"
                         CommandParameter="{Binding DataContext, ElementName=root}"
-                        Content="Delete all data and upgrade"
+                        Content="Upgrade instance"
                         Style="{StaticResource ErrorButton}" 
                         HorizontalAlignment="Left"
                         Padding="10,10"

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
@@ -17,7 +17,13 @@
 
     class ServiceControlAdvancedViewModel : RxProgressScreen, IHandle<RefreshInstances>
     {
-        public ServiceControlAdvancedViewModel(BaseService instance, IEventAggregator eventAggregator, StartServiceControlInMaintenanceModeCommand maintenanceModeCommand, DeleteServiceControlInstanceCommand deleteInstanceCommand, ForceUpgradeServiceControlInstanceCommand forceUpgradeCommand)
+        public ServiceControlAdvancedViewModel(
+            BaseService instance,
+            IEventAggregator eventAggregator,
+            StartServiceControlInMaintenanceModeCommand maintenanceModeCommand,
+            DeleteServiceControlInstanceCommand deleteInstanceCommand,
+            ForceUpgradeServiceControlInstanceCommand forceUpgradeCommand
+            )
         {
             ServiceControlInstance = (ServiceControlBaseService)instance;
             DisplayName = "ADVANCED OPTIONS";

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
@@ -17,7 +17,7 @@
 
     class ServiceControlAdvancedViewModel : RxProgressScreen, IHandle<RefreshInstances>
     {
-        public ServiceControlAdvancedViewModel(BaseService instance, IEventAggregator eventAggregator, StartServiceControlInMaintenanceModeCommand maintenanceModeCommand, DeleteServiceControlInstanceCommand deleteInstanceCommand)
+        public ServiceControlAdvancedViewModel(BaseService instance, IEventAggregator eventAggregator, StartServiceControlInMaintenanceModeCommand maintenanceModeCommand, DeleteServiceControlInstanceCommand deleteInstanceCommand, ForceUpgradeServiceControlInstanceCommand forceUpgradeCommand)
         {
             ServiceControlInstance = (ServiceControlBaseService)instance;
             DisplayName = "ADVANCED OPTIONS";
@@ -28,6 +28,7 @@
                 await eventAggregator.PublishOnUIThreadAsync(new RefreshInstances());
             });
             DeleteCommand = deleteInstanceCommand;
+            ForceUpgradeCommand = forceUpgradeCommand;
             OpenUrl = new OpenURLCommand();
             CopyToClipboard = new CopyToClipboardCommand();
             StopMaintenanceModeCommand = ReactiveCommand.CreateFromTask<ServiceControlAdvancedViewModel>(async _ =>
@@ -50,6 +51,8 @@
         public bool MaintenanceModeSupported => ServiceControlInstance.Version >= ServiceControlSettings.MaintenanceMode.SupportedFrom;
 
         public ICommand DeleteCommand { get; set; }
+
+        public ICommand ForceUpgradeCommand { get; set; }
 
         public ICommand Cancel { get; set; }
 
@@ -114,6 +117,8 @@
             }
         }
 
+        public bool ForcedUpgradeAllowed => ForceUpgradeCommand.CanExecute(this);
+
         public Task HandleAsync(RefreshInstances message, CancellationToken cancellationToken)
         {
             NotifyOfPropertyChange("AllowStop");
@@ -123,7 +128,7 @@
             return Task.CompletedTask;
         }
 
-        public async Task<bool> StartServiceInMaintenanceMode(IProgressObject progress)
+        public async Task<bool> StartService(IProgressObject progress, bool maintenanceMode)
         {
             var disposeProgress = progress == null;
             var result = false;
@@ -134,7 +139,15 @@
                 progress.Report(new ProgressDetails("Starting Service"));
                 await Task.Run(() =>
                 {
-                    ServiceControlInstance.EnableMaintenanceMode();
+                    if (maintenanceMode)
+                    {
+                        ServiceControlInstance.EnableMaintenanceMode();
+                    }
+                    else
+                    {
+                        ServiceControlInstance.DisableMaintenanceMode();
+                    }
+
                     result = ServiceControlInstance.TryStartService();
                 });
 

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
@@ -124,6 +124,10 @@ namespace ServiceControl.Config.UI.AdvancedOptions
             }
         }
 
+        public bool ForcedUpgradeAllowed => ForceUpgradeCommand.CanExecute(this);
+
+        public string ForcedUpgradeBackupLocation => $"{ServiceControlInstance.DBPath}_UpgradeBackup";
+
         public Task HandleAsync(RefreshInstances message, CancellationToken cancellationToken)
         {
             NotifyOfPropertyChange("AllowStop");

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace ServiceControl.Config.UI.AdvancedOptions
+namespace ServiceControl.Config.UI.AdvancedOptions
 {
     using System;
     using System.IO;
@@ -123,10 +123,6 @@
                 }
             }
         }
-
-        public bool ForcedUpgradeAllowed => ForceUpgradeCommand.CanExecute(this);
-
-        public string ForcedUpgradeBackupLocation => $"{ServiceControlInstance.DBPath}_UpgradeBackup";
 
         public Task HandleAsync(RefreshInstances message, CancellationToken cancellationToken)
         {

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Config.UI.AdvancedOptions
 {
     using System;
+    using System.IO;
     using System.Linq;
     using System.ServiceProcess;
     using System.Threading;
@@ -124,6 +125,8 @@
         }
 
         public bool ForcedUpgradeAllowed => ForceUpgradeCommand.CanExecute(this);
+
+        public string ForcedUpgradeBackupLocation => $"{ServiceControlInstance.DBPath}_UpgradeBackup";
 
         public Task HandleAsync(RefreshInstances message, CancellationToken cancellationToken)
         {

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
@@ -1,7 +1,6 @@
 namespace ServiceControl.Config.UI.AdvancedOptions
 {
     using System;
-    using System.IO;
     using System.Linq;
     using System.ServiceProcess;
     using System.Threading;

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
@@ -53,7 +53,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
 
             var serviceControlNewInstance = viewModel.InstallErrorInstance ? ServiceControlNewInstance.CreateWithDefaultPersistence() : null;
 
-            if (viewModel.InstallAuditInstance)
+            if (viewModel.InstallErrorInstance)
             {
                 serviceControlNewInstance.DisplayName = viewModel.ServiceControl.InstanceName;
                 serviceControlNewInstance.Name = viewModel.ServiceControl.InstanceName.Replace(' ', '.');

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
@@ -156,6 +156,11 @@
         {
             get
             {
+                if (ServiceInstance is IServiceControlInstance primaryInstance)
+                {
+                    return primaryInstance.PersistenceManifest.DisplayName;
+                }
+
                 if (ServiceInstance is IServiceControlAuditInstance auditInstance)
                 {
                     return auditInstance.PersistenceManifest.DisplayName;

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -7,7 +7,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
     using System.Security.AccessControl;
     using Ionic.Zip;
 
-    static class FileUtils
+    public static class FileUtils
     {
         public static string SanitizeFolderName(string folderName)
         {

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -7,7 +7,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
     using System.Security.AccessControl;
     using Ionic.Zip;
 
-    public static class FileUtils
+    static class FileUtils
     {
         public static string SanitizeFolderName(string folderName)
         {

--- a/src/ServiceControlInstaller.Engine/Instances/StorageEngineNames.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/StorageEngineNames.cs
@@ -1,4 +1,4 @@
-﻿namespace ServiceControlInstaller.Engine.Instances
+namespace ServiceControlInstaller.Engine.Instances
 {
     public static class StorageEngineNames
     {

--- a/src/ServiceControlInstaller.Engine/Instances/StorageEngineNames.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/StorageEngineNames.cs
@@ -3,5 +3,6 @@ namespace ServiceControlInstaller.Engine.Instances
     public static class StorageEngineNames
     {
         public const string RavenDB = "RavenDB";
+        public const string RavenDB5 = "RavenDB5";
     }
 }


### PR DESCRIPTION
### Changes in the PR

* For primary instance, version 4.x running on RavenDB35 users are able to do a "forced upgrade" that move the existing data to a backup location and creates a new instance with no data
* Bug fix that prevented users from being able to create new instances with SCMU on `master`

### UI

<img width="634" alt="image" src="https://github.com/Particular/ServiceControl/assets/1092707/cee784fe-882e-42a5-b723-dd49d25a8c08">
