### PR TITLE
Address MessageContext.Body TODOs

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -22,7 +22,6 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.5" />
     <PackageVersion Include="Mindscape.Raygun4Net.NetCore" Version="8.0.0" />

--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditIngestionUnitOfWork.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Audit.Persistence.InMemory
 {
+    using System;
     using System.Threading.Tasks;
     using Auditing.BodyStorage;
     using ServiceControl.Audit.Auditing;
@@ -7,19 +8,12 @@
     using ServiceControl.Audit.Persistence.UnitOfWork;
     using ServiceControl.SagaAudit;
 
-    class InMemoryAuditIngestionUnitOfWork : IAuditIngestionUnitOfWork
+    class InMemoryAuditIngestionUnitOfWork(
+        InMemoryAuditDataStore dataStore,
+        BodyStorageEnricher bodyStorageEnricher)
+        : IAuditIngestionUnitOfWork
     {
-        public InMemoryAuditIngestionUnitOfWork(InMemoryAuditDataStore dataStore,
-            BodyStorageEnricher bodyStorageEnricher)
-        {
-            this.dataStore = dataStore;
-            this.bodyStorageEnricher = bodyStorageEnricher;
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            return new ValueTask();
-        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
         public Task RecordKnownEndpoint(KnownEndpoint knownEndpoint)
         {
@@ -27,21 +21,15 @@
             return Task.CompletedTask;
         }
 
-        public async Task RecordProcessedMessage(ProcessedMessage processedMessage, byte[] body)
+        public async Task RecordProcessedMessage(ProcessedMessage processedMessage, ReadOnlyMemory<byte> body)
         {
-            if (body != null)
+            if (body.Length > 0)
             {
                 await bodyStorageEnricher.StoreAuditMessageBody(body, processedMessage);
             }
             await dataStore.SaveProcessedMessage(processedMessage);
         }
 
-        public Task RecordSagaSnapshot(SagaSnapshot sagaSnapshot)
-        {
-            return dataStore.SaveSagaSnapshot(sagaSnapshot);
-        }
-
-        InMemoryAuditDataStore dataStore;
-        BodyStorageEnricher bodyStorageEnricher;
+        public Task RecordSagaSnapshot(SagaSnapshot sagaSnapshot) => dataStore.SaveSagaSnapshot(sagaSnapshot);
     }
 }

--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditIngestionUnitOfWork.cs
@@ -23,7 +23,7 @@
 
         public async Task RecordProcessedMessage(ProcessedMessage processedMessage, ReadOnlyMemory<byte> body)
         {
-            if (body.Length > 0)
+            if (!body.IsEmpty)
             {
                 await bodyStorageEnricher.StoreAuditMessageBody(body, processedMessage);
             }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/UnitOfWork/RavenAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/UnitOfWork/RavenAuditIngestionUnitOfWork.cs
@@ -25,14 +25,14 @@
         public async Task RecordProcessedMessage(ProcessedMessage processedMessage, ReadOnlyMemory<byte> body)
         {
             processedMessage.MessageMetadata["ContentLength"] = body.Length;
-            if (body.Length > 0)
+            if (!body.IsEmpty)
             {
                 processedMessage.MessageMetadata["BodyUrl"] = $"/messages/{processedMessage.Id}/body";
             }
 
             await bulkInsert.StoreAsync(processedMessage, GetExpirationMetadata());
 
-            if (body.Length > 0)
+            if (!body.IsEmpty)
             {
                 await using var stream = new ReadOnlyStream(body);
                 var contentType = processedMessage.Headers.GetValueOrDefault(Headers.ContentType, "text/xml");

--- a/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
@@ -84,7 +84,7 @@
             var unitOfWork = AuditIngestionUnitOfWorkFactory.StartNew(1);
 
             var body = new byte[100];
-            new Random().NextBytes(body);
+            Random.Shared.NextBytes(body);
             var processedMessage = MakeMessage();
 
             await unitOfWork.RecordProcessedMessage(processedMessage, body);
@@ -116,7 +116,7 @@
             var unitOfWork = AuditIngestionUnitOfWorkFactory.StartNew(1);
 
             var body = new byte[MAX_BODY_SIZE + 1000];
-            new Random().NextBytes(body);
+            Random.Shared.NextBytes(body);
             var processedMessage = MakeMessage();
 
             await unitOfWork.RecordProcessedMessage(processedMessage, body);

--- a/src/ServiceControl.Audit.Persistence/UnitOfWork/IAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence/UnitOfWork/IAuditIngestionUnitOfWork.cs
@@ -8,7 +8,7 @@
 
     public interface IAuditIngestionUnitOfWork : IAsyncDisposable
     {
-        Task RecordProcessedMessage(ProcessedMessage processedMessage, byte[] body = null);
+        Task RecordProcessedMessage(ProcessedMessage processedMessage, ReadOnlyMemory<byte> body = default);
         Task RecordSagaSnapshot(SagaSnapshot sagaSnapshot);
         Task RecordKnownEndpoint(KnownEndpoint knownEndpoint);
     }

--- a/src/ServiceControl.Audit/Auditing/AuditEnricherContext.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditEnricherContext.cs
@@ -18,15 +18,9 @@
 
         public IDictionary<string, object> Metadata { get; }
 
-        public void AddForSend(ICommand command)
-        {
-            outgoingCommands.Add(command);
-        }
+        public void AddForSend(ICommand command) => outgoingCommands.Add(command);
 
-        public void AddForSend(TransportOperation transportOperation)
-        {
-            outgoingSends.Add(transportOperation);
-        }
+        public void AddForSend(TransportOperation transportOperation) => outgoingSends.Add(transportOperation);
 
         readonly IList<ICommand> outgoingCommands;
         readonly IList<TransportOperation> outgoingSends;

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -137,8 +137,14 @@
             {
                 if (queueIngestor != null)
                 {
-                    // TODO NSB8 can raise cancellation exception
-                    await queueIngestor.StopReceive(cancellationToken);
+                    try
+                    {
+                        await queueIngestor.StopReceive(cancellationToken);
+                    }
+                    catch (OperationCanceledException e) when (e.CancellationToken == cancellationToken)
+                    {
+                        // ignored
+                    }
                 }
 
                 queueIngestor = null; // Setting to null so that it doesn't exit when it retries in line 185
@@ -172,7 +178,10 @@
                 await stoppable.StopReceive(cancellationToken);
                 logger.Info("Shutting down. Infrastructure shut down completed");
             }
-            // TODO NSB8 catch cancellation?
+            catch (OperationCanceledException e) when (e.CancellationToken == cancellationToken)
+            {
+                // ignored
+            }
             finally
             {
                 logger.Info("Shutting down. Start/stop semaphore releasing");

--- a/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
@@ -67,7 +67,7 @@
                 {
                     if (log.IsDebugEnabled)
                     {
-                        log.Debug($"Forwarding {contexts.Count} messages");
+                        log.Debug($"Forwarding {stored.Count} messages");
                     }
                     await Forward(stored, settings.AuditLogQueue);
                     if (log.IsDebugEnabled)
@@ -76,7 +76,7 @@
                     }
                 }
 
-                foreach (var context in stored)
+                foreach (var context in contexts)
                 {
                     context.GetTaskCompletionSource().TrySetResult(true);
                 }

--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -87,7 +87,7 @@
 
                         using (auditBulkInsertDurationMeter.Measure())
                         {
-                            await unitOfWork.RecordProcessedMessage(processedMessage, context.Body.ToArray()); //TODO ROM<byte> to array
+                            await unitOfWork.RecordProcessedMessage(processedMessage, context.Body);
                         }
 
                         storedContexts.Add(context);

--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -69,7 +69,7 @@
                 foreach (var context in contexts)
                 {
                     // Any message context that failed during processing will have a faulted task and should be skipped
-                    if(context.GetTaskCompletionSource().Task.IsFaulted)
+                    if (context.GetTaskCompletionSource().Task.IsFaulted)
                     {
                         continue;
                     }
@@ -112,7 +112,7 @@
 
                         ingestedSagaAuditMeter.Mark();
                     }
-                    
+
                     storedContexts.Add(context);
                 }
 
@@ -234,7 +234,7 @@
                 {
                     Logger.Warn($"Processing of saga audit message '{context.NativeMessageId}' failed.", e);
                 }
-                
+
                 // releasing the failed message context early so that they can be retried outside the current batch
                 context.GetTaskCompletionSource().TrySetException(e);
             }

--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -210,7 +210,7 @@
             try
             {
                 SagaUpdatedMessage message;
-                using (var memoryStream = Memory.Manager.GetStream(context.NativeMessageId, context.Body.ToArray(), 0, context.Body.Length)) //TODO More ROM<byte> to array here
+                using (var memoryStream = new ReadOnlyStream(context.Body))
                 using (var streamReader = new StreamReader(memoryStream))
                 using (var reader = new JsonTextReader(streamReader))
                 {

--- a/src/ServiceControl.Infrastructure/Memory.cs
+++ b/src/ServiceControl.Infrastructure/Memory.cs
@@ -1,9 +1,0 @@
-﻿namespace ServiceControl.Infrastructure
-{
-    using Microsoft.IO;
-
-    public static class Memory
-    {
-        public static readonly RecyclableMemoryStreamManager Manager = new RecyclableMemoryStreamManager();
-    }
-}

--- a/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
+++ b/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
@@ -2,16 +2,71 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
 {
     int position = 0;
 
-    public override void Flush() => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        long index = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => position + offset,
+            SeekOrigin.End => memory.Length + offset,
+            _ => throw new ArgumentException("The input seek mode is not valid.", nameof(origin))
+        };
 
-    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        position = unchecked((int)index);
+
+        return index;
+    }
 
     public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void CopyTo(Stream destination, int bufferSize)
+    {
+        ReadOnlySpan<byte> source = memory.Span[position..];
+
+        position += source.Length;
+
+        destination.Write(source);
+    }
+
+    public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        try
+        {
+            CopyTo(destination, bufferSize);
+
+            return Task.CompletedTask;
+        }
+        catch (OperationCanceledException e)
+        {
+            return Task.FromCanceled(e.CancellationToken);
+        }
+        catch (Exception e)
+        {
+            return Task.FromException(e);
+        }
+    }
+
+    public override int ReadByte()
+    {
+        if (position == memory.Length)
+        {
+            return -1;
+        }
+
+        return memory.Span[position++];
+    }
 
     public override int Read(byte[] buffer, int offset, int count)
     {
@@ -42,11 +97,69 @@ public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
         return bytesToCopy;
     }
 
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<int>(cancellationToken);
+        }
+
+        try
+        {
+            int result = Read(buffer.AsSpan());
+
+            return Task.FromResult(result);
+        }
+        catch (OperationCanceledException e)
+        {
+            return Task.FromCanceled<int>(e.CancellationToken);
+        }
+        catch (Exception e)
+        {
+            return Task.FromException<int>(e);
+        }
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
+        }
+
+        try
+        {
+            int result = Read(buffer.Span);
+
+            return new ValueTask<int>(result);
+        }
+        catch (OperationCanceledException e)
+        {
+            return new ValueTask<int>(Task.FromCanceled<int>(e.CancellationToken));
+        }
+        catch (Exception e)
+        {
+            return new ValueTask<int>(Task.FromException<int>(e));
+        }
+    }
+
     public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
