### PR TITLE
Check for removed transports, and deduplicate all other install checks

### DIFF
--- a/src/LegacyArtifacts/Transports/AzureServiceBus/transport.manifest
+++ b/src/LegacyArtifacts/Transports/AzureServiceBus/transport.manifest
@@ -7,6 +7,7 @@
       "TypeName": "ServiceControl.Transports.ASB.ASBEndpointTopologyTransportCustomization, ServiceControl.Transports.ASB",
       "SampleConnectionString": "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>;QueueLengthQueryDelayInterval=<IntervalInMilliseconds(Default=500ms)>",
       "AvailableInSCMU": false,
+      "Removed": true,
       "Aliases": [
         "AzureServiceBus",
         "Azure Service Bus - Endpoint-oriented topology (Old)",
@@ -21,6 +22,7 @@
       "TypeName": "ServiceControl.Transports.ASB.ASBForwardingTopologyTransportCustomization, ServiceControl.Transports.ASB",
       "SampleConnectionString": "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>;QueueLengthQueryDelayInterval=<IntervalInMilliseconds(Default=500ms)>",
       "AvailableInSCMU": false,
+      "Removed": true,
       "AutoMigrateTo": "NetStandardAzureServiceBus",
       "Aliases": [
         "Azure Service Bus - Forwarding topology (Legacy)",

--- a/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
@@ -13,7 +13,7 @@
         {
             this.windowManager = windowManager;
             this.addInstance = addInstance;
-            this.installer = installer;
+            commandChecks = new CommandChecks(installer, windowManager);
         }
 
         [FeatureToggle(Feature.LicenseChecks)]
@@ -21,14 +21,9 @@
 
         public override async Task ExecuteAsync(object obj)
         {
-            if (LicenseChecks)
+            if (!await commandChecks.CanAddInstance(LicenseChecks))
             {
-                var licenseCheckResult = installer.CheckLicenseIsValid();
-                if (!licenseCheckResult.Valid)
-                {
-                    await windowManager.ShowMessage("LICENSE ERROR", $"Install could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact contact@particular.net", hideCancel: true);
-                    return;
-                }
+                return;
             }
 
             var instanceViewModel = addInstance();
@@ -37,6 +32,6 @@
 
         readonly Func<MonitoringAddViewModel> addInstance;
         readonly IServiceControlWindowManager windowManager;
-        readonly MonitoringInstanceInstaller installer;
+        readonly CommandChecks commandChecks;
     }
 }

--- a/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
@@ -4,16 +4,15 @@
     using System.Threading.Tasks;
     using Framework;
     using Framework.Commands;
-    using Framework.Modules;
     using UI.InstanceAdd;
 
     class AddMonitoringInstanceCommand : AwaitableAbstractCommand<object>
     {
-        public AddMonitoringInstanceCommand(IServiceControlWindowManager windowManager, Func<MonitoringAddViewModel> addInstance, MonitoringInstanceInstaller installer) : base(null)
+        public AddMonitoringInstanceCommand(IServiceControlWindowManager windowManager, Func<MonitoringAddViewModel> addInstance, CommandChecks commandChecks) : base(null)
         {
             this.windowManager = windowManager;
             this.addInstance = addInstance;
-            commandChecks = new CommandChecks(installer, windowManager);
+            this.commandChecks = commandChecks;
         }
 
         [FeatureToggle(Feature.LicenseChecks)]

--- a/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
@@ -15,12 +15,9 @@
             this.commandChecks = commandChecks;
         }
 
-        [FeatureToggle(Feature.LicenseChecks)]
-        public bool LicenseChecks { get; set; }
-
         public override async Task ExecuteAsync(object obj)
         {
-            if (!await commandChecks.CanAddInstance(LicenseChecks))
+            if (!await commandChecks.CanAddInstance())
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
@@ -17,7 +17,7 @@
 
         public override async Task ExecuteAsync(object obj)
         {
-            if (!await commandChecks.CanAddInstance())
+            if (!await commandChecks.CanAddInstance(needsRavenDB: false))
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
@@ -16,12 +16,9 @@
             this.commandChecks = commandChecks;
         }
 
-        [FeatureToggle(Feature.LicenseChecks)]
-        public bool LicenseChecks { get; set; }
-
         public override async Task ExecuteAsync(object obj)
         {
-            if (!await commandChecks.CanAddInstance(LicenseChecks))
+            if (!await commandChecks.CanAddInstance())
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
@@ -18,7 +18,7 @@
 
         public override async Task ExecuteAsync(object obj)
         {
-            if (!await commandChecks.CanAddInstance())
+            if (!await commandChecks.CanAddInstance(needsRavenDB: true))
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/CommandChecks.cs
+++ b/src/ServiceControl.Config/Commands/CommandChecks.cs
@@ -4,6 +4,7 @@
     using System.Threading.Tasks;
     using ServiceControl.Config.Framework;
     using ServiceControl.Config.Framework.Modules;
+    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
@@ -92,6 +93,15 @@
 
                     return false;
                 }
+            }
+
+            if (instance.TransportPackage.IsOldRabbitMQTransport() &&
+                !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
+                   "Do you want to proceed?",
+                   "Yes, my RabbitMQ broker meets the minimum requirements",
+                   "No, cancel the upgrade"))
+            {
+                return false;
             }
 
             return true;

--- a/src/ServiceControl.Config/Commands/CommandChecks.cs
+++ b/src/ServiceControl.Config/Commands/CommandChecks.cs
@@ -3,7 +3,9 @@
     using System.Threading.Tasks;
     using ServiceControl.Config.Framework;
     using ServiceControl.Config.Framework.Modules;
+    using ServiceControlInstaller.Engine;
     using ServiceControlInstaller.Engine.Instances;
+    using ServiceControlInstaller.Engine.Validation;
 
     public class CommandChecks
     {
@@ -32,6 +34,13 @@
             if (cantUpdateTransport)
             {
                 await windowManager.ShowMessage("DEPRECATED MESSAGE TRANSPORT", $"The message transport '{instance.TransportPackage.DisplayName}' is not available in this version of ServiceControl, and this instance cannot be upgraded.", acceptText: "Cancel Upgrade", hideCancel: true);
+                return false;
+            }
+
+            bool needsRavenDB = instance is IServiceControlBaseInstance;
+            if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB, out var missingMessage))
+            {
+                await windowManager.ShowMessage("Missing prerequisites", missingMessage, acceptText: "Cancel", hideCancel: true);
                 return false;
             }
 

--- a/src/ServiceControl.Config/Commands/CommandChecks.cs
+++ b/src/ServiceControl.Config/Commands/CommandChecks.cs
@@ -22,7 +22,7 @@
             this.windowManager = windowManager;
         }
 
