### PR TITLE
Logging fixes and improvements

### DIFF
--- a/src/ServiceControl.AcceptanceTests.RavenDB/StartupModeTests.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/StartupModeTests.cs
@@ -54,7 +54,7 @@
 
         [Test]
         public async Task CanRunImportFailedMessagesMode()
-            => await new TestableImportFailedErrorsCommand().Execute(new HostArguments(Array.Empty<string>()), settings, new LoggingSettings());
+            => await new TestableImportFailedErrorsCommand().Execute(new HostArguments(Array.Empty<string>()), settings);
 
         class TestableImportFailedErrorsCommand : ImportFailedErrorsCommand
         {

--- a/src/ServiceControl.AcceptanceTests.RavenDB/StartupModeTests.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/StartupModeTests.cs
@@ -6,7 +6,6 @@
     using Microsoft.Extensions.Hosting;
     using NServiceBus;
     using NUnit.Framework;
-    using Particular.ServiceControl;
     using Particular.ServiceControl.Hosting;
     using Persistence;
     using Persistence.RavenDB;
@@ -55,7 +54,7 @@
 
         [Test]
         public async Task CanRunImportFailedMessagesMode()
-            => await new TestableImportFailedErrorsCommand().Execute(new HostArguments(Array.Empty<string>()), settings);
+            => await new TestableImportFailedErrorsCommand().Execute(new HostArguments(Array.Empty<string>()), settings, new LoggingSettings());
 
         class TestableImportFailedErrorsCommand : ImportFailedErrorsCommand
         {
@@ -63,7 +62,7 @@
             {
                 var configuration = base.CreateEndpointConfiguration(settings);
 
-                //HINT: we want to exclude this assembly to prevent loading features that are part of the acceptance testing framework  
+                //HINT: we want to exclude this assembly to prevent loading features that are part of the acceptance testing framework
                 var thisAssembly = new[] { typeof(StartupModeTests).Assembly.GetName().Name };
 
                 configuration.AssemblyScanner().ExcludeAssemblies(thisAssembly);

--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -92,10 +92,14 @@
             setSettings(settings);
             Settings = settings;
 
+            var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(logPath);
+            var loggingSettings = new LoggingSettings(defaultLevel: LogLevel.Debug, logPath: logPath);
+
             using (new DiagnosticTimer($"Creating infrastructure for {instanceName}"))
             {
                 var setupCommand = new SetupCommand();
-                await setupCommand.Execute(new HostArguments(Array.Empty<string>()), settings);
+                await setupCommand.Execute(new HostArguments([]), settings, loggingSettings);
             }
 
             var configuration = new EndpointConfiguration(instanceName);
@@ -105,10 +109,6 @@
 
             using (new DiagnosticTimer($"Starting ServiceControl {instanceName}"))
             {
-                var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-                Directory.CreateDirectory(logPath);
-
-                var loggingSettings = new LoggingSettings(settings.ServiceName, defaultLevel: LogLevel.Debug, logPath: logPath);
                 var hostBuilder = WebApplication.CreateBuilder(new WebApplicationOptions
                 {
                     // Force the DI container to run the dependency resolution check to verify all dependencies can be resolved

--- a/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -88,10 +88,15 @@ namespace ServiceControl.Audit.AcceptanceTests.TestSupport
                 ConfigurationManager.AppSettings.Set($"ServiceControl.Audit/{persisterSpecificSetting.Key}", persisterSpecificSetting.Value);
             }
 
+            var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(logPath);
+
+            var loggingSettings = new LoggingSettings(defaultLevel: NLog.LogLevel.Debug, logPath: logPath);
+
             using (new DiagnosticTimer($"Creating infrastructure for {instanceName}"))
             {
                 var setupCommand = new SetupCommand();
-                await setupCommand.Execute(new HostArguments(Array.Empty<string>()), settings);
+                await setupCommand.Execute(new HostArguments([]), settings, loggingSettings);
             }
 
             var configuration = new EndpointConfiguration(instanceName);
@@ -101,10 +106,6 @@ namespace ServiceControl.Audit.AcceptanceTests.TestSupport
 
             using (new DiagnosticTimer($"Starting ServiceControl {instanceName}"))
             {
-                var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-                Directory.CreateDirectory(logPath);
-
-                var loggingSettings = new LoggingSettings(settings.ServiceName, defaultLevel: NLog.LogLevel.Debug, logPath: logPath);
                 var hostBuilder = WebApplication.CreateBuilder(new WebApplicationOptions
                 {
                     // Force the DI container to run the dependency resolution check to verify all dependencies can be resolved

--- a/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
@@ -30,10 +30,7 @@
 
             var settings = CreateTestSettings();
 
-            var controller = new RootController(
-                new LoggingSettings(),
-                settings
-            )
+            var controller = new RootController(settings)
             {
                 ControllerContext = controllerContext,
                 Url = new UrlHelper(actionContext)

--- a/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
@@ -31,7 +31,7 @@
             var settings = CreateTestSettings();
 
             var controller = new RootController(
-                new LoggingSettings("testEndpoint"),
+                new LoggingSettings(),
                 settings
             )
             {

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -1,4 +1,11 @@
 {
+  "LoggingSettings": {
+    "LogLevel": {
+      "Name": "Info",
+      "Ordinal": 2
+    },
+    "LogPath": "C:\\Logs"
+  },
   "MessageFilter": null,
   "ValidateConfiguration": true,
   "SkipQueueCreation": false,

--- a/src/ServiceControl.Audit.UnitTests/Infrastructure/When_instance_is_setup.cs
+++ b/src/ServiceControl.Audit.UnitTests/Infrastructure/When_instance_is_setup.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Audit.Infrastructure;
     using Audit.Infrastructure.Hosting;
     using Audit.Infrastructure.Hosting.Commands;
     using Audit.Infrastructure.Settings;
@@ -28,7 +27,7 @@
             };
 
             var setupCommand = new SetupCommand();
-            await setupCommand.Execute(new HostArguments(Array.Empty<string>()), settings);
+            await setupCommand.Execute(new HostArguments([]), settings, new LoggingSettings());
 
             CollectionAssert.AreEquivalent(new[]
             {

--- a/src/ServiceControl.Audit.UnitTests/Infrastructure/When_instance_is_setup.cs
+++ b/src/ServiceControl.Audit.UnitTests/Infrastructure/When_instance_is_setup.cs
@@ -27,7 +27,7 @@
             };
 
             var setupCommand = new SetupCommand();
-            await setupCommand.Execute(new HostArguments([]), settings, new LoggingSettings());
+            await setupCommand.Execute(new HostArguments([]), settings);
 
             CollectionAssert.AreEquivalent(new[]
             {

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -27,7 +27,6 @@
             TransportSettings transportSettings,
             Metrics metrics,
             IFailedAuditStorage failedImportsStorage,
-            LoggingSettings loggingSettings,
             AuditIngestionCustomCheck.State ingestionState,
             AuditIngestor auditIngestor,
             IAuditIngestionUnitOfWorkFactory unitOfWorkFactory,
@@ -53,7 +52,7 @@
                 FullMode = BoundedChannelFullMode.Wait
             });
 
-            errorHandlingPolicy = new AuditIngestionFaultPolicy(failedImportsStorage, loggingSettings, OnCriticalError);
+            errorHandlingPolicy = new AuditIngestionFaultPolicy(failedImportsStorage, settings.LoggingSettings, OnCriticalError);
 
             watchdog = new Watchdog("audit message ingestion", EnsureStarted, EnsureStopped, ingestionState.ReportError, ingestionState.Clear, settings.TimeToRestartAuditIngestionAfterFailure, logger);
 

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/AbstractCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/AbstractCommand.cs
@@ -5,6 +5,6 @@
 
     abstract class AbstractCommand
     {
-        public abstract Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings);
+        public abstract Task Execute(HostArguments args, Settings settings);
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/AbstractCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/AbstractCommand.cs
@@ -1,9 +1,10 @@
 ﻿namespace ServiceControl.Audit.Infrastructure.Hosting.Commands
 {
     using System.Threading.Tasks;
+    using ServiceControl.Audit.Infrastructure.Settings;
 
     abstract class AbstractCommand
     {
-        public abstract Task Execute(HostArguments args, Settings.Settings settings);
+        public abstract Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings);
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/CommandRunner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/CommandRunner.cs
@@ -3,15 +3,16 @@
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using ServiceControl.Audit.Infrastructure.Settings;
 
     class CommandRunner(List<Type> commands)
     {
-        public async Task Execute(HostArguments args, Settings.Settings settings)
+        public async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
         {
             foreach (var commandType in commands)
             {
                 var command = (AbstractCommand)Activator.CreateInstance(commandType);
-                await command.Execute(args, settings);
+                await command.Execute(args, settings, loggingSettings);
             }
         }
     }

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/CommandRunner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/CommandRunner.cs
@@ -7,12 +7,12 @@
 
     class CommandRunner(List<Type> commands)
     {
-        public async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
+        public async Task Execute(HostArguments args, Settings settings)
         {
             foreach (var commandType in commands)
             {
                 var command = (AbstractCommand)Activator.CreateInstance(commandType);
-                await command.Execute(args, settings, loggingSettings);
+                await command.Execute(args, settings);
             }
         }
     }

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
@@ -11,7 +11,7 @@
 
     class ImportFailedAuditsCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
+        public override async Task Execute(HostArguments args, Settings settings)
         {
             settings.IngestAuditMessages = false;
 
@@ -24,7 +24,7 @@
             {
                 tokenSource.Cancel();
                 return Task.CompletedTask;
-            }, settings, endpointConfiguration, loggingSettings);
+            }, settings, endpointConfiguration);
 
             using var app = hostBuilder.Build();
             await app.StartAsync(tokenSource.Token);

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
@@ -6,18 +6,16 @@
     using Auditing;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
-    using NLog;
     using NServiceBus;
     using Settings;
 
     class ImportFailedAuditsCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings)
+        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
         {
             settings.IngestAuditMessages = false;
 
             var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
-            var loggingSettings = new LoggingSettings(settings.ServiceName, LogLevel.Info);
 
             using var tokenSource = new CancellationTokenSource();
 

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/MaintenanceModeCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/MaintenanceModeCommand.cs
@@ -9,7 +9,7 @@
 
     class MaintenanceModeCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
+        public override async Task Execute(HostArguments args, Settings settings)
         {
             var persistenceConfiguration = PersistenceConfigurationFactory.LoadPersistenceConfiguration(settings.PersistenceType);
             var persistenceSettings = persistenceConfiguration.BuildPersistenceSettings(settings);

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/MaintenanceModeCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/MaintenanceModeCommand.cs
@@ -5,10 +5,11 @@
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Hosting.WindowsServices;
     using Persistence;
+    using ServiceControl.Audit.Infrastructure.Settings;
 
     class MaintenanceModeCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings.Settings settings)
+        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
         {
             var persistenceConfiguration = PersistenceConfigurationFactory.LoadPersistenceConfiguration(settings.PersistenceType);
             var persistenceSettings = persistenceConfiguration.BuildPersistenceSettings(settings);

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/RunCommand.cs
@@ -8,7 +8,7 @@
 
     class RunCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
+        public override async Task Execute(HostArguments args, Settings settings)
         {
             var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
             var assemblyScanner = endpointConfiguration.AssemblyScanner();
@@ -19,7 +19,7 @@
             {
                 //Do nothing. The transports in NSB 8 are designed to handle broker outages. Audit ingestion will be paused when broker is unavailable.
                 return Task.CompletedTask;
-            }, settings, endpointConfiguration, loggingSettings);
+            }, settings, endpointConfiguration);
             hostBuilder.AddServiceControlAuditApi();
 
             var app = hostBuilder.Build();

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/RunCommand.cs
@@ -8,13 +8,11 @@
 
     class RunCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings)
+        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
         {
             var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
             var assemblyScanner = endpointConfiguration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
-
-            var loggingSettings = new LoggingSettings(settings.ServiceName);
 
             var hostBuilder = WebApplication.CreateBuilder();
             hostBuilder.AddServiceControlAudit((_, __) =>

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
@@ -10,7 +10,7 @@
 
     class SetupCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings)
+        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
         {
             settings.SkipQueueCreation = args.SkipQueueCreation;
 

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
@@ -10,7 +10,7 @@
 
     class SetupCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
+        public override async Task Execute(HostArguments args, Settings settings)
         {
             settings.SkipQueueCreation = args.SkipQueueCreation;
 

--- a/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
@@ -50,8 +50,8 @@ namespace ServiceControl.Audit.Infrastructure
             nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget));
 
             // Defaults
-            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel, fileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel < LogLevel.Info ? loggingSettings.LoggingLevel : LogLevel.Info, consoleTarget));
+            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel, fileTarget));
+            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel < LogLevel.Info ? loggingSettings.LogLevel : LogLevel.Info, consoleTarget));
 
             NLog.LogManager.Configuration = nlogConfig;
 
@@ -59,7 +59,7 @@ namespace ServiceControl.Audit.Infrastructure
 
             var logger = LogManager.GetLogger("LoggingConfiguration");
             var logEventInfo = new LogEventInfo { TimeStamp = DateTime.UtcNow };
-            logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), loggingSettings.LoggingLevel.Name);
+            logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), loggingSettings.LogLevel.Name);
         }
 
         const long megaByte = 1024 * 1024;

