### PR TITLE
Relax minimum version from 4.33.0 to 4.26.0 for instances

### DIFF
--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
@@ -10,7 +10,7 @@
             new(1, 48, 0),
             new(2, 1, 5),
             new(3, 8, 4),
-            new(4, 33, 0),
+            new(4, 26, 0), // Introduced RavenDB5 audit persistence
         };
 
         public SemanticVersion[] UpgradePath { get; private init; }


### PR DESCRIPTION
Relax minimum version from 4.33.0 to 4.26.0 for INSTANCES as #3860 does the check on the installer version.