### PR TITLE
Exclude Microsoft.Extensions.DependencyModel only

### DIFF
--- a/src/ServiceControl.Management.PowerShell/InstallerEngineAssemblyLoadContext.cs
+++ b/src/ServiceControl.Management.PowerShell/InstallerEngineAssemblyLoadContext.cs
@@ -14,7 +14,7 @@ class InstallerEngineAssemblyLoadContext : AssemblyLoadContext
         var executingAssemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         var assemblyPath = Path.Combine(executingAssemblyDirectory, "InstallerEngine", "ServiceControlInstaller.Engine.dll");
 
-        resolver = new DependencyResolver(assemblyPath);
+        resolver = new(assemblyPath);
     }
 
     protected override Assembly Load(AssemblyName assemblyName)

--- a/src/ServiceControl.Management.PowerShell/ModuleAssemblyInitializer.cs
+++ b/src/ServiceControl.Management.PowerShell/ModuleAssemblyInitializer.cs
@@ -14,13 +14,14 @@
 
         static Assembly Resolve(AssemblyLoadContext defaultLoadContext, AssemblyName assemblyName)
         {
-            if (assemblyName.Name.Contains("ServiceControlInstaller.Engine"))
+            // Don't try to use InstallerEngineAssemblyLoadContext to resolve the assembly it has a dependency on
+            if (assemblyName.Name.Contains("Microsoft.Extensions.DependencyModel"))
             {
-                return installerEngineLoadContext.LoadFromAssemblyName(assemblyName);
+                return null;
             }
             else
             {
-                return null;
+                return installerEngineLoadContext.LoadFromAssemblyName(assemblyName);
             }
         }
     }


### PR DESCRIPTION
Backport of #3902 for the `release-5.0` branch.