### PR TITLE
False  disk space error notification

### DIFF
--- a/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckFreeDiskSpace.cs
+++ b/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckFreeDiskSpace.cs
@@ -13,8 +13,7 @@
         public CheckFreeDiskSpace(RavenPersisterSettings settings) : base("ServiceControl database", "Storage space", TimeSpan.FromMinutes(5))
         {
             dataPath = settings.DatabasePath;
-            percentageThreshold = settings.DataSpaceRemainingThreshold;
-
+            percentageThreshold = settings.DataSpaceRemainingThreshold / 100m;
             Logger.Debug($"Check ServiceControl data drive space remaining custom check starting. Threshold {percentageThreshold:P0}");
         }
 


### PR DESCRIPTION
- Resolves: https://github.com/Particular/ServiceControl/issues/3933

### Symptoms

Custom check shows a false positive on disk space as reported in:

- https://github.com/Particular/ServiceControl/issues/3933

### Who's affected

ServiceControl version 5 users

### Root cause

Settings value was not divided by 100 which causes a false positive. Division aligned with audit implementation.
