### PR TITLE
Increase RavenDB MaxServerStartupTimeDuration from 1 to 2 minutes to prevent unrecoverable crash

### DIFF
--- a/src/ServiceControl.AcceptanceTests.RavenDB/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/SharedEmbeddedServer.cs
@@ -19,7 +19,7 @@ static class SharedEmbeddedServer
         {
             DatabasePath = dbPath,
             LogPath = Path.Combine(basePath, "Logs"),
-            LogsMode = "Operations",
+            LogsMode = Sparrow.Logging.LogMode.Operations,
             DatabaseMaintenancePort = PortUtility.FindAvailablePort(RavenPersisterSettings.DatabaseMaintenancePortDefault)
         };
 

--- a/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseConfiguration.cs
@@ -11,7 +11,8 @@
             TimeSpan auditRetentionPeriod,
             int maxBodySizeToStore,
             int minimumStorageLeftRequiredForIngestion,
-            ServerConfiguration serverConfiguration)
+            ServerConfiguration serverConfiguration,
+            bool maintenanceMode)
         {
             Name = name;
             ExpirationProcessTimerInSeconds = expirationProcessTimerInSeconds;
@@ -20,6 +21,7 @@
             MaxBodySizeToStore = maxBodySizeToStore;
             ServerConfiguration = serverConfiguration;
             MinimumStorageLeftRequiredForIngestion = minimumStorageLeftRequiredForIngestion;
+            MaintenanceMode = maintenanceMode;
         }
 
         public string Name { get; }
@@ -37,5 +39,7 @@
         public int MaxBodySizeToStore { get; }
 
         public int MinimumStorageLeftRequiredForIngestion { get; internal set; } //Setting for ATT only
+
+        public bool MaintenanceMode { get; internal set; }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/EmbeddedDatabase.cs
@@ -51,10 +51,20 @@
 
             var nugetPackagesPath = Path.Combine(databaseConfiguration.ServerConfiguration.DbPath, "Packages", "NuGet");
 
+            var maxServerStartupTimeDuration = TimeSpan.FromSeconds(120); // Aligns it with the Windows default max startup duration of 125s https://stackoverflow.com/a/29928342/199551
             var logsMode = databaseConfiguration.ServerConfiguration.LogsMode;
+
+            if (databaseConfiguration.MaintenanceMode)
+            {
+                // Under maintenance mode it is intentional to allow the database to take a long time to start as RavenDB sometimes will recover corrupted/deleted file system data
+                maxServerStartupTimeDuration = TimeSpan.FromDays(365);
+            }
+
+
             logger.InfoFormat("Loading RavenDB license from {0}", licenseFileNameAndServerDirectory.LicenseFileName);
             var serverOptions = new ServerOptions
             {
+                MaxServerStartupTimeDuration = maxServerStartupTimeDuration,
                 CommandLineArgs = new List<string>
                 {
                     $"--License.Path=\"{licenseFileNameAndServerDirectory.LicenseFileName}\"",

--- a/src/ServiceControl.Audit.Persistence.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/EmbeddedDatabase.cs
@@ -58,6 +58,7 @@
             {
                 // Under maintenance mode it is intentional to allow the database to take a long time to start as RavenDB sometimes will recover corrupted/deleted file system data
                 maxServerStartupTimeDuration = TimeSpan.FromDays(365);
+                logsMode = Sparrow.Logging.LogMode.Information;
             }
 
 

--- a/src/ServiceControl.Audit.Persistence.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/EmbeddedDatabase.cs
@@ -51,13 +51,14 @@
 
             var nugetPackagesPath = Path.Combine(databaseConfiguration.ServerConfiguration.DbPath, "Packages", "NuGet");
 
+            var logsMode = databaseConfiguration.ServerConfiguration.LogsMode;
             logger.InfoFormat("Loading RavenDB license from {0}", licenseFileNameAndServerDirectory.LicenseFileName);
             var serverOptions = new ServerOptions
             {
                 CommandLineArgs = new List<string>
                 {
                     $"--License.Path=\"{licenseFileNameAndServerDirectory.LicenseFileName}\"",
-                    $"--Logs.Mode={databaseConfiguration.ServerConfiguration.LogsMode}",
+                    $"--Logs.Mode={logsMode}",
                     // HINT: If this is not set, then Raven will pick a default location relative to the server binaries
                     // See https://github.com/ravendb/ravendb/issues/15694
                     $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\""

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
@@ -3,7 +3,9 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using NServiceBus.Logging;
     using Raven.Client.Documents;
+    using Raven.Client.Exceptions.Database;
 
     class RavenEmbeddedPersistenceLifecycle : IRavenPersistenceLifecycle
     {
@@ -26,7 +28,20 @@
         {
             database = EmbeddedDatabase.Start(databaseConfiguration);
 
-            documentStore = await database.Connect(cancellationToken);
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    documentStore = await database.Connect(cancellationToken);
+                }
+                catch (DatabaseLoadTimeoutException e)
+                {
+                    Log.Warn("Could not connect to database. Retrying in 500ms...", e);
+                    await Task.Delay(500, cancellationToken);
+                }
+            }
         }
 
         public Task Stop(CancellationToken cancellationToken)
@@ -39,7 +54,7 @@
 
         IDocumentStore documentStore;
         EmbeddedDatabase database;
-
+        static readonly ILog Log = LogManager.GetLogger(typeof(RavenEmbeddedPersistenceLifecycle));
         readonly DatabaseConfiguration databaseConfiguration;
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -68,11 +68,11 @@
                     throw new InvalidOperationException($"{LogPathKey}  must be specified when using embedded server.");
                 }
 
-                var logsMode = "Operations";
+                var logsMode = Sparrow.Logging.LogMode.Operations;
 
                 if (settings.PersisterSpecificSettings.TryGetValue(RavenDbLogLevelKey, out var ravenDbLogLevel))
                 {
-                    logsMode = RavenDbLogLevelToLogsModeMapper.Map(ravenDbLogLevel);
+                    logsMode = (Sparrow.Logging.LogMode)Enum.Parse(typeof(Sparrow.Logging.LogMode), RavenDbLogLevelToLogsModeMapper.Map(ravenDbLogLevel));
                 }
 
                 serverConfiguration = new ServerConfiguration(dbPath, serverUrl, logPath, logsMode);

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -105,7 +105,9 @@
                 settings.AuditRetentionPeriod,
                 settings.MaxBodySizeToStore,
                 minimumStorageLeftRequiredForIngestion,
-                serverConfiguration);
+                serverConfiguration,
+                settings.MaintenanceMode
+                );
         }
 
         static int GetExpirationProcessTimerInSeconds(PersistenceSettings settings)

