### PR TITLE
Use IHostApplicationLifetime to detect ServiceControl is shutting down and RavenDB doesn't need to be restarted

### DIFF
--- a/src/ServiceControl.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
@@ -4,12 +4,13 @@
     using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.Hosting;
     using NServiceBus.Logging;
     using Raven.Client.Documents;
     using Raven.Client.Exceptions.Database;
     using ServiceControl.Persistence;
 
-    class RavenEmbeddedPersistenceLifecycle(RavenPersisterSettings databaseConfiguration)
+    class RavenEmbeddedPersistenceLifecycle(IHostApplicationLifetime lifetime, RavenPersisterSettings databaseConfiguration)
         : IPersistenceLifecycle, IDisposable
     {
         public IDocumentStore GetDocumentStore()
@@ -24,7 +25,7 @@
 
         public async Task Initialize(CancellationToken cancellationToken)
         {
-            database = EmbeddedDatabase.Start(databaseConfiguration);
+            database = EmbeddedDatabase.Start(lifetime, databaseConfiguration);
 
             while (true)
             {

--- a/src/ServiceControl.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.Hosting;
     using NUnit.Framework;
     using Raven.Client.ServerWide.Operations;
     using ServiceControl.Persistence.RavenDB;
@@ -11,7 +12,7 @@
 
     static class SharedEmbeddedServer
     {
-        public static async Task<EmbeddedDatabase> GetInstance(CancellationToken cancellationToken = default)
+        public static async Task<EmbeddedDatabase> GetInstance(IHostApplicationLifetime lifetime, CancellationToken cancellationToken = default)
         {
             if (embeddedDatabase != null)
             {
@@ -34,7 +35,7 @@
                     DatabaseMaintenancePort = PortUtility.FindAvailablePort(RavenPersisterSettings.DatabaseMaintenancePortDefault)
                 };
 
-                embeddedDatabase = EmbeddedDatabase.Start(settings);
+                embeddedDatabase = EmbeddedDatabase.Start(lifetime, settings);
 
                 //make sure that the database is up
                 using var documentStore = await embeddedDatabase.Connect(cancellationToken);

--- a/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
+++ b/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
@@ -5,11 +5,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using NServiceBus;
 using NUnit.Framework;
 using Raven.Client.Documents;
-using ServiceControl.Infrastructure.DomainEvents;
 using ServiceControl.Operations.BodyStorage;
 using ServiceControl.Persistence;
 using ServiceControl.Persistence.MessageRedirects;
@@ -17,7 +14,6 @@ using ServiceControl.Persistence.RavenDB;
 using ServiceControl.Persistence.Recoverability;
 using ServiceControl.Persistence.Tests;
 using ServiceControl.Persistence.UnitOfWork;
-using ServiceControl.PersistenceTests;
 
 //[Parallelizable(ParallelScope.All)]
 [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
@@ -35,7 +31,7 @@ public abstract class PersistenceTestBase
 
         await TestContext.Out.WriteLineAsync($"Test Database Name: {databaseName}");
 
-        embeddedServer = await SharedEmbeddedServer.GetInstance();
+        embeddedServer = await SharedEmbeddedServer.GetInstance(new MockHostApplicationLifetime());
 
         PersistenceSettings = new RavenPersisterSettings
         {
@@ -142,5 +138,23 @@ public abstract class PersistenceTestBase
     protected IIngestionUnitOfWorkFactory IngestionUnitOfWorkFactory => GetRequiredService<IIngestionUnitOfWorkFactory>();
     protected IEventLogDataStore EventLogDataStore => GetRequiredService<IEventLogDataStore>();
     protected IRetryDocumentDataStore RetryDocumentDataStore => GetRequiredService<IRetryDocumentDataStore>();
+}
 
+class MockHostApplicationLifetime : IHostApplicationLifetime, IDisposable
+{
+    readonly CancellationTokenSource startedToken = new();
+    readonly CancellationTokenSource stoppedToken = new();
+    readonly CancellationTokenSource stoppingToken = new();
+    public void Started() => startedToken.Cancel();
+    CancellationToken IHostApplicationLifetime.ApplicationStarted => startedToken.Token;
+    CancellationToken IHostApplicationLifetime.ApplicationStopping => stoppingToken.Token;
+    CancellationToken IHostApplicationLifetime.ApplicationStopped => stoppedToken.Token;
+    public void Dispose()
+    {
+        stoppedToken.Cancel();
+        startedToken.Dispose();
+        stoppedToken.Dispose();
+        stoppingToken.Dispose();
+    }
+    public void StopApplication() => stoppingToken.Cancel();
 }


### PR DESCRIPTION
- [ ] Apply the same logic to the Audit instance