### PR TITLE
Custom lifetime manager to prevent Windows Service start timeout - Custom lifetime concrete types

### DIFF
--- a/src/ServiceControl/Hosting/Commands/MaintenanceModeCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/MaintenanceModeCommand.cs
@@ -1,13 +1,10 @@
 ﻿namespace ServiceControl.Hosting.Commands
 {
-    using System;
     using System.Threading.Tasks;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Particular.ServiceControl;
     using Particular.ServiceControl.Commands;
     using Particular.ServiceControl.Hosting;
-    using Persistence;
     using ServiceBus.Management.Infrastructure.Settings;
 
     class MaintenanceModeCommand : AbstractCommand
@@ -17,21 +14,10 @@
             var bootstrapper = new MaintenanceBootstrapper(settings);
             var hostBuilder = bootstrapper.HostBuilder;
 
-            if (args.RunAsWindowsService)
-            {
-                hostBuilder.UseWindowsService();
-            }
-            else
-            {
-                await Console.Out.WriteLineAsync("RavenDB Maintenance Mode - Press CTRL+C to exit");
-
-                hostBuilder.UseConsoleLifetime();
-            }
+            hostBuilder.AddPersistenceInitializingLifetime(args.RunAsWindowsService);
 
             using (var host = hostBuilder.Build())
             {
-                // Initialized IDocumentStore, this is needed as many hosted services have (indirect) dependencies on it.
-                await host.Services.GetRequiredService<IPersistenceLifecycle>().Initialize();
                 await host.RunAsync();
             }
         }

--- a/src/ServiceControl/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/RunCommand.cs
@@ -1,9 +1,7 @@
 ﻿namespace Particular.ServiceControl.Commands
 {
     using System.Threading.Tasks;
-    using global::ServiceControl.Persistence;
     using Hosting;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using NServiceBus;
     using ServiceBus.Management.Infrastructure.Settings;
@@ -23,19 +21,10 @@
             var bootstrapper = new Bootstrapper(settings, endpointConfiguration, loggingSettings);
             var hostBuilder = bootstrapper.HostBuilder;
 
-            if (args.RunAsWindowsService)
-            {
-                hostBuilder.UseWindowsService();
-            }
-            else
-            {
-                hostBuilder.UseConsoleLifetime();
-            }
+            hostBuilder.AddPersistenceInitializingLifetime(args.RunAsWindowsService);
 
             using (var host = hostBuilder.Build())
             {
-                // Initialized IDocumentStore, this is needed as many hosted services have (indirect) dependencies on it.
-                await host.Services.GetRequiredService<IPersistenceLifecycle>().Initialize();
                 await host.RunAsync();
             }
         }

--- a/src/ServiceControl/Hosting/HostBuilderLifetimes/HostBuilderLifetimeExtensions.cs
+++ b/src/ServiceControl/Hosting/HostBuilderLifetimes/HostBuilderLifetimeExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace Microsoft.Extensions.Hosting
+{
+    using Microsoft.Extensions.DependencyInjection;
+    using ServiceControl.Hosting;
+
+    static class HostBuilderLifetimeExtensions
+    {
+        public static void AddPersistenceInitializingLifetime(this IHostBuilder hostBuilder, bool runAsWindowsService)
+        {
+            if (runAsWindowsService)
+            {
+                hostBuilder.UseWindowsService();
+
+                hostBuilder.ConfigureServices(s =>
+                {
+                    s.AddSingleton<IHostLifetime, PersisterInitializingWindowsServiceLifetime>();
+                });
+            }
+            else
+            {
+                hostBuilder.UseConsoleLifetime();
+
+                hostBuilder.ConfigureServices(s =>
+                {
+                    s.AddSingleton<IHostLifetime, PersisterInitializingConsoleLifetime>();
+                });
+            }
+        }
+    }
+}

--- a/src/ServiceControl/Hosting/HostBuilderLifetimes/PersisterInitializingConsoleLifetime.cs
+++ b/src/ServiceControl/Hosting/HostBuilderLifetimes/PersisterInitializingConsoleLifetime.cs
@@ -1,0 +1,31 @@
+﻿namespace ServiceControl.Hosting
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Hosting.Internal;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using ServiceControl.Persistence;
+
+    sealed class PersisterInitializingConsoleLifetime : ConsoleLifetime, IHostLifetime
+    {
+        readonly IPersistenceLifecycle persistenceLifecycle;
+
+        public PersisterInitializingConsoleLifetime(
+            IOptions<ConsoleLifetimeOptions> options, IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, IOptions<HostOptions> hostOptions, ILoggerFactory loggerFactory, // base constructor
+            IPersistenceLifecycle persistenceLifecycle
+            ) : base(options, environment, applicationLifetime, hostOptions, loggerFactory)
+        {
+            this.persistenceLifecycle = persistenceLifecycle;
+        }
+
+        public new async Task WaitForStartAsync(CancellationToken cancellationToken)
+        {
+            await base.WaitForStartAsync(cancellationToken);
+            // Initialize needs to happen after WaitForStartAsync to ensure the lifetime implementation is invoked and
+            // for windows services that process signals back to the service control manager (scm) that it is started.
+            await persistenceLifecycle.Initialize(cancellationToken);
+        }
+    }
+}

--- a/src/ServiceControl/Hosting/HostBuilderLifetimes/PersisterInitializingWindowsServiceLifetime.cs
+++ b/src/ServiceControl/Hosting/HostBuilderLifetimes/PersisterInitializingWindowsServiceLifetime.cs
@@ -1,0 +1,31 @@
+﻿namespace ServiceControl.Hosting
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Hosting.WindowsServices;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using ServiceControl.Persistence;
+
+    sealed class PersisterInitializingWindowsServiceLifetime : WindowsServiceLifetime, IHostLifetime
+    {
+        readonly IPersistenceLifecycle persistenceLifecycle;
+
+        public PersisterInitializingWindowsServiceLifetime(
+            IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory, IOptions<HostOptions> optionsAccessor, IOptions<WindowsServiceLifetimeOptions> windowsServiceOptionsAccessor, // base constructor
+            IPersistenceLifecycle persistenceLifecycle
+            ) : base(environment, applicationLifetime, loggerFactory, optionsAccessor, windowsServiceOptionsAccessor)
+        {
+            this.persistenceLifecycle = persistenceLifecycle;
+        }
+
+        public new async Task WaitForStartAsync(CancellationToken cancellationToken)
+        {
+            await base.WaitForStartAsync(cancellationToken);
+            // Initialize needs to happen after WaitForStartAsync to ensure the lifetime implementation is invoked and
+            // for windows services that process signals back to the service control manager (scm) that it is started.
+            await persistenceLifecycle.Initialize(cancellationToken);
+        }
+    }
+}

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <!-- Needed for build ordering -->
-  <Import Project="..\ProjectReferences.Persisters.Primary.props"  />
+  <Import Project="..\ProjectReferences.Persisters.Primary.props" />
   <Import Project="..\ProjectReferences.Transports.props" />
 
   <ItemGroup>


### PR DESCRIPTION
- Resolves: https://github.com/Particular/ServiceControl/issues/3909

Using custom lifecycle(s) that invoke `IPersistenceLifecycle.Initialize()` as part of `IHostLifetime.WaitForStartAsync(..)` so that the application will not timeout in the (Windows) Service Control Manager and kill the process.