--- a/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
@@ -1,9 +1,7 @@
 namespace ServiceControl.Audit.Infrastructure
 {
     using System;
-    using System.Diagnostics;
     using System.IO;
-    using System.Linq;
     using NLog;
     using NLog.Config;
     using NLog.Extensions.Logging;
@@ -23,81 +21,47 @@ namespace ServiceControl.Audit.Infrastructure
                 return;
             }
 
-            var version = FileVersionInfo.GetVersionInfo(typeof(LoggingConfigurator).Assembly.Location).ProductVersion;
             var nlogConfig = new LoggingConfiguration();
             var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:|${exception:format=tostring}}");
-            var header = $@"-------------------------------------------------------------
-ServiceControl Audit Version:				{version}
--------------------------------------------------------------";
 
             var fileTarget = new FileTarget
             {
+                Name = "file",
                 ArchiveEvery = FileArchivePeriod.Day,
                 FileName = Path.Combine(loggingSettings.LogPath, "logfile.${shortdate}.txt"),
                 ArchiveFileName = Path.Combine(loggingSettings.LogPath, "logfile.{#}.txt"),
                 ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
                 Layout = simpleLayout,
                 MaxArchiveFiles = 14,
-                ArchiveAboveSize = 30 * MegaByte
-            };
-
-            var ravenFileTarget = new FileTarget
-            {
-                ArchiveEvery = FileArchivePeriod.Day,
-                FileName = Path.Combine(loggingSettings.LogPath, "ravenlog.${shortdate}.txt"),
-                ArchiveFileName = Path.Combine(loggingSettings.LogPath, "ravenlog.{#}.txt"),
-                ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
-                Layout = simpleLayout,
-                MaxArchiveFiles = 14,
-                ArchiveAboveSize = 30 * MegaByte
+                ArchiveAboveSize = 30 * megaByte
             };
 
             var consoleTarget = new ColoredConsoleTarget
             {
+                Name = "console",
                 Layout = simpleLayout,
+                DetectConsoleAvailable = true,
+                DetectOutputRedirected = true,
                 UseDefaultRowHighlightingRules = true
             };
 
-            var nullTarget = new NullTarget();
-
-            nlogConfig.AddTarget("console", consoleTarget);
-            nlogConfig.AddTarget("debugger", fileTarget);
-            nlogConfig.AddTarget("raven", ravenFileTarget);
-            nlogConfig.AddTarget("null", nullTarget);
-
             // Always want to see license logging regardless of default logging level
             nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, fileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget)
-            {
-                Final = true
-            });
-
+            nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget));
 
             // Defaults
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel, fileTarget));
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel < LogLevel.Info ? loggingSettings.LoggingLevel : LogLevel.Info, consoleTarget));
-
-
-            if (!loggingSettings.LogToConsole)
-            {
-                foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
-                {
-                    nlogConfig.LoggingRules.Remove(rule);
-                }
-            }
 
             NLog.LogManager.Configuration = nlogConfig;
 
             LogManager.UseFactory(new ExtensionsLoggerFactory(new NLogLoggerFactory()));
 
             var logger = LogManager.GetLogger("LoggingConfiguration");
-            var logEventInfo = new LogEventInfo
-            {
-                TimeStamp = DateTime.UtcNow
-            };
+            var logEventInfo = new LogEventInfo { TimeStamp = DateTime.UtcNow };
             logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), loggingSettings.LoggingLevel.Name);
         }
 