-        public async Task<bool> CanUpgradeInstance(BaseService instance, bool licenseCheck)
+        public async Task<bool> CanUpgradeInstance(BaseService instance, bool licenseCheck, bool forceUpgradeDb = false)
         {
             // Check for license
             if (licenseCheck)
@@ -54,25 +54,28 @@
             // RavenDB 5+ check
             if (instance is IServiceControlBaseInstance baseInstance)
             {
-                var compatibleStorageEngine = baseInstance.PersistenceManifest.Name == StorageEngineNames.RavenDB;
-
-                if (!compatibleStorageEngine)
+                if (!forceUpgradeDb)
                 {
-                    var upgradeGuide4to5url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
+                    var compatibleStorageEngine = baseInstance.PersistenceManifest.Name == StorageEngineNames.RavenDB;
 
-                    var openUpgradeGuide = await windowManager.ShowYesNoDialog("STORAGE ENGINE INCOMPATIBLE",
-                        $"Please note that the storage format has changed and the {baseInstance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}",
-                        "Open online ServiceControl 4 to 5 upgrade guide in system default browser?",
-                        "Yes",
-                        "No"
-                    );
-
-                    if (openUpgradeGuide)
+                    if (!compatibleStorageEngine)
                     {
-                        Process.Start(new ProcessStartInfo(upgradeGuide4to5url) { UseShellExecute = true });
-                    }
+                        var upgradeGuide4to5url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
 
-                    return false;
+                        var openUpgradeGuide = await windowManager.ShowYesNoDialog("STORAGE ENGINE INCOMPATIBLE",
+                            $"Please note that the storage format has changed and the {baseInstance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}",
+                            "Open online ServiceControl 4 to 5 upgrade guide in system default browser?",
+                            "Yes",
+                            "No"
+                        );
+
+                        if (openUpgradeGuide)
+                        {
+                            Process.Start(new ProcessStartInfo(upgradeGuide4to5url) { UseShellExecute = true });
+                        }
+
+                        return false;
+                    }
                 }
 
                 // TODO: Why doesn't the Monitoring instance do this check? Should it?

--- a/src/ServiceControl.Config/Commands/CommandChecks.cs
+++ b/src/ServiceControl.Config/Commands/CommandChecks.cs
@@ -1,0 +1,41 @@
+﻿namespace ServiceControl.Config.Commands
+{
+    using System.Threading.Tasks;
+    using ServiceControl.Config.Framework;
+    using ServiceControl.Config.Framework.Modules;
+    using ServiceControlInstaller.Engine.Instances;
+
+    public class CommandChecks
+    {
+        readonly ServiceControlInstanceInstaller serviceControlInstaller;
+        readonly IServiceControlWindowManager windowManager;
+
+        public CommandChecks(ServiceControlInstanceInstaller serviceControlInstaller, IServiceControlWindowManager windowManager)
+        {
+            this.serviceControlInstaller = serviceControlInstaller;
+            this.windowManager = windowManager;
+        }
+
+        public async Task<bool> CanUpgradeInstance(BaseService instance, bool licenseCheck)
+        {
+            if (licenseCheck)
+            {
+                var licenseCheckResult = serviceControlInstaller.CheckLicenseIsValid();
+                if (!licenseCheckResult.Valid)
+                {
+                    await windowManager.ShowMessage("LICENSE ERROR", $"Upgrade could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact contact@particular.net", hideCancel: true);
+                    return false;
+                }
+            }
+
+            var cantUpdateTransport = instance.TransportPackage.Removed && instance.TransportPackage.AutoMigrateTo is null;
+            if (cantUpdateTransport)
+            {
+                await windowManager.ShowMessage("DEPRECATED MESSAGE TRANSPORT", $"The message transport '{instance.TransportPackage.DisplayName}' is not available in this version of ServiceControl, and this instance cannot be upgraded.", acceptText: "Cancel Upgrade", hideCancel: true);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/ServiceControl.Config/Commands/CommandChecks.cs
+++ b/src/ServiceControl.Config/Commands/CommandChecks.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Config.Commands
 {
     using System.Diagnostics;
+    using System.ServiceProcess;
     using System.Threading.Tasks;
     using ServiceControl.Config.Framework;
     using ServiceControl.Config.Framework.Modules;
@@ -105,6 +106,21 @@
             }
 
             return true;
+        }
+
+        public async Task<bool> StopBecauseInstanceIsRunning(BaseService instance, string instanceName)
+        {
+            if (instance.Service.Status == ServiceControllerStatus.Stopped)
+            {
+                return false;
+            }
+
+            var proceed = await windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {serviceControlInstaller.ZipInfo.Version}",
+                $"{instanceName} needs to be stopped in order to upgrade to version {serviceControlInstaller.ZipInfo.Version}.",
+                "Do you want to proceed?",
+                "Yes, I want to proceed", "No");
+
+            return !proceed;
         }
     }
 }

--- a/src/ServiceControl.Config/Commands/CommandChecks.cs
+++ b/src/ServiceControl.Config/Commands/CommandChecks.cs
@@ -20,10 +20,10 @@
             this.windowManager = windowManager;
         }
 
-        public async Task<bool> CanAddInstance(bool licenseCheck)
+        public async Task<bool> CanAddInstance()
         {
             // Check for license
-            if (licenseCheck && !await IsLicenseOk())
+            if (!await IsLicenseOk())
             {
                 return false;
             }
@@ -31,10 +31,10 @@
             return true;
         }
 
-        public async Task<bool> CanUpgradeInstance(BaseService instance, bool licenseCheck, bool forceUpgradeDb = false)
+        public async Task<bool> CanUpgradeInstance(BaseService instance, bool forceUpgradeDb = false)
         {
             // Check for license
-            if (licenseCheck && !await IsLicenseOk())
+            if (!await IsLicenseOk())
             {
                 return false;
             }

--- a/src/ServiceControl.Config/Commands/CommandChecks.cs
+++ b/src/ServiceControl.Config/Commands/CommandChecks.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Config.Commands
 {
+    using System.Diagnostics;
     using System.Threading.Tasks;
     using ServiceControl.Config.Framework;
     using ServiceControl.Config.Framework.Modules;
@@ -20,6 +21,7 @@
 
         public async Task<bool> CanUpgradeInstance(BaseService instance, bool licenseCheck)
         {
+            // Check for license
             if (licenseCheck)
             {
                 var licenseCheckResult = serviceControlInstaller.CheckLicenseIsValid();
@@ -30,6 +32,7 @@
                 }
             }
 
+            // Check for transports that can't be upgraded
             var cantUpdateTransport = instance.TransportPackage.Removed && instance.TransportPackage.AutoMigrateTo is null;
             if (cantUpdateTransport)
             {
@@ -37,11 +40,37 @@
                 return false;
             }
 
+            // Validate .NET Framework requirements
             bool needsRavenDB = instance is IServiceControlBaseInstance;
             if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB, out var missingMessage))
             {
                 await windowManager.ShowMessage("Missing prerequisites", missingMessage, acceptText: "Cancel", hideCancel: true);
                 return false;
+            }
+
+            // RavenDB 5+ check
+            if (instance is IServiceControlBaseInstance baseInstance)
+            {
+                var compatibleStorageEngine = baseInstance.PersistenceManifest.Name == StorageEngineNames.RavenDB;
+
+                if (!compatibleStorageEngine)
+                {
+                    var upgradeGuide4to5url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
+
+                    var openUpgradeGuide = await windowManager.ShowYesNoDialog("STORAGE ENGINE INCOMPATIBLE",
+                        $"Please note that the storage format has changed and the {baseInstance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}",
+                        "Open online ServiceControl 4 to 5 upgrade guide in system default browser?",
+                        "Yes",
+                        "No"
+                    );
+
+                    if (openUpgradeGuide)
+                    {
+                        Process.Start(new ProcessStartInfo(upgradeGuide4to5url) { UseShellExecute = true });
+                    }
+
+                    return false;
+                }
             }
 
             return true;

