### PR TITLE
Handle future transport/persistence settings without crashing

### DIFF
--- a/src/ServiceControl.Audit.Persistence.Tests/InstallationTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/InstallationTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.IO;
-    using System.Linq;
     using System.Text.Json;
     using NUnit.Framework;
     using Particular.Approvals;
@@ -34,7 +33,7 @@
             var logPath = Path.Combine(Path.GetTempPath(), TestContext.CurrentContext.Test.ID, "log");
 
             newInstance.InstallPath = installPath;
-            newInstance.TransportPackage = ServiceControlCoreTransports.All.Single(t => t.Name == TransportNames.MSMQ);
+            newInstance.TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ);
 
             newInstance.DBPath = dbPath;
             newInstance.LogPath = logPath;

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlEditorViewModel.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.Config.UI.InstanceAdd;
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Input;
 using Framework.Rx;
 using PropertyChanged;
@@ -12,7 +11,7 @@ public class ServiceControlEditorViewModel : RxProgressScreen
 {
     public ServiceControlEditorViewModel()
     {
-        Transports = ServiceControlCoreTransports.All.Where(t => t.AvailableInSCMU);
+        Transports = ServiceControlCoreTransports.GetSupportedTransports();
         ServiceControl = new ServiceControlInformation(this);
         ServiceControlAudit = new ServiceControlAuditInformation(this);
     }

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
@@ -166,7 +166,12 @@
                     return "InMemory";
                 }
 
-                return "RavenDB 3.5";
+                if (ServiceInstance.Version.Major <= 4)
+                {
+                    return "RavenDB 3.5";
+                }
+
+                return "Unknown";
             }
         }
 

--- a/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMonitoringEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/SharedInstanceEditor/SharedMonitoringEditorViewModel.cs
@@ -4,20 +4,19 @@ namespace ServiceControl.Config.UI.SharedInstanceEditor
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Windows.Input;
     using Framework.Rx;
     using PropertyChanged;
+    using ServiceControl.Config.Extensions;
     using ServiceControlInstaller.Engine.Instances;
     using Validation;
-    using ServiceControl.Config.Extensions;
     using Validations = Validation.Validations;
 
     public class SharedMonitoringEditorViewModel : RxProgressScreen
     {
         public SharedMonitoringEditorViewModel()
         {
-            Transports = ServiceControlCoreTransports.All.Where(t => t.AvailableInSCMU);
+            Transports = ServiceControlCoreTransports.GetSupportedTransports();
         }
 
         [DoNotNotify]

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
@@ -151,7 +151,7 @@
             newAuditInstance.ForwardAuditMessages = ForwardAuditMessages.ToBool();
             newAuditInstance.AuditRetentionPeriod = AuditRetentionPeriod;
             newAuditInstance.ConnectionString = ConnectionString;
-            newAuditInstance.TransportPackage = ServiceControlCoreTransports.All.First(t => t.Matches(Transport));
+            newAuditInstance.TransportPackage = ServiceControlCoreTransports.Find(Transport);
             newAuditInstance.SkipQueueCreation = SkipQueueCreation;
             newAuditInstance.ServiceControlQueueAddress = ServiceControlQueueAddress;
             newAuditInstance.EnableFullTextSearchOnBodies = EnableFullTextSearchOnBodies;

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
@@ -121,7 +121,7 @@ namespace ServiceControl.Management.PowerShell
                 Port = Port,
                 ErrorQueue = ErrorQueue,
                 ConnectionString = ConnectionString,
-                TransportPackage = ServiceControlCoreTransports.All.First(t => t.Matches(Transport)),
+                TransportPackage = ServiceControlCoreTransports.Find(Transport),
                 SkipQueueCreation = SkipQueueCreation
             };
             var details = monitoringNewInstance;

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
@@ -166,7 +166,7 @@ namespace ServiceControl.Management.PowerShell
                 ForwardErrorMessages = ForwardErrorMessages.ToBool(),
                 ErrorRetentionPeriod = ErrorRetentionPeriod,
                 ConnectionString = ConnectionString,