-        const long MegaByte = 1024 * 1024;
+        const long megaByte = 1024 * 1024;
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Audit/Infrastructure/LoggingConfigurator.cs
@@ -1,18 +1,18 @@
 namespace ServiceControl.Audit.Infrastructure
 {
+    using System;
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using NLog;
     using NLog.Config;
+    using NLog.Extensions.Logging;
     using NLog.Layouts;
     using NLog.Targets;
     using NServiceBus.Extensions.Logging;
-    using LogManager = NServiceBus.Logging.LogManager;
     using Settings;
     using LogLevel = NLog.LogLevel;
-    using NLog.Extensions.Logging;
-    using NLog;
-    using System;
+    using LogManager = NServiceBus.Logging.LogManager;
 
     static class LoggingConfigurator
     {

--- a/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
@@ -9,13 +9,12 @@ namespace ServiceControl.Audit.Infrastructure
     using NServiceBus;
     using NServiceBus.Configuration.AdvancedExtensibility;
     using ServiceControl.Infrastructure;
-    using Settings;
     using Transports;
 
     static class NServiceBusFactory
     {
         public static void Configure(Settings.Settings settings, ITransportCustomization transportCustomization,
-            TransportSettings transportSettings, LoggingSettings loggingSettings,
+            TransportSettings transportSettings,
             Func<ICriticalErrorContext, CancellationToken, Task> onCriticalError, EndpointConfiguration configuration)
         {
             var endpointName = settings.ServiceName;
@@ -47,8 +46,8 @@ namespace ServiceControl.Audit.Infrastructure
                 configuration.ReportCustomChecksTo(settings.ServiceControlQueueAddress);
             }
 
-            configuration.GetSettings().Set(loggingSettings);
-            configuration.SetDiagnosticsPath(loggingSettings.LogPath);
+            configuration.GetSettings().Set(settings.LoggingSettings);
+            configuration.SetDiagnosticsPath(settings.LoggingSettings.LogPath);
 
             configuration.UseSerialization<NewtonsoftJsonSerializer>();
 

--- a/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
@@ -8,7 +8,7 @@ namespace ServiceControl.Audit.Infrastructure.Settings
 
     public class LoggingSettings(LogLevel defaultLevel = null, string logPath = null)
     {
-        public LogLevel LoggingLevel { get; } = InitializeLogLevel(defaultLevel);
+        public LogLevel LogLevel { get; } = InitializeLogLevel(defaultLevel);
 
         public string LogPath { get; } = SettingsReader.Read(Settings.SettingsRootNamespace, "LogPath", Environment.ExpandEnvironmentVariables(logPath ?? DefaultLogLocation()));
 
@@ -38,14 +38,14 @@ namespace ServiceControl.Audit.Infrastructure.Settings
         // debugging or if the entry is removed manually. In those circumstances default to the folder containing the exe
         static string DefaultLogLocation() => Path.Combine(AppContext.BaseDirectory, ".logs");
 
-        public Microsoft.Extensions.Logging.LogLevel ToHostLogLevel() => LoggingLevel switch
+        public Microsoft.Extensions.Logging.LogLevel ToHostLogLevel() => LogLevel switch
         {
-            _ when LoggingLevel == LogLevel.Trace => Microsoft.Extensions.Logging.LogLevel.Trace,
-            _ when LoggingLevel == LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
-            _ when LoggingLevel == LogLevel.Info => Microsoft.Extensions.Logging.LogLevel.Information,
-            _ when LoggingLevel == LogLevel.Warn => Microsoft.Extensions.Logging.LogLevel.Warning,
-            _ when LoggingLevel == LogLevel.Error => Microsoft.Extensions.Logging.LogLevel.Error,
-            _ when LoggingLevel == LogLevel.Fatal => Microsoft.Extensions.Logging.LogLevel.Critical,
+            _ when LogLevel == LogLevel.Trace => Microsoft.Extensions.Logging.LogLevel.Trace,
+            _ when LogLevel == LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
+            _ when LogLevel == LogLevel.Info => Microsoft.Extensions.Logging.LogLevel.Information,
+            _ when LogLevel == LogLevel.Warn => Microsoft.Extensions.Logging.LogLevel.Warning,
+            _ when LogLevel == LogLevel.Error => Microsoft.Extensions.Logging.LogLevel.Error,
+            _ when LogLevel == LogLevel.Fatal => Microsoft.Extensions.Logging.LogLevel.Critical,
             _ => Microsoft.Extensions.Logging.LogLevel.None
         };
 

--- a/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
@@ -9,7 +9,7 @@ namespace ServiceControl.Audit.Infrastructure.Settings
 
     public class LoggingSettings
     {
-        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, string logPath = null)
+        public LoggingSettings(LogLevel defaultLevel = null, string logPath = null)
         {
             LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
             LogPath = SettingsReader.Read(Settings.SettingsRootNamespace, "LogPath", Environment.ExpandEnvironmentVariables(logPath ?? DefaultLogLocation()));

--- a/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
@@ -9,18 +9,15 @@ namespace ServiceControl.Audit.Infrastructure.Settings
 
     public class LoggingSettings
     {
-        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, string logPath = null, bool logToConsole = true)
+        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, string logPath = null)
         {
             LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
             LogPath = SettingsReader.Read(Settings.SettingsRootNamespace, "LogPath", Environment.ExpandEnvironmentVariables(logPath ?? DefaultLogLocation()));
-            LogToConsole = logToConsole;
         }
 
         public LogLevel LoggingLevel { get; }
 
         public string LogPath { get; }
-
-        public bool LogToConsole { get; }
 
         LogLevel InitializeLevel(string key, LogLevel defaultLevel)
         {

--- a/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/LoggingSettings.cs
@@ -2,26 +2,22 @@ namespace ServiceControl.Audit.Infrastructure.Settings
 {
     using System;
     using System.IO;
-    using System.Reflection;
     using Configuration;
     using NLog;
     using NLog.Common;
 
-    public class LoggingSettings
+    public class LoggingSettings(LogLevel defaultLevel = null, string logPath = null)
     {
-        public LoggingSettings(LogLevel defaultLevel = null, string logPath = null)
+        public LogLevel LoggingLevel { get; } = InitializeLogLevel(defaultLevel);
+
+        public string LogPath { get; } = SettingsReader.Read(Settings.SettingsRootNamespace, "LogPath", Environment.ExpandEnvironmentVariables(logPath ?? DefaultLogLocation()));
+
+        static LogLevel InitializeLogLevel(LogLevel defaultLevel)
         {
-            LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
-            LogPath = SettingsReader.Read(Settings.SettingsRootNamespace, "LogPath", Environment.ExpandEnvironmentVariables(logPath ?? DefaultLogLocation()));
-        }
+            defaultLevel ??= LogLevel.Info;
 
-        public LogLevel LoggingLevel { get; }
+            var levelText = SettingsReader.Read<string>(Settings.SettingsRootNamespace, logLevelKey);
 
-        public string LogPath { get; }
-
-        LogLevel InitializeLevel(string key, LogLevel defaultLevel)
-        {
-            var levelText = SettingsReader.Read<string>(Settings.SettingsRootNamespace, key);
             if (string.IsNullOrWhiteSpace(levelText))
             {
                 return defaultLevel;
@@ -33,47 +29,26 @@ namespace ServiceControl.Audit.Infrastructure.Settings
             }
             catch
             {
-                InternalLogger.Warn($"Failed to parse {key} setting. Defaulting to {defaultLevel.Name}.");
+                InternalLogger.Warn($"Failed to parse {logLevelKey} setting. Defaulting to {defaultLevel.Name}.");
                 return defaultLevel;
             }
         }
 
         // SC installer always populates LogPath in app.config on installation/change/upgrade so this will only be used when
         // debugging or if the entry is removed manually. In those circumstances default to the folder containing the exe
-        static string DefaultLogLocation()
-        {
-            var assemblyLocation = Assembly.GetExecutingAssembly().Location;
-            return Path.Combine(Path.GetDirectoryName(assemblyLocation), ".logs");
-        }
+        static string DefaultLogLocation() => Path.Combine(AppContext.BaseDirectory, ".logs");
 
-        public Microsoft.Extensions.Logging.LogLevel ToHostLogLevel()
+        public Microsoft.Extensions.Logging.LogLevel ToHostLogLevel() => LoggingLevel switch
         {
-            if (LoggingLevel == LogLevel.Debug)
-            {
-                return Microsoft.Extensions.Logging.LogLevel.Debug;
-            }
-            if (LoggingLevel == LogLevel.Error)
-            {
-                return Microsoft.Extensions.Logging.LogLevel.Error;
-            }
-            if (LoggingLevel == LogLevel.Fatal)
-            {
-                return Microsoft.Extensions.Logging.LogLevel.Critical;
-            }
-            if (LoggingLevel == LogLevel.Warn)
-            {
-                return Microsoft.Extensions.Logging.LogLevel.Warning;
-            }
-            if (LoggingLevel == LogLevel.Info)
-            {
-                return Microsoft.Extensions.Logging.LogLevel.Information;
-            }
-            if (LoggingLevel == LogLevel.Trace)
-            {
-                return Microsoft.Extensions.Logging.LogLevel.Trace;
-            }
+            _ when LoggingLevel == LogLevel.Trace => Microsoft.Extensions.Logging.LogLevel.Trace,
+            _ when LoggingLevel == LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
+            _ when LoggingLevel == LogLevel.Info => Microsoft.Extensions.Logging.LogLevel.Information,
+            _ when LoggingLevel == LogLevel.Warn => Microsoft.Extensions.Logging.LogLevel.Warning,
+            _ when LoggingLevel == LogLevel.Error => Microsoft.Extensions.Logging.LogLevel.Error,
+            _ when LoggingLevel == LogLevel.Fatal => Microsoft.Extensions.Logging.LogLevel.Critical,
+            _ => Microsoft.Extensions.Logging.LogLevel.None
+        };
 
-            return Microsoft.Extensions.Logging.LogLevel.None;
-        }
+        const string logLevelKey = "LogLevel";
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -287,8 +287,11 @@
 
         void TryLoadLicenseFromConfig() => LicenseFileText = SettingsReader.Read<string>(SettingsRootNamespace, "LicenseText");
 
-        ILog logger = LogManager.GetLogger(typeof(Settings));
+        // logger is intentionally not static to prevent it from being initialized before LoggingConfigurator.ConfigureLogging has been called
+        readonly ILog logger = LogManager.GetLogger(typeof(Settings));
+
         int maxBodySizeToStore = SettingsReader.Read(SettingsRootNamespace, "MaxBodySizeToStore", MaxBodySizeToStoreDefault);
+
         public const string DEFAULT_SERVICE_NAME = "Particular.ServiceControl.Audit";
         public static readonly SettingsRootNamespace SettingsRootNamespace = new("ServiceControl.Audit");
 

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -10,16 +10,19 @@
 
     public class Settings
     {
-        // Service name is what the user chose when installing the instance or is passing on the command line.
-        // We use this as the default endpoint name.
-        public static Settings FromConfiguration(string serviceName) =>
-            new(
-                SettingsReader.Read(SettingsRootNamespace, "InternalQueueName", serviceName) // endpoint name can also be overriden via config
-            );
-
-        public Settings(string serviceName, string transportType = null, string persisterType = null)
+        public Settings(string serviceName = null, string transportType = null, string persisterType = null, LoggingSettings loggingSettings = null)
         {
+            LoggingSettings = loggingSettings ?? new();
+
             ServiceName = serviceName;
+
+            if (string.IsNullOrEmpty(serviceName))
+            {
+                ServiceName = DEFAULT_SERVICE_NAME;
+            }
+
+            // Overwrite the service name if it is specified in ENVVAR, reg, or config file
+            ServiceName = SettingsReader.Read(SettingsRootNamespace, "InternalQueueName", ServiceName);
 
             TransportType = transportType ?? SettingsReader.Read<string>(SettingsRootNamespace, "TransportType");
 
@@ -66,6 +69,8 @@
                 AuditLogQueue = Subscope(AuditQueue);
             }
         }
+
+        public LoggingSettings LoggingSettings { get; }
 
         //HINT: acceptance tests only
         public Func<MessageContext, bool> MessageFilter { get; set; }

--- a/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceControl.Audit.Infrastructure.WebApi
 {
-    using System;
     using Configuration;
     using Microsoft.AspNetCore.Http.Extensions;
     using Microsoft.AspNetCore.Mvc;
@@ -10,10 +9,9 @@
     [Route("api")]
     public class RootController : ControllerBase
     {
-        public RootController(LoggingSettings loggingSettings, Settings settings)
+        public RootController(Settings settings)
         {
             this.settings = settings;
-            this.loggingSettings = loggingSettings;
         }
 
         [Route("")]
@@ -52,8 +50,8 @@
                     settings.ServiceName,
                     Logging = new
                     {
-                        loggingSettings.LogPath,
-                        LoggingLevel = loggingSettings.LoggingLevel.Name,
+                        settings.LoggingSettings.LogPath,
+                        LoggingLevel = settings.LoggingSettings.LogLevel.Name
                     }
                 },
                 DataRetention = new
@@ -83,7 +81,6 @@
             return Ok(content);
         }
 
-        readonly LoggingSettings loggingSettings;
         readonly Settings settings;
 
         public class RootUrls

--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -33,12 +33,12 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName);
+            var loggingSettings = new LoggingSettings();
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             settings = Settings.FromConfiguration(arguments.ServiceName);
 
-            await new CommandRunner(arguments.Commands).Execute(arguments, settings);
+            await new CommandRunner(arguments.Commands).Execute(arguments, settings, loggingSettings);
         }
 
         static Assembly ResolveAssembly(AssemblyLoadContext loadContext, AssemblyName assemblyName)

--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -22,7 +22,7 @@
         static async Task Main(string[] args)
         {
             AssemblyLoadContext.Default.Resolving += ResolveAssembly;
-            AppDomain.CurrentDomain.UnhandledException += (s, e) => Logger.Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
+            AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
             ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());
 
@@ -75,7 +75,5 @@
 
             return null;
         }
-
-        static readonly ILog Logger = LogManager.GetLogger(typeof(Program));
     }
 }

--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -36,9 +36,9 @@
             var loggingSettings = new LoggingSettings();
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
-            settings = Settings.FromConfiguration(arguments.ServiceName);
+            settings = new Settings(arguments.ServiceName, loggingSettings: loggingSettings);
 
-            await new CommandRunner(arguments.Commands).Execute(arguments, settings, loggingSettings);
+            await new CommandRunner(arguments.Commands).Execute(arguments, settings);
         }
 
         static Assembly ResolveAssembly(AssemblyLoadContext loadContext, AssemblyName assemblyName)

