### PR TITLE
Fix incorrect usage of DateTime.Now

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_fails.cs
@@ -39,7 +39,7 @@
                         HostId = Guid.Empty,
                         Name = "Testing"
                     },
-                    FailedAt = DateTime.Now,
+                    FailedAt = DateTime.UtcNow,
                     FailureReason = "Because I can"
                 });
             });

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_succeeds.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_succeeds.cs
@@ -38,7 +38,7 @@
                         HostId = Guid.Empty,
                         Name = "Testing"
                     },
-                    SucceededAt = DateTime.Now
+                    SucceededAt = DateTime.UtcNow
                 });
             });
 

--- a/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
@@ -101,7 +101,7 @@ ServiceControl Audit Version:				{version}
             var logger = LogManager.GetLogger("LoggingConfiguration");
             var logEventInfo = new LogEventInfo
             {
-                TimeStamp = DateTime.Now
+                TimeStamp = DateTime.UtcNow
             };
             logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), loggingSettings.LoggingLevel.Name);
         }

--- a/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
+++ b/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
@@ -35,7 +35,7 @@
             DisplayName = "ServiceControl Config";
             IsModal = false;
             LoadAppVersion();
-            CopyrightInfo = $"{DateTime.Now.Year} © Particular Software";
+            CopyrightInfo = $"{DateTime.UtcNow.Year} © Particular Software";
             addInstance.OnCommandExecuting = () => ShowingMenuOverlay = false;
             addMonitoringInstance.OnCommandExecuting = () => ShowingMenuOverlay = false;
 

--- a/src/ServiceControl.Infrastructure.Metrics/Counter.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/Counter.cs
@@ -20,7 +20,7 @@
             eventsPerSecond = new int[2];
             movingAverage = new int[300];
             movingAverageEpochs = new long[300];
-            epoch = DateTime.Now.Minute;
+            epoch = DateTime.UtcNow.Minute;
         }
 
         public void Mark()

--- a/src/ServiceControl.Infrastructure.Metrics/Meter.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/Meter.cs
@@ -26,7 +26,7 @@
             movingAverageSums = new long[300];
             movingAverageCounts = new long[300];
             movingAverageEpochs = new long[300];
-            epoch = DateTime.Now.Minute;
+            epoch = DateTime.UtcNow.Minute;
         }
 
         public Measurement Measure() => new Measurement(this, enabled);

--- a/src/ServiceControl.LicenseManagement/LicenseDetails.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseDetails.cs
@@ -31,7 +31,7 @@
                 UpgradeProtectionExpiration = license.UpgradeProtectionExpiration,
                 //If expiration date is greater that 50 years treat is as no expiration date
                 ExpirationDate = license.ExpirationDate.HasValue
-                    ? (license.ExpirationDate.Value > DateTime.Now.AddYears(50) ? null : license.ExpirationDate)
+                    ? (license.ExpirationDate.Value > DateTime.UtcNow.AddYears(50) ? null : license.ExpirationDate)
                     : license.ExpirationDate,
                 RegisteredTo = license.RegisteredTo,
                 IsCommercialLicense = license.IsCommercialLicense,

--- a/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
@@ -84,7 +84,7 @@ Selected Transport:					{settings.TransportType}
             var logger = LogManager.GetLogger("LoggingConfiguration");
             var logEventInfo = new LogEventInfo
             {
-                TimeStamp = DateTime.Now
+                TimeStamp = DateTime.UtcNow
             };
             logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), settings.LogLevel.Name);
         }

--- a/src/ServiceControl.Monitoring/Infrastructure/WebApi/CachingHttpHandler.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/WebApi/CachingHttpHandler.cs
@@ -18,7 +18,7 @@
 
             if (!response.Content.Headers.Contains("Last-Modified"))
             {
-                response.Content.Headers.Add("Last-Modified", DateTime.Now.ToUniversalTime().ToString("R"));
+                response.Content.Headers.Add("Last-Modified", DateTime.UtcNow.ToString("R"));
             }
 
             if (!response.Headers.Contains("Cache-Control"))

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/ArchiveDocumentManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/ArchiveDocumentManager.cs
@@ -35,7 +35,7 @@
                 ArchiveType = archiveType,
                 TotalNumberOfMessages = numberOfMessages,
                 NumberOfMessagesArchived = 0,
-                Started = DateTime.Now,
+                Started = DateTime.UtcNow,
                 GroupName = groupName,
                 NumberOfBatches = (int)Math.Ceiling(numberOfMessages / (float)batchSize),
                 CurrentBatch = 0

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/ArchivingManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/ArchivingManager.cs
@@ -60,7 +60,7 @@
 
             summary.TotalNumberOfMessages = 0;
             summary.NumberOfMessagesArchived = 0;
-            summary.Started = DateTime.Now;
+            summary.Started = DateTime.UtcNow;
             summary.GroupName = "Undefined";
             summary.NumberOfBatches = 0;
             summary.CurrentBatch = 0;

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/UnarchiveDocumentManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/UnarchiveDocumentManager.cs
@@ -27,7 +27,7 @@
                 ArchiveType = archiveType,
                 TotalNumberOfMessages = numberOfMessages,
                 NumberOfMessagesUnarchived = 0,
-                Started = DateTime.Now,
+                Started = DateTime.UtcNow,
                 GroupName = groupName,
                 NumberOfBatches = (int)Math.Ceiling(numberOfMessages / (float)batchSize),
                 CurrentBatch = 0

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/UnarchivingManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/UnarchivingManager.cs
@@ -60,7 +60,7 @@
 
             summary.TotalNumberOfMessages = 0;
             summary.NumberOfMessagesUnarchived = 0;
