### PR TITLE
Primary instances: Missing critical DI registrations in maintenance mode

### DIFF
--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
@@ -25,13 +25,13 @@
 
         public void Configure(IServiceCollection serviceCollection)
         {
+            serviceCollection.AddSingleton<PersistenceSettings>(settings);
+            serviceCollection.AddSingleton(settings);
+
             if (settings.MaintenanceMode)
             {
                 return;
             }
-
-            serviceCollection.AddSingleton<PersistenceSettings>(settings);
-            serviceCollection.AddSingleton(settings);
 
             serviceCollection.AddSingleton<IServiceControlSubscriptionStorage, RavenSubscriptionStorage>();
             serviceCollection.AddSingleton<ISubscriptionStorage>(p => p.GetRequiredService<IServiceControlSubscriptionStorage>());


### PR DESCRIPTION
- Resolves https://github.com/Particular/ServiceControl/issues/3889

### Symptoms

Launching maintenance mode fails in ServiceControl Management with:

> System.ComponentModel.Win32Exception (1053): The service did not respond to the start or control request in a timely fashion.

ServiceControl fails with the following log entry:

```txt
2023-12-19 11:52:26.464 ERROR Unhandled exception was caught.
System.InvalidOperationException: Unable to resolve service for type 'RavenPersisterSettings' while attempting to activate 'ServiceControl.Persistence.RavenDB.RavenEmbeddedPersistenceLifecycle'.
```

### Who's affected

All 5.0.x primary instances

### Root cause

In maintenance mode settings were not DI registered which resulted in DI not being able to build/resolve `IPersistenceLifecycle`.