--- a/src/ServiceControl.Config/Commands/CommandChecks.cs
+++ b/src/ServiceControl.Config/Commands/CommandChecks.cs
@@ -4,7 +4,6 @@
     using System.ServiceProcess;
     using System.Threading.Tasks;
     using ServiceControl.Config.Framework;
-    using ServiceControl.Config.Framework.Modules;
     using ServiceControl.Engine.Extensions;
     using ServiceControl.LicenseManagement;
     using ServiceControlInstaller.Engine;
@@ -14,12 +13,10 @@
 
     public class CommandChecks
     {
-        readonly InstallerBase installer;
         readonly IServiceControlWindowManager windowManager;
 
-        public CommandChecks(InstallerBase installer, IServiceControlWindowManager windowManager)
+        public CommandChecks(IServiceControlWindowManager windowManager)
         {
-            this.installer = installer;
             this.windowManager = windowManager;
         }
 
@@ -92,7 +89,7 @@
                     var nextVersion = upgradeInfo.UpgradePath[0];
                     await windowManager.ShowMessage("VERSION UPGRADE INCOMPATIBLE",
                         "<Section xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" xml:space=\"preserve\" TextAlignment=\"Left\" LineHeight=\"Auto\" IsHyphenationEnabled=\"False\" xml:lang=\"en-us\">\r\n" +
-                        $"<Paragraph>You must upgrade to version(s) {upgradeInfo} before upgrading to version {installer.ZipInfo.Version}:</Paragraph>\r\n" +
+                        $"<Paragraph>You must upgrade to version(s) {upgradeInfo} before upgrading to version {Constants.CurrentVersion}:</Paragraph>\r\n" +
                         "<List MarkerStyle=\"Decimal\" Margin=\"0,0,0,0\" Padding=\"0,0,0,0\">\r\n" +
                         $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install version {nextVersion} from https://github.com/Particular/ServiceControl/releases/tag/{nextVersion}</Paragraph></ListItem>" +
                         $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Upgrade this instance to version {nextVersion}.</Paragraph></ListItem>\r\n" +
@@ -107,7 +104,7 @@
             }
 
             if (instance.TransportPackage.IsOldRabbitMQTransport() &&
-                !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
+                !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {Constants.CurrentVersion} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
                    "Do you want to proceed?",
                    "Yes, my RabbitMQ broker meets the minimum requirements",
                    "No, cancel the upgrade"))
@@ -137,8 +134,8 @@
                 return false;
             }
 
-            var proceed = await windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {installer.ZipInfo.Version}",
-                $"{instanceName} needs to be stopped in order to upgrade to version {installer.ZipInfo.Version}.",
+            var proceed = await windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {Constants.CurrentVersion}",
+                $"{instanceName} needs to be stopped in order to upgrade to version {Constants.CurrentVersion}.",
                 "Do you want to proceed?",
                 "Yes, I want to proceed", "No");
 

--- a/src/ServiceControl.Config/Commands/CommandChecks.cs
+++ b/src/ServiceControl.Config/Commands/CommandChecks.cs
@@ -120,7 +120,8 @@
                     }
                 }
 
-                // TODO: Why doesn't the Monitoring instance do this check? Should it?
+                // To be clear, Monitoring doesn't bother with this check because it's all in-memory storage
+                // so you could hypothetically change to any version at any time
                 var upgradeInfo = UpgradeInfo.GetUpgradePathFor(instance.Version);
                 if (upgradeInfo.HasIncompatibleVersion)
                 {

--- a/src/ServiceControl.Config/Commands/CommandChecks.cs
+++ b/src/ServiceControl.Config/Commands/CommandChecks.cs
@@ -5,6 +5,7 @@
     using ServiceControl.Config.Framework;
     using ServiceControl.Config.Framework.Modules;
     using ServiceControlInstaller.Engine;
+    using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.Validation;
 
@@ -68,6 +69,26 @@
                     {
                         Process.Start(new ProcessStartInfo(upgradeGuide4to5url) { UseShellExecute = true });
                     }
+
+                    return false;
+                }
+
+                // TODO: Why doesn't the Monitoring instance do this check? Should it?
+                var upgradeInfo = UpgradeInfo.GetUpgradePathFor(instance.Version);
+                if (upgradeInfo.HasIncompatibleVersion)
+                {
+                    var nextVersion = upgradeInfo.UpgradePath[0];
+                    await windowManager.ShowMessage("VERSION UPGRADE INCOMPATIBLE",
+                        "<Section xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" xml:space=\"preserve\" TextAlignment=\"Left\" LineHeight=\"Auto\" IsHyphenationEnabled=\"False\" xml:lang=\"en-us\">\r\n" +
+                        $"<Paragraph>You must upgrade to version(s) {upgradeInfo} before upgrading to version {serviceControlInstaller.ZipInfo.Version}:</Paragraph>\r\n" +
+                        "<List MarkerStyle=\"Decimal\" Margin=\"0,0,0,0\" Padding=\"0,0,0,0\">\r\n" +
+                        $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install version {nextVersion} from https://github.com/Particular/ServiceControl/releases/tag/{nextVersion}</Paragraph></ListItem>" +
+                        $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Upgrade this instance to version {nextVersion}.</Paragraph></ListItem>\r\n" +
+                        "<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install the latest version from https://particular.net/start-servicecontrol-download</Paragraph></ListItem>\r\n" +
+                        "<ListItem Margin=\"48,0,0,0\"><Paragraph>Upgrade this instance to the latest version of ServiceControl.</Paragraph></ListItem>\r\n" +
+                        "</List>\r\n" +
+                        "</Section>",
+                        hideCancel: true);
 
                     return false;
                 }

--- a/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
@@ -17,13 +17,14 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
     public ForceUpgradeServiceControlInstanceCommand(
         IServiceControlWindowManager windowManager,
         IEventAggregator eventAggregator,
-        ServiceControlInstanceInstaller serviceControlInstaller)
+        ServiceControlInstanceInstaller serviceControlInstaller,
+        CommandChecks commandChecks)
         : base(ForcedUpgradeAllowed)
     {
         this.windowManager = windowManager;
         this.eventAggregator = eventAggregator;
         this.serviceControlInstaller = serviceControlInstaller;
-        commandChecks = new CommandChecks(serviceControlInstaller, windowManager);
+        this.commandChecks = commandChecks;
     }
 
     [FeatureToggle(Feature.LicenseChecks)]

--- a/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
@@ -27,9 +27,6 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
         this.commandChecks = commandChecks;
     }
 
