### PR TITLE
Custom lifetime manager to prevent Windows Service start timeout - Generic IHostLifetime wrapper 

### DIFF
--- a/src/ServiceControl/Hosting/Commands/CustomLivetimes/HostBuilderLifetimeExtensions.cs
+++ b/src/ServiceControl/Hosting/Commands/CustomLivetimes/HostBuilderLifetimeExtensions.cs
@@ -1,0 +1,33 @@
+﻿namespace Particular.ServiceControl.Commands
+{
+    using global::ServiceControl.Persistence;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Hosting.Internal;
+    using Microsoft.Extensions.Hosting.WindowsServices;
+
+    static class HostBuilderLifetimeExtensions
+    {
+        public static void SetupLifetime(this IHostBuilder hostBuilder, bool runAsWindowsService)
+        {
+            if (runAsWindowsService)
+            {
+                hostBuilder.UseWindowsService();
+                hostBuilder.ConfigureServices(s =>
+                {
+                    s.AddSingleton<WindowsServiceLifetime>();
+                    s.AddSingleton<IHostLifetime>(b => new PersisterInitializingLifetimeWrapper(b.GetRequiredService<IPersistenceLifecycle>(), b.GetRequiredService<WindowsServiceLifetime>()));
+                });
+            }
+            else
+            {
+                hostBuilder.UseConsoleLifetime();
+                hostBuilder.ConfigureServices(s =>
+                {
+                    s.AddSingleton<ConsoleLifetime>();
+                    s.AddSingleton<IHostLifetime>(b => new PersisterInitializingLifetimeWrapper(b.GetRequiredService<IPersistenceLifecycle>(), b.GetRequiredService<ConsoleLifetime>()));
+                });
+            }
+        }
+    }
+}

--- a/src/ServiceControl/Hosting/Commands/CustomLivetimes/PersisterInitializingLifetimeWrapper.cs
+++ b/src/ServiceControl/Hosting/Commands/CustomLivetimes/PersisterInitializingLifetimeWrapper.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using ServiceControl.Persistence;
+
+
+sealed class PersisterInitializingLifetimeWrapper : IHostLifetime
+{
+    readonly IPersistenceLifecycle persistenceLifecycle;
+    readonly IHostLifetime implementation;
+
+    public PersisterInitializingLifetimeWrapper(
+        IPersistenceLifecycle persistenceLifecycle,
+        IHostLifetime implementation
+        )
+    {
+        this.persistenceLifecycle = persistenceLifecycle;
+        this.implementation = implementation;
+    }
+
+    public async Task WaitForStartAsync(CancellationToken cancellationToken)
+    {
+        await implementation.WaitForStartAsync(cancellationToken);
+        await persistenceLifecycle.Initialize(cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => implementation.StopAsync(cancellationToken);
+}

--- a/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
@@ -27,6 +27,7 @@
             var bootstrapper = new Bootstrapper(settings, busConfiguration, loggingSettings);
             using (var host = bootstrapper.HostBuilder.Build())
             {
+                // TODO: Put in BackgroundService, take a dependency on IApplicationLifetime and invoke IApplicationLifetime.StopApplication();
                 var lifeCycle = host.Services.GetRequiredService<IPersistenceLifecycle>();
                 await lifeCycle.Initialize(); // Initialized IDocumentStore, this is needed as many hosted services have (indirect) dependencies on it.
 

--- a/src/ServiceControl/Hosting/Commands/MaintenanceModeCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/MaintenanceModeCommand.cs
@@ -1,13 +1,10 @@
 ﻿namespace ServiceControl.Hosting.Commands
 {
-    using System;
     using System.Threading.Tasks;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Particular.ServiceControl;
     using Particular.ServiceControl.Commands;
     using Particular.ServiceControl.Hosting;
-    using Persistence;
     using ServiceBus.Management.Infrastructure.Settings;
 
     class MaintenanceModeCommand : AbstractCommand
@@ -17,21 +14,10 @@
             var bootstrapper = new MaintenanceBootstrapper(settings);
             var hostBuilder = bootstrapper.HostBuilder;
 
-            if (args.RunAsWindowsService)
-            {
-                hostBuilder.UseWindowsService();
-            }
-            else
-            {
-                await Console.Out.WriteLineAsync("RavenDB Maintenance Mode - Press CTRL+C to exit");
-
-                hostBuilder.UseConsoleLifetime();
-            }
+            hostBuilder.SetupLifetime(args.RunAsWindowsService);
 
             using (var host = hostBuilder.Build())
             {
-                // Initialized IDocumentStore, this is needed as many hosted services have (indirect) dependencies on it.
-                await host.Services.GetRequiredService<IPersistenceLifecycle>().Initialize();
                 await host.RunAsync();
             }
         }

--- a/src/ServiceControl/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/RunCommand.cs
@@ -1,9 +1,7 @@
 ﻿namespace Particular.ServiceControl.Commands
 {
     using System.Threading.Tasks;
-    using global::ServiceControl.Persistence;
     using Hosting;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using NServiceBus;
     using ServiceBus.Management.Infrastructure.Settings;
@@ -23,19 +21,10 @@
             var bootstrapper = new Bootstrapper(settings, endpointConfiguration, loggingSettings);
             var hostBuilder = bootstrapper.HostBuilder;
 
-            if (args.RunAsWindowsService)
-            {
-                hostBuilder.UseWindowsService();
-            }
-            else
-            {
-                hostBuilder.UseConsoleLifetime();
-            }
+            hostBuilder.SetupLifetime(args.RunAsWindowsService);
 
             using (var host = hostBuilder.Build())
             {
-                // Initialized IDocumentStore, this is needed as many hosted services have (indirect) dependencies on it.
-                await host.Services.GetRequiredService<IPersistenceLifecycle>().Initialize();
                 await host.RunAsync();
             }
         }


### PR DESCRIPTION
- Related to: https://github.com/Particular/ServiceControl/issues/3909
- Alternative to: https://github.com/Particular/ServiceControl/pull/3926
- 
A `PersisterInitializingLifetimeWrapper` that is DI configured to use a specific console or windowsservice lifetime.