### PR TITLE
Bundle self-contained version of RavenDB Server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
           dotnet-version: |
             8.0.x
             7.0.x
+      - name: Download RavenDB Server
+        shell: pwsh
+        run: ./tools/download-ravendb-server.ps1
       - name: Build
         run: dotnet build src --configuration Release -graph
       - name: Zip PowerShell module

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
         uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: 8.0.x
+      - name: Download RavenDB Server
+        shell: pwsh
+        run: ./tools/download-ravendb-server.ps1
       - name: Build
         run: dotnet build src --configuration Release -graph
       - name: Build ServiceControl Management

--- a/src/ServiceControl.Config/AppBootstrapper.cs
+++ b/src/ServiceControl.Config/AppBootstrapper.cs
@@ -90,7 +90,7 @@
 
             await DisplayRootViewForAsync<ShellViewModel>();
 
-            if (DotnetVersionValidator.FrameworkRequirementsAreMissing(true, out var message))
+            if (DotnetVersionValidator.FrameworkRequirementsAreMissing(out var message))
             {
                 message += $"{Environment.NewLine}{Environment.NewLine}Until the prerequisites are installed, no ServiceControl instances can be installed.";
 

--- a/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddMonitoringInstanceCommand.cs
@@ -17,7 +17,7 @@
 
         public override async Task ExecuteAsync(object obj)
         {
-            if (!await commandChecks.CanAddInstance(needsRavenDB: false))
+            if (!await commandChecks.CanAddInstance())
             {
                 return;
             }

--- a/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
@@ -18,7 +18,7 @@
 
         public override async Task ExecuteAsync(object obj)
         {
-            if (!await commandChecks.CanAddInstance(needsRavenDB: true))
+            if (!await commandChecks.CanAddInstance())
             {
                 return;
             }

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
@@ -164,7 +164,7 @@
             var installer = new UnattendAuditInstaller(logger);
 
             var checks = new PowerShellCommandChecks(this, Acknowledgements);
-            if (!checks.CanAddInstance(needsRavenDB: true).GetAwaiter().GetResult())
+            if (!checks.CanAddInstance().GetAwaiter().GetResult())
             {
                 return;
             }

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
@@ -134,7 +134,7 @@ namespace ServiceControl.Management.PowerShell
             var installer = new UnattendMonitoringInstaller(logger);
 
             var checks = new PowerShellCommandChecks(this, Acknowledgements);
-            if (!checks.CanAddInstance(needsRavenDB: true).GetAwaiter().GetResult())
+            if (!checks.CanAddInstance().GetAwaiter().GetResult())
             {
                 return;
             }

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
@@ -176,7 +176,7 @@ namespace ServiceControl.Management.PowerShell
             try
             {
                 var checks = new PowerShellCommandChecks(this, Acknowledgements);
-                if (!checks.CanAddInstance(needsRavenDB: true).GetAwaiter().GetResult())
+                if (!checks.CanAddInstance().GetAwaiter().GetResult())
                 {
                     return;
                 }

--- a/src/ServiceControl.Persistence.RavenDB/ServiceControl.Persistence.RavenDB.csproj
+++ b/src/ServiceControl.Persistence.RavenDB/ServiceControl.Persistence.RavenDB.csproj
@@ -26,8 +26,13 @@
   <ItemGroup>
     <!-- Artifact does not include RavenDBServer directory. -->
     <Artifact Include="$(OutputPath)" DirExclude="RavenDBServer" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl\Persisters\RavenDB" />
-    <!-- This instance copies RavenDBServer directory to artifacts for both Primary and Audit instances. -->
-    <Artifact Include="$(OutputPath)\RavenDBServer" DestinationFolder="$(ArtifactsPath)RavenDBServer" />
+    
+    <!--
+    This instance copies RavenDBServer directory to artifacts for both Primary and Audit instances during development, but during
+    a CI build, this is skipped because the CI and Release workflows have already downloaded a self-contained version of RavenDB
+    to that location already.
+    -->
+    <Artifact Condition="'$(CI)' != 'true'" Include="$(OutputPath)\RavenDBServer" DestinationFolder="$(ArtifactsPath)RavenDBServer" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControlInstaller.Engine.UnitTests/Validation/RuntimeNetVersionTest.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Validation/RuntimeNetVersionTest.cs
@@ -38,7 +38,12 @@
         public void TestValidatorLogic()
         {
             // Should always pass on CI because we download the latest available dotnet SDK
-            Assert.IsFalse(DotnetVersionValidator.FrameworkRequirementsAreMissing(true, out var _));
+            var isMissing = DotnetVersionValidator.FrameworkRequirementsAreMissing(true, out var message);
+
+            if (isMissing)
+            {
+                throw new Exception(message);
+            }
         }
 
         static RavenServerVersions GetFromRavenServerRuntimeConfig()

--- a/src/ServiceControlInstaller.Engine.UnitTests/Validation/RuntimeNetVersionTest.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Validation/RuntimeNetVersionTest.cs
@@ -2,10 +2,6 @@
 {
     using System;
     using System.IO;
-    using System.Linq;
-    using System.Xml;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
     using NUnit.Framework;
     using ServiceControlInstaller.Engine.Validation;
 
@@ -13,32 +9,10 @@
     class RuntimeNetVersionTest
     {
         [Test]
-        public void EnsureCorrectRuntimeVersionIsShipped()
-        {
-            var raven = GetFromRavenServerRuntimeConfig();
-            Console.WriteLine(raven);
-
-            const string somethingWrong = "There is something wrong with the logic used to find the .NET version that RavenDB needs to run.";
-            Assert.IsNotNull(raven.NetRuntime, somethingWrong);
-            Assert.IsNotNull(raven.AspNetCore, somethingWrong);
-
-            var minVersion = DotnetVersionValidator.MinimumVersionString;
-
-            Console.WriteLine($"Minimum version requested by ServiceControl: {minVersion}");
-
-            var versionsOk = DotnetVersionValidator.DotnetVersionOk(raven.NetRuntime, minVersion) && DotnetVersionValidator.DotnetVersionOk(raven.AspNetCore, minVersion);
-            string howToFix = $"The .NET/AspNetCore runtime {minVersion} validated by the installer is incorrect and won't allow RavenDB to run. Update the DotnetVersionValidator.MinimumVersionString constant to a version matching or newer than what is needed by RavenDB. ({raven})";
-
-            Assert.IsTrue(versionsOk, howToFix);
-            Console.WriteLine("Versions are OK");
-        }
-
-        [Test]
-        [Ignore("Currently failing on CI, temporarily ignored", Until = "2023-11-27")]
         public void TestValidatorLogic()
         {
             // Should always pass on CI because we download the latest available dotnet SDK
-            var isMissing = DotnetVersionValidator.FrameworkRequirementsAreMissing(true, out var message);
+            var isMissing = DotnetVersionValidator.FrameworkRequirementsAreMissing(out var message);
 
             if (isMissing)
             {
@@ -62,67 +36,6 @@
             Assert.That(Directory.Exists(runtimes), Is.EqualTo(isLocal));  // Only in local development
             Assert.That(File.Exists(systemCollections), Is.EqualTo(isCI)); // Only on CI
             Assert.That(File.Exists(aspNetCoreHttp), Is.EqualTo(isCI));    // Only on CI
-        }
-
-        static RavenServerVersions GetFromRavenServerRuntimeConfig()
-        {
-            // First get RavenDB package version
-            var packageConfigPath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "Directory.Packages.props"));
-
-            var doc = new XmlDocument();
-            doc.Load(packageConfigPath);
-
-            var ravenNode = doc.DocumentElement.SelectSingleNode("/Project/ItemGroup/PackageVersion[@Include='RavenDB.Embedded']");
-            var ravenPackageVersion = ravenNode.Attributes["Version"].Value;
-
-            // Now find Raven.Server.runtimeconfig.json
-            var nugetPath = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
-
-            if (string.IsNullOrWhiteSpace(nugetPath))
-            {
-                nugetPath = Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE"), ".nuget", "packages");
-            }
-
-            var packagePath = Path.Combine(nugetPath, "ravendb.embedded", ravenPackageVersion);
-            var contentFilesPath = Path.Combine(packagePath, "contentFiles");
-
-            var filePaths = Directory.GetFiles(contentFilesPath, "Raven.Server.runtimeconfig.json", SearchOption.AllDirectories);
-
-            var firstFileText = File.ReadAllText(filePaths.FirstOrDefault());
-
-            var json = JsonConvert.DeserializeObject<JObject>(firstFileText);
-
-            var frameworks = json["runtimeOptions"]["frameworks"] as JArray;
-
-            var versions = new RavenServerVersions();
-
-            foreach (var fw in frameworks.OfType<JObject>())
-            {
-                var name = fw["name"].Value<string>();
-                var versionString = fw["version"].Value<string>();
-
-                if (Version.TryParse(versionString, out var version))
-                {
-                    if (name == "Microsoft.NETCore.App")
-                    {
-                        versions.NetRuntime = version;
-                    }
-                    else if (name == "Microsoft.AspNetCore.App")
-                    {
-                        versions.AspNetCore = version;
-                    }
-                }
-            }
-
-            return versions;
-        }
-
-        class RavenServerVersions
-        {
-            public Version NetRuntime;
-            public Version AspNetCore;
-
-            public override string ToString() => $"RavenServer Minimum Versions: NetCoreApp = {NetRuntime}, AspNetCore = {AspNetCore}";
         }
     }
 }

--- a/src/ServiceControlInstaller.Engine.UnitTests/Validation/RuntimeNetVersionTest.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Validation/RuntimeNetVersionTest.cs
@@ -46,6 +46,24 @@
             }
         }
 
+        [Test]
+        public void CheckForSelfContainedRavenDB()
+        {
+            bool isCI = Environment.GetEnvironmentVariable("CI") == "true";
+            bool isLocal = !isCI;
+
+            var ravenServerPath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "..", "deploy", "RavenDBServer"));
+            var ravenStudio = Path.Combine(ravenServerPath, "Raven.Studio.zip");
+            var runtimes = Path.Combine(ravenServerPath, "runtimes");
+            var systemCollections = Path.Combine(ravenServerPath, "System.Collections.dll");
+            var aspNetCoreHttp = Path.Combine(ravenServerPath, "Microsoft.AspNetCore.Http.dll");
+
+            FileAssert.Exists(ravenStudio); // No matter what
+            Assert.That(Directory.Exists(runtimes), Is.EqualTo(isLocal));  // Only in local development
+            Assert.That(File.Exists(systemCollections), Is.EqualTo(isCI)); // Only on CI
+            Assert.That(File.Exists(aspNetCoreHttp), Is.EqualTo(isCI));    // Only on CI
+        }
+
         static RavenServerVersions GetFromRavenServerRuntimeConfig()
         {
             // First get RavenDB package version

--- a/src/ServiceControlInstaller.Engine/Validation/AbstractCommandChecks.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/AbstractCommandChecks.cs
@@ -21,7 +21,7 @@
         protected abstract Task NotifyForIncompatibleUpgradeVersion(UpgradeInfo upgradeInfo);
         protected abstract Task NotifyError(string title, string message);
 
-        public async Task<bool> CanAddInstance(bool needsRavenDB)
+        public async Task<bool> CanAddInstance()
         {
             // Check for license
             if (!await IsLicenseOk().ConfigureAwait(false))
@@ -29,7 +29,7 @@
                 return false;
             }
 
-            if (await FrameworkRequirementsAreMissing(needsRavenDB).ConfigureAwait(false))
+            if (await FrameworkRequirementsAreMissing().ConfigureAwait(false))
             {
                 return false;
             }
@@ -120,8 +120,7 @@
             }
 
             // Validate .NET Framework requirements
