### PR TITLE
Renamed DatabasePort to DataBaseMaintenancePort for backwardscompatibility

### DIFF
--- a/src/ServiceControl.AcceptanceTests.RavenDB/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/SharedEmbeddedServer.cs
@@ -20,7 +20,7 @@ static class SharedEmbeddedServer
             DatabasePath = dbPath,
             LogPath = Path.Combine(basePath, "Logs"),
             LogsMode = "Operations",
-            DatabasePort = PortUtility.FindAvailablePort(RavenPersisterSettings.DatabasePortDefault)
+            DatabaseMaintenancePort = PortUtility.FindAvailablePort(RavenPersisterSettings.DatabaseMaintenancePortDefault)
         };
 
         var instance = EmbeddedDatabase.Start(settings);

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/SharedEmbeddedServer.cs
@@ -20,7 +20,7 @@ static class SharedEmbeddedServer
             DatabasePath = dbPath,
             LogPath = Path.Combine(basePath, "Logs"),
             LogsMode = "Operations",
-            DatabasePort = PortUtility.FindAvailablePort(RavenPersisterSettings.DatabasePortDefault)
+            DatabaseMaintenancePort = PortUtility.FindAvailablePort(RavenPersisterSettings.DatabaseMaintenancePortDefault)
         };
 
         var instance = EmbeddedDatabase.Start(settings);

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -45,7 +45,7 @@
                 ConnectionString = GetSetting<string>(RavenBootstrapper.ConnectionStringKey, default),
                 DatabaseName = GetSetting(RavenBootstrapper.DatabaseNameKey, RavenPersisterSettings.DatabaseNameDefault),
                 DatabasePath = GetSetting<string>(RavenBootstrapper.DatabasePathKey, default),
-                DatabasePort = GetSetting(RavenBootstrapper.DatabaseMaintenancePortKey, RavenPersisterSettings.DatabasePortDefault),
+                DatabaseMaintenancePort = GetSetting(RavenBootstrapper.DatabaseMaintenancePortKey, RavenPersisterSettings.DatabaseMaintenancePortDefault),
                 ExpirationProcessTimerInSeconds = GetSetting(RavenBootstrapper.ExpirationProcessTimerInSecondsKey, 600),
                 MinimumStorageLeftRequiredForIngestion = GetSetting(RavenBootstrapper.MinimumStorageLeftRequiredForIngestionKey, CheckMinimumStorageRequiredForIngestion.MinimumStorageLeftRequiredForIngestionDefault),
                 DataSpaceRemainingThreshold = GetSetting(DataSpaceRemainingThresholdKey, CheckFreeDiskSpace.DataSpaceRemainingThresholdDefault),

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
@@ -4,7 +4,7 @@ using ServiceControl.Persistence;
 
 class RavenPersisterSettings : PersistenceSettings
 {
-    public int DatabasePort { get; set; } = DatabasePortDefault;
+    public int DatabaseMaintenancePort { get; set; } = DatabaseMaintenancePortDefault;
     public int ExpirationProcessTimerInSeconds { get; set; } = ExpirationProcessTimerInSecondsDefault;
     public int MinimumStorageLeftRequiredForIngestion { get; set; } = CheckMinimumStorageRequiredForIngestion.MinimumStorageLeftRequiredForIngestionDefault;
     public int DataSpaceRemainingThreshold { get; set; } = CheckFreeDiskSpace.DataSpaceRemainingThresholdDefault;
@@ -16,7 +16,7 @@ class RavenPersisterSettings : PersistenceSettings
     /// <summary>
     /// Computed connection string to access embedded RavenDB API and RavenDB Studio
     /// </summary>
-    public string ServerUrl => $"http://localhost:{DatabasePort}";
+    public string ServerUrl => $"http://localhost:{DatabaseMaintenancePort}";
 
     /// <summary>
     /// User provided external RavenDB instance connection string
@@ -28,7 +28,7 @@ class RavenPersisterSettings : PersistenceSettings
     public string DatabaseName { get; set; } = DatabaseNameDefault;
 
     public const string DatabaseNameDefault = "primary";
-    public const int DatabasePortDefault = 33334;
+    public const int DatabaseMaintenancePortDefault = 33334;
     public const int ExpirationProcessTimerInSecondsDefault = 600;
     public const string LogsModeDefault = "Operations";
 }

--- a/src/ServiceControl.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
@@ -19,7 +19,7 @@ static class SharedEmbeddedServer
             DatabasePath = dbPath,
             LogPath = Path.Combine(basePath, "Logs"),
             LogsMode = "Operations",
-            DatabasePort = PortUtility.FindAvailablePort(RavenPersisterSettings.DatabasePortDefault)
+            DatabaseMaintenancePort = PortUtility.FindAvailablePort(RavenPersisterSettings.DatabaseMaintenancePortDefault)
         };
 
         var instance = EmbeddedDatabase.Start(settings);


### PR DESCRIPTION
Renamed DatabasePort to DataBaseMaintenancePort for backwardscompatibility as previously used in v4 and earlier