### PR TITLE
🔨 Remove obsolete RavenDBLogLevel logic from SC Core

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/EmbeddedDatabase.cs
@@ -172,6 +172,7 @@
 -------------------------------------------------------------
 Database Size:                      {ByteSize.FromBytes(dataSize).ToString("#.##", CultureInfo.InvariantCulture)}
 Database Folder Size:               {ByteSize.FromBytes(folderSize).ToString("#.##", CultureInfo.InvariantCulture)}
+RavenDB Logging Level:              {configuration.ServerConfiguration.LogsMode}
 -------------------------------------------------------------";
 
             logger.Info(startupMessage);

--- a/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Bootstrapper.cs
@@ -116,7 +116,6 @@ ServiceControl Audit Version:       {version}
 Audit Retention Period:             {settings.AuditRetentionPeriod}
 Forwarding Audit Messages:          {settings.ForwardAuditMessages}
 ServiceControl Logging Level:       {loggingSettings.LoggingLevel}
-RavenDB Logging Level:              {loggingSettings.RavenDBLogLevel}
 Transport Customization:            {settings.TransportType},
 Persistence Customization:          {settings.PersistenceType},
 Persistence:                        {persistenceConfiguration.Name}

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
@@ -19,7 +19,7 @@
 
             using (var tokenSource = new CancellationTokenSource())
             {
-                var loggingSettings = new LoggingSettings(settings.ServiceName, LogLevel.Info, LogLevel.Info);
+                var loggingSettings = new LoggingSettings(settings.ServiceName, LogLevel.Info);
                 var bootstrapper = new Bootstrapper(
                     ctx => { tokenSource.Cancel(); },
                     settings,

--- a/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
@@ -65,14 +65,6 @@ ServiceControl Audit Version:				{version}
             nlogConfig.AddTarget("raven", ravenFileTarget);
             nlogConfig.AddTarget("null", nullTarget);
 
-            // Only want to see raven errors
-            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", loggingSettings.RavenDBLogLevel, ravenFileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", LogLevel.Error, consoleTarget)); //Noise reduction - Only RavenDB errors on the console
-            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", LogLevel.Debug, nullTarget)
-            {
-                Final = true
-            }); //Will swallow debug and above messages
-
             // Always want to see license logging regardless of default logging level
             nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, fileTarget));
             nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget)

--- a/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
@@ -7,17 +7,14 @@ namespace ServiceControl.Audit.Infrastructure.Settings
 
     class LoggingSettings
     {
-        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null, bool logToConsole = true)
+        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, string logPath = null, bool logToConsole = true)
         {
             LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
-            RavenDBLogLevel = InitializeLevel("RavenDBLogLevel", defaultRavenDBLevel ?? LogLevel.Warn);
             LogPath = Environment.ExpandEnvironmentVariables(SettingsReader<string>.Read("LogPath", logPath ?? DefaultLogPathForInstance(serviceName)));
             LogToConsole = logToConsole;
         }
 
         public LogLevel LoggingLevel { get; }
-
-        public LogLevel RavenDBLogLevel { get; }
 
         public string LogPath { get; }
 

--- a/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
@@ -51,7 +51,6 @@
                     {
                         loggingSettings.LogPath,
                         LoggingLevel = loggingSettings.LoggingLevel.Name,
-                        RavenDBLogLevel = loggingSettings.RavenDBLogLevel.Name
                     }
                 },
                 DataRetention = new

--- a/src/ServiceControl.Persistence.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Persistence.RavenDB/EmbeddedDatabase.cs
@@ -158,6 +158,7 @@
 -------------------------------------------------------------
 Database Size:                      {ByteSize.FromBytes(dataSize).ToString("#.##", CultureInfo.InvariantCulture)}
 Database Folder Size:               {ByteSize.FromBytes(folderSize).ToString("#.##", CultureInfo.InvariantCulture)}
+RavenDB Logging Level:              {settings.LogsMode}
 -------------------------------------------------------------";
 
             logger.Info(startupMessage);

--- a/src/ServiceControl/Bootstrapper.cs
+++ b/src/ServiceControl/Bootstrapper.cs
@@ -150,7 +150,6 @@ Error Retention Period:             {settings.ErrorRetentionPeriod}
 Ingest Error Messages:              {settings.IngestErrorMessages}
 Forwarding Error Messages:          {settings.ForwardErrorMessages}
 ServiceControl Logging Level:       {loggingSettings.LoggingLevel}
-RavenDB Logging Level:              {loggingSettings.RavenDBLogLevel}
 Selected Transport Customization:   {settings.TransportType}
 -------------------------------------------------------------";
 

--- a/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
@@ -23,7 +23,7 @@
 
             EndpointConfiguration busConfiguration = CreateEndpointConfiguration(settings);
 
-            var loggingSettings = new LoggingSettings(settings.ServiceName, LogLevel.Info, LogLevel.Info);
+            var loggingSettings = new LoggingSettings(settings.ServiceName, LogLevel.Info);
             var bootstrapper = new Bootstrapper(settings, busConfiguration, loggingSettings);
             using (var host = bootstrapper.HostBuilder.Build())
             {

--- a/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
@@ -7,17 +7,14 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
     class LoggingSettings
     {
-        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, LogLevel defaultRavenDBLevel = null, string logPath = null, bool logToConsole = true)
+        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, string logPath = null, bool logToConsole = true)
         {
             LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
-            RavenDBLogLevel = InitializeLevel("RavenDBLogLevel", defaultRavenDBLevel ?? LogLevel.Warn);
             LogPath = Environment.ExpandEnvironmentVariables(SettingsReader.Read("LogPath", logPath ?? DefaultLogPathForInstance(serviceName)));
             LogToConsole = logToConsole;
         }
 
         public LogLevel LoggingLevel { get; }
-
-        public LogLevel RavenDBLogLevel { get; }
 
         public string LogPath { get; }
 

--- a/src/ServiceControl/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/RootController.cs
@@ -71,7 +71,6 @@
                     {
                         loggingSettings.LogPath,
                         LoggingLevel = loggingSettings.LoggingLevel.Name,
-                        RavenDBLogLevel = loggingSettings.RavenDBLogLevel.Name
                     }
                 },
                 DataRetention = new

--- a/src/ServiceControl/LoggingConfigurator.cs
+++ b/src/ServiceControl/LoggingConfigurator.cs
@@ -67,14 +67,6 @@ ServiceControl Version:				{version}
             nlogConfig.AddTarget("raven", ravenFileTarget);
             nlogConfig.AddTarget("bitbucket", nullTarget);
 
-            // Only want to see raven errors
-            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", loggingSettings.RavenDBLogLevel, ravenFileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", LogLevel.Error, consoleTarget)); //Noise reduction - Only RavenDB errors on the console
-            nlogConfig.LoggingRules.Add(new LoggingRule("Raven.*", LogLevel.Debug, nullTarget)
-            {
-                Final = true
-            }); //Will swallow debug and above messages
-
             // Always want to see license logging regardless of default logging level
             nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, fileTarget));
             nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget)


### PR DESCRIPTION
Remove obsolete RavenDBLogLevel logic from SC Core as persister implementations load the setting themselves.

Noticed this while writing upgrade guidance around the new values. Should have been removed when we removed the RavenDB 3.5 projects.