### PR TITLE
Add support for Azure Service Bus entities partitioning

### DIFF
--- a/src/ServiceControl.Transports.ASBS.Tests/ConnectionStringParserTests.cs
+++ b/src/ServiceControl.Transports.ASBS.Tests/ConnectionStringParserTests.cs
@@ -34,6 +34,9 @@
                 //Custom query delay interval
                 yield return new TestCaseData("Endpoint=sb://some.endpoint.name/;QueueLengthQueryDelayInterval=15000",
                     new ConnectionSettings(new SharedAccessSignatureAuthentication("Endpoint=sb://some.endpoint.name/;QueueLengthQueryDelayInterval=15000"), queryDelayInterval: TimeSpan.FromSeconds(15)));
+                //EnablePartitioning
+                yield return new TestCaseData("Endpoint=sb://some.endpoint.name/;EnablePartitioning=True",
+                    new ConnectionSettings(new SharedAccessSignatureAuthentication("Endpoint=sb://some.endpoint.name/;EnablePartitioning=True"), enablePartitioning: true));
             }
         }
 
@@ -61,13 +64,13 @@
 
             Assert.AreEqual(JsonSerializer.Serialize(expected), JsonSerializer.Serialize(actual));
 
-            //needed since System..Text.Json doesn't handle polymorphic properties
+            //needed since System.Text.Json doesn't handle polymorphic properties
             Assert.AreEqual(
                 JsonSerializer.Serialize(expected.AuthenticationMethod, expected.AuthenticationMethod.GetType()),
                 JsonSerializer.Serialize(actual.AuthenticationMethod, actual.AuthenticationMethod.GetType()));
 
 
-            //needed since System..Text.Json doesn't handle polymorphic properties
+            //needed since System.Text.Json doesn't handle polymorphic properties
             if (expected.AuthenticationMethod is TokenCredentialAuthentication expectedAuthentication)
             {
                 var actualAuthentication = actual.AuthenticationMethod as TokenCredentialAuthentication;

--- a/src/ServiceControl.Transports.ASBS/ASBSTransportCustomization.cs
+++ b/src/ServiceControl.Transports.ASBS/ASBSTransportCustomization.cs
@@ -27,6 +27,8 @@
                 transport.Topology = TopicTopology.Single(connectionSettings.TopicName);
             }
 
+            transport.EnablePartitioning = connectionSettings.EnablePartitioning;
+
             transport.ConfigureNameShorteners();
 
             transport.TransportTransactionMode = transport.GetSupportedTransactionModes().Contains(preferredTransactionMode) ? preferredTransactionMode : TransportTransactionMode.ReceiveOnly;

--- a/src/ServiceControl.Transports.ASBS/ConnectionSettings.cs
+++ b/src/ServiceControl.Transports.ASBS/ConnectionSettings.cs
@@ -4,15 +4,16 @@
 
     public class ConnectionSettings
     {
-        public ConnectionSettings(
-            AuthenticationMethod authenticationSettings,
+        public ConnectionSettings(AuthenticationMethod authenticationSettings,
             string topicName = default,
             bool useWebSockets = default,
+            bool enablePartitioning = default,
             TimeSpan? queryDelayInterval = default)
         {
             AuthenticationMethod = authenticationSettings;
             TopicName = topicName;
             UseWebSockets = useWebSockets;
+            EnablePartitioning = enablePartitioning;
             QueryDelayInterval = queryDelayInterval;
         }
 
@@ -23,5 +24,7 @@
         public string TopicName { get; }
 
         public bool UseWebSockets { get; }
+
+        public bool EnablePartitioning { get; }
     }
 }

--- a/src/ServiceControl.Transports.ASBS/ConnectionStringParser.cs
+++ b/src/ServiceControl.Transports.ASBS/ConnectionStringParser.cs
@@ -62,6 +62,16 @@
                 clientIdString = (string)clientId;
             }
 
+            var enablePartitioning = false;
+            if (builder.TryGetValue("EnablePartitioning", out var enablePartitioningString))
+            {
+                if (!bool.TryParse((string)enablePartitioningString, out enablePartitioning))
+                {
+                    throw new Exception(
+                        $"Cannot enable partitioning, the specified value '{enablePartitioningString}' cannot be converted to a bool.");
+                }
+            }
+
             var shouldUseManagedIdentity = builder.TryGetValue("Authentication", out var authType) && (string)authType == "Managed Identity";
 
             if (shouldUseManagedIdentity)
@@ -72,6 +82,7 @@
                   new TokenCredentialAuthentication(fullyQualifiedNamespace, clientIdString),
                   topicNameString,
                   useWebSockets,
+                  enablePartitioning,
                   queryDelayInterval);
             }
 
@@ -84,6 +95,7 @@
                 new SharedAccessSignatureAuthentication(connectionString),
                 topicNameString,
                 useWebSockets,
+                enablePartitioning,
                 queryDelayInterval);
         }
     }

--- a/src/ServiceControl.Transports.ASBS/transport.manifest
+++ b/src/ServiceControl.Transports.ASBS/transport.manifest
@@ -5,7 +5,7 @@
       "Name": "NetStandardAzureServiceBus",
       "DisplayName": "Azure Service Bus",
       "TypeName": "ServiceControl.Transports.ASBS.ASBSTransportCustomization, ServiceControl.Transports.ASBS",
-      "SampleConnectionString": "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>;QueueLengthQueryDelayInterval=<IntervalInMilliseconds(Default=500ms)>;TopicName=<TopicBundleName(Default=bundle-1)>",
+      "SampleConnectionString": "Endpoint=sb://[namespace].servicebus.windows.net; SharedSecretIssuer=<owner>;SharedSecretValue=<someSecret>;QueueLengthQueryDelayInterval=<IntervalInMilliseconds(Default=500ms)>;TopicName=<TopicBundleName(Default=bundle-1)>;EnablePartitioning=<true|false(Default=false)>",
       "AvailableInSCMU": true,
       "Aliases": [
         "ServiceControl.Transports.AzureServiceBus.AzureServiceBusTransport, ServiceControl.Transports.AzureServiceBus"


### PR DESCRIPTION
- Related to #3958 

This PR supports Azure Service Bus partitioned entities by adding support for the `EnablePartitioning` flag in the connection string.

- [ ] Backport to `net8`
- [ ] Backport to `4.x`
- [ ] Backport to `5.x`