-    [FeatureToggle(Feature.LicenseChecks)]
-    public bool LicenseChecks { get; set; }
-
     static bool ForcedUpgradeAllowed(ServiceControlAdvancedViewModel model)
     {
         var instance = InstanceFinder.ServiceControlInstances().FirstOrDefault(i => i.Name == model.Name);
@@ -42,7 +39,7 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
         var instance = InstanceFinder.FindInstanceByName<ServiceControlInstance>(model.Name);
         instance.Service.Refresh();
 
-        if (!await commandChecks.CanUpgradeInstance(instance, LicenseChecks, forceUpgradeDb: true))
+        if (!await commandChecks.CanUpgradeInstance(instance, forceUpgradeDb: true))
         {
             return;
         }

--- a/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/ForceUpgradeServiceControlInstanceCommand.cs
@@ -17,13 +17,13 @@ class ForceUpgradeServiceControlInstanceCommand : AwaitableAbstractCommand<Servi
     public ForceUpgradeServiceControlInstanceCommand(
         IServiceControlWindowManager windowManager,
         IEventAggregator eventAggregator,
-        ServiceControlInstanceInstaller serviceControlInstaller,
-        CommandChecks commandChecks) : base(ForcedUpgradeAllowed)
+        ServiceControlInstanceInstaller serviceControlInstaller)
+        : base(ForcedUpgradeAllowed)
     {
         this.windowManager = windowManager;
         this.eventAggregator = eventAggregator;
         this.serviceControlInstaller = serviceControlInstaller;
-        this.commandChecks = commandChecks;
+        commandChecks = new CommandChecks(serviceControlInstaller, windowManager);
     }
 
     [FeatureToggle(Feature.LicenseChecks)]

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -21,13 +21,12 @@
         public UpgradeAuditInstanceCommand(
             IServiceControlWindowManager windowManager,
             IEventAggregator eventAggregator,
-            ServiceControlAuditInstanceInstaller serviceControlAuditInstaller,
-            CommandChecks commandChecks)
+            ServiceControlAuditInstanceInstaller serviceControlAuditInstaller)
         {
             this.windowManager = windowManager;
             this.eventAggregator = eventAggregator;
             this.serviceControlAuditInstaller = serviceControlAuditInstaller;
-            this.commandChecks = commandChecks;
+            commandChecks = new CommandChecks(serviceControlAuditInstaller, windowManager);
         }
 
         [FeatureToggle(Feature.LicenseChecks)]

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -47,25 +47,6 @@
                 return;
             }
 
-            var upgradeInfo = UpgradeInfo.GetUpgradePathFor(instance.Version);
-            if (upgradeInfo.HasIncompatibleVersion)
-            {
-                var nextVersion = upgradeInfo.UpgradePath[0];
-                await windowManager.ShowMessage("VERSION UPGRADE INCOMPATIBLE",
-                    "<Section xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" xml:space=\"preserve\" TextAlignment=\"Left\" LineHeight=\"Auto\" IsHyphenationEnabled=\"False\" xml:lang=\"en-us\">\r\n" +
-                    $"<Paragraph>You must upgrade to version(s) {upgradeInfo} before upgrading to version {serviceControlInstaller.ZipInfo.Version}:</Paragraph>\r\n" +
-                    "<List MarkerStyle=\"Decimal\" Margin=\"0,0,0,0\" Padding=\"0,0,0,0\">\r\n" +
-                    $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install version {nextVersion} from https://github.com/Particular/ServiceControl/releases/tag/{nextVersion}</Paragraph></ListItem>" +
-                    $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Upgrade this instance to version {nextVersion}.</Paragraph></ListItem>\r\n" +
-                    "<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install the latest version from https://particular.net/start-servicecontrol-download</Paragraph></ListItem>\r\n" +
-                    "<ListItem Margin=\"48,0,0,0\"><Paragraph>Upgrade this instance to the latest version of ServiceControl.</Paragraph></ListItem>\r\n" +
-                    "</List>\r\n" +
-                    "</Section>",
-                    hideCancel: true);
-
-                return;
-            }
-
             var upgradeOptions = new ServiceControlUpgradeOptions();
 
             if (!instance.AppConfig.AppSettingExists(AuditInstanceSettingsList.EnableFullTextSearchOnBodies.Name))

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.Config.Commands
 {
     using System;
-    using System.Diagnostics;
     using System.ServiceProcess;
     using System.Threading.Tasks;
     using Caliburn.Micro;
@@ -45,27 +44,6 @@
 
             if (!await commandChecks.CanUpgradeInstance(instance, LicenseChecks))
             {
-                return;
-            }
-
-            var compatibleStorageEngine = instance.PersistenceManifest.Name == StorageEngineNames.RavenDB;
-
-            if (!compatibleStorageEngine)
-            {
-                var upgradeGuide4to5url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
-
-                var openUpgradeGuide = await windowManager.ShowYesNoDialog("STORAGE ENGINE INCOMPATIBLE",
-                    $"Please note that the storage format has changed and the {instance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}",
-                    "Open online ServiceControl 4 to 5 upgrade guide in system default browser?",
-                    "Yes",
-                    "No"
-                );
-
-                if (openUpgradeGuide)
-                {
-                    Process.Start(new ProcessStartInfo(upgradeGuide4to5url) { UseShellExecute = true });
-                }
-
                 return;
             }
 

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -8,7 +8,6 @@
     using Framework;
     using Framework.Commands;
     using Framework.Modules;
-    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
@@ -67,15 +66,6 @@
                     await eventAggregator.PublishOnUIThreadAsync(new RefreshInstances());
                     return;
                 }
-            }
-
-            if (instance.TransportPackage.IsOldRabbitMQTransport() &&
-                !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
-                   "Do you want to proceed?",
-                   "Yes, my RabbitMQ broker meets the minimum requirements",
-                   "No, cancel the upgrade"))
-            {
-                return;
             }
 
             if (instance.Service.Status != ServiceControllerStatus.Stopped &&

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.Config.Commands
 {
     using System;
-    using System.ServiceProcess;
     using System.Threading.Tasks;
     using Caliburn.Micro;
     using Events;
@@ -22,13 +21,11 @@
         public UpgradeAuditInstanceCommand(
             IServiceControlWindowManager windowManager,
             IEventAggregator eventAggregator,
-            ServiceControlInstanceInstaller serviceControlInstaller,
             ServiceControlAuditInstanceInstaller serviceControlAuditInstaller,
             CommandChecks commandChecks)
         {
             this.windowManager = windowManager;
             this.eventAggregator = eventAggregator;
-            this.serviceControlInstaller = serviceControlInstaller;
             this.serviceControlAuditInstaller = serviceControlAuditInstaller;
             this.commandChecks = commandChecks;
         }
@@ -68,11 +65,7 @@
                 }
             }
 
-            if (instance.Service.Status != ServiceControllerStatus.Stopped &&
-                !await windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {serviceControlInstaller.ZipInfo.Version}",
-                    $"{model.Name} needs to be stopped in order to upgrade to version {serviceControlInstaller.ZipInfo.Version}.",
-                    "Do you want to proceed?",
-                    "Yes, I want to proceed", "No"))
+            if (await commandChecks.StopBecauseInstanceIsRunning(instance, model.Name))
             {
                 return;
             }
@@ -128,7 +121,6 @@
 
         readonly IEventAggregator eventAggregator;
         readonly IServiceControlWindowManager windowManager;
