### PR TITLE
Fix cmdlet connection string validation

### DIFF
--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
@@ -100,12 +100,15 @@
         {
             var transport = ServiceControlCoreTransports.Find(Transport);
 
-            if (transport.SampleConnectionString is not null && string.IsNullOrEmpty(ConnectionString))
+            var requiresConnectionString = !string.IsNullOrEmpty(transport.SampleConnectionString);
+            var hasConnectionString = !string.IsNullOrEmpty(ConnectionString);
+
+            if (requiresConnectionString && !hasConnectionString)
             {
                 throw new Exception($"ConnectionString is mandatory for '{Transport}'");
             }
 
-            if (transport.SampleConnectionString is null && !string.IsNullOrEmpty(ConnectionString))
+            if (!requiresConnectionString && hasConnectionString)
             {
                 throw new Exception($"'{Transport}' does not use a connection string.");
             }

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
@@ -75,12 +75,15 @@ namespace ServiceControl.Management.PowerShell
         {
             var transport = ServiceControlCoreTransports.Find(Transport);
 
-            if (transport.SampleConnectionString is not null && string.IsNullOrEmpty(ConnectionString))
+            var requiresConnectionString = !string.IsNullOrEmpty(transport.SampleConnectionString);
+            var hasConnectionString = !string.IsNullOrEmpty(ConnectionString);
+
+            if (requiresConnectionString && !hasConnectionString)
             {
                 throw new Exception($"ConnectionString is mandatory for '{Transport}'");
             }
 
-            if (transport.SampleConnectionString is null && !string.IsNullOrEmpty(ConnectionString))
+            if (!requiresConnectionString && hasConnectionString)
             {
                 throw new Exception($"'{Transport}' does not use a connection string.");
             }

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
@@ -104,12 +104,15 @@ namespace ServiceControl.Management.PowerShell
         {
             var transport = ServiceControlCoreTransports.Find(Transport);
 
-            if (transport.SampleConnectionString is not null && string.IsNullOrEmpty(ConnectionString))
+            var requiresConnectionString = !string.IsNullOrEmpty(transport.SampleConnectionString);
+            var hasConnectionString = !string.IsNullOrEmpty(ConnectionString);
+
+            if (requiresConnectionString && !hasConnectionString)
             {
                 throw new Exception($"ConnectionString is mandatory for '{Transport}'");
             }
 
-            if (transport.SampleConnectionString is null && !string.IsNullOrEmpty(ConnectionString))
+            if (!requiresConnectionString && hasConnectionString)
             {
                 throw new Exception($"'{Transport}' does not use a connection string.");
             }

--- a/src/ServiceControl.Transports.Msmq/transport.manifest
+++ b/src/ServiceControl.Transports.Msmq/transport.manifest
@@ -5,7 +5,7 @@
       "Name": "MSMQ",
       "DisplayName": "MSMQ",
       "TypeName": "ServiceControl.Transports.Msmq.MsmqTransportCustomization, ServiceControl.Transports.Msmq",
-      "SampleConnectionString": "",
+      "SampleConnectionString": null,
       "AvailableInSCMU": true,
       "Default": true,
       "Aliases": [

--- a/src/ServiceControl.Transports.Msmq/transport.manifest
+++ b/src/ServiceControl.Transports.Msmq/transport.manifest
@@ -5,7 +5,7 @@
       "Name": "MSMQ",
       "DisplayName": "MSMQ",
       "TypeName": "ServiceControl.Transports.Msmq.MsmqTransportCustomization, ServiceControl.Transports.Msmq",
-      "SampleConnectionString": null,
+      "SampleConnectionString": "",
       "AvailableInSCMU": true,
       "Default": true,
       "Aliases": [


### PR DESCRIPTION
Powershell cmdlets for creating error, audit and monitoring instance failed for MSMQ because sample connection string value was tested against `null` while it was `""` (empty string)