--- a/src/ServiceControl.Audit.Persistence.RavenDB/ServerConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/ServerConfiguration.cs
@@ -8,7 +8,7 @@
             ConnectionString = connectionString;
         }
 
-        public ServerConfiguration(string dbPath, string serverUrl, string logPath, string logsMode)
+        public ServerConfiguration(string dbPath, string serverUrl, string logPath, Sparrow.Logging.LogMode logsMode)
         {
             UseEmbeddedServer = true;
             DbPath = dbPath;
@@ -22,6 +22,6 @@
         public string DbPath { get; internal set; } //Setter for ATT only
         public string ServerUrl { get; }
         public string LogPath { get; }
-        public string LogsMode { get; set; }
+        public Sparrow.Logging.LogMode LogsMode { get; set; }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
@@ -26,7 +26,7 @@
                 var logsMode = Sparrow.Logging.LogMode.Operations;
                 var serverUrl = $"http://localhost:{PortUtility.FindAvailablePort(33334)}";
 
-                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, 5, new ServerConfiguration(dbPath, serverUrl, logPath, logsMode)));
+                embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, 5, new ServerConfiguration(dbPath, serverUrl, logPath, logsMode), maintenanceMode: false));
 
                 //make sure that the database is up
                 while (true)

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
@@ -4,6 +4,7 @@
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
+    using NServiceBus.Logging;
     using NUnit.Framework;
     using ServiceControl.Audit.Persistence.RavenDB;
     using TestHelper;
@@ -40,8 +41,9 @@
 
                         return embeddedDatabase;
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
+                        Log.Warn("Could not connect to database. Retrying in 500ms...", e);
                         await Task.Delay(500, cancellationToken);
                     }
                 }
@@ -68,5 +70,6 @@
 
         static EmbeddedDatabase embeddedDatabase;
         static SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
+        static readonly ILog Log = LogManager.GetLogger(typeof(SharedEmbeddedServer));
     }
 }

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
@@ -23,7 +23,7 @@
 
                 var dbPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Tests", "AuditData");
                 var logPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Logs");