-        readonly ServiceControlInstanceInstaller serviceControlInstaller;
         readonly ServiceControlAuditInstanceInstaller serviceControlAuditInstaller;
         readonly CommandChecks commandChecks;
     }

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -21,12 +21,13 @@
         public UpgradeAuditInstanceCommand(
             IServiceControlWindowManager windowManager,
             IEventAggregator eventAggregator,
-            ServiceControlAuditInstanceInstaller serviceControlAuditInstaller)
+            ServiceControlAuditInstanceInstaller serviceControlAuditInstaller,
+            CommandChecks commandChecks)
         {
             this.windowManager = windowManager;
             this.eventAggregator = eventAggregator;
             this.serviceControlAuditInstaller = serviceControlAuditInstaller;
-            commandChecks = new CommandChecks(serviceControlAuditInstaller, windowManager);
+            this.commandChecks = commandChecks;
         }
 
         [FeatureToggle(Feature.LicenseChecks)]

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -13,7 +13,6 @@
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
-    using ServiceControlInstaller.Engine.Validation;
     using UI.InstanceDetails;
 
     class UpgradeAuditInstanceCommand : AwaitableAbstractCommand<InstanceDetailsViewModel>
@@ -109,12 +108,6 @@
                     await eventAggregator.PublishOnUIThreadAsync(new RefreshInstances());
                     return;
                 }
-            }
-
-            if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB: true, out var missingMessage))
-            {
-                await windowManager.ShowMessage("Missing prerequisites", missingMessage, acceptText: "Cancel", hideCancel: true);
-                return;
             }
 
             if (instance.TransportPackage.IsOldRabbitMQTransport() &&

--- a/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeAuditInstanceCommand.cs
@@ -30,15 +30,12 @@
             this.commandChecks = commandChecks;
         }
 
-        [FeatureToggle(Feature.LicenseChecks)]
-        public bool LicenseChecks { get; set; }
-
         public override async Task ExecuteAsync(InstanceDetailsViewModel model)
         {
             var instance = InstanceFinder.FindInstanceByName<ServiceControlAuditInstance>(model.Name);
             instance.Service.Refresh();
 
-            if (!await commandChecks.CanUpgradeInstance(instance, LicenseChecks))
+            if (!await commandChecks.CanUpgradeInstance(instance))
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
@@ -17,12 +17,12 @@
         {
         }
 
-        public UpgradeMonitoringInstanceCommand(IServiceControlWindowManager windowManager, IEventAggregator eventAggregator, MonitoringInstanceInstaller installer, CommandChecks commandChecks)
+        public UpgradeMonitoringInstanceCommand(IServiceControlWindowManager windowManager, IEventAggregator eventAggregator, MonitoringInstanceInstaller installer)
         {
             this.windowManager = windowManager;
             this.eventAggregator = eventAggregator;
             this.installer = installer;
-            this.commandChecks = commandChecks;
+            commandChecks = new CommandChecks(installer, windowManager);
         }
 
         [FeatureToggle(Feature.LicenseChecks)]

--- a/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
@@ -25,15 +25,12 @@
             this.commandChecks = commandChecks;
         }
 
-        [FeatureToggle(Feature.LicenseChecks)]
-        public bool LicenseChecks { get; set; }
-
         public override async Task ExecuteAsync(InstanceDetailsViewModel model)
         {
             var instance = InstanceFinder.FindMonitoringInstance(model.Name);
             instance.Service.Refresh();
 
-            if (!await commandChecks.CanUpgradeInstance(instance, LicenseChecks))
+            if (!await commandChecks.CanUpgradeInstance(instance))
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
@@ -8,7 +8,6 @@
     using Framework;
     using Framework.Commands;
     using Framework.Modules;
-    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
     using UI.InstanceDetails;
@@ -36,15 +35,6 @@
             instance.Service.Refresh();
 
             if (!await commandChecks.CanUpgradeInstance(instance, LicenseChecks))
-            {
-                return;
-            }
-
-            if (instance.TransportPackage.IsOldRabbitMQTransport() &&
-                !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
-                   "Do you want to proceed?",
-                   "Yes, my RabbitMQ broker meets the minimum requirements",
-                   "No, cancel the upgrade"))
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
@@ -11,7 +11,6 @@
     using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
-    using ServiceControlInstaller.Engine.Validation;
     using UI.InstanceDetails;
 
     class UpgradeMonitoringInstanceCommand : AwaitableAbstractCommand<InstanceDetailsViewModel>
@@ -38,12 +37,6 @@
 
             if (!await commandChecks.CanUpgradeInstance(instance, LicenseChecks))
             {
-                return;
-            }
-
-            if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB: false, out var missingMessage))
-            {
-                await windowManager.ShowMessage("Missing prerequisites", missingMessage, acceptText: "Cancel", hideCancel: true);
                 return;
             }
 

--- a/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeMonitoringInstanceCommand.cs
@@ -17,12 +17,12 @@
         {
         }
 
-        public UpgradeMonitoringInstanceCommand(IServiceControlWindowManager windowManager, IEventAggregator eventAggregator, MonitoringInstanceInstaller installer)
+        public UpgradeMonitoringInstanceCommand(IServiceControlWindowManager windowManager, IEventAggregator eventAggregator, MonitoringInstanceInstaller installer, CommandChecks commandChecks)
         {
             this.windowManager = windowManager;
             this.eventAggregator = eventAggregator;
             this.installer = installer;
-            commandChecks = new CommandChecks(installer, windowManager);
+            this.commandChecks = commandChecks;
         }
 
         [FeatureToggle(Feature.LicenseChecks)]

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -14,7 +14,6 @@
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
-    using ServiceControlInstaller.Engine.Validation;
     using UI.InstanceDetails;
     using UI.MessageBox;
     using Validation;
@@ -193,12 +192,6 @@
                     await eventAggregator.PublishOnUIThreadAsync(new RefreshInstances());
                     return;
                 }
-            }
-
-            if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB: true, out var missingMessage))
-            {
-                await windowManager.ShowMessage("Missing prerequisites", missingMessage, acceptText: "Cancel", hideCancel: true);
-                return;
             }
 
             if (instance.TransportPackage.IsOldRabbitMQTransport() &&

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -26,14 +26,13 @@
         public UpgradeServiceControlInstanceCommand(
             IServiceControlWindowManager windowManager,
             IEventAggregator eventAggregator,
-            ServiceControlInstanceInstaller serviceControlInstaller,
-            CommandChecks commandChecks
+            ServiceControlInstanceInstaller serviceControlInstaller
             )
         {
             this.windowManager = windowManager;
             this.eventAggregator = eventAggregator;
             this.serviceControlInstaller = serviceControlInstaller;
-            this.commandChecks = commandChecks;
+            commandChecks = new CommandChecks(serviceControlInstaller, windowManager);
         }
 
         [FeatureToggle(Feature.LicenseChecks)]

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -36,15 +36,12 @@
             this.commandChecks = commandChecks;
         }
 
