### PR TITLE
Make ScatterGather not depend on HttpContext

### DIFF
--- a/src/ServiceControl.UnitTests/ScatterGather/MessageView_ScatterGatherTest.cs
+++ b/src/ServiceControl.UnitTests/ScatterGather/MessageView_ScatterGatherTest.cs
@@ -5,18 +5,17 @@
     using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
+    using CompositeViews.Messages;
     using NUnit.Framework;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.CompositeViews.Messages;
-    using ServiceControl.Persistence.Infrastructure;
 
     abstract class MessageView_ScatterGatherTest
     {
         [SetUp]
         public void SetUp()
         {
-            var api = new TestApi(null, null, null, null);
+            var api = new TestApi(null, null, null);
 
             Results = api.AggregateResults(new ScatterGatherApiMessageViewContext(null, new SortInfo()), GetData());
         }
@@ -67,8 +66,8 @@
 
         class TestApi : ScatterGatherApiMessageView<object, ScatterGatherApiMessageViewContext>
         {
-            public TestApi(object dataStore, Settings settings, IHttpClientFactory httpClientFactory, IHttpContextAccessor httpContextAccessor)
-                : base(dataStore, settings, httpClientFactory, httpContextAccessor)
+            public TestApi(object dataStore, Settings settings, IHttpClientFactory httpClientFactory)
+                : base(dataStore, settings, httpClientFactory)
             {
             }
 

--- a/src/ServiceControl/CompositeViews/AuditCounts/GetAuditCountsForEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/AuditCounts/GetAuditCountsForEndpointApi.cs
@@ -4,11 +4,10 @@
     using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
+    using Messages;
+    using Persistence;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.CompositeViews.Messages;
-    using ServiceControl.Persistence;
-    using ServiceControl.Persistence.Infrastructure;
 
     // The endpoint is included for consistency reasons but is actually not required here because the query
     // is forwarded to the remote instance. But this at least enforces us to declare the controller action
@@ -19,10 +18,10 @@
     public class GetAuditCountsForEndpointApi(
         IErrorMessageDataStore dataStore,
         Settings settings,
-        IHttpClientFactory httpClientFactory,
-        IHttpContextAccessor httpContextAccessor)
+        IHttpClientFactory httpClientFactory
+    )
         : ScatterGatherApi<IErrorMessageDataStore, AuditCountsForEndpointContext, IList<AuditCount>>(dataStore, settings,
-            httpClientFactory, httpContextAccessor)
+            httpClientFactory)
     {
         static readonly IList<AuditCount> Empty = new List<AuditCount>(0).AsReadOnly();
 

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
@@ -3,14 +3,14 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
+    using Persistence;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Persistence;
-    using ServiceControl.Persistence.Infrastructure;
 
     public class GetAllMessagesApi : ScatterGatherApiMessageView<IErrorMessageDataStore, ScatterGatherApiMessageViewWithSystemMessagesContext>
     {
-        public GetAllMessagesApi(IErrorMessageDataStore dataStore, Settings settings, IHttpClientFactory httpClientFactory, IHttpContextAccessor httpContextAccessor) : base(dataStore, settings, httpClientFactory, httpContextAccessor)
+        public GetAllMessagesApi(IErrorMessageDataStore dataStore, Settings settings,
+            IHttpClientFactory httpClientFactory) : base(dataStore, settings, httpClientFactory)
         {
         }
 

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
@@ -3,10 +3,9 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
+    using Persistence;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Persistence;
-    using ServiceControl.Persistence.Infrastructure;
 
     public record AllMessagesForEndpointContext(
         PagingInfo PagingInfo,
@@ -17,7 +16,8 @@ namespace ServiceControl.CompositeViews.Messages
 
     public class GetAllMessagesForEndpointApi : ScatterGatherApiMessageView<IErrorMessageDataStore, AllMessagesForEndpointContext>
     {
-        public GetAllMessagesForEndpointApi(IErrorMessageDataStore dataStore, Settings settings, IHttpClientFactory httpClientFactory, IHttpContextAccessor httpContextAccessor) : base(dataStore, settings, httpClientFactory, httpContextAccessor)
+        public GetAllMessagesForEndpointApi(IErrorMessageDataStore dataStore, Settings settings,
+            IHttpClientFactory httpClientFactory) : base(dataStore, settings, httpClientFactory)
         {
         }
 

--- a/src/ServiceControl/CompositeViews/Messages/GetMessagesByConversationController.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetMessagesByConversationController.cs
@@ -2,6 +2,8 @@
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Infrastructure.WebApi;
+    using Microsoft.AspNetCore.Http.Extensions;
     using Microsoft.AspNetCore.Mvc;
     using Persistence.Infrastructure;
 
@@ -12,8 +14,17 @@
     {
         [Route("conversations/{conversationId:required:minlength(1)}")]
         [HttpGet]
-        public Task<IList<MessagesView>> Messages([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo,
-            [FromQuery(Name = "include_system_messages")] bool includeSystemMessages, string conversationId) =>
-            byConversationApi.Execute(new(pagingInfo, sortInfo, includeSystemMessages, conversationId));
+        public async Task<IList<MessagesView>> Messages([FromQuery] PagingInfo pagingInfo,
+            [FromQuery] SortInfo sortInfo,
+            [FromQuery(Name = "include_system_messages")]
+            bool includeSystemMessages, string conversationId)
+        {
+            QueryResult<IList<MessagesView>> result = await byConversationApi.Execute(
+                new MessagesByConversationContext(pagingInfo, sortInfo, includeSystemMessages, conversationId),
+                Request.GetEncodedPathAndQuery());
+
+            Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
+            return result.Results;
+        }
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
@@ -3,10 +3,9 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
+    using Persistence;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Persistence;
-    using ServiceControl.Persistence.Infrastructure;
 
     public record MessagesByConversationContext(
         PagingInfo PagingInfo,
@@ -18,8 +17,8 @@ namespace ServiceControl.CompositeViews.Messages
     public class MessagesByConversationApi : ScatterGatherApiMessageView<IErrorMessageDataStore, MessagesByConversationContext>
     {
         public MessagesByConversationApi(IErrorMessageDataStore dataStore, Settings settings,
-            IHttpClientFactory httpClientFactory, IHttpContextAccessor httpContextAccessor) : base(dataStore, settings,
-            httpClientFactory, httpContextAccessor)
+            IHttpClientFactory httpClientFactory) : base(dataStore, settings,
+            httpClientFactory)
         {
         }
 

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
@@ -5,14 +5,11 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using System.Text.Json;
     using System.Threading.Tasks;
     using Infrastructure.WebApi;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Http.Extensions;
     using NServiceBus.Logging;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Persistence.Infrastructure;
     using JsonSerializer = System.Text.Json.JsonSerializer;
 
     interface IApi
@@ -30,23 +27,21 @@ namespace ServiceControl.CompositeViews.Messages
         where TIn : ScatterGatherContext
         where TOut : class
     {
-        protected ScatterGatherApi(TDataStore store, Settings settings, IHttpClientFactory httpClientFactory, IHttpContextAccessor httpContextAccessor)
+        protected ScatterGatherApi(TDataStore store, Settings settings, IHttpClientFactory httpClientFactory)
         {
-            this.httpContextAccessor = httpContextAccessor;
             DataStore = store;
             Settings = settings;
             HttpClientFactory = httpClientFactory;
-            Logger = LogManager.GetLogger(GetType());
+            logger = LogManager.GetLogger(GetType());
         }
 
         protected TDataStore DataStore { get; }
         Settings Settings { get; }
         IHttpClientFactory HttpClientFactory { get; }
 
-        public async Task<TOut> Execute(TIn input)
+        public async Task<QueryResult<TOut>> Execute(TIn input, string pathAndQuery)
         {
             var remotes = Settings.RemoteInstances;
-            var pathAndQuery = httpContextAccessor.HttpContext!.Request.GetEncodedPathAndQuery();
             var instanceId = Settings.InstanceId;
             var tasks = new List<Task<QueryResult<TOut>>>(remotes.Length + 1)
             {
@@ -65,9 +60,7 @@ namespace ServiceControl.CompositeViews.Messages
             var results = await Task.WhenAll(tasks);
             var response = AggregateResults(input, results);
 
-            httpContextAccessor.HttpContext!.Response.WithQueryStatsAndPagingInfo(response.QueryStats, input.PagingInfo);
-
-            return response.Results;
+            return response;
         }
 
         async Task<QueryResult<TOut>> LocalCall(TIn input, string instanceId)
@@ -127,18 +120,19 @@ namespace ServiceControl.CompositeViews.Messages
             catch (HttpRequestException httpRequestException)
             {
                 remoteInstanceSetting.TemporarilyUnavailable = true;
-                Logger.Warn($"An HttpRequestException occurred when querying remote instance at {remoteInstanceSetting.BaseAddress}. The instance at uri: {remoteInstanceSetting.BaseAddress} will be temporarily disabled.",
+                logger.Warn(
+                    $"An HttpRequestException occurred when querying remote instance at {remoteInstanceSetting.BaseAddress}. The instance at uri: {remoteInstanceSetting.BaseAddress} will be temporarily disabled.",
                     httpRequestException);
                 return QueryResult<TOut>.Empty();
             }
             catch (OperationCanceledException)
             {
-                Logger.Warn($"Failed to query remote instance at {remoteInstanceSetting.BaseAddress} due to a timeout");
+                logger.Warn($"Failed to query remote instance at {remoteInstanceSetting.BaseAddress} due to a timeout");
                 return QueryResult<TOut>.Empty();
             }
             catch (Exception exception)
             {
-                Logger.Warn($"Failed to query remote instance at {remoteInstanceSetting.BaseAddress}.", exception);
+                logger.Warn($"Failed to query remote instance at {remoteInstanceSetting.BaseAddress}.", exception);
                 return QueryResult<TOut>.Empty();
             }
         }
@@ -168,7 +162,6 @@ namespace ServiceControl.CompositeViews.Messages
             return new QueryResult<TOut>(remoteResults, new QueryStatsInfo(etag, totalCount, isStale: false));
         }
 
-        readonly ILog Logger;
-        readonly IHttpContextAccessor httpContextAccessor;
+        readonly ILog logger;
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApiMessageView.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApiMessageView.cs
@@ -3,9 +3,8 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
-    using Microsoft.AspNetCore.Http;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Persistence.Infrastructure;
 
     public record ScatterGatherApiMessageViewWithSystemMessagesContext(
         PagingInfo PagingInfo,
@@ -17,7 +16,8 @@ namespace ServiceControl.CompositeViews.Messages
     public abstract class ScatterGatherApiMessageView<TDataStore, TInput> : ScatterGatherApi<TDataStore, TInput, IList<MessagesView>>
         where TInput : ScatterGatherApiMessageViewContext
     {
-        protected ScatterGatherApiMessageView(TDataStore dataStore, Settings settings, IHttpClientFactory httpClientFactory, IHttpContextAccessor httpContextAccessor) : base(dataStore, settings, httpClientFactory, httpContextAccessor)
+        protected ScatterGatherApiMessageView(TDataStore dataStore, Settings settings,
+            IHttpClientFactory httpClientFactory) : base(dataStore, settings, httpClientFactory)
         {
         }
 

--- a/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
@@ -3,10 +3,9 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
+    using Persistence;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Persistence;
-    using ServiceControl.Persistence.Infrastructure;
 
     public record SearchApiContext(
         PagingInfo PagingInfo,
@@ -16,9 +15,8 @@ namespace ServiceControl.CompositeViews.Messages
 
     public class SearchApi : ScatterGatherApiMessageView<IErrorMessageDataStore, SearchApiContext>
     {
-        public SearchApi(IErrorMessageDataStore dataStore, Settings settings, IHttpClientFactory httpClientFactory,
-            IHttpContextAccessor httpContextAccessor) : base(dataStore, settings, httpClientFactory,
-            httpContextAccessor)
+        public SearchApi(IErrorMessageDataStore dataStore, Settings settings, IHttpClientFactory httpClientFactory) :
+            base(dataStore, settings, httpClientFactory)
         {
         }
 

--- a/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
@@ -3,10 +3,9 @@ namespace ServiceControl.CompositeViews.Messages
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Http;
+    using Persistence;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Persistence;
-    using ServiceControl.Persistence.Infrastructure;
 
     public record SearchEndpointContext(
         PagingInfo PagingInfo,
@@ -18,9 +17,7 @@ namespace ServiceControl.CompositeViews.Messages
     public class SearchEndpointApi : ScatterGatherApiMessageView<IErrorMessageDataStore, SearchEndpointContext>
     {
         public SearchEndpointApi(IErrorMessageDataStore dataStore, Settings settings,
-            IHttpClientFactory httpClientFactory,
-            IHttpContextAccessor httpContextAccessor) : base(dataStore, settings, httpClientFactory,
-            httpContextAccessor)
+            IHttpClientFactory httpClientFactory) : base(dataStore, settings, httpClientFactory)
         {
         }
 

--- a/src/ServiceControl/Infrastructure/WebApi/HttpResponseExtensions.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/HttpResponseExtensions.cs
@@ -7,7 +7,7 @@ namespace ServiceControl.Infrastructure.WebApi
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.WebUtilities;
     using Microsoft.Extensions.Primitives;
-    using ServiceControl.Persistence.Infrastructure;
+    using Persistence.Infrastructure;
 
     static class HttpResponseExtensions
     {

--- a/src/ServiceControl/Monitoring/Web/EndpointsMonitoringController.cs
+++ b/src/ServiceControl/Monitoring/Web/EndpointsMonitoringController.cs
@@ -3,11 +3,13 @@
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using CompositeViews.Messages;
+    using Infrastructure.WebApi;
+    using Microsoft.AspNetCore.Http.Extensions;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Primitives;
-    using ServiceControl.CompositeViews.Messages;
-    using ServiceControl.Persistence;
-    using ServiceControl.Persistence.Infrastructure;
+    using Persistence;
+    using Persistence.Infrastructure;
 
     public class EndpointUpdateModel
     {
@@ -56,7 +58,14 @@
 
         [Route("endpoints/known")]
         [HttpGet]
-        public Task<IList<KnownEndpointsView>> KnownEndpoints([FromQuery] PagingInfo pagingInfo) => knownEndpointsApi.Execute(new ScatterGatherContext(pagingInfo));
+        public async Task<IList<KnownEndpointsView>> KnownEndpoints([FromQuery] PagingInfo pagingInfo)
+        {
+            QueryResult<IList<KnownEndpointsView>> result =
+                await knownEndpointsApi.Execute(new ScatterGatherContext(pagingInfo), Request.GetEncodedPathAndQuery());
+
+            Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
+            return result.Results;
+        }
 
         [Route("endpoints/{endpointId}")]
         [HttpPatch]

--- a/src/ServiceControl/Monitoring/Web/GetKnownEndpointsApi.cs
+++ b/src/ServiceControl/Monitoring/Web/GetKnownEndpointsApi.cs
@@ -5,12 +5,16 @@
     using System.Net.Http;
     using System.Threading.Tasks;
     using CompositeViews.Messages;
-    using Microsoft.AspNetCore.Http;
+    using Persistence;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Persistence;
-    using ServiceControl.Persistence.Infrastructure;
 
-    public class GetKnownEndpointsApi(IEndpointInstanceMonitoring store, Settings settings, IHttpClientFactory httpClientFactory, IHttpContextAccessor httpContextAccessor) : ScatterGatherApi<IEndpointInstanceMonitoring, ScatterGatherContext, IList<KnownEndpointsView>>(store, settings, httpClientFactory, httpContextAccessor)
+    public class GetKnownEndpointsApi(
+        IEndpointInstanceMonitoring store,
+        Settings settings,
+        IHttpClientFactory httpClientFactory)
+        : ScatterGatherApi<IEndpointInstanceMonitoring, ScatterGatherContext, IList<KnownEndpointsView>>(store,
+            settings, httpClientFactory)
     {
         protected override Task<QueryResult<IList<KnownEndpointsView>>> LocalQuery(ScatterGatherContext input)
         {

--- a/src/ServiceControl/SagaAudit/GetSagaByIdApi.cs
+++ b/src/ServiceControl/SagaAudit/GetSagaByIdApi.cs
@@ -5,16 +5,16 @@ namespace ServiceControl.SagaAudit
     using System.Net.Http;
     using System.Threading.Tasks;
     using CompositeViews.Messages;
-    using Microsoft.AspNetCore.Http;
+    using Persistence;
+    using Persistence.Infrastructure;
     using ServiceBus.Management.Infrastructure.Settings;
-    using ServiceControl.Persistence;
-    using ServiceControl.Persistence.Infrastructure;
 
     public record SagaByIdContext(PagingInfo PagingInfo, Guid SagaId) : ScatterGatherContext(PagingInfo);
 
     public class GetSagaByIdApi : ScatterGatherApi<ISagaAuditDataStore, SagaByIdContext, SagaHistory>
     {
-        public GetSagaByIdApi(ISagaAuditDataStore dataStore, Settings settings, IHttpClientFactory httpClientFactory, IHttpContextAccessor httpContextAccessor) : base(dataStore, settings, httpClientFactory, httpContextAccessor)
+        public GetSagaByIdApi(ISagaAuditDataStore dataStore, Settings settings, IHttpClientFactory httpClientFactory) :
+            base(dataStore, settings, httpClientFactory)
         {
         }
 

--- a/src/ServiceControl/SagaAudit/SagasController.cs
+++ b/src/ServiceControl/SagaAudit/SagasController.cs
@@ -2,8 +2,10 @@ namespace ServiceControl.SagaAudit
 {
     using System;
     using System.Threading.Tasks;
+    using Infrastructure.WebApi;
+    using Microsoft.AspNetCore.Http.Extensions;
     using Microsoft.AspNetCore.Mvc;
-    using ServiceControl.Persistence.Infrastructure;
+    using Persistence.Infrastructure;
 
     [ApiController]
     [Route("api")]
@@ -11,6 +13,13 @@ namespace ServiceControl.SagaAudit
     {
         [Route("sagas/{id}")]
         [HttpGet]
-        public Task<SagaHistory> Sagas([FromQuery] PagingInfo pagingInfo, Guid id) => getSagaByIdApi.Execute(new SagaByIdContext(pagingInfo, id));
+        public async Task<SagaHistory> Sagas([FromQuery] PagingInfo pagingInfo, Guid id)
+        {
+            QueryResult<SagaHistory> result =
+                await getSagaByIdApi.Execute(new SagaByIdContext(pagingInfo, id), Request.GetEncodedPathAndQuery());
+
+            Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
+            return result.Results;
+        }
     }
 }


### PR DESCRIPTION
This is a requirement for [#tf-cs3601-enable-the-platform-report-on-endpoint](https://particularsoftware.slack.com/archives/C06CUKQ3668), where we need to use some functionality of scatter-gather from outside the HTTP context.