-                var logsMode = "Operations";
+                var logsMode = Sparrow.Logging.LogMode.Operations;
                 var serverUrl = $"http://localhost:{PortUtility.FindAvailablePort(33334)}";
 
                 embeddedDatabase = EmbeddedDatabase.Start(new DatabaseConfiguration("audit", 60, true, TimeSpan.FromMinutes(5), 120000, 5, new ServerConfiguration(dbPath, serverUrl, logPath, logsMode)));

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -13,18 +13,25 @@ namespace ServiceControl.Monitoring
 
         static async Task Main(string[] args)
         {
-            AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
-            AppDomain.CurrentDomain.UnhandledException += (s, e) => LogException(e.ExceptionObject as Exception);
+            try
+            {
+                AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
+                AppDomain.CurrentDomain.UnhandledException += (s, e) => LogException(e.ExceptionObject as Exception);
 
-            var arguments = new HostArguments(args);
+                var arguments = new HostArguments(args);
 
-            LoadSettings(arguments);
+                LoadSettings(arguments);
 
-            var runAsWindowsService = !Environment.UserInteractive && !arguments.Portable;
-            LoggingConfigurator.Configure(settings, !runAsWindowsService);
+                var runAsWindowsService = !Environment.UserInteractive && !arguments.Portable;
+                LoggingConfigurator.Configure(settings, !runAsWindowsService);
 
-            await new CommandRunner(arguments.Commands)
-                .Run(settings);
+                await new CommandRunner(arguments.Commands)
+                    .Run(settings);
+            }
+            finally
+            {
+                NLog.LogManager.Shutdown();
+            }
         }
 
         static void LoadSettings(HostArguments args)

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/SharedEmbeddedServer.cs
@@ -19,7 +19,7 @@ static class SharedEmbeddedServer
         {
             DatabasePath = dbPath,
             LogPath = Path.Combine(basePath, "Logs"),
-            LogsMode = "Operations",
+            LogsMode = Sparrow.Logging.LogMode.Operations,
             DatabaseMaintenancePort = PortUtility.FindAvailablePort(RavenPersisterSettings.DatabaseMaintenancePortDefault)
         };
 

--- a/src/ServiceControl.Persistence.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Persistence.RavenDB/EmbeddedDatabase.cs
@@ -50,10 +50,19 @@
 
             var nugetPackagesPath = Path.Combine(settings.DatabasePath, "Packages", "NuGet");
 
+            var maxServerStartupTimeDuration = TimeSpan.FromSeconds(120); // Aligns it with the Windows default max startup duration of 125s https://stackoverflow.com/a/29928342/199551
             var logsMode = settings.LogsMode;