--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -9,7 +9,6 @@
     using Infrastructure.Hosting;
     using Infrastructure.Hosting.Commands;
     using Infrastructure.Settings;
-    using Microsoft.Extensions.Hosting.WindowsServices;
     using NServiceBus.Logging;
     using ServiceControl.Audit.Persistence;
     using ServiceControl.Configuration;
@@ -34,7 +33,7 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName, logToConsole: !WindowsServiceHelpers.IsWindowsService());
+            var loggingSettings = new LoggingSettings(arguments.ServiceName);
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             settings = Settings.FromConfiguration(arguments.ServiceName);

--- a/src/ServiceControl.Monitoring.AcceptanceTests/PerformanceTests.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/PerformanceTests.cs
@@ -5,7 +5,6 @@
     using System.Diagnostics;
     using System.Dynamic;
     using System.Linq;
-    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using HdrHistogram;

--- a/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
@@ -1,15 +1,17 @@
 {
   "EndpointName": "Particular.Monitoring",
+  "LoggingSettings": {
+    "LogLevel": {
+      "Name": "Info",
+      "Ordinal": 2
+    },
+    "LogPath": "C:\\Logs"
+  },
   "Portable": false,
   "ServiceName": "Particular.Monitoring",
   "TransportType": "NServiceBus.ServiceControlLearningTransport, ServiceControl.Transports.LearningTransport",
   "ConnectionString": null,
   "ErrorQueue": "error",
-  "LogPath": "C:\\Logs",
-  "LogLevel": {
-    "Name": "Warn",
-    "Ordinal": 3
-  },
   "Username": null,
   "EnableInstallers": false,
   "HttpHostName": "localhost",

--- a/src/ServiceControl.Monitoring.UnitTests/app.config
+++ b/src/ServiceControl.Monitoring.UnitTests/app.config
@@ -4,7 +4,6 @@
     <add key="Monitoring/HttpHostname" value="localhost" />
     <add key="Monitoring/HttpPort" value="9999" />
     <add key="Monitoring/LogPath" value="C:\Logs" />
-    <add key="Monitoring/LogLevel" value="Warn" />
     <add key="Monitoring/TransportType" value="NServiceBus.ServiceControlLearningTransport, ServiceControl.Transports.LearningTransport" />
   </appSettings>
 </configuration>

--- a/src/ServiceControl.Monitoring/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Monitoring/HostApplicationBuilderExtensions.cs
@@ -34,7 +34,7 @@ public static class HostApplicationBuilderExtensions
 
         hostBuilder.Logging.ClearProviders();
         hostBuilder.Logging.AddNLog();
-        hostBuilder.Logging.SetMinimumLevel(settings.ToHostLogLevel());
+        hostBuilder.Logging.SetMinimumLevel(settings.LoggingSettings.ToHostLogLevel());
 
         var services = hostBuilder.Services;
         services.AddSingleton(settings);
@@ -92,7 +92,7 @@ public static class HostApplicationBuilderExtensions
         config.DefineCriticalErrorAction(onCriticalError);
 
         config.GetSettings().Set(settings);
-        config.SetDiagnosticsPath(settings.LogPath);
+        config.SetDiagnosticsPath(settings.LoggingSettings.LogPath);
         config.LimitMessageProcessingConcurrencyTo(settings.MaximumConcurrencyLevel);
 
         config.UseSerialization<NewtonsoftJsonSerializer>();

--- a/src/ServiceControl.Monitoring/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Monitoring/HostApplicationBuilderExtensions.cs
@@ -33,9 +33,8 @@ public static class HostApplicationBuilderExtensions
         hostBuilder.Services.AddWindowsService();
 
         hostBuilder.Logging.ClearProviders();
-        //HINT: configuration used by NLog comes from MonitorLog.cs
         hostBuilder.Logging.AddNLog();
-        hostBuilder.Logging.SetMinimumLevel(ToHostLogLevel(settings.LogLevel));
+        hostBuilder.Logging.SetMinimumLevel(settings.ToHostLogLevel());
 
         var services = hostBuilder.Services;
         services.AddSingleton(settings);
@@ -133,39 +132,4 @@ public static class HostApplicationBuilderExtensions
 
     static RawMessage.Entry ToEntry(QueueLengthEntry entryDto) =>
         new RawMessage.Entry { DateTicks = entryDto.DateTicks, Value = entryDto.Value };
-
-    public static LogLevel ToHostLogLevel(NLog.LogLevel logLevel)
-    {
-        if (logLevel == NLog.LogLevel.Debug)
-        {
-            return LogLevel.Debug;
-        }
-
-        if (logLevel == NLog.LogLevel.Error)
-        {
-            return LogLevel.Error;
-        }
-
-        if (logLevel == NLog.LogLevel.Fatal)
-        {
-            return LogLevel.Critical;
-        }
-
-        if (logLevel == NLog.LogLevel.Warn)
-        {
-            return LogLevel.Warning;
-        }
-
-        if (logLevel == NLog.LogLevel.Info)
-        {
-            return LogLevel.Information;
-        }
-
-        if (logLevel == NLog.LogLevel.Trace)
-        {
-            return LogLevel.Trace;
-        }
-
-        return LogLevel.None;
-    }
 }

--- a/src/ServiceControl.Monitoring/Hosting/Commands/CommandRunner.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/CommandRunner.cs
@@ -11,7 +11,7 @@ namespace ServiceControl.Monitoring
             this.commands = commands;
         }
 
