### PR TITLE
Aligns behavior regarding `RavenDbLogLevel` setting

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -72,7 +72,7 @@
 
                 if (settings.PersisterSpecificSettings.TryGetValue(RavenDbLogLevelKey, out var ravenDbLogLevel))
                 {
-                    logsMode = MapRavenDbLogLevelToLogsMode(ravenDbLogLevel);
+                    logsMode = RavenDbLogLevelToLogsModeMapper.Map(ravenDbLogLevel);
                 }
 
                 serverConfiguration = new ServerConfiguration(dbPath, serverUrl, logPath, logsMode);
@@ -106,26 +106,6 @@
                 settings.MaxBodySizeToStore,
                 minimumStorageLeftRequiredForIngestion,
                 serverConfiguration);
-        }
-
-        static string MapRavenDbLogLevelToLogsMode(string ravenDbLogLevel)
-        {
-            switch (ravenDbLogLevel.ToLower())
-            {
-                case "off":         // Backwards compatibility with 4.x
-                case "none":
-                    return "None";
-                case "trace":       // Backwards compatibility with 4.x
-                case "debug":       // Backwards compatibility with 4.x
-                case "info":        // Backwards compatibility with 4.x
-                case "information":
-                    return "Information";
-                case "operations":
-                    return "Operations";
-                default:
-                    Logger.WarnFormat("Unknown log level '{0}', mapped to 'Operations'");
-                    return "Operations";
-            }
         }
 
         static int GetExpirationProcessTimerInSeconds(PersistenceSettings settings)

--- a/src/ServiceControl.Infrastructure/RavenDbLogLevelToLogsModeMapper.cs
+++ b/src/ServiceControl.Infrastructure/RavenDbLogLevelToLogsModeMapper.cs
@@ -1,0 +1,29 @@
+﻿namespace ServiceControl
+{
+    using NServiceBus.Logging;
+
+    public class RavenDbLogLevelToLogsModeMapper
+    {
+        static readonly ILog Logger = LogManager.GetLogger(typeof(RavenDbLogLevelToLogsModeMapper));
+
+        public static string Map(string ravenDbLogLevel)
+        {
+            switch (ravenDbLogLevel.ToLower())
+            {
+                case "off": // Backwards compatibility with 4.x
+                case "none":
+                    return "None";
+                case "trace": // Backwards compatibility with 4.x
+                case "debug": // Backwards compatibility with 4.x
+                case "info": // Backwards compatibility with 4.x
+                case "information":
+                    return "Information";
+                case "operations":
+                    return "Operations";
+                default:
+                    Logger.WarnFormat("Unknown log level '{0}', mapped to 'Operations'");
+                    return "Operations";
+            }
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.RavenDB/RavenBootstrapper.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenBootstrapper.cs
@@ -10,6 +10,6 @@
         public const string MinimumStorageLeftRequiredForIngestionKey = "MinimumStorageLeftRequiredForIngestion";
         public const string DatabaseNameKey = "RavenDB5/DatabaseName";
         public const string LogsPathKey = "LogPath";
-        public const string LogsModeKey = "LogMode";
+        public const string RavenDbLogLevelKey = "RavenDBLogLevel";
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -3,7 +3,6 @@
     using System;
     using NServiceBus.Logging;
     using ServiceControl.Operations;
-    using Sparrow.Logging;
 
     class RavenPersistenceConfiguration : IPersistenceConfiguration
     {
@@ -43,7 +42,7 @@
             }
 
             var ravenDbLogLevel = GetSetting(RavenBootstrapper.RavenDbLogLevelKey, "Warn");
-            var logsMode = MapRavenDbLogLevelToLogsMode(ravenDbLogLevel);
+            var logsMode = RavenDbLogLevelToLogsModeMapper.Map(ravenDbLogLevel);
 
             var settings = new RavenPersisterSettings
             {
@@ -69,26 +68,6 @@
             return settings;
         }
 
-        static string MapRavenDbLogLevelToLogsMode(string ravenDbLogLevel)
-        {
-            switch (ravenDbLogLevel.ToLower())
-            {
-                case "off":         // Backwards compatibility with 4.x
-                case "none":
-                    return "None";
-                case "trace":       // Backwards compatibility with 4.x
-                case "debug":       // Backwards compatibility with 4.x
-                case "info":        // Backwards compatibility with 4.x
-                case "information":
-                    return "Information";
-                case "operations":
-                    return "Operations";
-                default:
-                    Logger.WarnFormat("Unknown log level '{0}', mapped to 'Operations'");
-                    return "Operations";
-            }
-        }
-
         public IPersistence Create(PersistenceSettings settings)
         {
             var specificSettings = (RavenPersisterSettings)settings;
@@ -100,7 +79,5 @@
 
             return new RavenPersistence(specificSettings);
         }
-
-        static readonly ILog Logger = LogManager.GetLogger(typeof(RavenPersistenceConfiguration));
     }
 }


### PR DESCRIPTION
- Resolves https://github.com/Particular/ServiceControl/issues/3253

Aligned behavior between primary and audit regarding `RavenDbLogLevel` setting. Accepts old values (RavenDB 3.5) and maps these to RavenDB5 values but also accepts RavenDB5 values. Also refactored to that the mapping is case-insensitive.