### PR TITLE
Force upgrade for audit instance and added force upgrade to Powershell

### DIFF
--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
@@ -131,7 +131,7 @@
                         <TextBlock FontSize="12px" FontWeight="Bold" Text="{Binding ForcedUpgradeBackupLocation}" /> directory.
                         <LineBreak/>
                         <LineBreak/>
-                        If you want perform the migration preserving the error data follow
+                        If you want perform the migration preserving the data follow
                         <Hyperlink Command="{Binding OpenUrl}" CommandParameter="https://docs.particular.net/servicecontrol/upgrades/4to5/">
                             the version 4 to 5 upgrade guide
                         </Hyperlink>.

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
@@ -22,7 +22,8 @@ namespace ServiceControl.Config.UI.AdvancedOptions
             IEventAggregator eventAggregator,
             StartServiceControlInMaintenanceModeCommand maintenanceModeCommand,
             DeleteServiceControlInstanceCommand deleteInstanceCommand,
-            ForceUpgradeServiceControlInstanceCommand forceUpgradeCommand
+            ForceUpgradePrimaryInstanceCommand forceUpgradePrimaryCommand,
+            ForceUpgradeAuditInstanceCommand forceUpgradeAuditCommand
             )
         {
             ServiceControlInstance = (ServiceControlBaseService)instance;
@@ -34,7 +35,16 @@ namespace ServiceControl.Config.UI.AdvancedOptions
                 await eventAggregator.PublishOnUIThreadAsync(new RefreshInstances());
             });
             DeleteCommand = deleteInstanceCommand;
