### PR TITLE
Set minimum version requirement to 4.33.0 to fix incorrect minimum version requirement

### DIFF
--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
@@ -10,7 +10,7 @@
             new(1, 48, 0),
             new(2, 1, 5),
             new(3, 8, 4),
-            new(4, 33, 3),
+            new(4, 33, 0),
         };
 
         public Version[] UpgradePath { get; private init; }


### PR DESCRIPTION
Incorrect minimum version requirement (4.33.3 which is not planned) which is set to 4.33.0