### PR TITLE
Enable building on non-Windows OS without errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: dotnet build src --configuration Release -graph --no-restore
       - name: Build ServiceControl Management
-        run: dotnet publish src\ServiceControl.Config\ServiceControl.Config.csproj --configuration Release --runtime win-x64 --no-build --output assets
+        run: dotnet publish src\ServiceControl.Config\ServiceControl.Config.csproj --no-build --output assets
       - name: Sign NuGet packages
         uses: Particular/sign-nuget-packages-action@v1.0.0
         with:

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MinVerMinimumMajorMinor>5.0</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>5.1</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
   </PropertyGroup>
 

--- a/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
+++ b/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
-    <PlatformTarget>x64</PlatformTarget>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 

--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -12,6 +12,7 @@
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
+++ b/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
@@ -81,4 +81,10 @@
     <FileUpdate Files="@(ModuleFile)" Pattern="{{Date}}" ReplacementText="$([System.DateTime]::UtcNow.ToString(yyyy))" />
   </Target>
 
+  <Target Name="WorkaroundForSqlClientWindowsFormsReference" BeforeTargets="AddTransitiveFrameworkReferences">
+    <ItemGroup>
+      <TransitiveFrameworkReference Remove="@(TransitiveFrameworkReference)" Condition="'%(TransitiveFrameworkReference.Identity)' == 'Microsoft.WindowsDesktop.App.WindowsForms'" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Engine.UnitTests/ServiceControlInstaller.Engine.UnitTests.csproj
@@ -18,4 +18,10 @@
     <PackageReference Include="PublicApiGenerator" />
   </ItemGroup>
 
+  <Target Name="WorkaroundForSqlClientWindowsFormsReference" BeforeTargets="AddTransitiveFrameworkReferences">
+    <ItemGroup>
+      <TransitiveFrameworkReference Remove="@(TransitiveFrameworkReference)" Condition="'%(TransitiveFrameworkReference.Identity)' == 'Microsoft.WindowsDesktop.App.WindowsForms'" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -38,4 +38,10 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="WorkaroundForSqlClientWindowsFormsReference" BeforeTargets="AddTransitiveFrameworkReferences">
+    <ItemGroup>
+      <TransitiveFrameworkReference Remove="@(TransitiveFrameworkReference)" Condition="'%(TransitiveFrameworkReference.Identity)' == 'Microsoft.WindowsDesktop.App.WindowsForms'" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
These changes let non-Windows operating systems build successfully without any errors.

This PR is about building locally. It doesn't add Linux builds in CI or do anything to make SC run on Linux.

Note: I've also included a bump to `MinVerMinimumMajorMinor` that was needed because 5.0.0 was not tagged on a commit visible to `master`.