### PR TITLE
Make root controller test pass, but...

### DIFF
--- a/src/ServiceControl.AcceptanceTests/RootControllerTests.cs
+++ b/src/ServiceControl.AcceptanceTests/RootControllerTests.cs
@@ -23,7 +23,7 @@
                 settings.RemoteInstances = new[]
                 {
                     new RemoteInstanceSetting { ApiUri = localApiUrl, InstanceId = "remote1" },
-                    // new RemoteInstanceSetting { ApiUri = localApiUrl, InstanceId = "remote2" }
+                    new RemoteInstanceSetting { ApiUri = localApiUrl, InstanceId = "remote2" }
                 };
                 serviceName = settings.ServiceName;
             };

--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -13,6 +13,7 @@
     using Microsoft.AspNetCore.Hosting.Server;
     using Microsoft.AspNetCore.TestHost;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Hosting;
     using NLog;
     using NServiceBus;
@@ -168,6 +169,17 @@
                 });
 
                 hostBuilderCustomization(hostBuilder);
+                hostBuilder.Services.Replace(new ServiceDescriptor(typeof(IHttpClientFactory), new TestsHttpClientFactory(
+                    name =>
+                    {
+                        var client = host.GetTestServer().CreateClient();
+
+                        // As per this comment https://github.com/aspnet/Hosting/issues/1254#issuecomment-341901793
+                        // setting the BaseAddress for the test client is useless
+                        //client.BaseAddress = new Uri(settings.ApiUrl);
+
+                        return client;
+                    })));
 
                 host = hostBuilder.Build();
                 host.UseServiceControl();

--- a/src/ServiceControl.AcceptanceTests/TestSupport/TestsHttpClientFactory.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/TestsHttpClientFactory.cs
@@ -1,0 +1,9 @@
+namespace ServiceControl.AcceptanceTests.TestSupport;
+
+using System;
+using System.Net.Http;
+
+class TestsHttpClientFactory(Func<string, HttpClient> factory) : IHttpClientFactory
+{
+    public HttpClient CreateClient(string name) => factory(name);
+}

--- a/src/ServiceControl/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/RootController.cs
@@ -111,7 +111,7 @@
 
                     try
                     {
-                        var response = await httpClient.GetAsync("/configuration");
+                        var response = await httpClient.GetAsync("/api/configuration");
 
                         if (response.Headers.TryGetValues("X-Particular-Version", out var values))
                         {


### PR DESCRIPTION
It requires changing the address the root controller uses, which I believe will have unintended consequences in production. Something is still off.