### PR TITLE
Version checks when editing and upgrading

### DIFF
--- a/src/ServiceControl.Config/Commands/DeleteMonitoringlnstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/DeleteMonitoringlnstanceCommand.cs
@@ -22,6 +22,14 @@
 
         public override async Task ExecuteAsync(MonitoringAdvancedViewModel model)
         {
+            var instanceVersion = model.MonitoringInstance.Version;
+            var installerVersion = installer.ZipInfo.Version;
+
+            if (await InstallerVersionCompatibilityDialog.ShowValidation(instanceVersion, installerVersion, windowManager))
+            {
+                return;
+            }
+
             var confirmation = deleteInstanceConfirmation();
             confirmation.InstanceName = model.Name;
             var isConfirmed = await windowManager.ShowDialogAsync(confirmation);

--- a/src/ServiceControl.Config/Commands/DeleteServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/DeleteServiceControlInstanceCommand.cs
@@ -22,6 +22,14 @@
 
         public override async Task ExecuteAsync(ServiceControlAdvancedViewModel model)
         {
+            var instanceVersion = model.ServiceControlInstance.Version;
+            var installerVersion = installer.ZipInfo.Version;
+
+            if (await InstallerVersionCompatibilityDialog.ShowValidation(instanceVersion, installerVersion, windowManager))
+            {
+                return;
+            }
+
             var confirmation = deleteInstanceConfirmation();
             confirmation.InstanceName = model.Name;
             var isConfirmed = await windowManager.ShowDialogAsync(confirmation);

--- a/src/ServiceControl.Config/Commands/EditMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/EditMonitoringInstanceCommand.cs
@@ -6,22 +6,37 @@ namespace ServiceControl.Config.Commands
     using Events;
     using Framework;
     using Framework.Commands;
+    using ServiceControl.Config.Framework.Modules;
     using ServiceControlInstaller.Engine.Instances;
     using UI.InstanceDetails;
     using UI.InstanceEdit;
 
     class EditMonitoringInstanceCommand : AwaitableAbstractCommand<InstanceDetailsViewModel>
     {
-        public EditMonitoringInstanceCommand(IServiceControlWindowManager windowManager, Func<MonitoringInstance, MonitoringEditViewModel> editViewModel, IEventAggregator eventAggregator) : base(null)
+        public EditMonitoringInstanceCommand(
+            IServiceControlWindowManager windowManager,
+            Func<MonitoringInstance, MonitoringEditViewModel> editViewModel,
+            IEventAggregator eventAggregator,
+            MonitoringInstanceInstaller installer
+            ) : base(null)
         {
             this.windowManager = windowManager;
             this.editViewModel = editViewModel;
             this.eventAggregator = eventAggregator;
+            this.installer = installer;
         }
 
         public override async Task ExecuteAsync(InstanceDetailsViewModel viewModel)
         {
             var editVM = editViewModel((MonitoringInstance)viewModel.ServiceInstance);
+
+            var instanceVersion = viewModel.Version;
+            var installerVersion = installer.ZipInfo.Version;
+
+            if (await InstallerVersionCompatibilityDialog.ShowValidation(instanceVersion, installerVersion, windowManager))
+            {
+                return;
+            }
 
             if (await windowManager.ShowInnerDialog(editVM) ?? false)
             {
@@ -33,5 +48,6 @@ namespace ServiceControl.Config.Commands
         readonly Func<MonitoringInstance, MonitoringEditViewModel> editViewModel;
         readonly IEventAggregator eventAggregator;
         readonly IServiceControlWindowManager windowManager;
+        readonly MonitoringInstanceInstaller installer;
     }
 }

--- a/src/ServiceControl.Config/Commands/EditServiceControlAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/EditServiceControlAuditInstanceCommand.cs
@@ -17,13 +17,13 @@ namespace ServiceControl.Config.Commands
             IServiceControlWindowManager windowManager,
             Func<ServiceControlAuditInstance, ServiceControlAuditEditViewModel> editViewModel,
             IEventAggregator eventAggregator,
-            ServiceControlAuditInstanceInstaller serviceControlAuditInstaller
+            ServiceControlAuditInstanceInstaller installer
         ) : base(CanEditInstance)
         {
             this.windowManager = windowManager;
             this.editViewModel = editViewModel;
             this.eventAggregator = eventAggregator;
-            this.serviceControlAuditInstaller = serviceControlAuditInstaller;
+            this.installer = installer;
         }
 
         static bool CanEditInstance(InstanceDetailsViewModel viewModel)
@@ -37,7 +37,7 @@ namespace ServiceControl.Config.Commands
             var editVM = editViewModel((ServiceControlAuditInstance)viewModel.ServiceInstance);
 
             var instanceVersion = viewModel.Version;
-            var installerVersion = serviceControlAuditInstaller.ZipInfo.Version;
+            var installerVersion = installer.ZipInfo.Version;
 
             if (await InstallerVersionCompatibilityDialog.ShowValidation(instanceVersion, installerVersion, windowManager))
             {
@@ -54,6 +54,6 @@ namespace ServiceControl.Config.Commands
         readonly Func<ServiceControlAuditInstance, ServiceControlAuditEditViewModel> editViewModel;
         readonly IEventAggregator eventAggregator;
         readonly IServiceControlWindowManager windowManager;
-        readonly ServiceControlAuditInstanceInstaller serviceControlAuditInstaller;
+        readonly ServiceControlAuditInstanceInstaller installer;
     }
 }

--- a/src/ServiceControl.Config/Commands/EditServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/EditServiceControlInstanceCommand.cs
@@ -6,17 +6,25 @@ namespace ServiceControl.Config.Commands
     using Events;
     using Framework;
     using Framework.Commands;
+    using Framework.Modules;
     using ServiceControlInstaller.Engine.Instances;
     using UI.InstanceDetails;
     using UI.InstanceEdit;
 
     class EditServiceControlInstanceCommand : AwaitableAbstractCommand<InstanceDetailsViewModel>
     {
-        public EditServiceControlInstanceCommand(IServiceControlWindowManager windowManager, Func<ServiceControlInstance, ServiceControlEditViewModel> editViewModel, IEventAggregator eventAggregator) : base(CanEditInstance)
+        public EditServiceControlInstanceCommand(
+            IServiceControlWindowManager windowManager,
+            Func<ServiceControlInstance, ServiceControlEditViewModel> editViewModel,
+            IEventAggregator eventAggregator,
+            ServiceControlInstanceInstaller serviceControlInstaller
+
+            ) : base(CanEditInstance)
         {
             this.windowManager = windowManager;
             this.editViewModel = editViewModel;
             this.eventAggregator = eventAggregator;
+            this.serviceControlInstaller = serviceControlInstaller;
         }
 
         static bool CanEditInstance(InstanceDetailsViewModel viewModel)
@@ -29,6 +37,14 @@ namespace ServiceControl.Config.Commands
         {
             var editVM = editViewModel((ServiceControlInstance)viewModel.ServiceInstance);
 
+            var instanceVersion = viewModel.Version;
+            var installerVersion = serviceControlInstaller.ZipInfo.Version;
+
+            if (await InstallerVersionCompatibilityDialog.ShowValidation(instanceVersion, installerVersion, windowManager))
+            {
+                return;
+            }
+
             if (await windowManager.ShowInnerDialog(editVM) ?? false)
             {
                 editVM.UpdateInstanceFromViewModel((ServiceControlInstance)viewModel.ServiceInstance);
@@ -39,5 +55,6 @@ namespace ServiceControl.Config.Commands
         readonly Func<ServiceControlInstance, ServiceControlEditViewModel> editViewModel;
         readonly IEventAggregator eventAggregator;
         readonly IServiceControlWindowManager windowManager;
+        readonly ServiceControlInstanceInstaller serviceControlInstaller;
     }
 }

--- a/src/ServiceControl.Config/Commands/EditServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/EditServiceControlInstanceCommand.cs
@@ -17,14 +17,14 @@ namespace ServiceControl.Config.Commands
             IServiceControlWindowManager windowManager,
             Func<ServiceControlInstance, ServiceControlEditViewModel> editViewModel,
             IEventAggregator eventAggregator,
-            ServiceControlInstanceInstaller serviceControlInstaller
+            ServiceControlInstanceInstaller installer
 
             ) : base(CanEditInstance)
         {
             this.windowManager = windowManager;
             this.editViewModel = editViewModel;
             this.eventAggregator = eventAggregator;
-            this.serviceControlInstaller = serviceControlInstaller;
+            this.installer = installer;
         }
 
         static bool CanEditInstance(InstanceDetailsViewModel viewModel)
@@ -38,7 +38,7 @@ namespace ServiceControl.Config.Commands
             var editVM = editViewModel((ServiceControlInstance)viewModel.ServiceInstance);
 
             var instanceVersion = viewModel.Version;
-            var installerVersion = serviceControlInstaller.ZipInfo.Version;
+            var installerVersion = installer.ZipInfo.Version;
 
             if (await InstallerVersionCompatibilityDialog.ShowValidation(instanceVersion, installerVersion, windowManager))
             {
@@ -55,6 +55,6 @@ namespace ServiceControl.Config.Commands
         readonly Func<ServiceControlInstance, ServiceControlEditViewModel> editViewModel;
         readonly IEventAggregator eventAggregator;
         readonly IServiceControlWindowManager windowManager;
-        readonly ServiceControlInstanceInstaller serviceControlInstaller;
+        readonly ServiceControlInstanceInstaller installer;
     }
 }

