### PR TITLE
 HasUnderlyingProcessExited always returns true because the first process (0) results in a Win32Exception - 5.0

### DIFF
--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -106,20 +106,24 @@
 
         bool HasUnderlyingProcessExited()
         {
-            try
+            if (Service.ExePath == null)
             {
-                if (Service.ExePath != null)
-                {
-                    var process = Process.GetProcesses().FirstOrDefault(p => p.MainModule.FileName == Service.ExePath);
-                    return process == null;
-                }
-            }
-            catch
-            {
-                //Service isn't accessible
+                return true;
             }
 
-            return true;
+            return !Process
+                .GetProcesses()
+                .Any(p =>
+                {
+                    try
+                    {
+                        return p.MainModule.FileName == Service.ExePath;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                });
         }
 
         public string BackupAppConfig()


### PR DESCRIPTION
Backport of:

- #3868