### PR TITLE
Remove audit queue validation checks

### DIFF
--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModelValidator.cs
@@ -224,8 +224,6 @@ namespace ServiceControl.Config.UI.InstanceAdd
                     .WithMessage(string.Format(Validation.Validations.MSG_QUEUENAMES_NOT_EQUAL, "Audit", "Error Forwarding"))
                 .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.ErrorInstanceName, x.ConnectionString))
                     .WithMessage(string.Format(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit"))
-                .MustNotBeIn(x => Validations.UsedAuditQueueNames(x.SelectedTransport, x.AuditInstanceName, x.ConnectionString))
-                    .WithMessage(string.Format(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit"))
                 .When(x => x.InstallAuditInstance);
 
             RuleFor(x => x.AuditForwardingQueueName)
@@ -237,8 +235,6 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 .NotEqual(x => x.ErrorForwardingQueueName)
                     .WithMessage(string.Format(Validation.Validations.MSG_UNIQUEQUEUENAME, "Error Forwarding"))
                 .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.ErrorInstanceName, x.ConnectionString))
-                    .WithMessage(string.Format(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit Forwarding"))
-                .MustNotBeIn(x => Validations.UsedAuditQueueNames(x.SelectedTransport, x.AuditInstanceName, x.ConnectionString))
                     .WithMessage(string.Format(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit Forwarding"))
                 .When(x => x.InstallAuditInstance)
                 .When(x => x.AuditForwarding?.Value ?? false);

--- a/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlAuditEditViewModelValidator.cs
+++ b/src/ServiceControl.Config/UI/InstanceEdit/ServiceControlAuditEditViewModelValidator.cs
@@ -69,8 +69,6 @@ namespace ServiceControl.Config.UI.InstanceEdit
                     .WithMessage(string.Format(Validation.Validations.MSG_UNIQUEQUEUENAME, "Audit Forwarding"))
                 .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString))
                     .WithMessage(string.Format(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit"))
-                .MustNotBeIn(x => Validations.UsedAuditQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString))
-                    .WithMessage(string.Format(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit"))
                 .When(x => x.SubmitAttempted);
 
             RuleFor(x => x.AuditForwardingQueueName)
@@ -78,8 +76,6 @@ namespace ServiceControl.Config.UI.InstanceEdit
                     .WithMessage(string.Format(Validation.Validations.MSG_FORWARDINGQUEUENAME, "Audit Forwarding"))
                 .NotEqual(x => x.AuditQueueName)
                     .WithMessage(string.Format(Validation.Validations.MSG_QUEUENAMES_NOT_EQUAL, "Audit Forwarding", "Audit"))
-                .MustNotBeIn(x => Validations.UsedAuditQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString))
-                    .WithMessage(string.Format(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit Forwarding"))
                 .MustNotBeIn(x => Validations.UsedErrorQueueNames(x.SelectedTransport, x.InstanceName, x.ConnectionString))
                     .WithMessage(string.Format(Validation.Validations.MSG_QUEUE_ALREADY_ASSIGNED, "Audit Forwarding"))
                 .When(x => x.SubmitAttempted && x.AuditForwarding.Value);


### PR DESCRIPTION
Fixes #3535

When adding a new ServiceControl installation via ServiceControl Management, there are validation checks to ensure that two instances on the same machine do not use the same Audit queue or Audit Forwarding queue. This check made sense when there was only one audit instance per environment. Since the audit instance was split from the error instance, it is possible to run two audit instances in the same environment. It may make sense to run those against the same audit queue.

This PR removes those validation checks.