### PR TITLE
Updated license after  `LicenseTest.EnsureLicenseIsValid` failed

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenLicense.json
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenLicense.json
@@ -2,15 +2,18 @@
   "Id": "64c6a174-3f3a-4e7d-ac5d-b3eedd801460",
   "Name": "ParticularNservicebus (Israel)",
   "Keys": [
-    "kWznr3iTRWkzuYjFJH8IvS1LY",
-    "t5GJId7H/h5i4YjW2Z7YPgUoR",
-    "igl/wrjx4y6pmXcChQRnTu1TK",
-    "Q1scjkLMB2aaH9VZ5G2s4E0gz",
-    "08GaHnSOHpRVz6SgjFGcAqnEb",
-    "c0ZhNNOGsBcrOVx+KOq7+ggHs",
-    "MtKI8e8mCRcgiaTOkPURpAAyU",
-    "GKEkFCisMLQ4vMAcREjM0NRYX",
-    "GhufAh8AnwIgAJ8CIwBBMkMMR",
-    "AY4OTw9Pp8CISBiP1g="
+      "NKhWkUrAnwvE+M6VmSxK7J6am",
+      "D2JME/+XVMQq9xh18W4lClw+a",
+      "FDWF3ZqgA89/tIgwUyc8BZ09f",
+      "wSsdi8WzL/w01TOB00HuGQE4r",
+      "jAkg7BKr7LWIRfbg02KLhiU4M",
+      "Y1FQx8IA4BOBK0XP+X+aaWE48",
+      "fLmwuqGsSc0kg0rzFdYs9AAyU",
+      "GKEkFCisMLQ4vMAcREjM0NRYX",
+      "GhufAh8AnwIgAJ8CIwCfAiQgn",
+      "wIlIJ8CJiCfAicgnwIoIJ8CKS",
+      "CfAiognwIrIJ8CLACfAi0AnwI",
+      "uIJ8CLwCfAjAggQM2LjBDMEQG",
+      "ODk8PT6fAiEgYoFY"
   ]
 }

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/LicenseTest.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/LicenseTest.cs
@@ -35,7 +35,7 @@
                     Assert.That(details.Status, Is.EqualTo("Commercial"));
                     Assert.That(details.Expired, Is.False);
                     Assert.That(details.Type, Is.EqualTo("Professional"));
-                    Assert.That(DateTime.UtcNow.AddDays(14) < details.Expiration, "The RavenDB license expires in less than 2 weeks. Contact RavenDB for the new license.");
+                    Assert.That(DateTime.UtcNow.AddDays(14) < details.Expiration, $"The RavenDB license expires {details.Expiration} which is less than 2 weeks. Contact RavenDB at <sales@ravendb.net> for the new license.");
                 }
             }
         }

--- a/src/ServiceControl.Persistence.RavenDB/RavenLicense.json
+++ b/src/ServiceControl.Persistence.RavenDB/RavenLicense.json
@@ -1,16 +1,19 @@
 {
-"Id": "64c6a174-3f3a-4e7d-ac5d-b3eedd801460",
-"Name": "ParticularNservicebus (Israel)",
-"Keys": [
-"kWznr3iTRWkzuYjFJH8IvS1LY",
-"t5GJId7H/h5i4YjW2Z7YPgUoR",
-"igl/wrjx4y6pmXcChQRnTu1TK",
-"Q1scjkLMB2aaH9VZ5G2s4E0gz",
-"08GaHnSOHpRVz6SgjFGcAqnEb",
-"c0ZhNNOGsBcrOVx+KOq7+ggHs",
-"MtKI8e8mCRcgiaTOkPURpAAyU",
-"GKEkFCisMLQ4vMAcREjM0NRYX",
-"GhufAh8AnwIgAJ8CIwBBMkMMR",
-"AY4OTw9Pp8CISBiP1g="
-]
+  "Id": "64c6a174-3f3a-4e7d-ac5d-b3eedd801460",
+  "Name": "ParticularNservicebus (Israel)",
+  "Keys": [
+      "NKhWkUrAnwvE+M6VmSxK7J6am",
+      "D2JME/+XVMQq9xh18W4lClw+a",
+      "FDWF3ZqgA89/tIgwUyc8BZ09f",
+      "wSsdi8WzL/w01TOB00HuGQE4r",
+      "jAkg7BKr7LWIRfbg02KLhiU4M",
+      "Y1FQx8IA4BOBK0XP+X+aaWE48",
+      "fLmwuqGsSc0kg0rzFdYs9AAyU",
+      "GKEkFCisMLQ4vMAcREjM0NRYX",
+      "GhufAh8AnwIgAJ8CIwCfAiQgn",
+      "wIlIJ8CJiCfAicgnwIoIJ8CKS",
+      "CfAiognwIrIJ8CLACfAi0AnwI",
+      "uIJ8CLwCfAjAggQM2LjBDMEQG",
+      "ODk8PT6fAiEgYoFY"
+  ]
 }


### PR DESCRIPTION
Updated license after  `LicenseTest.EnsureLicenseIsValid` failed and updated test to show when the license expires for example if the test must need to be temporarily ignored to deploy.