-                TransportPackage = ServiceControlCoreTransports.All.First(t => t.Matches(Transport)),
+                TransportPackage = ServiceControlCoreTransports.Find(Transport),
                 SkipQueueCreation = SkipQueueCreation,
                 EnableFullTextSearchOnBodies = EnableFullTextSearchOnBodies,
             };

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/Transports/GetServiceControlTransportTypes.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/Transports/GetServiceControlTransportTypes.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceControl.Management.PowerShell
 {
-    using System.Linq;
     using System.Management.Automation;
     using ServiceControlInstaller.Engine.Instances;
 
@@ -9,7 +8,7 @@
     {
         protected override void ProcessRecord()
         {
-            WriteObject(ServiceControlCoreTransports.All.Select(PsTransportInfo.FromTransport), true);
+            WriteObject(ServiceControlCoreTransports.Select(PsTransportInfo.FromTransport), true);
         }
     }
 }

--- a/src/ServiceControlInstaller.Engine.UnitTests/Configuration/AuditInstanceTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Configuration/AuditInstanceTests.cs
@@ -2,12 +2,10 @@
 {
     using System;
     using System.IO;
-    using System.Linq;
     using System.ServiceProcess;
     using System.Xml;
     using NUnit.Framework;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
-    using ServiceControlInstaller.Engine.FileSystem;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.Services;
 
@@ -20,7 +18,7 @@
             var newInstance = ServiceControlAuditNewInstance.CreateWithPersistence(ZipFileFolder.FullName, "RavenDB35");
 
             newInstance.InstallPath = InstallPath;
-            newInstance.TransportPackage = ServiceControlCoreTransports.All.Single(t => t.Name == TransportNames.MSMQ);
+            newInstance.TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ);
             newInstance.DBPath = DbPath;
             newInstance.LogPath = LogPath;
             newInstance.HostName = "localhost";
@@ -56,7 +54,7 @@
             var newInstance = ServiceControlAuditNewInstance.CreateWithPersistence(ZipFileFolder.FullName, "RavenDB5");
 
             newInstance.InstallPath = InstallPath;
-            newInstance.TransportPackage = ServiceControlCoreTransports.All.Single(t => t.Name == TransportNames.MSMQ);
+            newInstance.TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ);
 
             newInstance.DBPath = DbPath;
             newInstance.LogPath = LogPath;
@@ -86,7 +84,7 @@
             var newInstance = ServiceControlAuditNewInstance.CreateWithPersistence(ZipFileFolder.FullName, "RavenDB35");
 
             newInstance.InstallPath = InstallPath;
-            newInstance.TransportPackage = ServiceControlCoreTransports.All.Single(t => t.Name == TransportNames.MSMQ);
+            newInstance.TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ);
             newInstance.DBPath = DbPath;
             newInstance.LogPath = LogPath;
             newInstance.HostName = "localhost";

--- a/src/ServiceControlInstaller.Engine.UnitTests/Configuration/NewAuditInstanceTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Configuration/NewAuditInstanceTests.cs
@@ -15,7 +15,7 @@
             var newInstance = ServiceControlAuditNewInstance.CreateWithDefaultPersistence(ZipFileFolder.FullName);
 
             newInstance.InstallPath = InstallPath;
-            newInstance.TransportPackage = ServiceControlCoreTransports.All.Single(t => t.Name == TransportNames.MSMQ);
+            newInstance.TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ);
 
             newInstance.DBPath = DbPath;
             newInstance.LogPath = LogPath;

--- a/src/ServiceControlInstaller.Engine.UnitTests/RunEngineTasksExplicitly.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/RunEngineTasksExplicitly.cs
@@ -67,7 +67,7 @@
                 AuditRetentionPeriod = TimeSpan.FromDays(SettingConstants.AuditRetentionPeriodDefaultInDaysForUI),
                 ErrorRetentionPeriod = TimeSpan.FromDays(SettingConstants.ErrorRetentionPeriodDefaultInDaysForUI),
                 ErrorQueue = "testerror",
-                TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.MSMQ),
+                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ),
                 ReportCard = new ReportCard(),
                 // but this fails for unit tests as the deploymentCache path is not used
                 // constructer of ServiceControlInstanceMetadata extracts version from zip

