### PR TITLE
Remove ServicePointManager usage

### DIFF
--- a/src/ServiceControl.AcceptanceTesting/EndpointTemplates/DefaultServerBase.cs
+++ b/src/ServiceControl.AcceptanceTesting/EndpointTemplates/DefaultServerBase.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.AcceptanceTesting.EndpointTemplates
 {
     using System;
-    using System.Net;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus;
@@ -19,8 +18,6 @@
 
         public virtual async Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizations, Func<EndpointConfiguration, Task> configurationBuilderCustomization)
         {
-            ServicePointManager.DefaultConnectionLimit = 100;
-
             var endpointConfiguration = new EndpointConfiguration(endpointCustomizations.EndpointName);
 
             endpointConfiguration.Pipeline.Register(new StampDispatchBehavior(runDescriptor.ScenarioContext), "Stamps outgoing messages with session ID");

--- a/src/ServiceControl.AcceptanceTests/TestSupport/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/AcceptanceTest.cs
@@ -3,7 +3,6 @@ namespace ServiceControl.AcceptanceTests
     using System;
     using System.Diagnostics;
     using System.IO;
-    using System.Net;
     using System.Net.Http;
     using System.Text.Json;
     using System.Threading;
@@ -20,18 +19,8 @@ namespace ServiceControl.AcceptanceTests
     using TestSupport;
 
     [TestFixture]
-    //[Parallelizable(ParallelScope.All)]
     abstract class AcceptanceTest : NServiceBusAcceptanceTest, IAcceptanceTestInfrastructureProvider
     {
-        protected AcceptanceTest()
-        {
-            ServicePointManager.DefaultConnectionLimit = int.MaxValue;
-            ServicePointManager.MaxServicePoints = int.MaxValue;
-            ServicePointManager.UseNagleAlgorithm = false; // Improvement for small tcp packets traffic, get buffered up to 1/2-second. If your storage communication is for small (less than ~1400 byte) payloads, this setting should help (especially when dealing with things like Azure Queues, which tend to have very small messages).
-            ServicePointManager.Expect100Continue = false; // This ensures tcp ports are free up quicker by the OS, prevents starvation of ports
-            ServicePointManager.SetTcpKeepAlive(true, 5000, 1000); // This is good for Azure because it reuses connections
-        }
-
         public IDomainEvents DomainEvents => serviceControlRunnerBehavior.DomainEvents;
         public HttpClient HttpClient => serviceControlRunnerBehavior.HttpClient;
         public JsonSerializerOptions SerializerOptions => serviceControlRunnerBehavior.SerializerOptions;

--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -53,7 +53,6 @@
                 ProcessRetryBatchesFrequency = TimeSpan.FromSeconds(2),
                 TimeToRestartErrorIngestionAfterFailure = TimeSpan.FromSeconds(2),
                 MaximumConcurrencyLevel = 2,
-                HttpDefaultConnectionLimit = int.MaxValue,
                 DisableHealthChecks = true,
                 MessageFilter = messageContext =>
                 {

--- a/src/ServiceControl.Audit.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/AcceptanceTest.cs
@@ -4,7 +4,6 @@ namespace ServiceControl.Audit.AcceptanceTests
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
-    using System.Net;
     using System.Net.Http;
     using System.Text.Json;
     using System.Threading.Tasks;
@@ -21,15 +20,6 @@ namespace ServiceControl.Audit.AcceptanceTests
     [TestFixture]
     abstract class AcceptanceTest : NServiceBusAcceptanceTest, IAcceptanceTestInfrastructureProvider
     {
-        protected AcceptanceTest()
-        {
-            ServicePointManager.DefaultConnectionLimit = int.MaxValue;
-            ServicePointManager.MaxServicePoints = int.MaxValue;
-            ServicePointManager.UseNagleAlgorithm = false; // Improvement for small tcp packets traffic, get buffered up to 1/2-second. If your storage communication is for small (less than ~1400 byte) payloads, this setting should help (especially when dealing with things like Azure Queues, which tend to have very small messages).
-            ServicePointManager.Expect100Continue = false; // This ensures tcp ports are free up quicker by the OS, prevents starvation of ports
-            ServicePointManager.SetTcpKeepAlive(true, 5000, 1000); // This is good for Azure because it reuses connections
-        }
-
         public HttpClient HttpClient => serviceControlRunnerBehavior.HttpClient;
         public JsonSerializerOptions SerializerOptions => serviceControlRunnerBehavior.SerializerOptions;
         protected IServiceProvider ServiceProvider => serviceControlRunnerBehavior.ServiceProvider;

--- a/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -42,7 +42,6 @@ namespace ServiceControl.Audit.AcceptanceTests.TestSupport
             {
                 TransportConnectionString = transportToUse.ConnectionString,
                 MaximumConcurrencyLevel = 2,
-                HttpDefaultConnectionLimit = int.MaxValue,
                 ServiceControlQueueAddress = "SHOULDNOTBEUSED",
                 MessageFilter = messageContext =>
                 {

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -18,7 +18,6 @@
   "AuditRetentionPeriod": "30.00:00:00",
   "MaxBodySizeToStore": 102400,
   "ServiceName": "Particular.ServiceControl.Audit",
-  "HttpDefaultConnectionLimit": 100,
   "TransportConnectionString": null,
   "MaximumConcurrencyLevel": 32,
   "DataSpaceRemainingThreshold": 20,

--- a/src/ServiceControl.Audit/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Audit/HostApplicationBuilderExtensions.cs
@@ -41,9 +41,6 @@ static class HostApplicationBuilderExtensions
             configuration.License(settings.LicenseFileText);
         }
 
-        // .NET default limit is 10. RavenDB in conjunction with transports that use HTTP exceeds that limit.
-        ServicePointManager.DefaultConnectionLimit = settings.HttpDefaultConnectionLimit;
-
         var transportSettings = MapSettings(settings);
         var transportCustomization = settings.LoadTransportCustomization();
 

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -35,7 +35,6 @@
             AuditRetentionPeriod = GetAuditRetentionPeriod();
             Port = SettingsReader.Read(SettingsRootNamespace, "Port", 44444);
             MaximumConcurrencyLevel = SettingsReader.Read(SettingsRootNamespace, "MaximumConcurrencyLevel", 32);
-            HttpDefaultConnectionLimit = SettingsReader.Read(SettingsRootNamespace, "HttpDefaultConnectionLimit", 100);
             DataSpaceRemainingThreshold = GetDataSpaceRemainingThreshold();
             ServiceControlQueueAddress = SettingsReader.Read<string>(SettingsRootNamespace, "ServiceControlQueueAddress");
             TimeToRestartAuditIngestionAfterFailure = GetTimeToRestartAuditIngestionAfterFailure();
@@ -131,7 +130,6 @@
 
         public string ServiceName { get; }
 
-        public int HttpDefaultConnectionLimit { get; set; }
         public string TransportConnectionString { get; set; }
         public int MaximumConcurrencyLevel { get; set; }
         public int DataSpaceRemainingThreshold { get; set; }

--- a/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
@@ -63,7 +63,6 @@
                 PerformanceTunning = new
                 {
                     settings.MaxBodySizeToStore,
-                    settings.HttpDefaultConnectionLimit,
                 },
                 Transport = new
                 {

--- a/src/ServiceControl.Monitoring.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/AcceptanceTest.cs
@@ -3,7 +3,6 @@ namespace ServiceControl.Monitoring.AcceptanceTests
     using System;
     using System.Diagnostics;
     using System.IO;
-    using System.Net;
     using System.Net.Http;
     using System.Text.Json;
     using AcceptanceTesting;
@@ -18,16 +17,6 @@ namespace ServiceControl.Monitoring.AcceptanceTests
     [TestFixture]
     abstract class AcceptanceTest : NServiceBusAcceptanceTest, IAcceptanceTestInfrastructureProvider
     {
-        protected AcceptanceTest()
-        {
-            ServicePointManager.DefaultConnectionLimit = int.MaxValue;
-            ServicePointManager.MaxServicePoints = int.MaxValue;
-            ServicePointManager.UseNagleAlgorithm = false; // Improvement for small tcp packets traffic, get buffered up to 1/2-second. If your storage communication is for small (less than ~1400 byte) payloads, this setting should help (especially when dealing with things like Azure Queues, which tend to have very small messages).
-            ServicePointManager.Expect100Continue = false; // This ensures tcp ports are free up quicker by the OS, prevents starvation of ports
-            ServicePointManager.SetTcpKeepAlive(true, 5000, 1000); // This is good for Azure because it reuses connections
-        }
-
-
         public HttpClient HttpClient => serviceControlRunnerBehavior.HttpClient;
         public JsonSerializerOptions SerializerOptions => serviceControlRunnerBehavior.SerializerOptions;
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
@@ -4,7 +4,6 @@ namespace ServiceControl.MultiInstance.AcceptanceTests
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
-    using System.Net;
     using System.Net.Http;
     using System.Text.Json;
     using AcceptanceTesting;
@@ -20,15 +19,6 @@ namespace ServiceControl.MultiInstance.AcceptanceTests
     [TestFixture]
     abstract class AcceptanceTest : NServiceBusAcceptanceTest, IAcceptanceTestInfrastructureProviderMultiInstance
     {
-        protected AcceptanceTest()
-        {
-            ServicePointManager.DefaultConnectionLimit = int.MaxValue;
-            ServicePointManager.MaxServicePoints = int.MaxValue;
-            ServicePointManager.UseNagleAlgorithm = false; // Improvement for small tcp packets traffic, get buffered up to 1/2-second. If your storage communication is for small (less than ~1400 byte) payloads, this setting should help (especially when dealing with things like Azure Queues, which tend to have very small messages).
-            ServicePointManager.Expect100Continue = false; // This ensures tcp ports are free up quicker by the OS, prevents starvation of ports
-            ServicePointManager.SetTcpKeepAlive(true, 5000, 1000); // This is good for Azure because it reuses connections
-        }
-
         protected static string ServiceControlInstanceName { get; } = Settings.DEFAULT_SERVICE_NAME;
         protected static string ServiceControlAuditInstanceName { get; } = Audit.Infrastructure.Settings.Settings.DEFAULT_SERVICE_NAME;
 

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -30,7 +30,6 @@
   "ErrorRetentionPeriod": "10.00:00:00",
   "EventsRetentionPeriod": "14.00:00:00",
   "ServiceName": "Particular.ServiceControl",
-  "HttpDefaultConnectionLimit": 100,
   "TransportConnectionString": null,
   "ProcessRetryBatchesFrequency": "00:00:30",
   "TimeToRestartErrorIngestionAfterFailure": "00:01:00",

--- a/src/ServiceControl/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl/HostApplicationBuilderExtensions.cs
@@ -48,9 +48,6 @@ namespace Particular.ServiceControl
                 EventSourceCreator.Create();
             }
 
-            // .NET default limit is 10. RavenDB in conjunction with transports that use HTTP exceeds that limit.
-            ServicePointManager.DefaultConnectionLimit = settings.HttpDefaultConnectionLimit;
-
             var transportCustomization = settings.LoadTransportCustomization();
             var transportSettings = MapSettings(settings);
 

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -49,7 +49,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
             ProcessRetryBatchesFrequency = TimeSpan.FromSeconds(30);
             MaximumConcurrencyLevel = SettingsReader.Read(SettingsRootNamespace, "MaximumConcurrencyLevel", 10);
             RetryHistoryDepth = SettingsReader.Read(SettingsRootNamespace, "RetryHistoryDepth", 10);
-            HttpDefaultConnectionLimit = SettingsReader.Read(SettingsRootNamespace, "HttpDefaultConnectionLimit", 100);
             AllowMessageEditing = SettingsReader.Read<bool>(SettingsRootNamespace, "AllowMessageEditing");
             NotificationsFilter = SettingsReader.Read<string>(SettingsRootNamespace, "NotificationsFilter");
             RemoteInstances = GetRemoteInstances().ToArray();
@@ -156,7 +155,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public TimeSpan EventsRetentionPeriod { get; }
         public string ServiceName { get; }
 
-        public int HttpDefaultConnectionLimit { get; set; }
         public string TransportConnectionString { get; set; }
         public TimeSpan ProcessRetryBatchesFrequency { get; set; }
         public TimeSpan TimeToRestartErrorIngestionAfterFailure { get; set; }

--- a/src/ServiceControl/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/RootController.cs
@@ -78,7 +78,6 @@
                 },
                 PerformanceTunning = new
                 {
-                    settings.HttpDefaultConnectionLimit,
                     settings.ExternalIntegrationsDispatchingBatchSize
                 },
                 PersistenceSettings = settings.PersisterSpecificSettings,


### PR DESCRIPTION
This PR removes the ServicePointManager usage. With NET ServicePointManager become largely either useless since the [HTTP connections are now managed on the HTTP clients or no longer best practice to call](https://github.com/dotnet/runtime/issues/88814). The acceptance test cases contained tweaks that were put in place during a time when the underlying transport SDKs were using web requests instead of HTTP Client. With the more modern versions of the transport, this is no longer necessary. Furthermore, we have also largely embarked on a journey where we configure the throughput relevant defaults that make sense for SC within the transport seam. 

For the production code we have decided to remove the `HttpDefaultConnectionLimit` since there is no global way anymore to manage those connections. Should we need a way to handle connection limits for various cases, we can introduce dedicated settings again in the future. While this is a "breaking change" that will roll out in a minor potentially, we have concluded adding a log warning is not really helping much other than indicating to a user the potential for cleaning up the app.config file.