### PR TITLE
Error instance setting to stop error ingestion only

### DIFF
--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -66,7 +66,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
             {
                 throw new Exception($"Error ingestion cannot be enabled when ServiceBus/ErrorQueue is '{ErrorQueue}'");
             }
-            
+
             if (hasValidErrorQueueName == false || IngestErrorMessages == false)
             {
                 logger.Info("Error ingestion disabled.");

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -58,7 +58,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
         {
             ErrorQueue = SettingsReader<string>.Read("ServiceBus", "ErrorQueue", "error");
 
-            var hasValidErrorQueueName = string.IsNullOrEmpty(ErrorQueue) && !ErrorQueue.Equals(Disabled, StringComparison.OrdinalIgnoreCase);
+            var hasValidErrorQueueName = !string.IsNullOrEmpty(ErrorQueue) && !ErrorQueue.Equals(Disabled, StringComparison.OrdinalIgnoreCase);
 
             IngestErrorMessages = !SettingsReader<bool>.Read("DisableErrorQueueIngestion", !hasValidErrorQueueName);
 

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -60,7 +60,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
             var hasValidErrorQueueName = !string.IsNullOrEmpty(ErrorQueue) && !ErrorQueue.Equals(Disabled, StringComparison.OrdinalIgnoreCase);
 
-            IngestErrorMessages = !SettingsReader<bool>.Read("IngestErrorMessages", hasValidErrorQueueName);
+            IngestErrorMessages = SettingsReader<bool>.Read("IngestErrorMessages", hasValidErrorQueueName);
 
             if (IngestErrorMessages && hasValidErrorQueueName == false)
             {

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -60,7 +60,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
             var hasValidErrorQueueName = !string.IsNullOrEmpty(ErrorQueue) && !ErrorQueue.Equals(Disabled, StringComparison.OrdinalIgnoreCase);
 
-            IngestErrorMessages = !SettingsReader<bool>.Read("DisableErrorQueueIngestion", !hasValidErrorQueueName);
+            IngestErrorMessages = !SettingsReader<bool>.Read("IngestErrorMessages", hasValidErrorQueueName);
 
             if (IngestErrorMessages && hasValidErrorQueueName == false)
             {

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -28,6 +28,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
             ErrorQueue = GetErrorQueue();
             ErrorLogQueue = GetErrorLogQueue(ErrorQueue);
+            IngestErrorMessages = SettingsReader<bool>.Read("IngestErrorMessages", true);
 
             TryLoadLicenseFromConfig();
 

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -26,9 +26,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
             // Overwrite the service name if it is specified in ENVVAR, reg, or config file
             ServiceName = SettingsReader<string>.Read("InternalQueueName", ServiceName);
 
-            ErrorQueue = GetErrorQueue();
-            ErrorLogQueue = GetErrorLogQueue(ErrorQueue);
-            IngestErrorMessages = SettingsReader<bool>.Read("IngestErrorMessages", true);
+            LoadErrorIngestionSettings();
 
             TryLoadLicenseFromConfig();
 
@@ -54,6 +52,51 @@ namespace ServiceBus.Management.Infrastructure.Settings
             DisableExternalIntegrationsPublishing = SettingsReader<bool>.Read("DisableExternalIntegrationsPublishing", false);
             EnableFullTextSearchOnBodies = SettingsReader<bool>.Read("EnableFullTextSearchOnBodies", true);
             DataStoreType = GetDataStoreType();
+        }
+
+        void LoadErrorIngestionSettings()
+        {
+            ErrorQueue = SettingsReader<string>.Read("ServiceBus", "ErrorQueue", "error");
+
+            var hasValidErrorQueueName = string.IsNullOrEmpty(ErrorQueue) && !ErrorQueue.Equals(Disabled, StringComparison.OrdinalIgnoreCase);
+
+            IngestErrorMessages = !SettingsReader<bool>.Read("DisableErrorQueueIngestion", !hasValidErrorQueueName);
+
+            if (IngestErrorMessages && hasValidErrorQueueName == false)
+            {
+                throw new Exception($"Error ingestion cannot be enabled when ServiceBus/ErrorQueue is '{ErrorQueue}'");
+            }
+            
+            if (hasValidErrorQueueName == false || IngestErrorMessages == false)
+            {
+                logger.Info("Error ingestion disabled.");
+            }
+
+            if (hasValidErrorQueueName == false)
+            {
+                if (string.IsNullOrEmpty(ErrorQueue))
+                {
+                    logger.Warn("No configuration value set for ServiceBus/ErrorQueue. If this is not intentional provide a value.");
+                }
+
+                ErrorLogQueue = null;
+                ErrorQueue = null;
+            }
+            else
+            {
+                var errorLogQueue = SettingsReader<string>.Read("ServiceBus", "ErrorLogQueue", null);
+
+                if (errorLogQueue == null)
+                {
+                    logger.Info("No settings found for error log queue to import, default name will be used");
+
+                    ErrorLogQueue = Subscope(ErrorQueue);
+                }
+                else
+                {
+                    ErrorLogQueue = errorLogQueue;
+                }
+            }
         }
 
         public string NotificationsFilter { get; set; }
@@ -232,45 +275,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
             var connectionStringSettings = ConfigurationManager.ConnectionStrings["NServiceBus/Transport"];
             return connectionStringSettings?.ConnectionString;
-        }
-
-        string GetErrorQueue()
-        {
-            var value = SettingsReader<string>.Read("ServiceBus", "ErrorQueue", "error");
-
-            if (value == null)
-            {
-                logger.Warn("No settings found for error queue to import, if this is not intentional please set add ServiceBus/ErrorQueue to your appSettings");
-                IngestErrorMessages = false;
-                return null;
-            }
-
-            if (value.Equals(Disabled, StringComparison.OrdinalIgnoreCase))
-            {
-                logger.Info("Error ingestion disabled.");
-                IngestErrorMessages = false;
-                return null; // needs to be null to not create the queues
-            }
-
-            return value;
-        }
-
-        string GetErrorLogQueue(string errorQueue)
-        {
-            if (errorQueue == null)
-            {
-                return null;
-            }
-
-            var value = SettingsReader<string>.Read("ServiceBus", "ErrorLogQueue", null);
-
-            if (value == null)
-            {
-                logger.Info("No settings found for error log queue to import, default name will be used");
-                return Subscope(errorQueue);
-            }
-
-            return value;
         }
 
         string GetDbPath()

--- a/src/ServiceControl/Recoverability/RecoverabilityComponent.cs
+++ b/src/ServiceControl/Recoverability/RecoverabilityComponent.cs
@@ -16,7 +16,6 @@
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using NServiceBus.Logging;
-    using NServiceBus.Raw;
     using NServiceBus.Transport;
     using Operations;
     using Operations.BodyStorage;

--- a/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
@@ -13,7 +13,6 @@ namespace ServiceControl.Recoverability
     using NServiceBus.Transport;
     using Raven.Client;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Persistence;
 
     class ReturnToSenderDequeuer : IHostedService
     {


### PR DESCRIPTION
This PR introduces a setting that turns off, the error ingestion process only. There is already `!disable` value that can be provided as `ErrorQueue` setting that stops the process as well. However, it also prevents users from being able to retry failed messages (an option needed when upgrading from ver 4 to 5 of ServiceControl with data migration).