-            bool needsRavenDB = instance is IServiceControlBaseInstance;
-            if (await FrameworkRequirementsAreMissing(needsRavenDB).ConfigureAwait(false))
+            if (await FrameworkRequirementsAreMissing().ConfigureAwait(false))
             {
                 return false;
             }
@@ -158,9 +157,9 @@
             return true;
         }
 
-        async Task<bool> FrameworkRequirementsAreMissing(bool needsRavenDB)
+        async Task<bool> FrameworkRequirementsAreMissing()
         {
-            if (DotnetVersionValidator.FrameworkRequirementsAreMissing(needsRavenDB, out var missingMessage))
+            if (DotnetVersionValidator.FrameworkRequirementsAreMissing(out var missingMessage))
             {
                 await NotifyForMissingSystemPrerequisites(missingMessage).ConfigureAwait(false);
                 return true;

--- a/src/ServiceControlInstaller.Engine/Validation/DotnetVersionValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/DotnetVersionValidator.cs
@@ -7,14 +7,9 @@
 
     public static class DotnetVersionValidator
     {
-        public const string MinimumVersionString = "7.0.13";
-
-        public static bool FrameworkRequirementsAreMissing(bool needsRavenDB, out string message)
+        public static bool FrameworkRequirementsAreMissing(out string message)
         {
             message = null;
-
-            var dotnetMinVersion = Version.Parse(MinimumVersionString);
-            var majorMinor = $"{dotnetMinVersion.Major}.{dotnetMinVersion.Minor}";
 
             if (!Environment.Is64BitProcess)
             {
@@ -33,56 +28,6 @@
                 missing.Add(".NET Framework 4.7.2 or later: Download from https://dotnet.microsoft.com/download/dotnet-framework");
             }
 
-            if (needsRavenDB) // Monitoring instances don't need RavenDB and (for now) only need .NET Framework
-            {
-                // .NET itself requires Visual C++ Redistributable on Windows 2012 or earlier: https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#additional-deps
-                // Server 2016 reports as 10.* while Server 2012 reports as 6.x
-                if (Environment.OSVersion.Platform == PlatformID.Win32NT && Environment.OSVersion.Version.Major < 10)
-                {
-                    // Key to use from https://learn.microsoft.com/en-us/cpp/windows/redistributing-visual-cpp-files?view=msvc-170#install-the-redistributable-packages
-                    // Exact version isn't even that important so we don't check it
-                    using var visualCppRedistributableKey = registry.OpenSubKey(@"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64");
-                    var installedValue = (int?)visualCppRedistributableKey?.GetValue("Installed");
-                    if (installedValue != 1)
-                    {
-                        missing.Add("Microsoft Visual C++ 2015-2022 Redistributable (x64): Download from https://aka.ms/vs/17/release/vc_redist.x64.exe");
-                    }
-                }
-
-                // Check for .NET Version
-                using var dotnetKey = registry.OpenSubKey(@"SOFTWARE\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App")
-                    ?? registry.OpenSubKey(@"SOFTWARE\WOW6432NODE\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App");
-
-                var dotnetNames = dotnetKey?.GetValueNames() ?? Array.Empty<string>();
-                var dotnetClosest = HighestMatchingMajorMinor(dotnetMinVersion, dotnetNames);
-                var dotnetOk = DotnetVersionOk(dotnetMinVersion, dotnetClosest);
-                if (!dotnetOk)
-                {
-                    var foundString = dotnetClosest != null ? $", found {dotnetClosest}" : string.Empty;
-                    missing.Add($".NET {dotnetMinVersion.Major} Runtime (x64), requires {dotnetMinVersion} or greater, found {dotnetClosest}: Download from https://dotnet.microsoft.com/download/dotnet/{majorMinor}");
-                }
-
-                // Check for ASP.NET Core
-                var aspOk = false;
-                string aspClosest = null;
-                using var aspNetKey = registry.OpenSubKey($@"SOFTWARE\Microsoft\ASP.NET Core\Shared Framework");
-                if (aspNetKey != null)
-                {
-                    var aspNetVersions = aspNetKey.GetSubKeyNames()
-                        .Where(key => key.StartsWith("v"))
-                        .SelectMany(key => aspNetKey.OpenSubKey(key).GetSubKeyNames())
-                        .ToArray();
-
-                    aspClosest = HighestMatchingMajorMinor(dotnetMinVersion, aspNetVersions);
-                    aspOk = DotnetVersionOk(dotnetMinVersion, aspClosest);
-                }
-                if (!aspOk)
-                {
-                    var foundString = aspClosest != null ? $", found {aspClosest}" : string.Empty;
-                    missing.Add($"ASP.NET Core {dotnetMinVersion.Major} Runtime (x64), requires {dotnetMinVersion} or greater{foundString}: Download from https://dotnet.microsoft.com/download/dotnet/{majorMinor}");
-                }
-            }
-
             if (missing.Count > 0)
             {
                 message = "ServiceControl cannot be installed because the system is missing the following prerequisites:"
@@ -92,23 +37,6 @@
             }
 
             return false;
-        }
-
-        static string HighestMatchingMajorMinor(Version requestedVersion, string[] versionChoices)
-        {
-            return versionChoices.Select(v => Version.TryParse(v, out var version) ? version : null)
-                .Where(v => v != null && v.Major <= requestedVersion.Major)
-                .OrderByDescending(v => v)
-                .FirstOrDefault()
-                ?.ToString();
-        }
-
-        internal static bool DotnetVersionOk(Version requestedVersion, string actualVersionString)
-        {
-            return Version.TryParse(actualVersionString, out var actualVersion)
-                && actualVersion.Major == requestedVersion.Major
-                && actualVersion.Minor == requestedVersion.Minor
-                && actualVersion >= requestedVersion;
         }
     }
 }

--- a/tools/download-ravendb-server.ps1
+++ b/tools/download-ravendb-server.ps1
@@ -18,13 +18,14 @@ Invoke-WebRequest $downloadUrl -OutFile $zipPath
 
 Write-Output "Unzipping archive..."
 $unzipPath = Join-Path $Env:TEMP "ravendb-extracted"
-Remove-Item $unzipPath -Force -Recurse
+if (Test-Path $unzipPath) { Remove-Item $unzipPath -Force -Recurse }
 Expand-Archive $zipPath $unzipPath
 
 $serverPath = Join-Path $unzipPath "Server"
-Remove-Item deploy/RavenDBServer -Force -Recurse
-Write-Output "Copying $serverPath to deploy/RavenDBServer"
-Copy-Item -Path $serverPath -Destination "deploy/RavenDBServer" -Recurse
+$deployPath = Join-Path $PWD.Path deploy RavenDBServer
+if (Test-Path $deployPath ) { Remove-Item $deployPath -Force -Recurse }
+Write-Output "Copying '$serverPath' to '$deployPath'"
+Copy-Item -Path $serverPath -Destination $deployPath -Recurse
 
 Write-Output "Deleting temporary files"
 Remove-Item $zipPath -Force

--- a/tools/download-ravendb-server.ps1
+++ b/tools/download-ravendb-server.ps1
@@ -1,0 +1,31 @@
+# This script is used during CI to download a self-contained RavenDB server version to deploy/RavenDBServer
+# so that it can be packaged with the ServiceControl installer.
+#
+# This is not necessary during local development, as the developer likely has the most recent version of
+# .NET and ASP.NET runtimes installed and can use them to run RavenDB.Embedded
+#
+# The ServiceControl.Persistence.RavenDB project is responsible for turning the RavenDBServer into an
+# artifact during development, but has a condition to skip that step on a CI server so that the
+# self-contained version is used instead.
+
+$version = (Select-Xml -Path src/Directory.Packages.props -XPath "/Project/ItemGroup/PackageVersion[@Include='RavenDB.Embedded']/@Version" | Select-Object -ExpandProperty Node).Value
+Write-Output "In Directory.Packages.props, RavenDB.Embedded is using version '$version'"
+
+$downloadUrl = "https://daily-builds.s3.amazonaws.com/RavenDB-$($version)-windows-x64.zip"
+$zipPath = Join-Path $Env:TEMP "ravendb.zip"
+Write-Output "Downloading RavenDB binaries from $downloadUrl to $zipPath"
+Invoke-WebRequest $downloadUrl -OutFile $zipPath
+
+Write-Output "Unzipping archive..."
+$unzipPath = Join-Path $Env:TEMP "ravendb-extracted"
+Remove-Item $unzipPath -Force -Recurse
+Expand-Archive $zipPath $unzipPath
+
+$serverPath = Join-Path $unzipPath "Server"
+Remove-Item deploy/RavenDBServer -Force -Recurse
+Write-Output "Copying $serverPath to deploy/RavenDBServer"
+Copy-Item -Path $serverPath -Destination "deploy/RavenDBServer" -Recurse
+
+Write-Output "Deleting temporary files"
+Remove-Item $zipPath -Force
+Remove-Item $unzipPath -Force -Recurse


### PR DESCRIPTION
During a CI build, we will parse the [Directory.Packages.props](https://github.com/Particular/ServiceControl/blob/master/src/Directory.Packages.props) file to discover the current version of RavenDB, and then download the self-contained version (which does not require .NET to be preinstalled on the system) from RavenDB and use that as the resource embedded in the installer.

This means that the .NET and ASP.NET runtimes are no longer needed as prerequisites for installation, leaving the only prerequisite as .NET Framework 4.7.2 for ServiceControl itself.

Once ServiceControl is updated to .NET, and is also deployed as self-contained, there will be no install prerequisites left.