### PR TITLE
Adjust PlatformSample files to match new deploy folder layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,6 @@ jobs:
         run: dotnet build src --configuration Release -graph --property:WindowsSelfContained=true
       - name: Build ServiceControl Management
         run: dotnet publish src\ServiceControl.Config\ServiceControl.Config.csproj --no-build --output assets --property:WindowsSelfContained=true
-      - name: Sign NuGet packages
-        uses: Particular/sign-nuget-packages-action@v1.0.0
-        with:
-          client-id: ${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}
-          client-secret: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
-          certificate-name: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
       - name: Create PowerShell module catalog
         run: New-FileCatalog -Path deploy\PowerShellModules\Particular.ServiceControl.Management -CatalogFilePath deploy\PowerShellModules\Particular.ServiceControl.Management\Particular.ServiceControl.Management.cat -CatalogVersion 2.0
       - name: Install AzureSignTool
@@ -89,17 +82,30 @@ jobs:
           name: assets
           path: assets/*
           retention-days: 1
-      - name: Publish NuGet packages
-        uses: actions/upload-artifact@v4.3.1
-        with:
-          name: nugets
-          path: nugets/*
-          retention-days: 1
       - name: Publish zips
         uses: actions/upload-artifact@v4.3.1
         with:
           name: zips
           path: zip/*
+          retention-days: 1
+      - name: Build PlatformSample package
+        run: |
+          Remove-Item deploy\Particular.ServiceControl* -recurse
+          dotnet clean src --configuration Release --property:WindowsSelfContained=true
+          dotnet build src\Particular.PlatformSample.ServiceControl\Particular.PlatformSample.ServiceControl.csproj --configuration Release -graph
+        shell: pwsh
+      - name: Sign NuGet packages
+        uses: Particular/sign-nuget-packages-action@v1.0.0
+        with:
+          client-id: ${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}
+          client-secret: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
+          certificate-name: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
+      - name: Publish NuGet packages
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: nugets
+          path: nugets/*
           retention-days: 1
       - name : Verify release artifact counts
         shell: pwsh

--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -27,7 +27,7 @@
       <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Transports\LearningTransport\**\*" PackagePath="platform\sc\servicecontrol\Transports\LearningTransport" />
 
       <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\**\*;$(ArtifactsPath)Particular.ServiceControl.Audit\Transports\**\*" PackagePath="platform\sc\servicecontrol-audit" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\InMemory\**\*" PackagePath="platform\sc\servicecontrol-audit\Persisters\InMemory" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\RavenDB\**\*" PackagePath="platform\sc\servicecontrol-audit\Persisters\RavenDB" />
       <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Transports\LearningTransport\**\*" PackagePath="platform\sc\servicecontrol-audit\Transports\LearningTransport" />
 
       <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Monitoring\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl.Monitoring\Transports\**\*" PackagePath="platform\sc\monitoring" />

--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -25,7 +25,6 @@
       <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl\Persisters\**\*;$(ArtifactsPath)Particular.ServiceControl\Transports\**\*" PackagePath="platform\sc\servicecontrol" />
       <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Persisters\RavenDB\**\*" PackagePath="platform\sc\servicecontrol\Persisters\RavenDB" />
       <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Transports\LearningTransport\**\*" PackagePath="platform\sc\servicecontrol\Transports\LearningTransport" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)RavenDBServer\**\*" PackagePath="platform\sc\servicecontrol\Persisters\RavenDB\RavenDBServer" />
 
       <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\**\*;$(ArtifactsPath)Particular.ServiceControl.Audit\Transports\**\*" PackagePath="platform\sc\servicecontrol-audit" />
       <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\InMemory\**\*" PackagePath="platform\sc\servicecontrol-audit\Persisters\InMemory" />

--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -22,17 +22,17 @@
 
   <Target Name="AddFilesToPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\ServiceControl\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Persisters\RavenDB\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)RavenDBServer\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance\RavenDBServer" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl\Persisters\**\*;$(ArtifactsPath)Particular.ServiceControl\Transports\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Persisters\RavenDB\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance\Persisters\RavenDB" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance\Transports\LearningTransport" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)RavenDBServer\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance\Persisters\RavenDB\RavenDBServer" />
 
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\ServiceControl.Audit\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\InMemory\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\**\*;$(ArtifactsPath)Particular.ServiceControl.Audit\Transports\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\InMemory\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance\Persisters\InMemory" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance\Transports\LearningTransport" />
 
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Monitoring\ServiceControl.Monitoring\**\*" PackagePath="platform\servicecontrol\monitoring-instance" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\monitoring-instance" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Monitoring\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl.Monitoring\Transports\**\*" PackagePath="platform\servicecontrol\monitoring-instance" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Monitoring\Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\monitoring-instance\Transports\LearningTransport" />
     </ItemGroup>
   </Target>
 

--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -22,17 +22,17 @@
 
   <Target Name="AddFilesToPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl\Persisters\**\*;$(ArtifactsPath)Particular.ServiceControl\Transports\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Persisters\RavenDB\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance\Persisters\RavenDB" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance\Transports\LearningTransport" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)RavenDBServer\**\*" PackagePath="platform\servicecontrol\servicecontrol-instance\Persisters\RavenDB\RavenDBServer" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl\Persisters\**\*;$(ArtifactsPath)Particular.ServiceControl\Transports\**\*" PackagePath="platform\sc\servicecontrol" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Persisters\RavenDB\**\*" PackagePath="platform\sc\servicecontrol\Persisters\RavenDB" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl\Transports\LearningTransport\**\*" PackagePath="platform\sc\servicecontrol\Transports\LearningTransport" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)RavenDBServer\**\*" PackagePath="platform\sc\servicecontrol\Persisters\RavenDB\RavenDBServer" />
 
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\**\*;$(ArtifactsPath)Particular.ServiceControl.Audit\Transports\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\InMemory\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance\Persisters\InMemory" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\servicecontrol-audit-instance\Transports\LearningTransport" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\**\*;$(ArtifactsPath)Particular.ServiceControl.Audit\Transports\**\*" PackagePath="platform\sc\servicecontrol-audit" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\InMemory\**\*" PackagePath="platform\sc\servicecontrol-audit\Persisters\InMemory" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Audit\Transports\LearningTransport\**\*" PackagePath="platform\sc\servicecontrol-audit\Transports\LearningTransport" />
 
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Monitoring\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl.Monitoring\Transports\**\*" PackagePath="platform\servicecontrol\monitoring-instance" />
-      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Monitoring\Transports\LearningTransport\**\*" PackagePath="platform\servicecontrol\monitoring-instance\Transports\LearningTransport" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Monitoring\**\*" Exclude="$(ArtifactsPath)Particular.ServiceControl.Monitoring\Transports\**\*" PackagePath="platform\sc\monitoring" />
+      <TfmSpecificPackageFile Include="$(ArtifactsPath)Particular.ServiceControl.Monitoring\Transports\LearningTransport\**\*" PackagePath="platform\sc\monitoring\Transports\LearningTransport" />
     </ItemGroup>
   </Target>
 

--- a/src/Particular.PlatformSample.ServiceControl/buildProps/build/Particular.PlatformSample.ServiceControl.props
+++ b/src/Particular.PlatformSample.ServiceControl/buildProps/build/Particular.PlatformSample.ServiceControl.props
@@ -1,18 +1,8 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <MSBuildAllProjects Condition="'$(MSBuildAssemblyVersion)' == '' Or '$(MSBuildAssemblyVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
+<Project>
 
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\..\platform\sc\servicecontrol\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="platform\servicecontrol\servicecontrol-instance" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\..\platform\sc\servicecontrol-audit\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="platform\servicecontrol\servicecontrol-audit-instance" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\..\platform\sc\monitoring\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="platform\servicecontrol\monitoring-instance" />
   </ItemGroup>
 

--- a/src/Particular.PlatformSample.ServiceControl/buildProps/build/Particular.PlatformSample.ServiceControl.props
+++ b/src/Particular.PlatformSample.ServiceControl/buildProps/build/Particular.PlatformSample.ServiceControl.props
@@ -5,15 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)\..\platform\servicecontrol\servicecontrol-instance\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="platform\servicecontrol\servicecontrol-instance" />
+    <None Include="$(MSBuildThisFileDirectory)\..\platform\sc\servicecontrol\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="platform\servicecontrol\servicecontrol-instance" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)\..\platform\servicecontrol\servicecontrol-audit-instance\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="platform\servicecontrol\servicecontrol-audit-instance" />
+    <None Include="$(MSBuildThisFileDirectory)\..\platform\sc\servicecontrol-audit\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="platform\servicecontrol\servicecontrol-audit-instance" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)\..\platform\servicecontrol\monitoring-instance\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="platform\servicecontrol\monitoring-instance" />
+    <None Include="$(MSBuildThisFileDirectory)\..\platform\sc\monitoring\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="platform\servicecontrol\monitoring-instance" />
   </ItemGroup>
 
 </Project>

--- a/src/Particular.PlatformSample.ServiceControl/buildProps/buildMultiTargeting/Particular.PlatformSample.ServiceControl.props
+++ b/src/Particular.PlatformSample.ServiceControl/buildProps/buildMultiTargeting/Particular.PlatformSample.ServiceControl.props
@@ -1,8 +1,4 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <MSBuildAllProjects Condition="'$(MSBuildAssemblyVersion)' == '' Or '$(MSBuildAssemblyVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
+<Project>
 
   <Import Project="../build/Particular.PlatformSample.ServiceControl.props" />
 


### PR DESCRIPTION
This PR adjusts the PlatformSample package to work with the changes we've made to ServiceControl:

- The package now understands the new deploy folder layout
- The release workflow has been adjusted to ensure the package contains framework-dependent binaries that work cross-platform
- RavenDB is no longer bundled in the package, which contributes to making the package work in cross-platform scenarios
- The audit instance once again uses the RavenDB persister

The changes here will require matching changes to the PlatformSample package as well, which are being done here: https://github.com/Particular/Particular.PlatformSample/pull/375