### PR TITLE
Use more reliable registry key for old SCMU check

### DIFF
--- a/src/ServiceControl.Config/AppBootstrapper.cs
+++ b/src/ServiceControl.Config/AppBootstrapper.cs
@@ -100,7 +100,7 @@
 
             if (OldScmuCheck.OldVersionOfServiceControlInstalled(out var installedVersion))
             {
-                message = $"An old version {installedVersion} of ServiceControl Management is installed, which will not work after installing new instances. Before installing ServiceControl 5 instances, you must either uninstall the {installedVersion} instance or update it to a 4.x version at least 4.33.0.";
+                message = $"An old version {installedVersion} of ServiceControl Management is installed, which will not work after installing new instances. Before installing ServiceControl 5 instances, you must either uninstall the {installedVersion} instance or update it to a 4.x version at least {OldScmuCheck.MinimumScmuVersion}.";
                 await windowManager.ShowMessage("Outdated Version Installed", message, acceptText: "I understand", hideCancel: true);
                 Application.Current.Shutdown(-1);
             }

--- a/src/ServiceControlInstaller.Engine/Validation/AbstractCommandChecks.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/AbstractCommandChecks.cs
@@ -200,7 +200,7 @@
         {
             if (OldScmuCheck.OldVersionOfServiceControlInstalled(out var installedVersion))
             {
-                var message = $"An old version {installedVersion} of ServiceControl Management is installed, which will not work after installing new instances. Before installing ServiceControl 5 instances, you must either uninstall the {installedVersion} instance or update it to a 4.x version at least 4.33.0.";
+                var message = $"An old version {installedVersion} of ServiceControl Management is installed, which will not work after installing new instances. Before installing ServiceControl 5 instances, you must either uninstall the {installedVersion} instance or update it to a 4.x version at least {OldScmuCheck.MinimumScmuVersion}.";
                 await NotifyError("Outdated Version Installed", message).ConfigureAwait(false);
                 return true;
             }


### PR DESCRIPTION
This key is what Add and Remove Programs uses, and so it's a more reliable check than the specific ParticularSoftware key, even though it's a little more complex to evaluate.