--- a/src/ServiceControlInstaller.Engine.UnitTests/Validation/QueueValidationTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Validation/QueueValidationTests.cs
@@ -16,13 +16,13 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
         public void Init()
         {
             var instanceA = new Mock<IServiceControlInstance>();
-            instanceA.SetupGet(p => p.TransportPackage).Returns(ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.MSMQ));
+            instanceA.SetupGet(p => p.TransportPackage).Returns(ServiceControlCoreTransports.Find(TransportNames.MSMQ));
             instanceA.SetupGet(p => p.ErrorQueue).Returns(@"error");
             instanceA.SetupGet(p => p.ErrorLogQueue).Returns(@"errorlog");
             instanceA.SetupGet(p => p.ForwardErrorMessages).Returns(true);
 
             var instanceB = new Mock<IServiceControlInstance>();
-            instanceB.SetupGet(p => p.TransportPackage).Returns(ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.RabbitMQClassicConventionalRoutingTopology || t.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology));
+            instanceB.SetupGet(p => p.TransportPackage).Returns(ServiceControlCoreTransports.Find(TransportNames.RabbitMQClassicConventionalRoutingTopology));
             instanceB.SetupGet(p => p.ErrorQueue).Returns(@"RMQerror");
             instanceB.SetupGet(p => p.ErrorLogQueue).Returns(@"RMQerrorlog");
             instanceB.SetupGet(p => p.ForwardErrorMessages).Returns(true);
@@ -40,7 +40,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
         {
             var newInstance = new ServiceControlNewInstance
             {
-                TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.MSMQ),
+                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ),
                 ErrorLogQueue = "errorlog",
                 ErrorQueue = "error"
             };
@@ -56,12 +56,12 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
         public void CheckChainingOfAuditQueues_ShouldSucceed()
         {
             var existingAudit = new Mock<IServiceControlAuditInstance>();
-            existingAudit.SetupGet(p => p.TransportPackage).Returns(ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.MSMQ));
+            existingAudit.SetupGet(p => p.TransportPackage).Returns(ServiceControlCoreTransports.Find(TransportNames.MSMQ));
             existingAudit.SetupGet(p => p.AuditQueue).Returns(@"audit");
 
             var newInstance = ServiceControlAuditNewInstance.CreateWithDefaultPersistence(GetZipFolder().FullName);
 
-            newInstance.TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.MSMQ);
+            newInstance.TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ);
             newInstance.AuditQueue = "audit";
 
             var validator = new QueueNameValidator(newInstance)
@@ -77,7 +77,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
         {
             var newInstance = new ServiceControlNewInstance
             {
-                TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.MSMQ),
+                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ),
                 ErrorLogQueue = "error",
                 ErrorQueue = "error",
                 ForwardErrorMessages = true
@@ -97,7 +97,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
         {
             var newInstance = new ServiceControlNewInstance
             {
-                TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.MSMQ),
+                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ),
                 ErrorLogQueue = "errorlog2",
                 ErrorQueue = "error2"
             };
@@ -115,7 +115,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
             var expectedError = "Some queue names specified are already assigned to another ServiceControl instance - Correct the values for ErrorLogQueue, ErrorQueue";
             var newInstance = new ServiceControlNewInstance
             {
-                TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.MSMQ),
+                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.MSMQ),
                 ErrorLogQueue = "errorlog",
                 ErrorQueue = "error",
                 ForwardErrorMessages = true
@@ -152,7 +152,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
 
             var newInstance = new ServiceControlNewInstance
             {
-                TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology),
+                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.RabbitMQQuorumConventionalRoutingTopology),
                 ErrorLogQueue = "errorlog",
                 ErrorQueue = "error",
                 ForwardErrorMessages = true