-        public async Task Run(Settings settings)
+        public async Task Execute(Settings settings)
         {
             foreach (var commandType in commands)
             {

--- a/src/ServiceControl.Monitoring/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/SetupCommand.cs
@@ -34,7 +34,7 @@ namespace ServiceControl.Monitoring
             return transportCustomization.ProvisionQueues(transportSettings, []);
         }
 
-        bool ValidateLicense(Monitoring.Settings settings)
+        bool ValidateLicense(Settings settings)
         {
             if (!string.IsNullOrWhiteSpace(settings.LicenseFileText))
             {

--- a/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
@@ -91,10 +91,10 @@ Selected Transport:					{settings.TransportType}
 
         public static LogLevel InitializeLevel()
         {
-            var level = LogLevel.Warn;
+            var level = LogLevel.Info;
             try
             {
-                level = LogLevel.FromString(SettingsReader.Read(Settings.SettingsRootNamespace, LogLevelKey, LogLevel.Warn.Name));
+                level = LogLevel.FromString(SettingsReader.Read(Settings.SettingsRootNamespace, LogLevelKey, LogLevel.Info.Name));
             }
             catch
             {

--- a/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
@@ -2,9 +2,7 @@
 {
     using System;
     using System.IO;
-    using Configuration;
     using NLog;
-    using NLog.Common;
     using NLog.Config;
     using NLog.Extensions.Logging;
     using NLog.Layouts;
@@ -62,23 +60,6 @@
             logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), settings.LogLevel.Name);
         }
 
-        public static LogLevel InitializeLevel()
-        {
-            var level = LogLevel.Info;
-            try
-            {
-                level = LogLevel.FromString(SettingsReader.Read(Settings.SettingsRootNamespace, LogLevelKey, LogLevel.Info.Name));
-            }
-            catch
-            {
-                InternalLogger.Warn($"Failed to parse {LogLevelKey} setting. Defaulting to Warn.");
-            }
-
-            return level;
-        }
-
         const long megaByte = 1024 * 1024;
-
-        const string LogLevelKey = "LogLevel";
     }
 }

--- a/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
@@ -1,9 +1,7 @@
 ﻿namespace ServiceControl.Monitoring
 {
     using System;
-    using System.Diagnostics;
     using System.IO;
-    using System.Linq;
     using Configuration;
     using NLog;
     using NLog.Common;
@@ -16,76 +14,51 @@
 
     static class LoggingConfigurator
     {
-        public static void Configure(Settings settings, bool logToConsole)
+        public static void Configure(Settings settings)
         {
             if (NLog.LogManager.Configuration != null)
             {
                 return;
             }
 
-            var version = FileVersionInfo.GetVersionInfo(typeof(LoggingConfigurator).Assembly.Location).ProductVersion;
             var nlogConfig = new LoggingConfiguration();
             var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:|${exception:format=tostring}}");
-            var header = $@"-------------------------------------------------------------
-ServiceControl Monitoring Version:				{version}
-Selected Transport:					{settings.TransportType}
--------------------------------------------------------------";
 
             var fileTarget = new FileTarget
             {
+                Name = "file",
                 ArchiveEvery = FileArchivePeriod.Day,
                 FileName = Path.Combine(settings.LogPath, "logfile.${shortdate}.txt"),
                 ArchiveFileName = Path.Combine(settings.LogPath, "logfile.{#}.txt"),
                 ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
                 Layout = simpleLayout,
                 MaxArchiveFiles = 14,
-                ArchiveAboveSize = 30 * MegaByte,
-                Header = new SimpleLayout(header)
+                ArchiveAboveSize = 30 * megaByte,
             };
 
             var consoleTarget = new ColoredConsoleTarget
             {
+                Name = "console",
                 Layout = simpleLayout,
+                DetectConsoleAvailable = true,
+                DetectOutputRedirected = true,
                 UseDefaultRowHighlightingRules = true
             };
 
-            var nullTarget = new NullTarget();
-
-            nlogConfig.AddTarget("console", consoleTarget);
-            nlogConfig.AddTarget("debugger", fileTarget);
-            nlogConfig.AddTarget("null", nullTarget);
-
-            //Suppress NSB license logging since this will have it's own
-            nlogConfig.LoggingRules.Add(new LoggingRule("NServiceBus.LicenseManager", LogLevel.Info, nullTarget) { Final = true });
-
             // Always want to see license logging regardless of default logging level
             nlogConfig.LoggingRules.Add(new LoggingRule("ServiceControl.Monitoring.Licensing.*", LogLevel.Info, fileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("ServiceControl.Monitoring.Licensing.*", LogLevel.Info, consoleTarget)
-            {
-                Final = true
-            });
+            nlogConfig.LoggingRules.Add(new LoggingRule("ServiceControl.Monitoring.Licensing.*", LogLevel.Info, consoleTarget));
 
             // Defaults
             nlogConfig.LoggingRules.Add(new LoggingRule("*", settings.LogLevel, fileTarget));
             nlogConfig.LoggingRules.Add(new LoggingRule("*", settings.LogLevel < LogLevel.Info ? settings.LogLevel : LogLevel.Info, consoleTarget));
-
-            if (!logToConsole)
-            {
-                foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
-                {
-                    nlogConfig.LoggingRules.Remove(rule);
-                }
-            }
 
             NLog.LogManager.Configuration = nlogConfig;
 
             LogManager.UseFactory(new ExtensionsLoggerFactory(new NLogLoggerFactory()));
 
             var logger = LogManager.GetLogger("LoggingConfiguration");
-            var logEventInfo = new LogEventInfo
-            {
-                TimeStamp = DateTime.UtcNow
-            };
+            var logEventInfo = new LogEventInfo { TimeStamp = DateTime.UtcNow };
             logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), settings.LogLevel.Name);
         }
 
@@ -104,7 +77,7 @@ Selected Transport:					{settings.TransportType}
             return level;
         }
 
-        const long MegaByte = 1024 * 1024;
+        const long megaByte = 1024 * 1024;
 
         const string LogLevelKey = "LogLevel";
     }

--- a/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/LoggingConfigurator.cs
@@ -12,7 +12,7 @@
 
     static class LoggingConfigurator
     {
-        public static void Configure(Settings settings)
+        public static void ConfigureLogging(LoggingSettings loggingSettings)
         {
             if (NLog.LogManager.Configuration != null)
             {
@@ -26,8 +26,8 @@
             {
                 Name = "file",
                 ArchiveEvery = FileArchivePeriod.Day,
-                FileName = Path.Combine(settings.LogPath, "logfile.${shortdate}.txt"),
-                ArchiveFileName = Path.Combine(settings.LogPath, "logfile.{#}.txt"),
+                FileName = Path.Combine(loggingSettings.LogPath, "logfile.${shortdate}.txt"),
+                ArchiveFileName = Path.Combine(loggingSettings.LogPath, "logfile.{#}.txt"),
                 ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
                 Layout = simpleLayout,
                 MaxArchiveFiles = 14,
@@ -48,8 +48,8 @@
             nlogConfig.LoggingRules.Add(new LoggingRule("ServiceControl.Monitoring.Licensing.*", LogLevel.Info, consoleTarget));
 
             // Defaults
-            nlogConfig.LoggingRules.Add(new LoggingRule("*", settings.LogLevel, fileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("*", settings.LogLevel < LogLevel.Info ? settings.LogLevel : LogLevel.Info, consoleTarget));
+            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel, fileTarget));
+            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel < LogLevel.Info ? loggingSettings.LogLevel : LogLevel.Info, consoleTarget));
 
             NLog.LogManager.Configuration = nlogConfig;
 
@@ -57,7 +57,7 @@
 
             var logger = LogManager.GetLogger("LoggingConfiguration");
             var logEventInfo = new LogEventInfo { TimeStamp = DateTime.UtcNow };
-            logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), settings.LogLevel.Name);
+            logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), loggingSettings.LogLevel.Name);
         }
 
         const long megaByte = 1024 * 1024;

--- a/src/ServiceControl.Monitoring/Licensing/LicenseManager.cs
+++ b/src/ServiceControl.Monitoring/Licensing/LicenseManager.cs
@@ -29,6 +29,6 @@
             Details = result.License;
         }
 
-        static readonly ILog Logger = LogManager.GetLogger(typeof(ActiveLicense));
+        static readonly ILog Logger = LogManager.GetLogger(typeof(LicenseManager));
     }
 }

--- a/src/ServiceControl.Monitoring/LoggingSettings.cs
+++ b/src/ServiceControl.Monitoring/LoggingSettings.cs
@@ -1,4 +1,4 @@
-namespace ServiceBus.Management.Infrastructure.Settings
+﻿namespace ServiceControl.Monitoring
 {
     using System;
     using System.IO;

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -22,18 +22,13 @@ namespace ServiceControl.Monitoring
 
             var arguments = new HostArguments(args);
 
-            LoadSettings(arguments);
+            var loggingSettings = new LoggingSettings();
+            LoggingConfigurator.ConfigureLogging(loggingSettings);
 
-            LoggingConfigurator.Configure(settings);
+            settings = new Settings(loggingSettings);
+            arguments.ApplyOverridesTo(settings);
 
             await new CommandRunner(arguments.Commands).Execute(settings);
-        }
-
-        static void LoadSettings(HostArguments args)
-        {
-            var _settings = new Settings();
-            args.ApplyOverridesTo(_settings);
-            settings = _settings;
         }
 
         static Assembly ResolveAssembly(AssemblyLoadContext loadContext, AssemblyName assemblyName)

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -5,7 +5,6 @@ namespace ServiceControl.Monitoring
     using System.Reflection;
     using System.Runtime.Loader;
     using System.Threading.Tasks;