-            summary.Started = DateTime.Now;
+            summary.Started = DateTime.UtcNow;
             summary.GroupName = "Undefined";
             summary.NumberOfBatches = 0;
             summary.CurrentBatch = 0;

--- a/src/ServiceControl.Persistence.Tests.RavenDB/Archiving/ArchiveGroupTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/Archiving/ArchiveGroupTests.cs
@@ -39,7 +39,7 @@
                     ArchiveType = ArchiveType.FailureGroup,
                     TotalNumberOfMessages = 2,
                     NumberOfMessagesArchived = 0,
-                    Started = DateTime.Now,
+                    Started = DateTime.UtcNow,
                     GroupName = "Test Group",
                     NumberOfBatches = 3,
                     CurrentBatch = 0
@@ -87,7 +87,7 @@
                     ArchiveType = ArchiveType.FailureGroup,
                     TotalNumberOfMessages = 2,
                     NumberOfMessagesArchived = 0,
-                    Started = DateTime.Now,
+                    Started = DateTime.UtcNow,
                     GroupName = "Test Group",
                     NumberOfBatches = 3,
                     CurrentBatch = 0

--- a/src/ServiceControl.Persistence.Tests.RavenDB/Unarchiving/UnarchiveGroupTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/Unarchiving/UnarchiveGroupTests.cs
@@ -39,7 +39,7 @@
                     ArchiveType = ArchiveType.FailureGroup,
                     TotalNumberOfMessages = 2,
                     NumberOfMessagesUnarchived = 2,
-                    Started = DateTime.Now,
+                    Started = DateTime.UtcNow,
                     GroupName = "Test Group",
                     NumberOfBatches = 3,
                     CurrentBatch = 0
@@ -87,7 +87,7 @@
                     ArchiveType = ArchiveType.FailureGroup,
                     TotalNumberOfMessages = 2,
                     NumberOfMessagesUnarchived = 0,
-                    Started = DateTime.Now,
+                    Started = DateTime.UtcNow,
                     GroupName = "Test Group",
                     NumberOfBatches = 3,
                     CurrentBatch = 0

--- a/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryArchive.cs
+++ b/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryArchive.cs
@@ -59,7 +59,7 @@
             ArchiveState = ArchiveState.ArchiveProgressing;
             NumberOfMessagesArchived += numberOfMessagesArchivedInBatch;
             CurrentBatch++;
-            Last = DateTime.Now;
+            Last = DateTime.UtcNow;
 
             return domainEvents.Raise(new ArchiveOperationBatchCompleted
             {
@@ -75,7 +75,7 @@
         {
             ArchiveState = ArchiveState.ArchiveFinalizing;
             NumberOfMessagesArchived = TotalNumberOfMessages;
-            Last = DateTime.Now;
+            Last = DateTime.UtcNow;
 
             return domainEvents.Raise(new ArchiveOperationFinalizing
             {
@@ -91,8 +91,8 @@
         {
             ArchiveState = ArchiveState.ArchiveCompleted;
             NumberOfMessagesArchived = TotalNumberOfMessages;
-            CompletionTime = DateTime.Now;
-            Last = DateTime.Now;
+            CompletionTime = DateTime.UtcNow;
+            Last = DateTime.UtcNow;
 
             return domainEvents.Raise(new ArchiveOperationCompleted
             {

--- a/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryUnarchive.cs
+++ b/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryUnarchive.cs
@@ -59,7 +59,7 @@
             ArchiveState = ArchiveState.ArchiveProgressing;
             NumberOfMessagesUnarchived += numberOfMessagesUnarchivedInBatch;
             CurrentBatch++;
-            Last = DateTime.Now;
+            Last = DateTime.UtcNow;
 
             return domainEvents.Raise(new UnarchiveOperationBatchCompleted
             {
@@ -75,7 +75,7 @@
         {
             ArchiveState = ArchiveState.ArchiveFinalizing;
             NumberOfMessagesUnarchived = TotalNumberOfMessages;
-            Last = DateTime.Now;
+            Last = DateTime.UtcNow;
 
             return domainEvents.Raise(new UnarchiveOperationFinalizing
             {
@@ -91,8 +91,8 @@
         {
             ArchiveState = ArchiveState.ArchiveCompleted;
             NumberOfMessagesUnarchived = TotalNumberOfMessages;
-            CompletionTime = DateTime.Now;
-            Last = DateTime.Now;
+            CompletionTime = DateTime.UtcNow;
+            Last = DateTime.UtcNow;
 
             return domainEvents.Raise(new UnarchiveOperationCompleted
             {

--- a/src/ServiceControl.Transports.RabbitMQ/ConnectionFactory.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/ConnectionFactory.cs
@@ -84,7 +84,7 @@
             lock (lockObject)
             {
                 connectionFactory.AutomaticRecoveryEnabled = automaticRecoveryEnabled;
-                connectionFactory.ClientProperties["connected"] = DateTime.Now.ToString("G");
+                connectionFactory.ClientProperties["connected"] = DateTime.UtcNow.ToString("G");
 
                 var connection = connectionFactory.CreateConnection(connectionName);
 

--- a/src/ServiceControl/LoggingConfigurator.cs
+++ b/src/ServiceControl/LoggingConfigurator.cs
@@ -101,7 +101,7 @@ ServiceControl Version:				{version}
             var logger = LogManager.GetLogger("LoggingConfiguration");
             var logEventInfo = new LogEventInfo
             {
-                TimeStamp = DateTime.Now
+                TimeStamp = DateTime.UtcNow
             };
             //logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), loggingSettings.LoggingLevel.Name);
         }


### PR DESCRIPTION
A lot of code was using `DateTime.Now`. This is the local time and should not be used for capturing time. It is affected by Daylight Saving Time (DST) changes and its slower than `.UtcNow` because it needs to convert the system its UTC time to a local time using the active timezone info.