-        [FeatureToggle(Feature.LicenseChecks)]
-        public bool LicenseChecks { get; set; }
-
         public override async Task ExecuteAsync(InstanceDetailsViewModel model)
         {
             var instance = InstanceFinder.FindInstanceByName<ServiceControlInstance>(model.Name);
             instance.Service.Refresh();
 
-            if (!await commandChecks.CanUpgradeInstance(instance, LicenseChecks))
+            if (!await commandChecks.CanUpgradeInstance(instance))
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.Config.Commands
 {
     using System;
-    using System.Diagnostics;
     using System.ServiceProcess;
     using System.Threading.Tasks;
     using Caliburn.Micro;
@@ -52,26 +51,7 @@
                 return;
             }
 
-            var compatibleStorageEngine = instance.PersistenceManifest.Name == StorageEngineNames.RavenDB;
 
-            if (!compatibleStorageEngine)
-            {
-                var upgradeGuide4to5url = "https://docs.particular.net/servicecontrol/upgrades/4to5/";
-
-                var openUpgradeGuide = await windowManager.ShowYesNoDialog("STORAGE ENGINE INCOMPATIBLE",
-                    $"Please note that the storage format has changed and the {instance.PersistenceManifest.DisplayName} storage engine is no longer available. Upgrading requires a side-by-side deployment of both versions. Migration guidance is available in the version 4 to 5 upgrade guidance at {upgradeGuide4to5url}",
-                    "Open online ServiceControl 4 to 5 upgrade guide in system default browser?",
-                    "Yes",
-                    "No"
-                );
-
-                if (openUpgradeGuide)
-                {
-                    Process.Start(new ProcessStartInfo(upgradeGuide4to5url) { UseShellExecute = true });
-                }
-
-                return;
-            }
 
             var upgradeInfo = UpgradeInfo.GetUpgradePathFor(instance.Version);
             if (upgradeInfo.HasIncompatibleVersion)

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -9,7 +9,6 @@
     using Framework;
     using Framework.Commands;
     using Framework.Modules;
-    using ServiceControl.Engine.Extensions;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
@@ -151,15 +150,6 @@
                     await eventAggregator.PublishOnUIThreadAsync(new RefreshInstances());
                     return;
                 }
-            }
-
-            if (instance.TransportPackage.IsOldRabbitMQTransport() &&
-                !await windowManager.ShowYesNoDialog("UPGRADE WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before upgrading.",
-                   "Do you want to proceed?",
-                   "Yes, my RabbitMQ broker meets the minimum requirements",
-                   "No, cancel the upgrade"))
-            {
-                return;
             }
 
             if (instance.Service.Status != ServiceControllerStatus.Stopped &&

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -26,13 +26,14 @@
         public UpgradeServiceControlInstanceCommand(
             IServiceControlWindowManager windowManager,
             IEventAggregator eventAggregator,
-            ServiceControlInstanceInstaller serviceControlInstaller
+            ServiceControlInstanceInstaller serviceControlInstaller,
+            CommandChecks commandChecks
             )
         {
             this.windowManager = windowManager;
             this.eventAggregator = eventAggregator;
             this.serviceControlInstaller = serviceControlInstaller;
-            commandChecks = new CommandChecks(serviceControlInstaller, windowManager);
+            this.commandChecks = commandChecks;
         }
 
         [FeatureToggle(Feature.LicenseChecks)]

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.Config.Commands
 {
     using System;
-    using System.ServiceProcess;
     using System.Threading.Tasks;
     using Caliburn.Micro;
     using Events;
@@ -152,11 +151,7 @@
                 }
             }
 
-            if (instance.Service.Status != ServiceControllerStatus.Stopped &&
-                !await windowManager.ShowYesNoDialog($"STOP INSTANCE AND UPGRADE TO {serviceControlInstaller.ZipInfo.Version}",
-                    $"{model.Name} needs to be stopped in order to upgrade to version {serviceControlInstaller.ZipInfo.Version}.",
-                    "Do you want to proceed?",
-                    "Yes, I want to proceed", "No"))
+            if (await commandChecks.StopBecauseInstanceIsRunning(instance, model.Name))
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/UpgradeServiceControlInstanceCommand.cs
@@ -51,27 +51,6 @@
                 return;
             }
 
-
-
-            var upgradeInfo = UpgradeInfo.GetUpgradePathFor(instance.Version);
-            if (upgradeInfo.HasIncompatibleVersion)
-            {
-                var nextVersion = upgradeInfo.UpgradePath[0];
-                await windowManager.ShowMessage("VERSION UPGRADE INCOMPATIBLE",
-                    "<Section xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" xml:space=\"preserve\" TextAlignment=\"Left\" LineHeight=\"Auto\" IsHyphenationEnabled=\"False\" xml:lang=\"en-us\">\r\n" +
-                    $"<Paragraph>You must upgrade to version(s) {upgradeInfo} before upgrading to version {serviceControlInstaller.ZipInfo.Version}:</Paragraph>\r\n" +
-                    "<List MarkerStyle=\"Decimal\" Margin=\"0,0,0,0\" Padding=\"0,0,0,0\">\r\n" +
-                    $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install version {nextVersion} from https://github.com/Particular/ServiceControl/releases/tag/{nextVersion}</Paragraph></ListItem>" +
-                    $"<ListItem Margin=\"48,0,0,0\"><Paragraph>Upgrade this instance to version {nextVersion}.</Paragraph></ListItem>\r\n" +
-                    "<ListItem Margin=\"48,0,0,0\"><Paragraph>Download and install the latest version from https://particular.net/start-servicecontrol-download</Paragraph></ListItem>\r\n" +
-                    "<ListItem Margin=\"48,0,0,0\"><Paragraph>Upgrade this instance to the latest version of ServiceControl.</Paragraph></ListItem>\r\n" +
-                    "</List>\r\n" +
-                    "</Section>",
-                    hideCancel: true);
-
-                return;
-            }
-
             if (instance.IsErrorQueueDisabled())
             {
                 await windowManager.ShowMessage("UPGRADE INCOMPATIBLE",

--- a/src/ServiceControl.Config/Features.cs
+++ b/src/ServiceControl.Config/Features.cs
@@ -20,7 +20,6 @@
     public static class Feature
     {
         public const string MonitoringInstances = "MonitoringInstances";
-        public const string LicenseChecks = "LicenseChecks";
     }
 
     public class FeatureToggles
@@ -48,7 +47,6 @@
         public void Start()
         {
             featureToggles.Enable(Feature.MonitoringInstances);
-            featureToggles.Enable(Feature.LicenseChecks);
         }
 
         FeatureToggles featureToggles;

--- a/src/ServiceControl.Config/Framework/Modules/CaliburnModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/CaliburnModule.cs
@@ -10,6 +10,7 @@
         protected override void Load(ContainerBuilder builder)
         {
             builder.RegisterType<ServiceControlWindowManager>().As<IWindowManager>().As<IServiceControlWindowManager>().InstancePerLifetimeScope();
+            builder.RegisterType<CommandChecks>().InstancePerLifetimeScope();
             builder.RegisterType<EventAggregator>().As<IEventAggregator>().InstancePerLifetimeScope();
 
             // register view models

--- a/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.Config.Framework.Modules
     using System;
     using System.Threading.Tasks;
     using Autofac;
+    using ServiceControl.Config.Commands;
     using ServiceControl.LicenseManagement;
     using ServiceControlInstaller.Engine.FileSystem;
     using ServiceControlInstaller.Engine.Instances;
@@ -18,6 +19,7 @@ namespace ServiceControl.Config.Framework.Modules
             builder.RegisterType<ServiceControlInstanceInstaller>().SingleInstance();
             builder.RegisterType<MonitoringInstanceInstaller>().SingleInstance();
             builder.RegisterType<ServiceControlAuditInstanceInstaller>().SingleInstance();
+            builder.RegisterType<CommandChecks>().InstancePerDependency();
         }
     }
 

--- a/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
@@ -3,8 +3,6 @@ namespace ServiceControl.Config.Framework.Modules
     using System;
     using System.Threading.Tasks;
     using Autofac;
-    using ServiceControl.Config.Commands;
-    using ServiceControl.LicenseManagement;
     using ServiceControlInstaller.Engine.FileSystem;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.ReportCard;
@@ -19,7 +17,6 @@ namespace ServiceControl.Config.Framework.Modules
             builder.RegisterType<ServiceControlInstanceInstaller>().SingleInstance();
             builder.RegisterType<MonitoringInstanceInstaller>().SingleInstance();
             builder.RegisterType<ServiceControlAuditInstanceInstaller>().SingleInstance();
-            builder.RegisterType<CommandChecks>().InstancePerDependency();
         }
     }
 