-            ForceUpgradeCommand = forceUpgradeCommand;
+
+            if (instance is ServiceControlAuditInstance)
+            {
+                ForceUpgradeCommand = forceUpgradeAuditCommand;
+            }
+            else if (instance is ServiceControlInstance)
+            {
+                ForceUpgradeCommand = forceUpgradePrimaryCommand;
+            }
+
             OpenUrl = new OpenURLCommand();
             CopyToClipboard = new CopyToClipboardCommand();
             StopMaintenanceModeCommand = ReactiveCommand.CreateFromTask<ServiceControlAdvancedViewModel>(async _ =>
@@ -125,7 +135,7 @@ namespace ServiceControl.Config.UI.AdvancedOptions
 
         public bool ForcedUpgradeAllowed => ForceUpgradeCommand.CanExecute(this);
 
-        public string ForcedUpgradeBackupLocation => $"{ServiceControlInstance.DBPath}_UpgradeBackup";
+        public string ForcedUpgradeBackupLocation => ServiceControlInstance.DatabaseBackupPath;
 
         public Task HandleAsync(RefreshInstances message, CancellationToken cancellationToken)
         {

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
@@ -21,7 +21,7 @@ namespace ServiceControl.Management.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]
         public string[] Acknowledgements { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if storage engine is incompatible resulting in data loss")]
+        [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if current instance is using an obsolete incompatibiel RavenDB3.5 storage engine resulting in data loss")]
         public SwitchParameter Force { get; set; }
 
         protected override void BeginProcessing()

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
@@ -21,7 +21,7 @@ namespace ServiceControl.Management.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]
         public string[] Acknowledgements { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if current instance is using an obsolete incompatibiel RavenDB3.5 storage engine resulting in data loss")]
+        [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if the current instance is using obsolete, incompatible RavenDB 3.5 storage engine. Replaces the database with a brand new one, removing all data previously stored.")]
         public SwitchParameter Force { get; set; }
 
         protected override void BeginProcessing()

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
@@ -22,7 +22,7 @@ namespace ServiceControl.Management.PowerShell
         public string[] Acknowledgements { get; set; }
 
         [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if storage engine is incompatible resulting in data loss")]
-        public SwitchParameter ForceRecreateDatabase { get; set; }
+        public SwitchParameter Force { get; set; }
 
         protected override void BeginProcessing()
         {
@@ -60,7 +60,7 @@ namespace ServiceControl.Management.PowerShell
                     ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -Acknowledgements {AcknowledgementValues.RabbitMQBrokerVersion310} if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
                 }
 
-                if (!installer.Upgrade(instance, ForceRecreateDatabase.IsPresent))
+                if (!installer.Upgrade(instance, Force.IsPresent))
                 {
                     ThrowTerminatingError(new ErrorRecord(new Exception($"Upgrade of {instance.Name} failed"), "UpgradeFailure", ErrorCategory.InvalidResult, null));
                 }

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/InvokeAuditUpgrade.cs
@@ -21,6 +21,9 @@ namespace ServiceControl.Management.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]
         public string[] Acknowledgements { get; set; }
 
+        [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if storage engine is incompatible resulting in data loss")]
+        public SwitchParameter ForceRecreateDatabase { get; set; }
+
         protected override void BeginProcessing()
         {
             Account.TestIfAdmin();
@@ -57,7 +60,7 @@ namespace ServiceControl.Management.PowerShell
                     ThrowTerminatingError(new ErrorRecord(new Exception($"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Use -Acknowledgements {AcknowledgementValues.RabbitMQBrokerVersion310} if you are sure your broker meets these requirements."), "Install Error", ErrorCategory.InvalidArgument, null));
                 }
 
-                if (!installer.Upgrade(instance))
+                if (!installer.Upgrade(instance, ForceRecreateDatabase.IsPresent))
                 {
                     ThrowTerminatingError(new ErrorRecord(new Exception($"Upgrade of {instance.Name} failed"), "UpgradeFailure", ErrorCategory.InvalidResult, null));
                 }

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
@@ -16,29 +16,6 @@ namespace ServiceControl.Management.PowerShell
         [Parameter(Mandatory = true, Position = 0, HelpMessage = "Specify the name of the ServiceControl Instance to update")]
         public string Name;
 
-        [Parameter(Mandatory = false, HelpMessage = "Specify the directory to use for the new ServiceControl Audit Instance")]
-        [ValidatePath]
-        public string InstallPath { get; set; }
-
-        [Parameter(Mandatory = false, HelpMessage = "Specify the directory that will contain the RavenDB database for the new ServiceControl Audit Instance")]
-        [ValidatePath]
-        public string DBPath { get; set; }
-
-        [Parameter(Mandatory = false, HelpMessage = "Specify the directory to use for the new ServiceControl Audit Logs")]
-        [ValidatePath]
-        public string LogPath { get; set; }
-
-        [Parameter(Mandatory = false, HelpMessage = "Specify the port number for the new ServiceControl Audit API to listen on")]
-        [ValidateRange(1, 49151)]
-        public int? Port { get; set; }
-
-        [Parameter(Mandatory = false, HelpMessage = "Specify the database maintenance port number for the new ServiceControl Audit instance to listen on")]
-        [ValidateRange(1, 49151)]
-        public int? DatabaseMaintenancePort { get; set; }
-
-        [Parameter(Mandatory = false, HelpMessage = "Service Account Password (if required)")]
-        public string ServiceAccountPassword { get; set; }
-
         [Parameter(Mandatory = false, HelpMessage = "Do not automatically create new queues")]
         public SwitchParameter SkipQueueCreation { get; set; }
 

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
@@ -51,6 +51,9 @@ namespace ServiceControl.Management.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]
         public string[] Acknowledgements { get; set; }
 
+        [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if storage engine is incompatible resulting in data loss")]
+        public SwitchParameter ForceRecreateDatabase { get; set; }
+
         protected override void BeginProcessing()
         {
             Account.TestIfAdmin();
@@ -77,7 +80,8 @@ namespace ServiceControl.Management.PowerShell
             var options = new ServiceControlUpgradeOptions
             {
                 SkipQueueCreation = SkipQueueCreation,
-                DisableFullTextSearchOnBodies = DisableFullTextSearchOnBodies
+                DisableFullTextSearchOnBodies = DisableFullTextSearchOnBodies,
+                ForceRecreateDatabase = ForceRecreateDatabase.IsPresent
             };
 
             if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB: true, out var missingMessage))

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
@@ -45,14 +45,11 @@ namespace ServiceControl.Management.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Disable full text search on error messages.")]
         public SwitchParameter DisableFullTextSearchOnBodies { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Reuse the specified log, db, and install paths even if they are not empty")]
+        [Parameter(Mandatory = false, HelpMessage = "Reuse the specified log, db, and install paths even if they are not empty and perform upgrade even if storage engine is incompatible resulting in data loss")]
         public SwitchParameter Force { get; set; }
 
         [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]
         public string[] Acknowledgements { get; set; }
-
-        [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if storage engine is incompatible resulting in data loss")]
-        public SwitchParameter ForceRecreateDatabase { get; set; }
 
         protected override void BeginProcessing()
         {
@@ -81,7 +78,7 @@ namespace ServiceControl.Management.PowerShell
             {
                 SkipQueueCreation = SkipQueueCreation,
                 DisableFullTextSearchOnBodies = DisableFullTextSearchOnBodies,
-                ForceRecreateDatabase = ForceRecreateDatabase.IsPresent
+                Force = Force.IsPresent
             };
 
             if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB: true, out var missingMessage))

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
@@ -45,7 +45,7 @@ namespace ServiceControl.Management.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Disable full text search on error messages.")]
         public SwitchParameter DisableFullTextSearchOnBodies { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Reuse the specified log, db, and install paths even if they are not empty and perform upgrade even if storage engine is incompatible resulting in data loss")]
+        [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if current instance is using an obsolete incompatibiel RavenDB3.5 storage engine resulting in data loss and reuse the specified log, db, and install paths even if they are not empty")]
         public SwitchParameter Force { get; set; }
 
         [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/InvokeServiceControlInstanceUpgrade.cs
@@ -22,7 +22,7 @@ namespace ServiceControl.Management.PowerShell
         [Parameter(Mandatory = false, HelpMessage = "Disable full text search on error messages.")]
         public SwitchParameter DisableFullTextSearchOnBodies { get; set; }
 
-        [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if current instance is using an obsolete incompatibiel RavenDB3.5 storage engine resulting in data loss and reuse the specified log, db, and install paths even if they are not empty")]
+        [Parameter(Mandatory = false, HelpMessage = "Perform upgrade even if the current instance is using obsolete, incompatible RavenDB 3.5 storage engine. Replaces the database with a brand new one, removing all data previously stored.")]
         public SwitchParameter Force { get; set; }
 
         [Parameter(Mandatory = false, HelpMessage = "Acknowledge mandatory requirements have been met.")]

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
@@ -434,10 +434,17 @@ namespace ServiceControlInstaller.Engine.Instances
             AppConfig.Save();
         }
 
+        public void CreateDatabaseBackup()
+        {
+            Directory.Move(DBPath, DatabaseBackupPath);
+        }
+
         public AppConfig AppConfig;
 
         public bool VersionHasServiceControlAuditFeatures => Version >= AuditFeatureMinVersion;
 
-        static Version AuditFeatureMinVersion = new Version(4, 0);
+        public string DatabaseBackupPath => DBPath + "_UpgradeBackup";
+
+        static Version AuditFeatureMinVersion = new(4, 0);
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlUpgradeOptions.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlUpgradeOptions.cs
@@ -11,7 +11,7 @@ namespace ServiceControlInstaller.Engine.Instances
         public int? MaintenancePort { get; set; }
         public bool SkipQueueCreation { get; set; }
         public string RemoteUrl { get; set; }
-        public bool ForceRecreateDatabase { get; set; }
+        public bool Force { get; set; }
 
         public void ApplyChangesToInstance(ServiceControlBaseService instance)
         {

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlUpgradeOptions.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlUpgradeOptions.cs
@@ -11,6 +11,7 @@ namespace ServiceControlInstaller.Engine.Instances
         public int? MaintenancePort { get; set; }
         public bool SkipQueueCreation { get; set; }
         public string RemoteUrl { get; set; }
+        public bool ForceRecreateDatabase { get; set; }
 
         public void ApplyChangesToInstance(ServiceControlBaseService instance)
         {

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
@@ -96,9 +96,9 @@
             return true;
         }
 
-        public bool Upgrade(ServiceControlAuditInstance instance, bool forceWithRecreate)
+        public bool Upgrade(ServiceControlAuditInstance instance, bool force)
         {
-            if (forceWithRecreate)
+            if (force)
             {
                 instance.CreateDatabaseBackup();
                 instance.PersistenceManifest = ServiceControlPersisters.GetAuditPersistence(StorageEngineNames.RavenDB);

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
@@ -96,14 +96,20 @@
             return true;
         }
 
-        public bool Upgrade(ServiceControlAuditInstance instance)
+        public bool Upgrade(ServiceControlAuditInstance instance, bool forceWithRecreate)
         {
+            if (forceWithRecreate)
+            {
+                instance.CreateDatabaseBackup();
+                instance.PersistenceManifest = ServiceControlPersisters.GetAuditPersistence(StorageEngineNames.RavenDB);
+            }
+
             var compatibleStorageEngine = instance.PersistenceManifest.Name == StorageEngineNames.RavenDB;
 
             if (!compatibleStorageEngine)
             {
-                var upgradeGuide4to5url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
-                logger.Error($"Upgrade aborted. Please note that the storage format has changed and the {instance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}");
+                var upgradeGuide4To5Url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
+                logger.Error($"Upgrade aborted. Please note that the storage format has changed and the {instance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4To5Url}");
                 return false;
             }
 
@@ -174,7 +180,7 @@
             return true;
         }
 
-        public bool Delete(string instanceName, bool removeDB, bool removeLogs)
+        public bool Delete(string instanceName, bool removeDatabase, bool removeLogs)
         {
             var instance = InstanceFinder.FindServiceControlInstance(instanceName);
             instance.ReportCard = new ReportCard();
@@ -196,7 +202,7 @@
                     instance.RemoveLogsFolder();
                 }
 
-                if (removeDB)
+                if (removeDatabase)
                 {
                     instance.RemoveDataBaseFolder();
                 }

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControlInstaller.Engine.Unattended
 {
     using System;
+    using System.IO;
     using System.Linq;
     using System.ServiceProcess;
     using System.Threading.Tasks;
@@ -93,6 +94,12 @@
 
         public bool Upgrade(ServiceControlInstance instance, ServiceControlUpgradeOptions options)
         {
+            if (options.ForceRecreateDatabase)
+            {
+                instance.CreateDatabaseBackup();
+                instance.PersistenceManifest = ServiceControlPersisters.GetPrimaryPersistence(StorageEngineNames.RavenDB);
+            }
+
             var compatibleStorageEngine = instance.PersistenceManifest.Name == StorageEngineNames.RavenDB;
 
             if (!compatibleStorageEngine)

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
@@ -94,7 +94,7 @@
 
         public bool Upgrade(ServiceControlInstance instance, ServiceControlUpgradeOptions options)
         {
-            if (options.ForceRecreateDatabase)
+            if (options.Force)
             {
                 instance.CreateDatabaseBackup();
                 instance.PersistenceManifest = ServiceControlPersisters.GetPrimaryPersistence(StorageEngineNames.RavenDB);


### PR DESCRIPTION
1. SCMU now also has an *Upgrade Instance* under advanced settings for audit instances.
2. Powershell cmdlets `Invoke-ServiceControlAuditInstanceUpgrade` and `Invoke-ServiceControlInstanceUpgrade` now have `-ForceRecreateDatabase` switch. When set the database path will be moved and the persister manifest will be forced to the latest Raven engine.

- [x]  Ensure https://github.com/Particular/ServiceControl/pull/3806 is merged
- [x]  Rebase on https://github.com/Particular/ServiceControl/pull/3808
- [x]  Refactored to use `Force` switch
- [x]  Ensure https://github.com/Particular/ServiceControl/pull/3808 is merged
