### PR TITLE
Update global package references

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.AspNet.SignalR.Client" Version="2.4.3" />
     <PackageVersion Include="Microsoft.AspNet.WebApi" Version="5.3.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -83,8 +83,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.1.2" />
-    <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.282" />
+    <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.1.10" />
+    <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.302" />
     <GlobalPackageReference Include="Particular.Packaging" Version="4.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
~~Looks like Dependabot doesn't catch these.~~

EDIT: On further investigation, it looks like it should be able to handle them, but Dependabot itself seems to be having problems. Looks like all the recent runs have failed: https://github.com/Particular/ServiceControl/network/updates/7298903/jobs

I also included updating Microsoft.Data.SqlClient since the currently referenced version is showing that there is a security vulnerability in it.