--- a/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
+++ b/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
@@ -15,7 +15,7 @@
             {
                 await windowManager.ShowMessage(
                     "Incompatible installer version",
-                    $"This instance version {instanceVersion} is newer than the installer version {installerVersion}. This installer can only edit instances with versions between {installerVersion.Major}.0.0 and {installerVersion}.",
+                    $"This instance version {instanceVersion} is newer than the installer version {installerVersion}. This installer can only edit or remove instances with versions between {installerVersion.Major}.0.0 and {installerVersion}.",
                     hideCancel: true
                     );
                 return true;
@@ -25,7 +25,7 @@
             {
                 await windowManager.ShowMessage(
                     "Incompatible installer version",
-                    $"This installer cannot edit instances created by a different major version. This instance can be edited by a {instanceVersion.Major}.* installer version greater or equal to {instanceVersion.Major}.{instanceVersion.Minor}.{instanceVersion.Build}.",
+                    $"This installer cannot edit or remove instances created by a different major version. This instance can be edited by a {instanceVersion.Major}.* installer version greater or equal to {instanceVersion.Major}.{instanceVersion.Minor}.{instanceVersion.Build}.",
                     hideCancel: true
                     );
                 return true;

--- a/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
+++ b/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
@@ -15,7 +15,7 @@
             {
                 await windowManager.ShowMessage(
                     "Incompatible installer to edit configuration for newer minor/patch release",
-                    $"Instance version {instanceVersion} is newer than installer version {installerVersion}. Installer can only edit instances for the same version ({installerVersion}) or older versions (between {installerVersion.Major}.0.0 - and {installerVersion} for this major ({installerVersion.Major}.minor.patch."
+                    $"Instance version {instanceVersion} is newer than installer version {installerVersion}. Installer can only edit instances for the same version or older versions (between {installerVersion.Major}.0.0 - and {installerVersion} for this major."
                     );
                 return true;
             }
@@ -24,7 +24,7 @@
             {
                 await windowManager.ShowMessage(
                     "Incompatible installer to edit configuration of different major release",
-                    $"Installer cannot edit configurations for installers of a different major version. Use installer version {installerVersion} or a newer {instanceVersion.Major}.minor.patch to edit the configuration of this instance."
+                    $"Installer cannot edit configurations for installers of a different major version. Use installer version {instanceVersion} or a newer {instanceVersion.Major}.minor.patch to edit the configuration of this instance."
                     );
                 return true;
             }

--- a/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
+++ b/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
@@ -1,0 +1,35 @@
+﻿namespace ServiceControl.Config.Commands
+{
+    using System;
+    using System.Threading.Tasks;
+    using Framework;
+
+    static class InstallerVersionCompatibilityDialog
+    {
+        public static async Task<bool> ShowValidation(Version instanceVersion, Version installerVersion, IServiceControlWindowManager windowManager)
+        {
+            var instanceIsNewer = instanceVersion > installerVersion;
+            var installerOfDifferentMajor = instanceVersion.Major != installerVersion.Major;
+
+            if (instanceIsNewer)
+            {
+                await windowManager.ShowMessage(
+                    "Incompatible installer to edit configuration for newer minor/patch release",
+                    $"Instance version {instanceVersion} is newer than installer version {installerVersion}. Installer can only edit instances for the same version ({installerVersion}) or older versions (between {installerVersion.Major}.0.0 - and {installerVersion} for this major ({installerVersion.Major}.minor.patch."
+                    );
+                return true;
+            }
+
+            if (installerOfDifferentMajor)
+            {
+                await windowManager.ShowMessage(
+                    "Incompatible installer to edit configuration of different major release",
+                    $"Installer cannot edit configurations for installers of a different major version. Use installer version {installerVersion} or a newer {instanceVersion.Major}.minor.patch to edit the configuration of this instance."
+                    );
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
+++ b/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
@@ -14,8 +14,8 @@
             if (instanceIsNewer)
             {
                 await windowManager.ShowMessage(
-                    "Incompatible installer to edit configuration for newer minor/patch release",
-                    $"Instance version {instanceVersion} is newer than installer version {installerVersion}. Installer can only edit instances for the same version or older versions (between {installerVersion.Major}.0.0 - and {installerVersion} for this major."
+                    "Incompatible installer version",
+                    $"This instance version {instanceVersion} is newer than the installer version {installerVersion}. This installer can only edit instances with versions between {installerVersion.Major}.0.0 and {installerVersion}."
                     );
                 return true;
             }
@@ -23,8 +23,8 @@
             if (installerOfDifferentMajor)
             {
                 await windowManager.ShowMessage(
-                    "Incompatible installer to edit configuration of different major release",
-                    $"Installer cannot edit configurations for installers of a different major version. Use installer version {instanceVersion} or a newer {instanceVersion.Major}.minor.patch to edit the configuration of this instance."
+                    "Incompatible installer version",
+                    $"This installer cannot edit instances created by a different major version. This instance can be edited by a {instanceVersion.Major}.* installer version greater or equal to {instanceVersion.Major}.{instanceVersion.Minor}.{instanceVersion.Build}."
                     );
                 return true;
             }

--- a/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
+++ b/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
@@ -15,7 +15,8 @@
             {
                 await windowManager.ShowMessage(
                     "Incompatible installer version",
-                    $"This instance version {instanceVersion} is newer than the installer version {installerVersion}. This installer can only edit instances with versions between {installerVersion.Major}.0.0 and {installerVersion}."
+                    $"This instance version {instanceVersion} is newer than the installer version {installerVersion}. This installer can only edit instances with versions between {installerVersion.Major}.0.0 and {installerVersion}.",
+                    hideCancel: true
                     );
                 return true;
             }
@@ -24,7 +25,8 @@
             {
                 await windowManager.ShowMessage(
                     "Incompatible installer version",
-                    $"This installer cannot edit instances created by a different major version. This instance can be edited by a {instanceVersion.Major}.* installer version greater or equal to {instanceVersion.Major}.{instanceVersion.Minor}.{instanceVersion.Build}."
+                    $"This installer cannot edit instances created by a different major version. This instance can be edited by a {instanceVersion.Major}.* installer version greater or equal to {instanceVersion.Major}.{instanceVersion.Minor}.{instanceVersion.Build}.",
+                    hideCancel: true
                     );
                 return true;
             }

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -96,7 +96,6 @@
                     "<Section xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" xml:space=\"preserve\" TextAlignment=\"Left\" LineHeight=\"Auto\" IsHyphenationEnabled=\"False\" xml:lang=\"en-us\">\r\n" +
                     $"<Paragraph>You must upgrade to version {upgradeInfo.RecommendedUpgradeVersion} before upgrading to version {serviceControlInstaller.ZipInfo.Version}:</Paragraph>\r\n" +
                     "<List MarkerStyle=\"Decimal\" Margin=\"0,0,0,0\" Padding=\"0,0,0,0\">\r\n" +
-                    $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Uninstall version {serviceControlInstaller.ZipInfo.Version}.</Paragraph></ListItem>\r\n" +
                     $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install version {upgradeInfo.RecommendedUpgradeVersion} from https://github.com/Particular/ServiceControl/releases/tag/{upgradeInfo.RecommendedUpgradeVersion}</Paragraph></ListItem>" +
                     $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Upgrade this instance to version {upgradeInfo.RecommendedUpgradeVersion}.</Paragraph></ListItem>\r\n" +
                     "<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install the latest version from https://particular.net/start-servicecontrol-download</Paragraph></ListItem>\r\n" +

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeControl.Details.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeControl.Details.cs
@@ -18,9 +18,9 @@
             {
                 RecommendedUpgradeVersion = new Version(3, 8, 2),
             },
-            new (new Version(5, 0), new Version(4, 33, 0))
+            new (new Version(5, 0), new Version(4, 0, 0))
             {
-                RecommendedUpgradeVersion = new Version(4, 33, 0),
+                RecommendedUpgradeVersion = new Version(4, 32, 3),
             }
         };
     }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeControl.Details.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeControl.Details.cs
@@ -6,17 +6,21 @@
     {
         internal static UpgradeInfo[] details =
         {
-            new UpgradeInfo(new Version(2, 0), new Version(1, 41, 3)) //https://github.com/Particular/ServiceControl/issues/1228
+            new (new Version(2, 0), new Version(1, 41, 3))
             {
                 RecommendedUpgradeVersion = new Version(1, 48, 0),
             },
-            new UpgradeInfo(new Version(3, 0), new Version(2, 1, 3)) //https://github.com/Particular/ServiceControl/issues/1228
+            new (new Version(3, 0), new Version(2, 1, 3))
             {
                 RecommendedUpgradeVersion = new Version(2, 1, 3),
             },
-            new UpgradeInfo(new Version(4, 0), new Version(3, 8, 2)) //https://github.com/Particular/ServiceControl/issues/1228
+            new (new Version(4, 0), new Version(3, 8, 2))
             {
                 RecommendedUpgradeVersion = new Version(3, 8, 2),
+            },
+            new (new Version(5, 0), new Version(4, 32, 3))
+            {
+                RecommendedUpgradeVersion = new Version(4, 32, 3),
             }
         };
     }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeControl.Details.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeControl.Details.cs
@@ -18,9 +18,9 @@
             {
                 RecommendedUpgradeVersion = new Version(3, 8, 2),
             },
-            new (new Version(5, 0), new Version(4, 32, 3))
+            new (new Version(5, 0), new Version(4, 33, 0))
             {
-                RecommendedUpgradeVersion = new Version(4, 32, 3),
+                RecommendedUpgradeVersion = new Version(4, 33, 0),
             }
         };
     }


### PR DESCRIPTION
1. Only allow upgrades to v5 from [4.32.3](https://github.com/Particular/ServiceControl/releases/tag/4.32.3)
2. Only allow editing of instance configuration if installer version if the same or newer minor/patch AND not of a different major release

![image](https://github.com/Particular/ServiceControl/assets/152998/ed35caf6-1b16-4317-b3aa-007f1f5d46e4)


Remaining work:

- [x] Apply same checks to monitoring instances
- [x] ~~Applying version checks to installer engine so these are also used by Powershell module~~
  - Not needed, Powershell only does upgrades and uses same meta data for upgrade version check as SCMU
- [x] Version check for advanced commands, not allow deleting NEWER instance versions