+    public override void WriteByte(byte value) => throw new NotSupportedException();
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+    public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException();
+
+    public override Task FlushAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+
+    public override void Flush() => throw new NotSupportedException();
+
     public override bool CanRead => true;
-    public override bool CanSeek => false;
+    public override bool CanSeek => true;
     public override bool CanWrite => false;
     public override long Length => memory.Length;
-    public override long Position { get => position; set => position = (int)value; }
+    public override long Position { get => position; set => position = unchecked((int)value); }
 }

--- a/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
+++ b/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
@@ -1,0 +1,52 @@
+﻿namespace ServiceControl.Infrastructure;
+
+using System;
+using System.IO;
+
+public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
+{
+    int position = 0;
+
+    public override void Flush() => throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var bytesToCopy = Math.Min(count, memory.Length - position);
+
+        var destination = buffer.AsSpan().Slice(offset, bytesToCopy);
+        var source = memory.Span.Slice(position, bytesToCopy);
+
+        source.CopyTo(destination);
+
+        position += bytesToCopy;
+
+        return bytesToCopy;
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        var bytesToCopy = Math.Min(memory.Length - position, buffer.Length);
+        if (bytesToCopy <= 0)
+        {
+            return 0;
+        }
+
+        var source = memory.Span.Slice(position, bytesToCopy);
+        source.CopyTo(buffer);
+
+        position += bytesToCopy;
+        return bytesToCopy;
+    }
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => memory.Length;
+    public override long Position { get => position; set => position = (int)value; }
+}