-    using Microsoft.Extensions.Hosting.WindowsServices;
     using NServiceBus.Logging;
     using ServiceControl.Configuration;
     using ServiceControl.Transports;
@@ -25,7 +24,7 @@ namespace ServiceControl.Monitoring
 
             LoadSettings(arguments);
 
-            LoggingConfigurator.Configure(settings, !WindowsServiceHelpers.IsWindowsService());
+            LoggingConfigurator.Configure(settings);
 
             await new CommandRunner(arguments.Commands)
                 .Run(settings);

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -17,7 +17,7 @@ namespace ServiceControl.Monitoring
         static async Task Main(string[] args)
         {
             AssemblyLoadContext.Default.Resolving += ResolveAssembly;
-            AppDomain.CurrentDomain.UnhandledException += (s, e) => Logger.Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
+            AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
             ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());
 
@@ -65,7 +65,5 @@ namespace ServiceControl.Monitoring
 
             return null;
         }
-
-        static readonly ILog Logger = LogManager.GetLogger(typeof(Program));
     }
 }

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -26,8 +26,7 @@ namespace ServiceControl.Monitoring
 
             LoggingConfigurator.Configure(settings);
 
-            await new CommandRunner(arguments.Commands)
-                .Run(settings);
+            await new CommandRunner(arguments.Commands).Execute(settings);
         }
 
         static void LoadSettings(HostArguments args)

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -3,24 +3,21 @@ namespace ServiceControl.Monitoring
     using System;
     using System.Collections.Generic;
     using System.Configuration;
-    using System.IO;
     using System.Threading.Tasks;
     using Configuration;
-    using NLog;
-    using NLog.Common;
     using Transports;
 
     public class Settings
     {
-        public Settings()
+        public Settings(LoggingSettings loggingSettings = null)
         {
+            LoggingSettings = loggingSettings ?? new();
+
             TryLoadLicenseFromConfig();
 
             TransportType = SettingsReader.Read<string>(SettingsRootNamespace, "TransportType");
 
             ConnectionString = GetConnectionString();
-            LogLevel = InitializeLogLevel();
-            LogPath = SettingsReader.Read(SettingsRootNamespace, "LogPath", DefaultLogLocation());
             ErrorQueue = SettingsReader.Read(SettingsRootNamespace, "ErrorQueue", "error");
             HttpHostName = SettingsReader.Read<string>(SettingsRootNamespace, "HttpHostname");
             HttpPort = SettingsReader.Read<string>(SettingsRootNamespace, "HttpPort");
@@ -31,17 +28,16 @@ namespace ServiceControl.Monitoring
 
         public string EndpointName
         {
-            get { return endpointName ?? ServiceName; }
-            set { endpointName = value; }
+            get => endpointName ?? ServiceName;
+            set => endpointName = value;
         }
 
+        public LoggingSettings LoggingSettings { get; }
         public bool Portable { get; set; } = false;
         public string ServiceName { get; set; } = DEFAULT_ENDPOINT_NAME;
         public string TransportType { get; set; }
         public string ConnectionString { get; set; }
         public string ErrorQueue { get; set; }
-        public string LogPath { get; set; }
-        public LogLevel LogLevel { get; set; }
         public string Username { get; set; }
         public bool EnableInstallers { get; set; }
         public string HttpHostName { get; set; }
@@ -51,43 +47,6 @@ namespace ServiceControl.Monitoring
         public string RootUrl => $"http://{HttpHostName}:{HttpPort}/";
         public int MaximumConcurrencyLevel { get; set; }
         public string LicenseFileText { get; set; }
-
-        static LogLevel InitializeLogLevel()
-        {
-            var defaultLevel = LogLevel.Info;
-
-            var levelText = SettingsReader.Read<string>(SettingsRootNamespace, logLevelKey);
-
-            if (string.IsNullOrWhiteSpace(levelText))
-            {
-                return defaultLevel;
-            }
-
-            try
-            {
-                return LogLevel.FromString(levelText);
-            }
-            catch
-            {
-                InternalLogger.Warn($"Failed to parse {logLevelKey} setting. Defaulting to {defaultLevel.Name}.");
-                return defaultLevel;
-            }
-        }
-
-        // SC installer always populates LogPath in app.config on installation/change/upgrade so this will only be used when
-        // debugging or if the entry is removed manually. In those circumstances default to the folder containing the exe
-        static string DefaultLogLocation() => Path.Combine(AppContext.BaseDirectory, ".logs");
-
-        public Microsoft.Extensions.Logging.LogLevel ToHostLogLevel() => LogLevel switch
-        {
-            _ when LogLevel == LogLevel.Trace => Microsoft.Extensions.Logging.LogLevel.Trace,
-            _ when LogLevel == LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
-            _ when LogLevel == LogLevel.Info => Microsoft.Extensions.Logging.LogLevel.Information,
-            _ when LogLevel == LogLevel.Warn => Microsoft.Extensions.Logging.LogLevel.Warning,
-            _ when LogLevel == LogLevel.Error => Microsoft.Extensions.Logging.LogLevel.Error,
-            _ when LogLevel == LogLevel.Fatal => Microsoft.Extensions.Logging.LogLevel.Critical,
-            _ => Microsoft.Extensions.Logging.LogLevel.None
-        };
 
         void TryLoadLicenseFromConfig() => LicenseFileText = SettingsReader.Read<string>(SettingsRootNamespace, "LicenseText");
 
@@ -123,7 +82,6 @@ namespace ServiceControl.Monitoring
 
         internal Func<string, Dictionary<string, string>, byte[], Func<Task>, Task> OnMessage { get; set; } = (messageId, headers, body, next) => next();
 
-        const string logLevelKey = "LogLevel";
         public const string DEFAULT_ENDPOINT_NAME = "Particular.Monitoring";
         public static readonly SettingsRootNamespace SettingsRootNamespace = new("Monitoring");
     }

--- a/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
+++ b/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.PersistenceTests
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -277,7 +276,7 @@
         class TestReturnToSenderDequeuer : ReturnToSenderDequeuer
         {
             public TestReturnToSenderDequeuer(ReturnToSender returnToSender, IErrorMessageDataStore store, IDomainEvents domainEvents, string endpointName)
-                : base(returnToSender, store, domainEvents, null, null, new Settings(endpointName))
+                : base(returnToSender, store, domainEvents, null, null, new Settings(serviceName: endpointName))
             {
             }
 

--- a/src/ServiceControl.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.UnitTests/API/APIApprovals.cs
@@ -30,7 +30,6 @@
 
             var controller = new RootController(
                 new ActiveLicense { IsValid = true },
-                new LoggingSettings(),
                 new Settings(),
                 httpClientFactory: null
                 )

--- a/src/ServiceControl.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.UnitTests/API/APIApprovals.cs
@@ -30,7 +30,7 @@
 
             var controller = new RootController(
                 new ActiveLicense { IsValid = true },
-                new LoggingSettings("testEndpoint"),
+                new LoggingSettings(),
                 new Settings(),
                 httpClientFactory: null
                 )

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -1,4 +1,11 @@
 {
+  "LoggingSettings": {
+    "LogLevel": {
+      "Name": "Info",
+      "Ordinal": 2
+    },
+    "LogPath": "C:\\Logs"
+  },
   "NotificationsFilter": null,
   "AllowMessageEditing": false,
   "MessageFilter": null,

--- a/src/ServiceControl/Hosting/Commands/AbstractCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/AbstractCommand.cs
@@ -6,6 +6,6 @@
 
     abstract class AbstractCommand
     {
-        public abstract Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings);
+        public abstract Task Execute(HostArguments args, Settings settings);
     }
 }

--- a/src/ServiceControl/Hosting/Commands/AbstractCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/AbstractCommand.cs
@@ -6,6 +6,6 @@
 
     abstract class AbstractCommand
     {
-        public abstract Task Execute(HostArguments args, Settings settings);
+        public abstract Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings);
     }
 }

--- a/src/ServiceControl/Hosting/Commands/CommandRunner.cs
+++ b/src/ServiceControl/Hosting/Commands/CommandRunner.cs
@@ -8,12 +8,12 @@
 
     class CommandRunner(List<Type> commands)
     {
-        public async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
+        public async Task Execute(HostArguments args, Settings settings)
         {
             foreach (var commandType in commands)
             {
                 var command = (AbstractCommand)Activator.CreateInstance(commandType);
-                await command.Execute(args, settings, loggingSettings);
+                await command.Execute(args, settings);
             }
         }
     }

--- a/src/ServiceControl/Hosting/Commands/CommandRunner.cs
+++ b/src/ServiceControl/Hosting/Commands/CommandRunner.cs
@@ -8,12 +8,12 @@
 
     class CommandRunner(List<Type> commands)
     {
-        public async Task Execute(HostArguments args, Settings settings)
+        public async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
         {
             foreach (var commandType in commands)
             {
                 var command = (AbstractCommand)Activator.CreateInstance(commandType);
-                await command.Execute(args, settings);
+                await command.Execute(args, settings, loggingSettings);
             }
         }
     }

--- a/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
@@ -13,7 +13,7 @@
 
     class ImportFailedErrorsCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
