### PR TITLE
Using SemanticVersion type that supports pre-release suffix

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -52,6 +52,7 @@
     <PackageVersion Include="NServiceBus.Transport.Msmq" Version="1.2.3" />
     <PackageVersion Include="NServiceBus.Transport.SqlServer" Version="6.3.4" />
     <PackageVersion Include="NServiceBus.Raw" Version="3.2.5" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.7.0" />
     <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="OwinHttpMessageHandler" Version="2.0.2" />

--- a/src/ServiceControl.Config.Tests/UpgradeControlTests.cs
+++ b/src/ServiceControl.Config.Tests/UpgradeControlTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace ServiceControl.Config.Tests
 {
-    using System;
     using System.Threading.Tasks;
+    using NuGet.Versioning;
     using NUnit.Framework;
     using ServiceControl.Config.UI.Shell;
 
@@ -12,9 +12,9 @@
         [Explicit]
         public async Task GetUpgradeInfoForTargetVersionSameMajor()
         {
-            var current = new Version("4.13.3");
+            var current = new SemanticVersion(4, 13, 3);
 
-            var releaseDetails = await VersionCheckerHelper.GetLatestRelease(current.ToString());
+            var releaseDetails = await VersionCheckerHelper.GetLatestRelease(current);
 
             Assert.IsNotNull(releaseDetails, "Failed to get a release details");
             Assert.That(releaseDetails.Version, Is.GreaterThanOrEqualTo(current), "Got a lower version than current");

--- a/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
+++ b/src/ServiceControl.Config/Commands/InstallerCompatibility.cs
@@ -1,13 +1,13 @@
 ﻿namespace ServiceControl.Config.Commands
 {
-    using System;
     using System.Threading.Tasks;
     using Framework;
+    using NuGet.Versioning;
     using ServiceControlInstaller.Engine.Instances;
 
     static class InstallerVersionCompatibilityDialog
     {
-        public static async Task<bool> ShowValidation(Version instanceVersion, IServiceControlWindowManager windowManager)
+        public static async Task<bool> ShowValidation(SemanticVersion instanceVersion, IServiceControlWindowManager windowManager)
         {
             var instanceIsNewer = instanceVersion > Constants.CurrentVersion;
             var installerOfDifferentMajor = instanceVersion.Major != Constants.CurrentVersion.Major;
@@ -26,7 +26,7 @@
             {
                 await windowManager.ShowMessage(
                     "Incompatible installer version",
-                    $"This installer cannot edit or remove instances created by a different major version. This instance can be edited by a {instanceVersion.Major}.* installer version greater or equal to {instanceVersion.Major}.{instanceVersion.Minor}.{instanceVersion.Build}.",
+                    $"This installer cannot edit or remove instances created by a different major version. This instance can be edited by a {instanceVersion.Major}.* installer version greater or equal to {instanceVersion.ToNormalizedString()}.",
                     hideCancel: true
                     );
                 return true;

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
@@ -125,13 +125,13 @@
                                    Text="{Binding}" />
                         <TextBlock Visibility="{Binding DataContext.HasNewVersion, ElementName=root, Converter={StaticResource boolToVis}}">
                             <Hyperlink Command="{Binding DataContext.UpgradeToNewVersionCommand, ElementName=root}" CommandParameter="{Binding DataContext, ElementName=root}">
-                                <TextBlock FontSize="13" Text="{Binding DataContext.NewVersion, ElementName=root, StringFormat=• UPGRADE TO V{0}}" />
+                                <TextBlock FontSize="13" Text="{Binding DataContext.NewVersion, ElementName=root, StringFormat=• UPGRADE TO {0}}" />
                             </Hyperlink>
                         </TextBlock>
                     </StackPanel>
                 </DataTemplate>
             </GroupBox.HeaderTemplate>
-            <TextBlock FontSize="14px" Text="{Binding Version}" />
+            <TextBlock FontSize="14px" Text="{Binding Version, StringFormat={}{0}}" />
         </GroupBox>
 
         <GroupBox Grid.Row="4"

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
@@ -12,6 +12,7 @@
     using Extensions;
     using Framework;
     using Framework.Rx;
+    using NuGet.Versioning;
     using ServiceControlInstaller.Engine;
     using ServiceControlInstaller.Engine.Instances;
 
@@ -134,7 +135,7 @@
 
         public string LogPath => ((IServicePaths)ServiceInstance).LogPath;
 
-        public Version Version => ServiceInstance.Version;
+        public SemanticVersion Version => ServiceInstance.Version;
 
         public InstanceType InstanceType { get; set; }
 
@@ -142,7 +143,7 @@
 
         public string InstanceTypeIcon => InstanceType == InstanceType.Monitoring ? "MonitoringInstanceIcon" : "ServiceControlInstanceIcon";
 
-        public Version NewVersion { get; }
+        public SemanticVersion NewVersion { get; }
 
         public bool HasNewVersion => Version < NewVersion;
 

--- a/src/ServiceControl.Config/UI/ListInstances/ListInstancesViewModel.cs
+++ b/src/ServiceControl.Config/UI/ListInstances/ListInstancesViewModel.cs
@@ -10,6 +10,7 @@
     using Events;
     using Framework.Rx;
     using InstanceDetails;
+    using NuGet.Versioning;
     using PropertyChanging;
     using ServiceControlInstaller.Engine.Instances;
 
@@ -35,7 +36,7 @@
             // on license change inform each instance to refresh the license (1.23.0 and below don't support this)
             foreach (var instance in Instances)
             {
-                if (instance.Version <= new Version("1.23.0"))
+                if (instance.Version <= new SemanticVersion(1, 23, 0))
                 {
                     continue;
                 }

--- a/src/ServiceControl.Config/UI/Shell/ShellView.xaml
+++ b/src/ServiceControl.Config/UI/Shell/ShellView.xaml
@@ -76,7 +76,7 @@
                 <Button Command="{Binding AddInstance}" Style="{StaticResource OriginalNewButton}" 
                         Visibility="{Binding ShowMonitoringInstances, 
                                      Converter={StaticResource boolToVisInverted}}"/>
-                
+
                 <ToggleButton Name="AddInstanceButton"
                               Style="{StaticResource NewButton}" 
                               IsChecked="{Binding ShowingMenuOverlay, Mode=TwoWay}"
@@ -183,7 +183,8 @@
 
                 <TextBlock FontSize="14px"
                            Foreground="{StaticResource Gray60Brush}"
-                           Text="{Binding VersionInfo}" />
+                           Text="{Binding AppVersion, StringFormat=v{0}}" />
+
 
                 <TextBlock Margin="20,0,0,0"
                            FontSize="14px"

--- a/src/ServiceControl.Config/UI/Shell/VersionCheckerHelper.cs
+++ b/src/ServiceControl.Config/UI/Shell/VersionCheckerHelper.cs
@@ -8,33 +8,34 @@
     using System.Net.Http.Headers;
     using System.Threading.Tasks;
     using Newtonsoft.Json;
+    using NuGet.Versioning;
 
     public static class VersionCheckerHelper
     {
-        public static async Task<Release> GetLatestRelease(string currentVersion)
+        public static async Task<Release> GetLatestRelease(SemanticVersion currentVersion)
         {
-            var current = new Version(currentVersion);
             List<Release> releases = await GetVersionInformation();
 
             if (releases != null)
             {
                 Release topversion = releases.Select(t => (t.Version, t)).Max().t;
 
-                if (topversion.Version > current)
+                if (topversion.Version > currentVersion)
                 {
                     return topversion;
                 }
             }
 
             // we have no release available
-            return new Release(current);
+            return new Release(currentVersion);
         }
 
         static async Task<List<Release>> GetVersionInformation()
         {
             try
             {
-                var json = await httpClient.GetStringAsync("https://s3.us-east-1.amazonaws.com/platformupdate.particular.net/servicecontrol.txt");
+                var json = await httpClient.GetStringAsync(
+                    "https://s3.us-east-1.amazonaws.com/platformupdate.particular.net/servicecontrol.txt");
 
                 return JsonConvert.DeserializeObject<List<Release>>(json);
             }
@@ -44,19 +45,14 @@
             }
         }
 
-        static readonly HttpClient httpClient = new HttpClient(new HttpClientHandler
-        {
-            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-        })
-        {
-            DefaultRequestHeaders =
+        static readonly HttpClient httpClient =
+            new HttpClient(new HttpClientHandler
             {
-                Accept =
-                {
-                    new MediaTypeWithQualityHeaderValue("application/json"),
-                }
-            }
-        };
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            })
+            {
+                DefaultRequestHeaders = { Accept = { new MediaTypeWithQualityHeaderValue("application/json"), } }
+            };
 
         public class Release
         {
@@ -64,37 +60,30 @@
             {
             }
 
-            public Release(Version current)
+            public Release(SemanticVersion current)
             {
-                Tag = current.ToString();
+                Tag = current.ToNormalizedString();
             }
 
-            [JsonProperty("tag")]
-            public string Tag { get; set; }
+            [JsonProperty("tag")] public string Tag { get; set; }
 
-            [JsonProperty("release")]
-            public Uri ReleaseUri { get; set; }
+            [JsonProperty("release")] public Uri ReleaseUri { get; set; }
 
-            [JsonProperty("published")]
-            public DateTimeOffset Published { get; set; }
+            [JsonProperty("published")] public DateTimeOffset Published { get; set; }
 
-            [JsonProperty("assets")]
-            public List<Asset> Assets { get; set; }
+            [JsonProperty("assets")] public List<Asset> Assets { get; set; }
 
             [JsonIgnore]
-            public Version Version => new Version(Tag);
+            public SemanticVersion Version => SemanticVersion.Parse(Tag);
         }
 
         public class Asset
         {
-            [JsonProperty("name")]
-            public string Name { get; set; }
+            [JsonProperty("name")] public string Name { get; set; }
 
-            [JsonProperty("size")]
-            public long Size { get; set; }
+            [JsonProperty("size")] public long Size { get; set; }
 
-            [JsonProperty("download")]
-            public Uri Download { get; set; }
+            [JsonProperty("download")] public Uri Download { get; set; }
         }
     }
 }

--- a/src/ServiceControl.Config/UI/Shell/VersionCheckerHelper.cs
+++ b/src/ServiceControl.Config/UI/Shell/VersionCheckerHelper.cs
@@ -34,8 +34,7 @@
         {
             try
             {
-                var json = await httpClient.GetStringAsync(
-                    "https://s3.us-east-1.amazonaws.com/platformupdate.particular.net/servicecontrol.txt");
+                var json = await httpClient.GetStringAsync("https://s3.us-east-1.amazonaws.com/platformupdate.particular.net/servicecontrol.txt");
 
                 return JsonConvert.DeserializeObject<List<Release>>(json);
             }
@@ -45,13 +44,18 @@
             }
         }
 
-        static readonly HttpClient httpClient =
-            new HttpClient(new HttpClientHandler
+        static readonly HttpClient httpClient = new HttpClient(new HttpClientHandler
             {
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
             })
             {
-                DefaultRequestHeaders = { Accept = { new MediaTypeWithQualityHeaderValue("application/json"), } }
+            DefaultRequestHeaders =
+            {
+                Accept =
+                {
+                    new MediaTypeWithQualityHeaderValue("application/json"),
+                }
+            }
             };
 
         public class Release
@@ -65,13 +69,17 @@
                 Tag = current.ToNormalizedString();
             }
 
-            [JsonProperty("tag")] public string Tag { get; set; }
+            [JsonProperty("tag")]
+            public string Tag { get; set; }
 
-            [JsonProperty("release")] public Uri ReleaseUri { get; set; }
+            [JsonProperty("release")]
+            public Uri ReleaseUri { get; set; }
 
-            [JsonProperty("published")] public DateTimeOffset Published { get; set; }
+            [JsonProperty("published")]
+            public DateTimeOffset Published { get; set; }
 
-            [JsonProperty("assets")] public List<Asset> Assets { get; set; }
+            [JsonProperty("assets")]
+            public List<Asset> Assets { get; set; }
 
             [JsonIgnore]
             public SemanticVersion Version => SemanticVersion.Parse(Tag);
@@ -79,11 +87,14 @@
 
         public class Asset
         {
-            [JsonProperty("name")] public string Name { get; set; }
+            [JsonProperty("name")]
+            public string Name { get; set; }
 
-            [JsonProperty("size")] public long Size { get; set; }
+            [JsonProperty("size")]
+            public long Size { get; set; }
 
-            [JsonProperty("download")] public Uri Download { get; set; }
+            [JsonProperty("download")]
+            public Uri Download { get; set; }
         }
     }
 }