@@ -186,7 +186,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
         {
             var newInstance = new ServiceControlNewInstance
             {
-                TransportPackage = ServiceControlCoreTransports.All.First(t => t.Name == TransportNames.RabbitMQQuorumConventionalRoutingTopology),
+                TransportPackage = ServiceControlCoreTransports.Find(TransportNames.RabbitMQQuorumConventionalRoutingTopology),
                 ErrorQueue = "RMQerror",
                 ErrorLogQueue = "RMQerrorlog",
                 ConnectionString = "afakeconnectionstring",

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -97,14 +97,9 @@
 
         TransportInfo DetermineTransportPackage()
         {
-            var transportAppSetting = AppConfig.Read(SettingsList.TransportType, ServiceControlCoreTransports.All.Single(t => t.Default).TypeName).Trim();
-            var transport = ServiceControlCoreTransports.All.FirstOrDefault(p => p.Matches(transportAppSetting));
-            if (transport != null)
-            {
-                return transport;
-            }
-
-            return ServiceControlCoreTransports.All.First(p => p.Default);
+            var transportAppSetting = AppConfig.Read<string>(SettingsList.TransportType, null)?.Trim();
+            var transport = ServiceControlCoreTransports.Find(transportAppSetting);
+            return transport;
         }
 
         public async Task ValidateChanges()

--- a/src/ServiceControlInstaller.Engine/Instances/PersistenceManifest.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/PersistenceManifest.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControlInstaller.Engine.Instances
 {
+    using System;
     using System.Collections.Generic;
 
     public class PersistenceManifest
@@ -24,5 +25,8 @@
             public string DefaultValue { get; set; }
             public bool Mandatory { get; set; }
         }
+
+        public bool Matches(string name) => Name.Equals(name, StringComparison.OrdinalIgnoreCase)
+            || TypeName.Equals(name, StringComparison.Ordinal);
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
@@ -82,18 +82,8 @@ namespace ServiceControlInstaller.Engine.Instances
 
             var zipInfo = ServiceControlAuditZipInfo.Find(deploymentCachePath);
 
-            var manifests = ServiceControlAuditPersisters.LoadAllManifests(zipInfo.FilePath);
-
             var persistenceType = AppConfig.Read<string>(AuditInstanceSettingsList.PersistenceType, null);
-
-            if (string.IsNullOrEmpty(persistenceType))
-            {
-                PersistenceManifest = manifests.Single(m => m.Name == "RavenDB35");
-            }
-            else
-            {
-                PersistenceManifest = manifests.Single(m => m.TypeName == persistenceType);
-            }
+            PersistenceManifest = ServiceControlAuditPersisters.GetPersistence(zipInfo.FilePath, persistenceType);
 
             TransportPackage = DetermineTransportPackage();
             ConnectionString = ReadConnectionString();

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
@@ -60,7 +60,7 @@ namespace ServiceControlInstaller.Engine.Instances
 
         protected override string GetTransportTypeSetting()
         {
-            return AppConfig.Read(AuditInstanceSettingsList.TransportType, ServiceControlCoreTransports.All.Single(t => t.Default).TypeName).Trim();
+            return AppConfig.Read<string>(AuditInstanceSettingsList.TransportType, null)?.Trim();
         }
 
         protected override string BaseServiceName => "ServiceControl.Audit";

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditNewInstance.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.IO;
-    using System.Linq;
     using System.Reflection;
     using System.Xml;
     using System.Xml.Serialization;
@@ -27,8 +26,7 @@
         public static ServiceControlAuditNewInstance CreateWithPersistence(string deploymentCachePath, string persistence)
         {
             var zipInfo = ServiceControlAuditZipInfo.Find(deploymentCachePath);
-            var persistenceManifest = ServiceControlAuditPersisters.LoadAllManifests(zipInfo.FilePath)
-                .Single(manifest => manifest.Name == persistence);
+            var persistenceManifest = ServiceControlAuditPersisters.GetPersistence(zipInfo.FilePath, persistence);
 
             return new ServiceControlAuditNewInstance(zipInfo.Version, persistenceManifest);
         }

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditPersisters.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditPersisters.cs
@@ -8,7 +8,7 @@
 
     public class ServiceControlAuditPersisters
     {
-        public static IReadOnlyList<PersistenceManifest> LoadAllManifests(string zipFilePath)
+        internal static IReadOnlyList<PersistenceManifest> LoadAllManifests(string zipFilePath)
         {
             using (var zipArchive = ZipFile.OpenRead(zipFilePath))
             {
@@ -30,6 +30,23 @@
 
                 return manifests;
             }
+        }
+
+        public static PersistenceManifest GetPersistence(string zipFilePath, string name)
+        {
+            var manifests = LoadAllManifests(zipFilePath);
+
+            if (string.IsNullOrEmpty(name))
+            {
+                // Must always remain RavenDB35 so that SCMU understands that an instance with no configured value is an old Raven 3.5 instance
+                return manifests.Single(m => m.Name == "RavenDB35");
+            }
+
+            return manifests.FirstOrDefault(m => m.Name == name || m.TypeName == name) ?? new PersistenceManifest
+            {
+                Name = $"Unknown Persistence: {name}",
+                Description = $"Unknown Persistence {name} may be from a future version of ServiceControl"
+            };
         }
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditPersisters.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditPersisters.cs
@@ -6,7 +6,7 @@
     using System.Linq;
     using Newtonsoft.Json;
 
-    public class ServiceControlAuditPersisters
+    public static class ServiceControlAuditPersisters
     {
         internal static IReadOnlyList<PersistenceManifest> LoadAllManifests(string zipFilePath)
         {
@@ -42,7 +42,7 @@
                 return manifests.Single(m => m.Name == "RavenDB35");
             }
 
-            return manifests.FirstOrDefault(m => m.Name == name || m.TypeName == name) ?? new PersistenceManifest
+            return manifests.FirstOrDefault(m => m.Matches(name)) ?? new PersistenceManifest
             {
                 Name = $"Unknown Persistence: {name}",
                 Description = $"Unknown Persistence {name} may be from a future version of ServiceControl"

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
@@ -145,13 +145,8 @@ namespace ServiceControlInstaller.Engine.Instances
         protected TransportInfo DetermineTransportPackage()
         {
             var transportAppSetting = GetTransportTypeSetting();
-            var transport = ServiceControlCoreTransports.All.FirstOrDefault(p => p.Matches(transportAppSetting));
-            if (transport != null)
-            {
-                return transport;
-            }
-
-            return ServiceControlCoreTransports.All.First(p => p.Default);
+            var transport = ServiceControlCoreTransports.Find(transportAppSetting);
+            return transport;
         }
 
         protected void RecreateUrlAcl(ServiceControlBaseService oldSettings)

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlCoreTransports.cs
@@ -6,7 +6,7 @@
 
     public class ServiceControlCoreTransports
     {
-        public static List<TransportInfo> All => new List<TransportInfo>
+        static readonly TransportInfo[] all = new TransportInfo[]
         {
             //INFO: Those types are used in the SCMU and in PS scripts. In both cases Match predicate is used to find a transport info.
             //      In the UI the matching is done based on the transport TypeName from app.config. In PS it's done based on human friendly names.
@@ -195,6 +195,9 @@
             },
         };
 
+        public static TransportInfo[] GetSupportedTransports() => all.Where(t => t.AvailableInSCMU).ToArray();
+        public static IEnumerable<T> Select<T>(Func<TransportInfo, T> selector) => all.Select(selector);
+
         static bool IncludeLearningTransport()
         {
             try
@@ -220,7 +223,16 @@
 
         public static TransportInfo Find(string name)
         {
-            return All.FirstOrDefault(p => p.Matches(name));
+            if (string.IsNullOrEmpty(name))
+            {
+                return all.FirstOrDefault(t => t.Default); // MSMQ
+            }
+
+            return all.FirstOrDefault(p => p.Matches(name)) ?? new TransportInfo
+            {
+                Name = $"Unknown Message Transport: {name}",
+                AvailableInSCMU = false
+            };
         }
 
         public static TransportInfo UpgradedTransportSeam(TransportInfo transport)

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -39,7 +39,7 @@ namespace ServiceControlInstaller.Engine.Instances
 
         protected override string GetTransportTypeSetting()
         {
-            return AppConfig.Read(ServiceControlSettings.TransportType, ServiceControlCoreTransports.All.Single(t => t.Default).TypeName).Trim();
+            return AppConfig.Read<string>(ServiceControlSettings.TransportType, null)?.Trim();
         }
 
         protected override AppConfig CreateAppConfig()


### PR DESCRIPTION
ServiceControl 5.0 and above will not have a Windows Installer, which means that a user can have multiple versions of Service Control Management that can be used back and forth without having to uninstall/reinstall a different version.

That introduces a bug in ServiceControl 4.x because, by definition, ServiceControl 4 versions will not be able to understand the different transports and persistence options that are introduced in the future.

This bugfix shows some "Unknown" text when an instance's transport or persistence is not known to the current ServiceControl version. This will be shipped as part of ServiceControl 4.33.0, which is intended to be the last minor version of the 4.x timeline, and will be the last to be installed through a Windows Installer.

So if you have a hybrid system and need to be able to install ServiceControl 5.x instances while still managing a few ServiceControl 4.x instances, update Service Control Management to 4.33 so you can open it and view the 5.x instances without crashing.