### PR TITLE
Connecting to RavenDB database can timeout with `DatabaseLoadTimeoutException`

### DIFF
--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
@@ -4,6 +4,7 @@
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
+    using NServiceBus.Logging;
     using NUnit.Framework;
     using ServiceControl.Audit.Persistence.RavenDB;
     using TestHelper;
@@ -40,8 +41,9 @@
 
                         return embeddedDatabase;
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
+                        Log.Warn("Could not connect to database. Retrying in 500ms...", e);
                         await Task.Delay(500, cancellationToken);
                     }
                 }
@@ -68,5 +70,6 @@
 
         static EmbeddedDatabase embeddedDatabase;
         static SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
+        static readonly ILog Log = LogManager.GetLogger(typeof(SharedEmbeddedServer));
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
@@ -4,7 +4,9 @@
     using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
+    using NServiceBus.Logging;
     using Raven.Client.Documents;
+    using Raven.Client.Exceptions.Database;
     using ServiceControl.Persistence;
 
     class RavenEmbeddedPersistenceLifecycle : IPersistenceLifecycle, IDisposable
@@ -27,7 +29,22 @@
         public async Task Initialize(CancellationToken cancellationToken)
         {
             database = EmbeddedDatabase.Start(databaseConfiguration);
-            documentStore = await database.Connect(cancellationToken);
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    documentStore = await database.Connect(cancellationToken);
+                    return;
+                }
+                catch (DatabaseLoadTimeoutException e)
+                {
+                    Log.Warn("Could not connect to database. Retrying in 500ms...", e);
+                    await Task.Delay(500, cancellationToken);
+                }
+            }
         }
 
         public void Dispose()
@@ -41,6 +58,7 @@
         EmbeddedDatabase database;
 
         readonly RavenPersisterSettings databaseConfiguration;
+        static readonly ILog Log = LogManager.GetLogger(typeof(RavenEmbeddedPersistenceLifecycle));
 
         ~RavenEmbeddedPersistenceLifecycle()
         {


### PR DESCRIPTION
Connecting to RavenDB database can timeout with `DatabaseLoadTimeoutException`. Will retry until the cancellationtoken is set