### PR TITLE
Added error, warn, fatal to backwards compatibility mapping and fixed format issue not logging value

### DIFF
--- a/src/ServiceControl.Infrastructure/RavenDbLogLevelToLogsModeMapper.cs
+++ b/src/ServiceControl.Infrastructure/RavenDbLogLevelToLogsModeMapper.cs
@@ -18,10 +18,13 @@
                 case "info": // Backwards compatibility with 4.x
                 case "information":
                     return "Information";
+                case "error": // Backwards compatibility with 4.x
+                case "warn": // Backwards compatibility with 4.x
+                case "fatal": // Backwards compatibility with 4.x
                 case "operations":
                     return "Operations";
                 default:
-                    Logger.WarnFormat("Unknown log level '{0}', mapped to 'Operations'");
+                    Logger.WarnFormat("Unknown log level '{0}', mapped to 'Operations'", ravenDbLogLevel);
                     return "Operations";
             }
         }


### PR DESCRIPTION
1. Added error, warn, fatal to backwards compatibility mapping
2. Fixed format issue not logging value introduced by 
https://github.com/Particular/ServiceControl/pull/3796