+        public override async Task Execute(HostArguments args, Settings settings)
         {
             settings.IngestErrorMessages = false;
             settings.RunRetryProcessor = false;
@@ -22,7 +22,7 @@
             EndpointConfiguration endpointConfiguration = CreateEndpointConfiguration(settings);
 
             var hostBuilder = Host.CreateApplicationBuilder();
-            hostBuilder.AddServiceControl(settings, endpointConfiguration, loggingSettings);
+            hostBuilder.AddServiceControl(settings, endpointConfiguration);
 
             using var app = hostBuilder.Build();
             await app.StartAsync();

--- a/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
@@ -5,7 +5,6 @@
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
-    using NLog;
     using NServiceBus;
     using Operations;
     using Particular.ServiceControl;
@@ -14,15 +13,13 @@
 
     class ImportFailedErrorsCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings)
+        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
         {
             settings.IngestErrorMessages = false;
             settings.RunRetryProcessor = false;
             settings.DisableHealthChecks = true;
 
             EndpointConfiguration endpointConfiguration = CreateEndpointConfiguration(settings);
-
-            var loggingSettings = new LoggingSettings(settings.ServiceName, LogLevel.Info);
 
             var hostBuilder = Host.CreateApplicationBuilder();
             hostBuilder.AddServiceControl(settings, endpointConfiguration, loggingSettings);

--- a/src/ServiceControl/Hosting/Commands/MaintenanceModeCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/MaintenanceModeCommand.cs
@@ -10,7 +10,7 @@
 
     class MaintenanceModeCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
+        public override async Task Execute(HostArguments args, Settings settings)
         {
             var hostBuilder = Host.CreateApplicationBuilder();
             hostBuilder.Services.AddPersistence(settings, maintenanceMode: true);

--- a/src/ServiceControl/Hosting/Commands/MaintenanceModeCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/MaintenanceModeCommand.cs
@@ -10,7 +10,7 @@
 
     class MaintenanceModeCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings)
+        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
         {
             var hostBuilder = Host.CreateApplicationBuilder();
             hostBuilder.Services.AddPersistence(settings, maintenanceMode: true);

--- a/src/ServiceControl/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/RunCommand.cs
@@ -11,15 +11,13 @@
 
     class RunCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings)
+        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
         {
-            var endpointConfiguration = new EndpointConfiguration(args.ServiceName);
+            var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
             var assemblyScanner = endpointConfiguration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
 
             settings.RunCleanupBundle = true;
-
-            var loggingSettings = new LoggingSettings(args.ServiceName);
 
             var hostBuilder = WebApplication.CreateBuilder();
             hostBuilder.AddServiceControl(settings, endpointConfiguration, loggingSettings);

--- a/src/ServiceControl/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/RunCommand.cs
@@ -11,7 +11,7 @@
 
     class RunCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
+        public override async Task Execute(HostArguments args, Settings settings)
         {
             var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
             var assemblyScanner = endpointConfiguration.AssemblyScanner();
@@ -20,7 +20,7 @@
             settings.RunCleanupBundle = true;
 
             var hostBuilder = WebApplication.CreateBuilder();
-            hostBuilder.AddServiceControl(settings, endpointConfiguration, loggingSettings);
+            hostBuilder.AddServiceControl(settings, endpointConfiguration);
             hostBuilder.AddServiceControlApi();
 
             var app = hostBuilder.Build();

--- a/src/ServiceControl/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/SetupCommand.cs
@@ -2,18 +2,18 @@
 {
     using System.Runtime.InteropServices;
     using System.Threading.Tasks;
+    using LicenseManagement;
     using NServiceBus.Logging;
     using Particular.ServiceControl;
     using Particular.ServiceControl.Hosting;
+    using Persistence;
     using ServiceBus.Management.Infrastructure.Installers;
     using ServiceBus.Management.Infrastructure.Settings;
-    using LicenseManagement;
-    using Persistence;
     using Transports;
 
     class SetupCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings)
+        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
         {
             settings.SkipQueueCreation = args.SkipQueueCreation;
 

--- a/src/ServiceControl/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/SetupCommand.cs
@@ -13,7 +13,7 @@
 
     class SetupCommand : AbstractCommand
     {
-        public override async Task Execute(HostArguments args, Settings settings, LoggingSettings loggingSettings)
+        public override async Task Execute(HostArguments args, Settings settings)
         {
             settings.SkipQueueCreation = args.SkipQueueCreation;
 

--- a/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
@@ -9,12 +9,11 @@ namespace ServiceBus.Management.Infrastructure
     using ServiceControl.Notifications.Email;
     using ServiceControl.Operations;
     using ServiceControl.Transports;
-    using Settings;
 
     static class NServiceBusFactory
     {
         public static void Configure(Settings.Settings settings, ITransportCustomization transportCustomization,
-            TransportSettings transportSettings, LoggingSettings loggingSettings, EndpointConfiguration configuration)
+            TransportSettings transportSettings, EndpointConfiguration configuration)
         {
             if (configuration == null)
             {
@@ -27,8 +26,8 @@ namespace ServiceBus.Management.Infrastructure
 
             transportCustomization.CustomizePrimaryEndpoint(configuration, transportSettings);
 
-            configuration.GetSettings().Set(loggingSettings);
-            configuration.SetDiagnosticsPath(loggingSettings.LogPath);
+            configuration.GetSettings().Set(settings.LoggingSettings);
+            configuration.SetDiagnosticsPath(settings.LoggingSettings.LogPath);
 
             if (settings.DisableExternalIntegrationsPublishing)
             {

--- a/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
@@ -9,18 +9,15 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
     public class LoggingSettings
     {
-        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, string logPath = null, bool logToConsole = true)
+        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, string logPath = null)
         {
             LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
             LogPath = SettingsReader.Read(Settings.SettingsRootNamespace, "LogPath", Environment.ExpandEnvironmentVariables(logPath ?? DefaultLogLocation()));
-            LogToConsole = logToConsole;
         }
 
         public LogLevel LoggingLevel { get; }
 
         public string LogPath { get; }
-
-        public bool LogToConsole { get; }
 
         LogLevel InitializeLevel(string key, LogLevel defaultLevel)
         {

--- a/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/LoggingSettings.cs
@@ -9,7 +9,7 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
     public class LoggingSettings
     {
-        public LoggingSettings(string serviceName, LogLevel defaultLevel = null, string logPath = null)
+        public LoggingSettings(LogLevel defaultLevel = null, string logPath = null)
         {
             LoggingLevel = InitializeLevel("LogLevel", defaultLevel ?? LogLevel.Info);
             LogPath = SettingsReader.Read(Settings.SettingsRootNamespace, "LogPath", Environment.ExpandEnvironmentVariables(logPath ?? DefaultLogLocation()));

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -20,10 +20,13 @@ namespace ServiceBus.Management.Infrastructure.Settings
             string serviceName = null,
             string transportType = null,
             string persisterType = null,
+            LoggingSettings loggingSettings = null,
             bool? forwardErrorMessages = default,
             TimeSpan? errorRetentionPeriod = default
             )
         {
+            LoggingSettings = loggingSettings ?? new();
+
             ServiceName = serviceName;
 
             if (string.IsNullOrEmpty(serviceName))
@@ -56,6 +59,8 @@ namespace ServiceBus.Management.Infrastructure.Settings
             TimeToRestartErrorIngestionAfterFailure = GetTimeToRestartErrorIngestionAfterFailure();
             DisableExternalIntegrationsPublishing = SettingsReader.Read(SettingsRootNamespace, "DisableExternalIntegrationsPublishing", false);
         }
+
+        public LoggingSettings LoggingSettings { get; }
 
         public string NotificationsFilter { get; set; }
 

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -419,7 +419,9 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
         void TryLoadLicenseFromConfig() => LicenseFileText = SettingsReader.Read<string>(SettingsRootNamespace, "LicenseText");
 
-        static readonly ILog logger = LogManager.GetLogger(typeof(Settings));
+        // logger is intentionally not static to prevent it from being initialized before LoggingConfigurator.ConfigureLogging has been called
+        readonly ILog logger = LogManager.GetLogger(typeof(Settings));
+
         public const string DEFAULT_SERVICE_NAME = "Particular.ServiceControl";
         public static readonly SettingsRootNamespace SettingsRootNamespace = new("ServiceControl");
 

--- a/src/ServiceControl/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/RootController.cs
@@ -6,7 +6,6 @@
     using System.Text.Json.Nodes;
     using System.Threading.Tasks;
     using Configuration;
-    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Http.Extensions;
     using Microsoft.AspNetCore.Mvc;
     using Particular.ServiceControl.Licensing;
@@ -16,7 +15,6 @@
     [Route("api")]
     public class RootController(
         ActiveLicense license,
-        LoggingSettings loggingSettings,
         Settings settings,
         IHttpClientFactory httpClientFactory)
         : ControllerBase
@@ -67,8 +65,8 @@
                     settings.ServiceName,
                     Logging = new
                     {
-                        loggingSettings.LogPath,
-                        LoggingLevel = loggingSettings.LoggingLevel.Name,
+                        settings.LoggingSettings.LogPath,
+                        LoggingLevel = settings.LoggingSettings.LogLevel.Name,
                     }
                 },
                 DataRetention = new

--- a/src/ServiceControl/LoggingConfigurator.cs
+++ b/src/ServiceControl/LoggingConfigurator.cs
@@ -1,18 +1,18 @@
 namespace Particular.ServiceControl
 {
+    using System;
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using NLog;
     using NLog.Config;
+    using NLog.Extensions.Logging;
     using NLog.Layouts;
     using NLog.Targets;
     using NServiceBus.Extensions.Logging;
-    using LogManager = NServiceBus.Logging.LogManager;
-    using LogLevel = NLog.LogLevel;
-    using NLog.Extensions.Logging;
-    using NLog;
-    using System;
     using ServiceBus.Management.Infrastructure.Settings;
+    using LogLevel = NLog.LogLevel;
+    using LogManager = NServiceBus.Logging.LogManager;
 
     static class LoggingConfigurator
     {

--- a/src/ServiceControl/LoggingConfigurator.cs
+++ b/src/ServiceControl/LoggingConfigurator.cs
@@ -50,8 +50,8 @@ namespace Particular.ServiceControl
             nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget));
 
             // Defaults
-            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel, fileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel < LogLevel.Info ? loggingSettings.LoggingLevel : LogLevel.Info, consoleTarget));
+            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel, fileTarget));
+            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel < LogLevel.Info ? loggingSettings.LogLevel : LogLevel.Info, consoleTarget));
 
             NLog.LogManager.Configuration = nlogConfig;
 
@@ -59,7 +59,7 @@ namespace Particular.ServiceControl
 
             var logger = LogManager.GetLogger("LoggingConfiguration");
             var logEventInfo = new LogEventInfo { TimeStamp = DateTime.UtcNow };
-            logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), loggingSettings.LoggingLevel.Name);
+            logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), loggingSettings.LogLevel.Name);
         }
 
         const long megaByte = 1024 * 1024;

