### PR TITLE
Invoke `NLog.LogManager.Shutdown();` as recommended by NLog guidance

### DIFF
--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -13,18 +13,25 @@ namespace ServiceControl.Monitoring
 
         static async Task Main(string[] args)
         {
-            AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
-            AppDomain.CurrentDomain.UnhandledException += (s, e) => LogException(e.ExceptionObject as Exception);
+            try
+            {
+                AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
+                AppDomain.CurrentDomain.UnhandledException += (s, e) => LogException(e.ExceptionObject as Exception);
 
-            var arguments = new HostArguments(args);
+                var arguments = new HostArguments(args);
 
-            LoadSettings(arguments);
+                LoadSettings(arguments);
 
-            var runAsWindowsService = !Environment.UserInteractive && !arguments.Portable;
-            LoggingConfigurator.Configure(settings, !runAsWindowsService);
+                var runAsWindowsService = !Environment.UserInteractive && !arguments.Portable;
+                LoggingConfigurator.Configure(settings, !runAsWindowsService);
 
-            await new CommandRunner(arguments.Commands)
-                .Run(settings);
+                await new CommandRunner(arguments.Commands)
+                    .Run(settings);
+            }
+            finally
+            {
+                NLog.LogManager.Shutdown();
+            }
         }
 
         static void LoadSettings(HostArguments args)

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -17,23 +17,30 @@
 
         static async Task Main(string[] args)
         {
-            AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
-            AppDomain.CurrentDomain.UnhandledException += (s, e) => LogException(e.ExceptionObject as Exception);
-
-            var arguments = new HostArguments(args);
-
-            if (arguments.Help)
+            try
             {
-                arguments.PrintUsage();
-                return;
+                AppDomain.CurrentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
+                AppDomain.CurrentDomain.UnhandledException += (s, e) => LogException(e.ExceptionObject as Exception);
+
+                var arguments = new HostArguments(args);
+
+                if (arguments.Help)
+                {
+                    arguments.PrintUsage();
+                    return;
+                }
+
+                var loggingSettings = new LoggingSettings(arguments.ServiceName, logToConsole: !arguments.RunAsWindowsService);
+                LoggingConfigurator.ConfigureLogging(loggingSettings);
+
+                settings = new Settings(arguments.ServiceName);
+
+                await new CommandRunner(arguments.Commands).Execute(arguments, settings);
             }
-
-            var loggingSettings = new LoggingSettings(arguments.ServiceName, logToConsole: !arguments.RunAsWindowsService);
-            LoggingConfigurator.ConfigureLogging(loggingSettings);
-
-            settings = new Settings(arguments.ServiceName);
-
-            await new CommandRunner(arguments.Commands).Execute(arguments, settings);
+            finally
+            {
+                NLog.LogManager.Shutdown();
+            }
         }
         static void LogException(Exception ex)
         {


### PR DESCRIPTION
Invoke `NLog.LogManager.Shutdown();` as recommended by NLog guidance  https://github.com/NLog/NLog/wiki/Tutorial#5-remember-to-flush even if `NLog.LogManager.AutoShutdown` is `true`.