@@ -39,10 +36,13 @@ namespace ServiceControl.Config.Framework.Modules
         }
     }
 
-    public class ServiceControlInstallerBase
+    public abstract class InstallerBase
     {
-        public PlatformZipInfo ZipInfo { get; protected set; }
+        public PlatformZipInfo ZipInfo { get; init; }
+    }
 
+    public class ServiceControlInstallerBase : InstallerBase
+    {
         internal async Task<ReportCard> Add(ServiceControlInstallableBase details, IProgress<ProgressDetails> progress, Func<PathInfo, Task<bool>> promptToProceed)
         {
             ZipInfo.ValidateZip();
@@ -229,52 +229,14 @@ namespace ServiceControl.Config.Framework.Modules
             instance.ReportCard.SetStatus();
             return instance.ReportCard;
         }
-
-        internal CheckLicenseResult CheckLicenseIsValid()
-        {
-            var license = LicenseManager.FindLicense();
-
-            if (license.Details.HasLicenseExpired())
-            {
-                return new CheckLicenseResult(false, "License has expired");
-            }
-
-            if (!license.Details.ValidForServiceControl)
-            {
-                return new CheckLicenseResult(false, "This license edition does not include ServiceControl");
-            }
-
-            var releaseDate = LicenseManager.GetReleaseDate();
-
-            if (license.Details.ReleaseNotCoveredByMaintenance(releaseDate))
-            {
-                return new CheckLicenseResult(false, "License does not cover this release of ServiceControl. Upgrade protection expired.");
-            }
-
-            return new CheckLicenseResult(true);
-        }
-
-        internal class CheckLicenseResult
-        {
-            public CheckLicenseResult(bool valid, string message = null)
-            {
-                Valid = valid;
-                Message = message;
-            }
-
-            public bool Valid { get; }
-            public string Message { get; }
-        }
     }
 
-    public class MonitoringInstanceInstaller
+    public class MonitoringInstanceInstaller : InstallerBase
     {
         public MonitoringInstanceInstaller()
         {
             ZipInfo = new PlatformZipInfo(Constants.MonitoringExe, "ServiceControl Monitoring", "Particular.ServiceControl.Monitoring.zip", Constants.CurrentVersion);
         }
-
-        public PlatformZipInfo ZipInfo { get; }
 
         internal async Task<ReportCard> Add(MonitoringNewInstance details, IProgress<ProgressDetails> progress, Func<PathInfo, Task<bool>> promptToProceed)
         {
@@ -445,42 +407,6 @@ namespace ServiceControl.Config.Framework.Modules
 
             instance.ReportCard.SetStatus();
             return instance.ReportCard;
-        }
-
-        internal CheckLicenseResult CheckLicenseIsValid()
-        {
-            var license = LicenseManager.FindLicense();
-
-            if (license.Details.HasLicenseExpired())
-            {
-                return new CheckLicenseResult(false, "License has expired");
-            }
-
-            if (!license.Details.ValidForServiceControl)
-            {
-                return new CheckLicenseResult(false, "This license edition does not include ServiceControl");
-            }
-
-            var releaseDate = LicenseManager.GetReleaseDate();
-
-            if (license.Details.ReleaseNotCoveredByMaintenance(releaseDate))
-            {
-                return new CheckLicenseResult(false, "License does not cover this release of ServiceControl Monitoring. Upgrade protection expired.");
-            }
-
-            return new CheckLicenseResult(true);
-        }
-
-        internal class CheckLicenseResult
-        {
-            public CheckLicenseResult(bool valid, string message = null)
-            {
-                Valid = valid;
-                Message = message;
-            }
-
-            public bool Valid { get; private set; }
-            public string Message { get; private set; }
         }
     }
 }

--- a/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddAttachment.cs
@@ -69,13 +69,6 @@
                 ServiceAccountPwd = viewModel.Password
             };
 
-            if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB: false, out var missingMessage))
-            {
-                await windowManager.ShowMessage("Missing prerequisites", missingMessage, acceptText: "Cancel", hideCancel: true);
-                viewModel.InProgress = false;
-                return;
-            }
-
             if (instanceMetadata.TransportPackage.IsLatestRabbitMQTransport() &&
                 !await windowManager.ShowYesNoDialog("INSTALL WARNING", $"ServiceControl version {installer.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before installing.",
                                                      "Do you want to proceed?",

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
@@ -7,19 +7,20 @@ namespace ServiceControl.Config.UI.InstanceAdd
     using Framework;
     using Framework.Modules;
     using ReactiveUI;
-    using ServiceControl.Engine.Extensions;
+    using ServiceControl.Config.Commands;
     using ServiceControlInstaller.Engine.Instances;
     using ServiceControlInstaller.Engine.Validation;
     using Validation;
 
     class ServiceControlAddAttachment : Attachment<ServiceControlAddViewModel>
     {
-        public ServiceControlAddAttachment(IServiceControlWindowManager windowManager, IEventAggregator eventAggregator, ServiceControlInstanceInstaller serviceControlInstaller, ServiceControlAuditInstanceInstaller serviceControlAuditInstaller)
+        public ServiceControlAddAttachment(IServiceControlWindowManager windowManager, IEventAggregator eventAggregator, ServiceControlInstanceInstaller serviceControlInstaller, ServiceControlAuditInstanceInstaller serviceControlAuditInstaller, CommandChecks commandChecks)
         {
             this.windowManager = windowManager;
             this.serviceControlInstaller = serviceControlInstaller;
             this.serviceControlAuditInstaller = serviceControlAuditInstaller;
             this.eventAggregator = eventAggregator;
+            this.commandChecks = commandChecks;
         }
 
         protected override void OnAttach()
@@ -100,12 +101,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 auditNewInstance.EnableFullTextSearchOnBodies = viewModel.ServiceControlAudit.EnableFullTextSearchOnBodies.Value;
             }
 
-            var transportPackage = serviceControlNewInstance != null ? serviceControlNewInstance.TransportPackage : auditNewInstance.TransportPackage;
-            if (transportPackage.IsLatestRabbitMQTransport() &&
-                !await windowManager.ShowYesNoDialog("INSTALL WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before installing.",
-                                                     "Do you want to proceed?",
-                                                     "Yes, my RabbitMQ broker meets the minimum requirements",
-                                                     "No, cancel the install"))
+            if (!await commandChecks.ValidateNewInstance(serviceControlNewInstance, auditNewInstance))
             {
                 viewModel.InProgress = false;
                 return;
@@ -194,5 +190,6 @@ namespace ServiceControl.Config.UI.InstanceAdd
         readonly IEventAggregator eventAggregator;
         readonly ServiceControlInstanceInstaller serviceControlInstaller;
         readonly ServiceControlAuditInstanceInstaller serviceControlAuditInstaller;
+        readonly CommandChecks commandChecks;
     }
 }

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
@@ -100,13 +100,6 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 auditNewInstance.EnableFullTextSearchOnBodies = viewModel.ServiceControlAudit.EnableFullTextSearchOnBodies.Value;
             }
 