--- a/src/ServiceControl.Config/UI/Shell/VersionCheckerHelper.cs
+++ b/src/ServiceControl.Config/UI/Shell/VersionCheckerHelper.cs
@@ -45,10 +45,10 @@
         }
 
         static readonly HttpClient httpClient = new HttpClient(new HttpClientHandler
-            {
-                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-            })
-            {
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+        })
+        {
             DefaultRequestHeaders =
             {
                 Accept =
@@ -56,7 +56,7 @@
                     new MediaTypeWithQualityHeaderValue("application/json"),
                 }
             }
-            };
+        };
 
         public class Release
         {

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/PsAuditInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/PsAuditInstance.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Management.PowerShell
 {
     using System;
+    using NuGet.Versioning;
     using ServiceControlInstaller.Engine.Instances;
 
     public class PsAuditInstance
@@ -28,7 +29,7 @@
 
         public string ServiceAccount { get; set; }
 
-        public Version Version { get; set; }
+        public SemanticVersion Version { get; set; }
 
         public string ServiceControlQueueAddress { get; set; }
 

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/PsMonitoringService.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/PsMonitoringService.cs
@@ -1,6 +1,6 @@
 ﻿namespace ServiceControl.Management.PowerShell.Cmdlets.Instances
 {
-    using System;
+    using NuGet.Versioning;
     using ServiceControlInstaller.Engine.Instances;
 
     public class PsMonitoringService
@@ -17,7 +17,7 @@
         public string ConnectionString { get; set; }
         public string ErrorQueue { get; set; }
         public string ServiceAccount { get; set; }
-        public Version Version { get; set; }
+        public SemanticVersion Version { get; set; }
 
         public static PsMonitoringService FromInstance(MonitoringInstance instance)
         {

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/PSServiceControl.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/PSServiceControl.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using NuGet.Versioning;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using ServiceControlInstaller.Engine.Instances;
 
@@ -36,7 +37,7 @@
 
         public string ServiceAccount { get; set; }
 
-        public Version Version { get; set; }
+        public SemanticVersion Version { get; set; }
 
         public object[] RemoteInstances { get; set; }
 

--- a/src/ServiceControlInstaller.Engine.UnitTests/Validation/QueueValidationTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Validation/QueueValidationTests.cs
@@ -2,9 +2,9 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Engine.Validation;
     using Instances;
+    using NuGet.Versioning;
     using NUnit.Framework;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
 
@@ -43,7 +43,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
 
             public string ServiceAccountPwd { get; set; }
 
-            public Version Version { get; set; }
+            public SemanticVersion Version { get; set; }
 
             public string DBPath { get; set; }
 
@@ -96,7 +96,7 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
 
             public string ServiceAccountPwd { get; set; }
 
-            public Version Version { get; set; }
+            public SemanticVersion Version { get; set; }
 
             public string DBPath { get; set; }
 

--- a/src/ServiceControlInstaller.Engine/Configuration/ConfigurationSectionExtensions.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ConfigurationSectionExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Configuration;
+    using NuGet.Versioning;
 
     static class ConfigurationSectionExtensions
     {
@@ -14,7 +15,7 @@
             }
         }
 
-        public static void Set(this KeyValueConfigurationCollection collection, SettingInfo keyInfo, string value, Version currentVersion = null)
+        public static void Set(this KeyValueConfigurationCollection collection, SettingInfo keyInfo, string value, SemanticVersion currentVersion = null)
         {
             // If either SupportedFrom or RemovedFrom exists then we need the currentVersion
             if (keyInfo.SupportedFrom != null || keyInfo.RemovedFrom != null)
@@ -44,7 +45,7 @@
         }
 
 
-        public static void RemoveIfRetired(this KeyValueConfigurationCollection collection, SettingInfo keyInfo, Version currentVersion)
+        public static void RemoveIfRetired(this KeyValueConfigurationCollection collection, SettingInfo keyInfo, SemanticVersion currentVersion)
         {
             if (keyInfo.RemovedFrom == null)
             {

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/AuditInstanceSettingsList.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/AuditInstanceSettingsList.cs
@@ -1,6 +1,6 @@
 namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
 {
-    using System;
+    using NuGet.Versioning;
 
     public static class AuditInstanceSettingsList
     {
@@ -17,6 +17,6 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
         public static readonly SettingInfo AuditRetentionPeriod = new SettingInfo { Name = "ServiceControl.Audit/AuditRetentionPeriod" };
         public static readonly SettingInfo MaintenanceMode = new SettingInfo { Name = "ServiceControl.Audit/MaintenanceMode" };
         public static readonly SettingInfo ServiceControlQueueAddress = new SettingInfo { Name = "ServiceControl.Audit/ServiceControlQueueAddress" };
-        public static readonly SettingInfo EnableFullTextSearchOnBodies = new SettingInfo { Name = "ServiceControl.Audit/EnableFullTextSearchOnBodies", SupportedFrom = new Version(4, 17, 0) };
+        public static readonly SettingInfo EnableFullTextSearchOnBodies = new SettingInfo { Name = "ServiceControl.Audit/EnableFullTextSearchOnBodies", SupportedFrom = new SemanticVersion(4, 17, 0) };
     }
 }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/Compatibility.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/Compatibility.cs
@@ -1,17 +1,17 @@
 ﻿namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
 {
-    using System;
+    using NuGet.Versioning;
 
     // For Removing and Adding Setting use SettingsList.cs
     public static class Compatibility
     {
-        public static CompatibilityInfo ForwardingQueuesAreOptional = new CompatibilityInfo { SupportedFrom = new Version(1, 29) };
-        public static CompatibilityInfo RemoteInstancesDoNotNeedQueueAddress = new CompatibilityInfo { SupportedFrom = new Version(4, 0) };
+        public static CompatibilityInfo ForwardingQueuesAreOptional = new CompatibilityInfo { SupportedFrom = new SemanticVersion(1, 29, 0) };
+        public static CompatibilityInfo RemoteInstancesDoNotNeedQueueAddress = new CompatibilityInfo { SupportedFrom = new SemanticVersion(4, 0, 0) };
 
         public class CompatibilityInfo
         {
-            public Version SupportedFrom { get; set; }
-            public Version RemovedFrom { get; set; }
+            public SemanticVersion SupportedFrom { get; set; }
+            public SemanticVersion RemovedFrom { get; set; }
         }
     }
 }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/SettingsList.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/SettingsList.cs
@@ -1,6 +1,6 @@
 namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
 {
-    using System;
+    using NuGet.Versioning;
 
     // See Compatibility.cs for version switching that isn't related to Settings
     public static class ServiceControlSettings
@@ -10,7 +10,7 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
         public static readonly SettingInfo DatabaseMaintenancePort = new SettingInfo
         {
             Name = "ServiceControl/DatabaseMaintenancePort",
-            SupportedFrom = new Version(2, 0, 0)
+            SupportedFrom = new SemanticVersion(2, 0, 0)
         };
         public static readonly SettingInfo HostName = new SettingInfo { Name = "ServiceControl/HostName" };
         public static readonly SettingInfo LogPath = new SettingInfo { Name = "ServiceControl/LogPath" };
@@ -18,13 +18,13 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
         public static readonly SettingInfo ForwardAuditMessages = new SettingInfo
         {
             Name = "ServiceControl/ForwardAuditMessages",
-            RemovedFrom = new Version(4, 0, 0)
+            RemovedFrom = new SemanticVersion(4, 0, 0)
         };
 
         public static readonly SettingInfo ForwardErrorMessages = new SettingInfo
         {
             Name = "ServiceControl/ForwardErrorMessages",
-            SupportedFrom = new Version(1, 11, 2)
+            SupportedFrom = new SemanticVersion(1, 11, 2)
         };
 
         public static readonly SettingInfo TransportType = new SettingInfo { Name = "ServiceControl/TransportType" };
@@ -32,50 +32,50 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
         public static readonly SettingInfo AuditQueue = new SettingInfo
         {
             Name = "ServiceBus/AuditQueue",
-            RemovedFrom = new Version(4, 0, 0)
+            RemovedFrom = new SemanticVersion(4, 0, 0)
         };
         public static readonly SettingInfo ErrorQueue = new SettingInfo { Name = "ServiceBus/ErrorQueue" };
         public static readonly SettingInfo ErrorLogQueue = new SettingInfo { Name = "ServiceBus/ErrorLogQueue" };
         public static readonly SettingInfo AuditLogQueue = new SettingInfo
         {
             Name = "ServiceBus/AuditLogQueue",
-            RemovedFrom = new Version(4, 0, 0)
+            RemovedFrom = new SemanticVersion(4, 0, 0)
         };
 
         public static SettingInfo AuditRetentionPeriod = new SettingInfo
         {
             Name = "ServiceControl/AuditRetentionPeriod",
-            SupportedFrom = new Version(1, 12, 1)
+            SupportedFrom = new SemanticVersion(1, 12, 1)
         };
 
         public static SettingInfo ErrorRetentionPeriod = new SettingInfo
         {
             Name = "ServiceControl/ErrorRetentionPeriod",
-            SupportedFrom = new Version(1, 12, 1)
+            SupportedFrom = new SemanticVersion(1, 12, 1)
         };
 
         public static SettingInfo HoursToKeepMessagesBeforeExpiring = new SettingInfo
         {
             Name = "ServiceControl/HoursToKeepMessagesBeforeExpiring",
-            RemovedFrom = new Version(1, 12, 1)
+            RemovedFrom = new SemanticVersion(1, 12, 1)
         };
 
         public static SettingInfo MaintenanceMode = new SettingInfo
         {
             Name = "ServiceControl/MaintenanceMode",
-            SupportedFrom = new Version(1, 18, 1)
+            SupportedFrom = new SemanticVersion(1, 18, 1)
         };
 
         public static SettingInfo RemoteInstances = new SettingInfo
         {
             Name = "ServiceControl/RemoteInstances",
-            SupportedFrom = new Version(1, 47, 0)
+            SupportedFrom = new SemanticVersion(1, 47, 0)
         };
 
         public static SettingInfo EnableFullTextSearchOnBodies = new SettingInfo
         {
             Name = "ServiceControl/EnableFullTextSearchOnBodies",
-            SupportedFrom = new Version(4, 17, 0)
+            SupportedFrom = new SemanticVersion(4, 17, 0)
         };
     }
 }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
@@ -1,11 +1,11 @@
 ﻿namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
 {
-    using System;
     using System.Linq;
+    using NuGet.Versioning;
 
     public class UpgradeInfo
     {
-        static readonly Version[] LatestMajors =
+        static readonly SemanticVersion[] LatestMajors =
         {
             new(1, 48, 0),
             new(2, 1, 5),
@@ -13,10 +13,10 @@
             new(4, 33, 3),
         };
 
-        public Version[] UpgradePath { get; private init; }
+        public SemanticVersion[] UpgradePath { get; private init; }
         public bool HasIncompatibleVersion { get; private init; }
 
-        public static UpgradeInfo GetUpgradePathFor(Version current) //5.0.0 // 4.24.0
+        public static UpgradeInfo GetUpgradePathFor(SemanticVersion current) //5.0.0 // 4.24.0
         {
             var upgradePath = LatestMajors
                 .Where(x => x > current)
@@ -29,6 +29,6 @@
             };
         }
 
-        public override string ToString() => string.Join<Version>(" ➡️ ", UpgradePath);
+        public override string ToString() => string.Join<SemanticVersion>(" ➡️ ", UpgradePath);
     }
 }

--- a/src/ServiceControlInstaller.Engine/Configuration/SettingInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/SettingInfo.cs
@@ -1,11 +1,11 @@
 ﻿namespace ServiceControlInstaller.Engine.Configuration
 {
-    using System;
+    using NuGet.Versioning;
 
     public class SettingInfo
     {
         public string Name { get; set; }
-        public Version SupportedFrom { get; set; }
-        public Version RemovedFrom { get; set; }
+        public SemanticVersion SupportedFrom { get; set; }
+        public SemanticVersion RemovedFrom { get; set; }
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -8,6 +8,7 @@
     using System.Threading;
     using Engine;
     using FileSystem;
+    using NuGet.Versioning;
     using Services;
     using TimeoutException = System.ServiceProcess.TimeoutException;
 
@@ -23,7 +24,7 @@
 
         public TransportInfo TransportPackage { get; set; }
 
-        public Version Version
+        public SemanticVersion Version
         {
             get
             {
@@ -31,10 +32,11 @@
                 if (File.Exists(Service.ExePath))
                 {
                     var fileVersion = FileVersionInfo.GetVersionInfo(Service.ExePath);
-                    return new Version(fileVersion.FileMajorPart, fileVersion.FileMinorPart, fileVersion.FileBuildPart);
+
+                    return SemanticVersion.Parse(fileVersion.ProductVersion);
                 }
 
-                return new Version(0, 0, 0);
+                return new SemanticVersion(0, 0, 0);
             }
         }
 

--- a/src/ServiceControlInstaller.Engine/Instances/Constants.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/Constants.cs
@@ -1,7 +1,7 @@
 ﻿namespace ServiceControlInstaller.Engine.Instances
 {
-    using System;
     using System.Reflection;
+    using NuGet.Versioning;
 
     public static class Constants
     {
@@ -9,19 +9,16 @@
         public const string ServiceControlAuditExe = "ServiceControl.Audit.exe";
         public const string MonitoringExe = "ServiceControl.Monitoring.exe";
 
-        public static Version CurrentVersion { get; }
+        public static SemanticVersion CurrentVersion { get; }
 
         static Constants()
         {
-            var attributes = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyMetadataAttribute>();
-            Version majorMinorPatch = null;
+            var attributes = Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyInformationalVersionAttribute>();
+            SemanticVersion majorMinorPatch = null;
 
             foreach (var attribute in attributes)
             {
-                if (attribute.Key == "MajorMinorPatch")
-                {
-                    majorMinorPatch = new Version(attribute.Value);
-                }
+                majorMinorPatch = SemanticVersion.Parse(attribute.InformationalVersion);
             }
 
             CurrentVersion = majorMinorPatch;

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
@@ -10,6 +10,7 @@
     using Accounts;
     using Configuration.Monitoring;
     using FileSystem;
+    using NuGet.Versioning;
     using Queues;
     using ReportCard;
     using Services;
@@ -58,7 +59,7 @@
         public bool SkipQueueCreation { get; set; }
 
 
-        public Version Version { get; }
+        public SemanticVersion Version { get; }
 
         public string Url => $"http://{HostName}:{Port}/";
 

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
@@ -12,6 +12,7 @@ namespace ServiceControlInstaller.Engine.Instances
     using Configuration;
     using Configuration.ServiceControl;
     using FileSystem;
+    using NuGet.Versioning;
     using Queues;
     using ReportCard;
     using Services;
@@ -443,6 +444,6 @@ namespace ServiceControlInstaller.Engine.Instances
 
         public string DatabaseBackupPath => DBPath + "_UpgradeBackup";
 
-        static Version AuditFeatureMinVersion = new(4, 0);
+        static SemanticVersion AuditFeatureMinVersion = new(4, 0, 0);
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstallableBase.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstallableBase.cs
@@ -10,6 +10,7 @@
     using System.Xml.Serialization;
     using Accounts;
     using FileSystem;
+    using NuGet.Versioning;
     using Queues;
     using ReportCard;
     using Services;
@@ -88,7 +89,7 @@
         public bool EnableFullTextSearchOnBodies { get; set; }
 
         [XmlIgnore]
-        public Version Version { get; set; }
+        public SemanticVersion Version { get; set; }
 
         [XmlIgnore]
         public string ServiceAccount { get; set; }

--- a/src/ServiceControlInstaller.Engine/Interfaces.cs
+++ b/src/ServiceControlInstaller.Engine/Interfaces.cs
@@ -4,6 +4,7 @@ namespace ServiceControlInstaller.Engine
     using System.Collections.Generic;
     using Configuration.ServiceControl;
     using Instances;
+    using NuGet.Versioning;
 
     public interface ILogging
     {
@@ -48,7 +49,7 @@ namespace ServiceControlInstaller.Engine
 
     public interface IVersionInfo
     {
-        Version Version { get; }
+        SemanticVersion Version { get; }
     }
 
     public interface IURLInfo

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="DotNetZip" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" />
     <PackageReference Include="System.Management" />
     <PackageReference Include="System.ServiceProcess.ServiceController" />
@@ -30,7 +31,7 @@
   <Target Name="EmbedInstallerResources" AfterTargets="ResolveProjectReferences">
     <ItemGroup>
       <Zip Include="..\..\zip\*.zip" />
-      <Manifest Include="..\..\deploy\**\persistence.manifest"  />
+      <Manifest Include="..\..\deploy\**\persistence.manifest" />
       <Manifest Include="..\..\deploy\Transports\**\transport.manifest" />
       <EmbeddedResource Include="@(Zip)" LogicalName="%(Filename)%(Extension)" />
       <EmbeddedResource Include="@(Manifest)" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />


### PR DESCRIPTION
Converts using `NuGet.Versioning.SemanticVersion` instead of `System.Version`. This allows using versions that have a pre-release suffix like `5.0.0-alpha.2.24`. This makes it easier for local testing upgrade logic