--- a/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
+++ b/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
@@ -29,8 +29,6 @@ public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
     static long ThrowArgumentExceptionSeekMode(string paramName)
         => throw new ArgumentException("The input seek mode is not valid.", paramName);
 
-    public override void SetLength(long value) => throw new NotSupportedException();
-
     public override void CopyTo(Stream destination, int bufferSize)
     {
         ReadOnlySpan<byte> source = memory.Span[position..];
@@ -161,6 +159,8 @@ public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
     public override Task FlushAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 
     public override void Flush() => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
 
     public override bool CanRead => true;
     public override bool CanSeek => true;

--- a/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
+++ b/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Infrastructure;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,13 +17,17 @@ public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
             SeekOrigin.Begin => offset,
             SeekOrigin.Current => position + offset,
             SeekOrigin.End => memory.Length + offset,
-            _ => throw new ArgumentException("The input seek mode is not valid.", nameof(origin))
+            _ => ThrowArgumentExceptionSeekMode(nameof(origin))
         };
 
         position = unchecked((int)index);
 
         return index;
     }
+
+    [DoesNotReturn]
+    static long ThrowArgumentExceptionSeekMode(string paramName)
+        => throw new ArgumentException("The input seek mode is not valid.", paramName);
 
     public override void SetLength(long value) => throw new NotSupportedException();
 