-            if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB: true, out var missingMessage))
-            {
-                await windowManager.ShowMessage("Missing prerequisites", missingMessage, acceptText: "Cancel", hideCancel: true);
-                viewModel.InProgress = false;
-                return;
-            }
-
             var transportPackage = serviceControlNewInstance != null ? serviceControlNewInstance.TransportPackage : auditNewInstance.TransportPackage;
             if (transportPackage.IsLatestRabbitMQTransport() &&
                 !await windowManager.ShowYesNoDialog("INSTALL WARNING", $"ServiceControl version {serviceControlInstaller.ZipInfo.Version} requires RabbitMQ broker version 3.10.0 or higher. Also, the stream_queue and quorum_queue feature flags must be enabled on the broker. Please confirm your broker meets the minimum requirements before installing.",

--- a/src/ServiceControl.Transports.RabbitMQ/transport.manifest
+++ b/src/ServiceControl.Transports.RabbitMQ/transport.manifest
@@ -1,5 +1,5 @@
 ﻿{
-  "Version": "1.0.0",  
+  "Version": "1.0.0",
   "Definitions": [
     {
       "Name": "RabbitMQ.ClassicConventionalRouting",
@@ -22,29 +22,6 @@
       ]
     },
     {
-      "Name": "RabbitMQ.ConventionalRouting",
-      "DisplayName": "RabbitMQ - Conventional routing topology",
-      "TypeName": "ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ",
-      "SampleConnectionString": "host=<HOSTNAME>;username=<USERNAME>;password=<PASSWORD>;DisableRemoteCertificateValidation=<true|false(default)>;UseExternalAuthMechanism=<true|false(default)>",
-      "AvailableInSCMU": false,
-      "AutoMigrateTo": "RabbitMQ.ClassicConventionalRouting",
-      "Aliases": [
-        "NServiceBus.RabbitMQTransport, NServiceBus.Transports.RabbitMQ",
-        "ServiceControl.Transports.RabbitMQ.ConventialRoutingTopologyRabbitMQTransport, ServiceControl.Transports.RabbitMQ"
-      ]
-    },
-    {
-      "Name": "RabbitMQ.DirectRouting",
-      "DisplayName": "RabbitMQ - Direct routing topology (Old)",
-      "TypeName": "ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ",
-      "SampleConnectionString": "host=<HOSTNAME>;username=<USERNAME>;password=<PASSWORD>;DisableRemoteCertificateValidation=<true|false(default)>;UseExternalAuthMechanism=<true|false(default)>",
-      "AvailableInSCMU": false,
-      "AutoMigrateTo": "RabbitMQ.ClassicDirectRouting",
-      "Aliases": [
-        "ServiceControl.Transports.RabbitMQ.DirectRoutingTopologyRabbitMQTransport, ServiceControl.Transports.RabbitMQ"
-      ]
-    },
-    {
       "Name": "RabbitMQ.QuorumConventionalRouting",
       "DisplayName": "RabbitMQ - Conventional routing topology (quorum queues)",
       "TypeName": "ServiceControl.Transports.RabbitMQ.RabbitMQQuorumConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ",
@@ -62,6 +39,31 @@
       "AvailableInSCMU": true,
       "Aliases": [
         "ServiceControl.Transports.RabbitMQ.QuorumDirectRoutingTopologyRabbitMQTransport, ServiceControl.Transports.RabbitMQ"
+      ]
+    },
+    {
+      "Name": "RabbitMQ.ConventionalRouting",
+      "DisplayName": "RabbitMQ - Conventional routing topology",
+      "TypeName": "ServiceControl.Transports.RabbitMQ.RabbitMQConventionalRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ",
+      "SampleConnectionString": "host=<HOSTNAME>;username=<USERNAME>;password=<PASSWORD>;DisableRemoteCertificateValidation=<true|false(default)>;UseExternalAuthMechanism=<true|false(default)>",
+      "AvailableInSCMU": false,
+      "Removed": true,
+      "AutoMigrateTo": "RabbitMQ.ClassicConventionalRouting",
+      "Aliases": [
+        "NServiceBus.RabbitMQTransport, NServiceBus.Transports.RabbitMQ",
+        "ServiceControl.Transports.RabbitMQ.ConventialRoutingTopologyRabbitMQTransport, ServiceControl.Transports.RabbitMQ"
+      ]
+    },
+    {
+      "Name": "RabbitMQ.DirectRouting",
+      "DisplayName": "RabbitMQ - Direct routing topology (Old)",
+      "TypeName": "ServiceControl.Transports.RabbitMQ.RabbitMQDirectRoutingTransportCustomization, ServiceControl.Transports.RabbitMQ",
+      "SampleConnectionString": "host=<HOSTNAME>;username=<USERNAME>;password=<PASSWORD>;DisableRemoteCertificateValidation=<true|false(default)>;UseExternalAuthMechanism=<true|false(default)>",
+      "AvailableInSCMU": false,
+      "Removed": true,
+      "AutoMigrateTo": "RabbitMQ.ClassicDirectRouting",
+      "Aliases": [
+        "ServiceControl.Transports.RabbitMQ.DirectRoutingTopologyRabbitMQTransport, ServiceControl.Transports.RabbitMQ"
       ]
     }
   ]

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -21,6 +21,8 @@
         public string ServiceAccount { get; set; }
         public string ServiceAccountPwd { get; set; }
 
+        public TransportInfo TransportPackage { get; set; }
+
         public Version Version
         {
             get

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -30,7 +30,6 @@
         public ReportCard ReportCard { get; set; }
         public int Port { get; set; }
         public string HostName { get; set; }
-        public TransportInfo TransportPackage { get; set; }
         public string ErrorQueue { get; set; }
         public string ConnectionString { get; set; }
         public string LogPath { get; set; }

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
@@ -85,7 +85,6 @@ namespace ServiceControlInstaller.Engine.Instances
         public string AuditLogQueue { get; set; }
         public bool ForwardAuditMessages { get; set; }
         public bool ForwardErrorMessages { get; set; }
-        public TransportInfo TransportPackage { get; set; }
         public string ConnectionString { get; set; }
         public TimeSpan ErrorRetentionPeriod { get; set; }
         public bool SkipQueueCreation { get; set; }

--- a/src/ServiceControlInstaller.Engine/Instances/TransportInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/TransportInfo.cs
@@ -12,6 +12,7 @@
         public string Help { get; set; }
         public bool Default { get; set; }
         public bool AvailableInSCMU { get; set; } = true;
+        public bool Removed { get; set; }
         public string AutoMigrateTo { get; set; }
         public string[] Aliases { get; set; } = Array.Empty<string>();
 


### PR DESCRIPTION
Adds a concept to show that Azure Service Bus Legacy and the old RabbitMQ transports are removed, and a check so that if the transport is removed and doesn't have an auto-upgrade path, it can't be installed/upgraded.

A lot of the pre-install and pre-upgrade checks were scattered and duplicated all over. This centralizes all those checks.

However, this PR does not do a similar dedupe process on the PowerShell cmdlets.