--- a/src/ServiceControl/LoggingConfigurator.cs
+++ b/src/ServiceControl/LoggingConfigurator.cs
@@ -1,9 +1,7 @@
 namespace Particular.ServiceControl
 {
     using System;
-    using System.Diagnostics;
     using System.IO;
-    using System.Linq;
     using NLog;
     using NLog.Config;
     using NLog.Extensions.Logging;
@@ -18,21 +16,17 @@ namespace Particular.ServiceControl
     {
         public static void ConfigureLogging(LoggingSettings loggingSettings)
         {
-            const long megaByte = 1024 * 1024;
             if (NLog.LogManager.Configuration != null)
             {
                 return;
             }
 
-            var version = FileVersionInfo.GetVersionInfo(typeof(LoggingConfigurator).Assembly.Location).ProductVersion;
             var nlogConfig = new LoggingConfiguration();
             var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:|${exception:format=tostring}}");
-            var header = $@"-------------------------------------------------------------
-ServiceControl Version:				{version}
--------------------------------------------------------------";
 
             var fileTarget = new FileTarget
             {
+                Name = "file",
                 ArchiveEvery = FileArchivePeriod.Day,
                 FileName = Path.Combine(loggingSettings.LogPath, "logfile.${shortdate}.txt"),
                 ArchiveFileName = Path.Combine(loggingSettings.LogPath, "logfile.{#}.txt"),
@@ -42,60 +36,32 @@ ServiceControl Version:				{version}
                 ArchiveAboveSize = 30 * megaByte
             };
 
-            var ravenFileTarget = new FileTarget
-            {
-                ArchiveEvery = FileArchivePeriod.Day,
-                FileName = Path.Combine(loggingSettings.LogPath, "ravenlog.${shortdate}.txt"),
-                ArchiveFileName = Path.Combine(loggingSettings.LogPath, "ravenlog.{#}.txt"),
-                ArchiveNumbering = ArchiveNumberingMode.DateAndSequence,
-                Layout = simpleLayout,
-                MaxArchiveFiles = 14,
-                ArchiveAboveSize = 30 * megaByte
-            };
-
             var consoleTarget = new ColoredConsoleTarget
             {
+                Name = "console",
                 Layout = simpleLayout,
+                DetectConsoleAvailable = true,
+                DetectOutputRedirected = true,
                 UseDefaultRowHighlightingRules = true
             };
 
-            var nullTarget = new NullTarget();
-
-            // There lines don't appear to be necessary.  The rules seem to work without implicitly adding the targets?!?
-            nlogConfig.AddTarget("console", consoleTarget);
-            nlogConfig.AddTarget("debugger", fileTarget);
-            nlogConfig.AddTarget("raven", ravenFileTarget);
-            nlogConfig.AddTarget("bitbucket", nullTarget);
-
             // Always want to see license logging regardless of default logging level
             nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, fileTarget));
-            nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget)
-            {
-                Final = true
-            });
+            nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget));
 
             // Defaults
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel, fileTarget));
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LoggingLevel < LogLevel.Info ? loggingSettings.LoggingLevel : LogLevel.Info, consoleTarget));
-
-            if (!loggingSettings.LogToConsole)
-            {
-                foreach (var rule in nlogConfig.LoggingRules.Where(p => p.Targets.Contains(consoleTarget)).ToList())
-                {
-                    nlogConfig.LoggingRules.Remove(rule);
-                }
-            }
 
             NLog.LogManager.Configuration = nlogConfig;
 
             LogManager.UseFactory(new ExtensionsLoggerFactory(new NLogLoggerFactory()));
 
             var logger = LogManager.GetLogger("LoggingConfiguration");
-            var logEventInfo = new LogEventInfo
-            {
-                TimeStamp = DateTime.UtcNow
-            };
+            var logEventInfo = new LogEventInfo { TimeStamp = DateTime.UtcNow };
             logger.InfoFormat("Logging to {0} with LogLevel '{1}'", fileTarget.FileName.Render(logEventInfo), loggingSettings.LoggingLevel.Name);
         }
+
+        const long megaByte = 1024 * 1024;
     }
 }

--- a/src/ServiceControl/Operations/ErrorIngestion.cs
+++ b/src/ServiceControl/Operations/ErrorIngestion.cs
@@ -27,7 +27,6 @@
             TransportSettings transportSettings,
             Metrics metrics,
             IErrorMessageDataStore dataStore,
-            LoggingSettings loggingSettings,
             ErrorIngestionCustomCheck.State ingestionState,
             ErrorIngestor ingestor,
             IIngestionUnitOfWorkFactory unitOfWorkFactory,
@@ -53,7 +52,7 @@
                 FullMode = BoundedChannelFullMode.Wait
             });
 
-            errorHandlingPolicy = new ErrorIngestionFaultPolicy(dataStore, loggingSettings, OnCriticalError);
+            errorHandlingPolicy = new ErrorIngestionFaultPolicy(dataStore, settings.LoggingSettings, OnCriticalError);
 
             watchdog = new Watchdog("failed message ingestion", EnsureStarted, EnsureStopped, ingestionState.ReportError, ingestionState.Clear, settings.TimeToRestartErrorIngestionAfterFailure, Logger);
 

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -10,7 +10,6 @@
     using global::ServiceControl.Persistence;
     using global::ServiceControl.Transports;
     using Hosting;
-    using Microsoft.Extensions.Hosting.WindowsServices;
     using NServiceBus.Logging;
     using ServiceBus.Management.Infrastructure.Settings;
 
@@ -33,7 +32,7 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName, logToConsole: !WindowsServiceHelpers.IsWindowsService());
+            var loggingSettings = new LoggingSettings(arguments.ServiceName);
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             settings = new Settings(arguments.ServiceName);

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -35,9 +35,9 @@
             var loggingSettings = new LoggingSettings();
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
-            settings = new Settings(arguments.ServiceName);
+            settings = new Settings(arguments.ServiceName, loggingSettings: loggingSettings);
 
-            await new CommandRunner(arguments.Commands).Execute(arguments, settings, loggingSettings);
+            await new CommandRunner(arguments.Commands).Execute(arguments, settings);
         }
 
         static Assembly ResolveAssembly(AssemblyLoadContext loadContext, AssemblyName assemblyName)

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -32,12 +32,12 @@
                 return;
             }
 
-            var loggingSettings = new LoggingSettings(arguments.ServiceName);
+            var loggingSettings = new LoggingSettings();
             LoggingConfigurator.ConfigureLogging(loggingSettings);
 
             settings = new Settings(arguments.ServiceName);
 
-            await new CommandRunner(arguments.Commands).Execute(arguments, settings);
+            await new CommandRunner(arguments.Commands).Execute(arguments, settings, loggingSettings);
         }
 
         static Assembly ResolveAssembly(AssemblyLoadContext loadContext, AssemblyName assemblyName)

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -21,7 +21,7 @@
         static async Task Main(string[] args)
         {
             AssemblyLoadContext.Default.Resolving += ResolveAssembly;
-            AppDomain.CurrentDomain.UnhandledException += (s, e) => Logger.Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
+            AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
             ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());
 
@@ -74,7 +74,5 @@
 
             return null;
         }
-
-        static readonly ILog Logger = LogManager.GetLogger(typeof(Program));
     }
 }


### PR DESCRIPTION
This PR fixes the problem where the NServiceBus logger was being used before NLog had been configured, so the default logger's text files would end up being written to the instance installation folders.

This also cleans up how logging settings were being passed around and makes the logging configuration more consistent across all three instance types.