### PR TITLE
Cap the maximum number of entries in SagaDetailsIndex to 50k

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
@@ -46,18 +46,7 @@
                 new SagaDetailsIndex()
             };
 
-            // If the SagaDetailsIndex exists but does not have a .Take(50000), then we remove the current SagaDetailsIndex and
-            // create a new one. If we do not remove the current one, then RavenDB will attempt to do a side-by-side migration.
-            // Doing a side-by-side migration results in the index never swapping if there is constant ingestion as RavenDB will wait.
-            // for the index to not be stale before swapping to the new index. Constant ingestion means the index will never be not-stale.
-            // This needs to stay in place until the next major version as the user could upgrade from an older version of the current
-            // Major (v5.x.x) which might still have the incorrect index.
-            var sagaDetailsIndexOperation = new GetIndexOperation("SagaDetailsIndex");
-            var sagaDetailsIndexDefinition = await documentStore.Maintenance.SendAsync(sagaDetailsIndexOperation, cancellationToken);
-            if (sagaDetailsIndexDefinition != null && !sagaDetailsIndexDefinition.Reduce.Contains("Take(50000)"))
-            {
-                await documentStore.Maintenance.SendAsync(new DeleteIndexOperation("SagaDetailsIndex"), cancellationToken);
-            }
+            await DeleteLegacySagaDetailsIndex(documentStore, cancellationToken);
 
             if (configuration.EnableFullTextSearch)
             {
@@ -80,6 +69,22 @@
             };
 
             await documentStore.Maintenance.SendAsync(new ConfigureExpirationOperation(expirationConfig), cancellationToken);
+        }
+
+        public static async Task DeleteLegacySagaDetailsIndex(IDocumentStore documentStore, CancellationToken cancellationToken)
+        {
+            // If the SagaDetailsIndex exists but does not have a .Take(50000), then we remove the current SagaDetailsIndex and
+            // create a new one. If we do not remove the current one, then RavenDB will attempt to do a side-by-side migration.
+            // Doing a side-by-side migration results in the index never swapping if there is constant ingestion as RavenDB will wait.
+            // for the index to not be stale before swapping to the new index. Constant ingestion means the index will never be not-stale.
+            // This needs to stay in place until the next major version as the user could upgrade from an older version of the current
+            // Major (v5.x.x) which might still have the incorrect index.
+            var sagaDetailsIndexOperation = new GetIndexOperation("SagaDetailsIndex");
+            var sagaDetailsIndexDefinition = await documentStore.Maintenance.SendAsync(sagaDetailsIndexOperation, cancellationToken);
+            if (sagaDetailsIndexDefinition != null && !sagaDetailsIndexDefinition.Reduce.Contains("Take(50000)"))
+            {
+                await documentStore.Maintenance.SendAsync(new DeleteIndexOperation("SagaDetailsIndex"), cancellationToken);
+            }
         }
 
         readonly DatabaseConfiguration configuration;

--- a/src/ServiceControl.Audit.Persistence.RavenDB/Indexes/SagaDetailsIndex.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/Indexes/SagaDetailsIndex.cs
@@ -53,6 +53,7 @@ namespace ServiceControl.SagaAudit
                     SagaType = first.SagaType,
                     Changes = g.SelectMany(x => x.Changes)
                         .OrderByDescending(x => x.FinishTime)
+                        .Take(50000)
                         .ToList()
                 };
 

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SagaDetailsIndexTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SagaDetailsIndexTests.cs
@@ -1,0 +1,49 @@
+﻿namespace ServiceControl.Audit.Persistence.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Raven.Client.Documents;
+    using Raven.Client.Documents.Operations.Indexes;
+    using ServiceControl.SagaAudit;
+
+    [TestFixture]
+    class SagaDetailsIndexTests : PersistenceTestFixture
+    {
+        [Test]
+        public async Task Should_only_reduce_the_last_50000_saga_state_changes()
+        {
+            var sagaType = "MySagaType";
+            var sagaState = "some-saga-state";
+
+            await IngestSagaAudits(new SagaSnapshot
+            {
+                SagaId = Guid.NewGuid(),
+                SagaType = sagaType,
+                Status = SagaStateChangeStatus.New,
+                StateAfterChange = sagaState
+            });
+
+            await configuration.CompleteDBOperation();
+
+            using (var session = configuration.DocumentStore.OpenAsyncSession())
+            {
+                var sagaDetailsIndexOperation = new GetIndexOperation("SagaDetailsIndex");
+                var sagaDetailsIndexDefinition = await configuration.DocumentStore.Maintenance.SendAsync(sagaDetailsIndexOperation);
+
+                Assert.IsTrue(sagaDetailsIndexDefinition.Reduce.Contains("Take(50000)"), "The SagaDetails index definition does not contain a .Take(50000) to limit the number of saga state changes that are reduced by the map/reduce");
+            }
+        }
+
+        async Task IngestSagaAudits(params SagaSnapshot[] snapshots)
+        {
+            var unitOfWork = StartAuditUnitOfWork(snapshots.Length);
+            foreach (var snapshot in snapshots)
+            {
+                await unitOfWork.RecordSagaSnapshot(snapshot);
+            }
+            await unitOfWork.DisposeAsync();
+            await configuration.CompleteDBOperation();
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceControl/issues/3351

This caps the maximum number of entries in the reduce stage of the map/reduce index to 50k messages. This should be more than sufficient for visualization purposes and also prevents the reduce step running out of memory.