--- a/src/ServiceControl.Infrastructure/ServiceControl.Infrastructure.csproj
+++ b/src/ServiceControl.Infrastructure/ServiceControl.Infrastructure.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     <PackageReference Include="NServiceBus" />
   </ItemGroup>
 

--- a/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
@@ -157,14 +157,7 @@
         }
 
         static string GetContentType(IReadOnlyDictionary<string, string> headers, string defaultContentType)
-        {
-            if (!headers.TryGetValue(Headers.ContentType, out var contentType))
-            {
-                contentType = defaultContentType;
-            }
-
-            return contentType;
-        }
+            => headers.GetValueOrDefault(Headers.ContentType, defaultContentType);
 
         static int MaxProcessingAttempts = 10;
         // large object heap starts above 85000 bytes and not above 85 KB!

--- a/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
@@ -150,9 +150,7 @@
             var uniqueId = context.Headers.UniqueId();
             var documentId = FailedMessageIdGenerator.MakeDocumentId(uniqueId);
 
-            // TODO NSB8 Fix this as soon as we target NET8. We might also need to rethink body access a bit and potentially
-            // remove the memory manager
-            var stream = Memory.Manager.GetStream(context.Body.ToArray());
+            var stream = new ReadOnlyStream(context.Body);
             var putAttachmentCmd = new PutAttachmentCommandData(documentId, "body", stream, contentType, changeVector: null);
 
             parentUnitOfWork.AddCommand(putAttachmentCmd);

--- a/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
@@ -48,8 +48,7 @@
                 {
                     try
                     {
-                        // TODO NSB8 Fix this as soon as we target NET8
-                        var bodyString = utf8.GetString(context.Body.ToArray());
+                        var bodyString = utf8.GetString(context.Body.Span);
                         processingAttempt.MessageMetadata.Add("MsgFullText", bodyString);
                     }
                     catch (ArgumentException)

--- a/src/ServiceControl.Transports.SqlServer/SqlServerTransportCustomization.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlServerTransportCustomization.cs
@@ -2,6 +2,7 @@
 {
     using System.Linq;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
     using NServiceBus;
     using NServiceBus.Configuration.AdvancedExtensibility;
     using NServiceBus.Logging;

--- a/src/ServiceControl.Transports.SqlServer/SqlServerTransportCustomization.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlServerTransportCustomization.cs
@@ -54,13 +54,15 @@
                 Logger.Error("The EnableDtc setting is no longer supported natively within ServiceControl. If you require distributed transactions, you will have to use a Transport Adapter (https://docs.particular.net/servicecontrol/transport-adapter/)");
             }
 
-            // TODO NSB8 replace with UnsafeAccessor?
-            transport.GetType().GetProperty("DisableDelayedDelivery", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(transport, true);
+            DisableDelayedDelivery(transport) = true;
 
             transport.TransportTransactionMode = transport.GetSupportedTransactionModes().Contains(preferredTransactionMode) ? preferredTransactionMode : TransportTransactionMode.ReceiveOnly;
 
             return transport;
         }
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "<DisableDelayedDelivery>k__BackingField")]
+        static extern ref bool DisableDelayedDelivery(SqlServerTransport transport);
 
         const string defaultSubscriptionTableName = "SubscriptionRouting";
 

--- a/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs
+++ b/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs
@@ -49,8 +49,9 @@
                 {
                     Id = errorContext.Message.MessageId,
                     Headers = errorContext.Message.Headers,
-                    Body = errorContext.Message.Body.ToArray() // TODO NSB8 Can this be adjusted?
-                }
+                    Body = errorContext.Message.Body.ToArray()
+                },
+                Id = FailedErrorImport.MakeDocumentId(Guid.NewGuid())
             };
 
             return Handle(errorContext.Exception, failure, cancellationToken);
@@ -70,13 +71,11 @@
 
         async Task DoLogging(Exception exception, FailedErrorImport failure, CancellationToken cancellationToken)
         {
-            failure.Id = FailedErrorImport.MakeDocumentId(Guid.NewGuid());
-
             // Write to data store
             await store.StoreFailedErrorImport(failure);
 
             // Write to Log Path
-            var filePath = Path.Combine(logPath, failure.Id + ".txt");
+            var filePath = Path.Combine(logPath, $"{failure.Id}.txt");
             await File.WriteAllTextAsync(filePath, exception.ToFriendlyString(), cancellationToken);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     <PackageReference Include="NLog.Extensions.Logging" />
     <PackageReference Include="NServiceBus.CustomChecks" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" />


### PR DESCRIPTION
- [x] Check the following scenario: In theory we keep the bulk ingestion around until the messages are completed. But for a transport that uses buffer it is possible for the buffer to go out of scope when a message in the batch failed. In such a case we might actually write garbage. 