### PR TITLE
Move persistence config into a dedicated AddServiceControlAuditInstallers extension

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
@@ -8,6 +8,7 @@
     using Persistence;
     using Settings;
     using Transports;
+    using WebApi;
 
     class SetupCommand : AbstractCommand
     {
@@ -46,13 +47,9 @@
             EventSource.Create();
 
             var hostBuilder = Host.CreateApplicationBuilder();
-            var persistenceConfiguration = PersistenceConfigurationFactory.LoadPersistenceConfiguration(settings.PersistenceType);
-            var persistenceSettings = persistenceConfiguration.BuildPersistenceSettings(settings);
-            var persistence = persistenceConfiguration.Create(persistenceSettings);
-            persistence.ConfigureInstaller(hostBuilder.Services);
+            hostBuilder.AddServiceControlAuditInstallers(settings);
 
             var host = hostBuilder.Build();
-
             await host.RunAsync();
         }
 

--- a/src/ServiceControl.Audit/Infrastructure/WebApi/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/HostApplicationBuilderExtensions.cs
@@ -4,6 +4,8 @@
     using Microsoft.AspNetCore.Builder;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
+    using Persistence;
+    using Settings;
 
     static class HostApplicationBuilderExtensions
     {
@@ -24,6 +26,14 @@
             });
             controllers.AddApplicationPart(Assembly.GetExecutingAssembly());
             controllers.AddJsonOptions(options => options.JsonSerializerOptions.CustomizeDefaults());
+        }
+
+        public static void AddServiceControlAuditInstallers(this IHostApplicationBuilder builder, Settings settings)
+        {
+            var persistenceConfiguration = PersistenceConfigurationFactory.LoadPersistenceConfiguration(settings.PersistenceType);
+            var persistenceSettings = persistenceConfiguration.BuildPersistenceSettings(settings);
+            var persistence = persistenceConfiguration.Create(persistenceSettings);
+            persistence.ConfigureInstaller(builder.Services);
         }
     }
 }


### PR DESCRIPTION
The same could be done for the primary and monitoring instances.

In the same `SetupCommand`, we create queues, if requested, without starting the Host. It might be worth investigating if it makes sense to align queue creation with the storage setup and make it so that's controlled by the host.