### PR TITLE
Ignore pre-release  in upgrade path version comparison

### DIFF
--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
@@ -19,7 +19,7 @@
         public static UpgradeInfo GetUpgradePathFor(SemanticVersion current) //5.0.0 // 4.24.0
         {
             var upgradePath = LatestMajors
-                .Where(x => x > current)
+                .Where(x => current.CompareTo(x, VersionComparison.Version) < 0)
                 .ToArray();
 
             return new UpgradeInfo


### PR DESCRIPTION
Version comparison didn't ignore pre releases resulting in the installer engine check requiring 4.33.0 to consider 4.33.0-preview to not match