### PR TITLE
Primary instances: Missing critical DI registrations in maintenance mode

### DIFF
--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
@@ -25,13 +25,13 @@
 
         public void Configure(IServiceCollection serviceCollection)
         {
+            serviceCollection.AddSingleton<PersistenceSettings>(settings);
+            serviceCollection.AddSingleton(settings);
+
             if (settings.MaintenanceMode)
             {
                 return;
             }
-
-            serviceCollection.AddSingleton<PersistenceSettings>(settings);
-            serviceCollection.AddSingleton(settings);
 
             serviceCollection.AddSingleton<IServiceControlSubscriptionStorage, RavenSubscriptionStorage>();
             serviceCollection.AddSingleton<ISubscriptionStorage>(p => p.GetRequiredService<IServiceControlSubscriptionStorage>());


### PR DESCRIPTION
Backport of

- https://github.com/Particular/ServiceControl/pull/3899