### PR TITLE
Fix incorrect ordering of the events

### DIFF
--- a/src/ServiceControl.Persistence.RavenDB/EventLogDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/EventLogDataStore.cs
@@ -5,7 +5,6 @@
     using EventLog;
     using Persistence.Infrastructure;
     using Raven.Client.Documents;
-    using Raven.Client.Documents.Session;
 
     class EventLogDataStore : IEventLogDataStore
     {
@@ -32,7 +31,7 @@
                 var results = await session
                     .Query<EventLogItem>()
                     .Statistics(out var stats)
-                    .OrderByDescending(p => p.RaisedAt, OrderingType.Double)
+                    .OrderByDescending(p => p.RaisedAt)
                     .Paging(pagingInfo)
                     .ToListAsync();
 


### PR DESCRIPTION
- Resolves: https://github.com/Particular/ServiceControl/issues/3921

Removes `OrderingType.Double`, with no value passed [RavenDB 5.x defaults to lexicographic ordering](https://ravendb.net/docs/article-page/5.4/csharp/client-api/session/querying/sort-query-results):

> When using RQL directly, if no ordering type is specified, then the server defaults to lexicographic ordering.

The document property on which is sorted is `RaisedAt`. This value is stored/interpreted as `2020-05-27T00:00:00.0000000Z`. Using lexicographic ordering will work correctly with these values.

### Symptoms

Incorrect order of events in ServicePulse events view.

### Who's affected

ServiceControl 5 instances

### Root cause

Incorrect `OrderingType` was passed to RavenDB query.