+
+            if (settings.MaintenanceMode)
+            {
+                // Under maintenance mode it is intentional to allow the database to take a long time to start as RavenDB sometimes will recover corrupted/deleted file system data
+                maxServerStartupTimeDuration = TimeSpan.FromDays(365);
+            }
+
             logger.InfoFormat("Loading RavenDB license from {0}", licenseFileNameAndServerDirectory.LicenseFileName);
             var serverOptions = new ServerOptions
             {
+                MaxServerStartupTimeDuration = maxServerStartupTimeDuration,
                 CommandLineArgs = new List<string>
                 {
                     $"--License.Path=\"{licenseFileNameAndServerDirectory.LicenseFileName}\"",

--- a/src/ServiceControl.Persistence.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Persistence.RavenDB/EmbeddedDatabase.cs
@@ -57,6 +57,7 @@
             {
                 // Under maintenance mode it is intentional to allow the database to take a long time to start as RavenDB sometimes will recover corrupted/deleted file system data
                 maxServerStartupTimeDuration = TimeSpan.FromDays(365);
+                logsMode = Sparrow.Logging.LogMode.Information;
             }
 
             logger.InfoFormat("Loading RavenDB license from {0}", licenseFileNameAndServerDirectory.LicenseFileName);

--- a/src/ServiceControl.Persistence.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.Persistence.RavenDB/EmbeddedDatabase.cs
@@ -50,13 +50,14 @@
 
             var nugetPackagesPath = Path.Combine(settings.DatabasePath, "Packages", "NuGet");
 
+            var logsMode = settings.LogsMode;
             logger.InfoFormat("Loading RavenDB license from {0}", licenseFileNameAndServerDirectory.LicenseFileName);
             var serverOptions = new ServerOptions
             {
                 CommandLineArgs = new List<string>
                 {
                     $"--License.Path=\"{licenseFileNameAndServerDirectory.LicenseFileName}\"",
-                    $"--Logs.Mode={settings.LogsMode}",
+                    $"--Logs.Mode={logsMode}",
                     // HINT: If this is not set, then Raven will pick a default location relative to the server binaries
                     // See https://github.com/ravendb/ravendb/issues/15694
                     $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\""

--- a/src/ServiceControl.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
@@ -44,7 +44,7 @@
 
         ~RavenEmbeddedPersistenceLifecycle()
         {
-            Trace.WriteLine("ERROR: RavenDbEmbeddedPersistenceLifecycle isn't properly disposed");
+            Trace.WriteLine($"ERROR: {nameof(RavenEmbeddedPersistenceLifecycle)} isn't properly disposed");
         }
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -41,7 +41,7 @@
             }
 
             var ravenDbLogLevel = GetSetting(RavenBootstrapper.RavenDbLogLevelKey, "Warn");
-            var logsMode = RavenDbLogLevelToLogsModeMapper.Map(ravenDbLogLevel);
+            var logsMode = (Sparrow.Logging.LogMode)Enum.Parse(typeof(Sparrow.Logging.LogMode), RavenDbLogLevelToLogsModeMapper.Map(ravenDbLogLevel));
 
             var settings = new RavenPersisterSettings
             {

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
@@ -24,11 +24,11 @@ class RavenPersisterSettings : PersistenceSettings
     public string ConnectionString { get; set; }
     public bool UseEmbeddedServer => string.IsNullOrWhiteSpace(ConnectionString);
     public string LogPath { get; set; }
-    public string LogsMode { get; set; } = LogsModeDefault;
+    public Sparrow.Logging.LogMode LogsMode { get; set; } = LogsModeDefault;
     public string DatabaseName { get; set; } = DatabaseNameDefault;
 
     public const string DatabaseNameDefault = "primary";
     public const int DatabaseMaintenancePortDefault = 33334;
     public const int ExpirationProcessTimerInSecondsDefault = 600;
-    public const string LogsModeDefault = "Operations";
+    public const Sparrow.Logging.LogMode LogsModeDefault = Sparrow.Logging.LogMode.Operations;
 }

--- a/src/ServiceControl.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
@@ -18,7 +18,7 @@ static class SharedEmbeddedServer
         {
             DatabasePath = dbPath,
             LogPath = Path.Combine(basePath, "Logs"),
-            LogsMode = "Operations",
+            LogsMode = Sparrow.Logging.LogMode.Operations,
             DatabaseMaintenancePort = PortUtility.FindAvailablePort(RavenPersisterSettings.DatabaseMaintenancePortDefault)
         };
 

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -17,23 +17,30 @@
 
         static async Task Main(string[] args)
         {
-            AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
-            AppDomain.CurrentDomain.UnhandledException += (s, e) => LogException(e.ExceptionObject as Exception);
-
-            var arguments = new HostArguments(args);
-
-            if (arguments.Help)
+            try
             {
-                arguments.PrintUsage();
-                return;
+                AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
+                AppDomain.CurrentDomain.UnhandledException += (s, e) => LogException(e.ExceptionObject as Exception);
+
+                var arguments = new HostArguments(args);
+
+                if (arguments.Help)
+                {
+                    arguments.PrintUsage();
+                    return;
+                }
+
+                var loggingSettings = new LoggingSettings(arguments.ServiceName, logToConsole: !arguments.RunAsWindowsService);
+                LoggingConfigurator.ConfigureLogging(loggingSettings);
+
+                settings = new Settings(arguments.ServiceName);
+
+                await new CommandRunner(arguments.Commands).Execute(arguments, settings);
             }
-
-            var loggingSettings = new LoggingSettings(arguments.ServiceName, logToConsole: !arguments.RunAsWindowsService);
-            LoggingConfigurator.ConfigureLogging(loggingSettings);
-
-            settings = new Settings(arguments.ServiceName);
-
-            await new CommandRunner(arguments.Commands).Execute(arguments, settings);
+            finally
+            {
+                NLog.LogManager.Shutdown();
+            }
         }
         static void LogException(Exception ex)
         {


### PR DESCRIPTION
Related to:

- https://github.com/Particular/ServiceControl/issues/3909

This fix includes:

- At start of the ravendb lifecycle a documentstore is created. Creating can timeout with `DatabaseLoadTimeoutException`. Startup logic adjusted to retry until success or cancellation and logging warnings for each creation failure.
- Increase RavenDB `MaxServerStartupTimeDuration` from 1 to 2 minutes to prevent unrecoverable crash for regular instance startup up and set to 365 days when launching with maintenance mode
- Set RavenDB `--Logs.Mode` to `Information` when launching the instance in maintenance mode
- Invoke `NLog.LogManager.Shutdown();` as recommended by NLog guidance as ` AppDomain.CurrentDomain.UnhandledException` that might resolves issues where log entries aren't always written to the log file for some customers.

Remaining work:

- Revert `MaxServerStartupTimeDuration` commit
- Revert `Logs.Mode` type change in patch but apply on `master` in separate PR

