### PR TITLE
DataStore interface changes around getting / recording throughput

### DIFF
--- a/src/Particular.ThroughputCollector.Contracts/Endpoint.cs
+++ b/src/Particular.ThroughputCollector.Contracts/Endpoint.cs
@@ -13,6 +13,5 @@ public record Endpoint(EndpointIdentifier Id)
     public string[] EndpointIndicators { get; set; }
     public string UserIndicator { get; set; }
     public string? Scope { get; set; }
-    public List<EndpointDailyThroughput> DailyThroughput { get; set; } = [];
     public DateOnly LastCollectedDate { get; set; }
 }

--- a/src/Particular.ThroughputCollector.Contracts/EndpointDailyThroughput.cs
+++ b/src/Particular.ThroughputCollector.Contracts/EndpointDailyThroughput.cs
@@ -1,6 +1,14 @@
 ﻿namespace Particular.ThroughputCollector.Contracts;
-public class EndpointDailyThroughput
+
+public readonly struct EndpointDailyThroughput(DateOnly date, long messageCount)
 {
-    public DateOnly DateUTC { get; set; }
-    public long TotalThroughput { get; set; }
+    public DateOnly DateUTC { get; } = date;
+
+    public long MessageCount { get; } = messageCount;
+
+    public void Deconstruct(out DateOnly date, out long messageCount)
+    {
+        date = DateUTC;
+        messageCount = MessageCount;
+    }
 }

--- a/src/Particular.ThroughputCollector.Contracts/ThroughputData.cs
+++ b/src/Particular.ThroughputCollector.Contracts/ThroughputData.cs
@@ -1,0 +1,15 @@
+﻿namespace Particular.ThroughputCollector.Contracts;
+
+public class ThroughputData : SortedList<DateOnly, long>
+{
+    public ThroughputData()
+    {
+    }
+
+    public ThroughputData(IEnumerable<EndpointDailyThroughput> throughput)
+        : base(throughput.ToDictionary(entry => entry.DateUTC, entry => entry.MessageCount))
+    {
+    }
+
+    public ThroughputSource ThroughputSource { get; set; }
+}

--- a/src/Particular.ThroughputCollector.Persistence.InMemory/InMemoryThroughputDataStore.cs
+++ b/src/Particular.ThroughputCollector.Persistence.InMemory/InMemoryThroughputDataStore.cs
@@ -96,7 +96,7 @@ class InMemoryThroughputDataStore() : IThroughputDataStore
         endpointsWithUserIndicator.DistinctBy(b => b.SanitizedName).ToList().ForEach(e =>
         {
             //if there are multiple sources of throughput for the endpoint, update them all
-            var existingEndpoints = GetAllEndpointThroughput(e.SanitizedName);
+            var existingEndpoints = GetAllConnectedEndpoints(e.SanitizedName);
 
             existingEndpoints.ForEach(u =>
             {
@@ -112,7 +112,7 @@ class InMemoryThroughputDataStore() : IThroughputDataStore
             t => t.Key >= DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-days) &&
                  t.Key <= DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1))));
 
-    private List<Endpoint> GetAllEndpointThroughput(string name) => endpoints.Where(w => w.SanitizedName == name).ToList();
+    private List<Endpoint> GetAllConnectedEndpoints(string name) => endpoints.Where(w => w.SanitizedName == name).ToList();
 
     public async Task SaveBrokerData(Broker broker, string? scopeType, Dictionary<string, string> data)
     {

--- a/src/Particular.ThroughputCollector.Persistence.RavenDb/ThroughputDataStore.cs
+++ b/src/Particular.ThroughputCollector.Persistence.RavenDb/ThroughputDataStore.cs
@@ -110,14 +110,8 @@ class ThroughputDataStore(
         using var session = store.OpenAsyncSession("throughput");
 
         var documentId = id.GenerateDocumentId();
-        var document = await session.LoadAsync<EndpointDocument>(documentId, cancellationToken);
-        if (document == null)
-        {
-            document = new EndpointDocument(id);
-
-            await session.StoreAsync(document, documentId, cancellationToken);
-            await session.SaveChangesAsync(cancellationToken);
-        }
+        var document = await session.LoadAsync<EndpointDocument>(documentId, cancellationToken) ??
+            throw new InvalidOperationException($"Endpoint {id.Name} from {id.ThroughputSource} does not exist ");
 
         var timeSeries = session.IncrementalTimeSeriesFor(documentId, ThroughputTimeSeriesName);
 

--- a/src/Particular.ThroughputCollector.Persistence.Tests/EndpointsTests.cs
+++ b/src/Particular.ThroughputCollector.Persistence.Tests/EndpointsTests.cs
@@ -1,324 +1,182 @@
-﻿namespace Particular.ThroughputCollector.Persistence.Tests
+﻿namespace Particular.ThroughputCollector.Persistence.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Particular.ThroughputCollector.Contracts;
+
+[TestFixture]
+class EndpointsTests : PersistenceTestFixture
 {
-    using System;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using NUnit.Framework;
-    using Particular.ThroughputCollector.Contracts;
-
-    [TestFixture]
-    class EndpointsTests : PersistenceTestFixture
+    [Test]
+    public async Task Should_add_new_endpoint_when_no_endpoints()
     {
-        [Test]
-        public async Task Should_add_new_endpoint_when_no_endpoints()
+        // Arrange
+        var endpoint = new Endpoint("Endpoint", ThroughputSource.Audit);
+
+        // Act
+        await DataStore.SaveEndpoint(endpoint);
+
+        // Assert
+        var endpoints = await DataStore.GetAllEndpoints();
+        var foundEndpoint = endpoints.Single();
+
+        Assert.That(foundEndpoint.Id.Name, Is.EqualTo(endpoint.Id.Name));
+        Assert.That(foundEndpoint.Id.ThroughputSource, Is.EqualTo(endpoint.Id.ThroughputSource));
+    }
+
+    [Test]
+    public async Task Should_add_new_endpoint_when_name_is_the_same_but_source_different()
+    {
+        // Arrange
+        var endpoint1 = new Endpoint("Endpoint1", ThroughputSource.Audit);
+        var endpoint2 = new Endpoint("Endpoint1", ThroughputSource.Broker);
+
+        // Act
+        await DataStore.SaveEndpoint(endpoint1);
+        await DataStore.SaveEndpoint(endpoint2);
+
+        // Assert
+        var endpoints = await DataStore.GetAllEndpoints();
+
+        Assert.That(endpoints.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task Should_update_endpoint_that_already_has_throughput_with_new_throughput()
+    {
+        // Arrange
+        var endpoint1 = new Endpoint("Endpoint1", ThroughputSource.Audit) { SanitizedName = "Endpoint1" };
+        await DataStore.SaveEndpoint(endpoint1);
+        await DataStore.RecordEndpointThroughput(endpoint1.Id.Name, ThroughputSource.Audit, DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), 50);
+
+        // Act
+        await DataStore.RecordEndpointThroughput(endpoint1.Id.Name, ThroughputSource.Audit, DateOnly.FromDateTime(DateTime.UtcNow), 100);
+
+        // Assert
+        var endpoints = await DataStore.GetAllEndpoints();
+        var throughput = await DataStore.GetEndpointThroughputByQueueName([endpoint1.SanitizedName]);
+
+        var foundEndpoint = endpoints.Single();
+        Assert.That(foundEndpoint.Id.Name, Is.EqualTo(endpoint1.Id.Name));
+        Assert.That(foundEndpoint.Id.ThroughputSource, Is.EqualTo(endpoint1.Id.ThroughputSource));
+        Assert.That(throughput, Contains.Key(endpoint1.SanitizedName));
+        Assert.That(throughput[endpoint1.SanitizedName].Count, Is.EqualTo(1), "Should be only a single ThroughputData returned");
+        Assert.That(throughput[endpoint1.SanitizedName].Single().Count, Is.EqualTo(2), "Should be two days of throughput data");
+    }
+
+    [Test]
+    public async Task Should_retrieve_matching_endpoint_when_same_source()
+    {
+        // Arrange
+        var endpoint = new Endpoint("Endpoint", ThroughputSource.Audit);
+        await DataStore.SaveEndpoint(endpoint);
+
+        // Act
+        var foundEndpoint = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Audit);
+
+        // Assert
+        Assert.That(foundEndpoint, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task Should_not_retrieve_matching_endpoint_when_different_source()
+    {
+        // Arrange
+        var endpoint = new Endpoint("Endpoint", ThroughputSource.Audit);
+        await DataStore.SaveEndpoint(endpoint);
+
+        // Act
+        var foundEndpoint = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Broker);
+
+        // Assert
+        Assert.That(foundEndpoint, Is.Null);
+    }
+
+    [Test]
+    public async Task Should_update_user_indicators_and_nothing_else()
+    {
+        // Arrange
+        var userIndicator = "someIndicator";
+
+        var endpoint = new Endpoint("Endpoint", ThroughputSource.Audit)
         {
-            var endpoint = new Endpoint("Endpoint", ThroughputSource.Audit)
-            {
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow),
-                        TotalThroughput = 50
-                    }
-                ]
-            };
+            SanitizedName = "Endpoint"
+        };
+        await DataStore.SaveEndpoint(endpoint);
 
-            await DataStore.RecordEndpointThroughput(endpoint.Id, endpoint.DailyThroughput);
+        // Act
+        await DataStore.UpdateUserIndicatorOnEndpoints([new Endpoint("Endpoint") { SanitizedName = "Endpoint", UserIndicator = userIndicator }]);
 
-            var endpoints = await DataStore.GetAllEndpoints();
+        // Assert
+        var foundEndpoint = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Audit);
 
-            var foundEndpoint = endpoints.Single();
-            Assert.That(foundEndpoint.Id.Name, Is.EqualTo(endpoint.Id.Name));
-            Assert.That(foundEndpoint.Id.ThroughputSource, Is.EqualTo(endpoint.Id.ThroughputSource));
-            Assert.That(foundEndpoint.DailyThroughput.Count, Is.EqualTo(endpoint.DailyThroughput.Count));
-        }
+        Assert.That(foundEndpoint, Is.Not.Null);
+        Assert.That(foundEndpoint.UserIndicator, Is.EqualTo(userIndicator));
+    }
 
-        [Test]
-        public async Task Should_add_new_endpoint_when_name_is_the_same_but_source_different()
+    [Test]
+    public async Task Should_not_add_endpoint_when_updating_user_indication()
+    {
+        // Arrange
+        var endpointWithUserIndicators = new Endpoint("Endpoint", ThroughputSource.Audit)
         {
-            var endpoint1 = new Endpoint("Endpoint1", ThroughputSource.Audit)
-            {
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow),
-                        TotalThroughput = 50
-                    }
-                ]
-            };
-            await DataStore.RecordEndpointThroughput(endpoint1.Id, endpoint1.DailyThroughput);
+            SanitizedName = "Endpoint",
+            UserIndicator = "someIndicator",
+        };
 
-            var endpoint2 = new Endpoint("Endpoint1", ThroughputSource.Broker)
-            {
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1),
-                        TotalThroughput = 600
-                    }
-                ]
-            };
-            await DataStore.RecordEndpointThroughput(endpoint2.Id, endpoint2.DailyThroughput);
+        // Act
+        await DataStore.UpdateUserIndicatorOnEndpoints([endpointWithUserIndicators]);
 
-            var endpoints = await DataStore.GetAllEndpoints();
+        // Assert
+        var foundEndpoint = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Audit);
+        var allEndpoints = await DataStore.GetAllEndpoints();
 
-            Assert.That(endpoints.Count, Is.EqualTo(2));
-        }
+        Assert.That(foundEndpoint, Is.Null);
+        Assert.That(allEndpoints.Count, Is.EqualTo(0));
+    }
 
+    [Test]
+    public async Task Should_update_indicators_on_all_endpoint_sources()
+    {
+        // Arrange
+        var userIndicator = "someIndicator";
 
-        [Test]
-        public async Task Should_update_endpoint_that_already_has_throughput_with_new_throughput()
-        {
-            var endpoint1 = new Endpoint("Endpoint1", ThroughputSource.Audit)
-            {
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow),
-                        TotalThroughput = 50
-                    }
-                ]
-            };
-            await DataStore.RecordEndpointThroughput(endpoint1.Id, endpoint1.DailyThroughput);
+        var endpointAudit = new Endpoint("Endpoint", ThroughputSource.Audit) { SanitizedName = "Endpoint" };
+        var endpointMonitoring = new Endpoint("Endpoint", ThroughputSource.Monitoring) { SanitizedName = "Endpoint" };
 
-            var endpoint2 = new Endpoint("Endpoint1", ThroughputSource.Audit)
-            {
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1),
-                        TotalThroughput = 100
-                    }
-                ]
-            };
-            await DataStore.RecordEndpointThroughput(endpoint2.Id, endpoint2.DailyThroughput);
+        await DataStore.SaveEndpoint(endpointAudit);
+        await DataStore.SaveEndpoint(endpointMonitoring);
 
-            var endpoints = await DataStore.GetAllEndpoints();
+        // Act
+        await DataStore.UpdateUserIndicatorOnEndpoints([new Endpoint("Endpoint") { SanitizedName = "Endpoint", UserIndicator = userIndicator }]);
 
-            var foundEndpoint = endpoints.Single();
-            Assert.That(foundEndpoint.Id.Name, Is.EqualTo(endpoint1.Id.Name));
-            Assert.That(foundEndpoint.Id.ThroughputSource, Is.EqualTo(endpoint1.Id.ThroughputSource));
-            Assert.That(foundEndpoint.DailyThroughput.Count, Is.EqualTo(2));
-        }
+        // Assert
+        var foundEndpointAudit = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Audit);
+        var foundEndpointMonitoring = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Monitoring);
 
-        [Test]
-        public async Task Should_not_update_endpoint_with_throughput_with_no_throughput()
-        {
-            var endpoint1 = new Endpoint("Endpoint1", ThroughputSource.Audit)
-            {
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1),
-                        TotalThroughput = 100
-                    }
-                ]
-            };
-            await DataStore.RecordEndpointThroughput(endpoint1.Id, endpoint1.DailyThroughput);
+        Assert.That(foundEndpointAudit, Is.Not.Null);
+        Assert.That(foundEndpointAudit.UserIndicator, Is.EqualTo(userIndicator));
 
-            var endpoint2 = new Endpoint("Endpoint1", ThroughputSource.Audit);
-            await DataStore.RecordEndpointThroughput(endpoint2.Id, endpoint2.DailyThroughput);
+        Assert.That(foundEndpointMonitoring, Is.Not.Null);
+        Assert.That(foundEndpointMonitoring.UserIndicator, Is.EqualTo(userIndicator));
+    }
 
-            var endpoints = await DataStore.GetAllEndpoints();
+    [TestCase(10, 5, false)]
+    [TestCase(10, 20, true)]
+    public async Task Should_correctly_report_throughput_existence_for_X_days(int daysSinceLastThroughputEntry, int timeFrameToCheck, bool expectedValue)
+    {
+        // Arrange
+        var endpointAudit = new Endpoint("Endpoint", ThroughputSource.Audit);
+        await DataStore.SaveEndpoint(endpointAudit);
 
-            var foundEndpoint = endpoints.Single();
-            Assert.That(foundEndpoint.Id.Name, Is.EqualTo(endpoint1.Id.Name));
-            Assert.That(foundEndpoint.Id.ThroughputSource, Is.EqualTo(endpoint1.Id.ThroughputSource));
-            Assert.That(foundEndpoint.DailyThroughput.Count, Is.EqualTo(1));
-        }
+        await DataStore.RecordEndpointThroughput(
+            endpointAudit.Id.Name,
+            ThroughputSource.Audit,
+            DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-daysSinceLastThroughputEntry),
+            50);
 
-        [Test]
-        public async Task Should_retrieve_matching_endpoint_when_same_source()
-        {
-            var endpoint = new Endpoint("Endpoint", ThroughputSource.Audit)
-            {
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow),
-                        TotalThroughput = 50
-                    }
-                ]
-            };
-
-            await DataStore.RecordEndpointThroughput(endpoint.Id, endpoint.DailyThroughput);
-
-            var foundEndpoint = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Audit);
-
-            Assert.That(foundEndpoint, Is.Not.Null);
-        }
-
-        [Test]
-        public async Task Should_not_retrieve_matching_endpoint_when_different_source()
-        {
-            var endpoint = new Endpoint("Endpoint", ThroughputSource.Audit)
-            {
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow),
-                        TotalThroughput = 50
-                    }
-                ]
-            };
-
-            await DataStore.RecordEndpointThroughput(endpoint.Id, endpoint.DailyThroughput);
-
-            var foundEndpoint = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Broker);
-
-            Assert.That(foundEndpoint, Is.Null);
-        }
-
-        [Test]
-        public async Task Should_update_user_indicators_and_nothing_else()
-        {
-            var endpoint = new Endpoint("Endpoint", ThroughputSource.Audit)
-            {
-                SanitizedName = "Endpoint",
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow),
-                        TotalThroughput = 50
-                    }
-                ]
-            };
-
-            await DataStore.SaveEndpoint(endpoint);
-            await DataStore.RecordEndpointThroughput(endpoint.Id, endpoint.DailyThroughput);
-
-            var foundEndpoint = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Audit);
-            Assert.That(foundEndpoint, Is.Not.Null);
-            Assert.That(foundEndpoint.DailyThroughput.Count, Is.EqualTo(1));
-            Assert.That(foundEndpoint.UserIndicator, Is.Null);
-
-            var userIndicator = "someIndicator";
-            var endpointWithUserIndicators = new Endpoint("Endpoint")
-            {
-                SanitizedName = "Endpoint",
-                UserIndicator = userIndicator
-            };
-
-            await DataStore.UpdateUserIndicatorOnEndpoints([endpointWithUserIndicators]);
-
-            foundEndpoint = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Audit);
-
-            Assert.That(foundEndpoint, Is.Not.Null);
-            Assert.That(foundEndpoint.DailyThroughput.Count, Is.EqualTo(1));
-            Assert.That(foundEndpoint.UserIndicator, Is.EqualTo(userIndicator));
-        }
-
-        [Test]
-        public async Task Should_not_add_endpoint_when_updating_user_indication()
-        {
-            var endpointWithUserIndicators = new Endpoint("Endpoint", ThroughputSource.Audit)
-            {
-                SanitizedName = "Endpoint",
-                UserIndicator = "someIndicator",
-            };
-
-            await DataStore.UpdateUserIndicatorOnEndpoints([endpointWithUserIndicators]);
-
-            var foundEndpoint = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Audit);
-            var allEndpoints = await DataStore.GetAllEndpoints();
-
-            Assert.That(foundEndpoint, Is.Null);
-            Assert.That(allEndpoints.Count, Is.EqualTo(0));
-        }
-
-        [Test]
-        public async Task Should_update_indicators_on_all_endpoint_sources()
-        {
-            var endpointAudit = new Endpoint("Endpoint", ThroughputSource.Audit)
-            {
-                SanitizedName = "Endpoint",
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow),
-                        TotalThroughput = 50
-                    }
-                ]
-            };
-
-            await DataStore.SaveEndpoint(endpointAudit);
-            await DataStore.RecordEndpointThroughput(endpointAudit.Id, endpointAudit.DailyThroughput);
-
-            var endpointMonitoring = new Endpoint("Endpoint", ThroughputSource.Monitoring)
-            {
-                SanitizedName = "Endpoint",
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow),
-                        TotalThroughput = 70
-                    }
-                ]
-            };
-
-            await DataStore.SaveEndpoint(endpointMonitoring);
-            await DataStore.RecordEndpointThroughput(endpointMonitoring.Id, endpointMonitoring.DailyThroughput);
-
-            var foundEndpointAudit = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Audit);
-            Assert.That(foundEndpointAudit, Is.Not.Null);
-            Assert.That(foundEndpointAudit.DailyThroughput.Count, Is.EqualTo(1));
-            Assert.That(foundEndpointAudit.UserIndicator, Is.Null);
-
-            var foundEndpointMonitoring = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Monitoring);
-            Assert.That(foundEndpointMonitoring, Is.Not.Null);
-            Assert.That(foundEndpointMonitoring.DailyThroughput.Count, Is.EqualTo(1));
-            Assert.That(foundEndpointMonitoring.UserIndicator, Is.Null);
-
-            var userIndicator = "someIndicator";
-
-            var endpointWithUserIndicators = new Endpoint("Endpoint")
-            {
-                SanitizedName = "Endpoint",
-                UserIndicator = userIndicator
-            };
-
-            await DataStore.UpdateUserIndicatorOnEndpoints([endpointWithUserIndicators]);
-
-            foundEndpointAudit = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Audit);
-            Assert.That(foundEndpointAudit, Is.Not.Null);
-            Assert.That(foundEndpointAudit.DailyThroughput.Count, Is.EqualTo(1));
-            Assert.That(foundEndpointAudit.UserIndicator, Is.EqualTo(userIndicator));
-
-            foundEndpointMonitoring = await DataStore.GetEndpoint("Endpoint", ThroughputSource.Monitoring);
-            Assert.That(foundEndpointMonitoring, Is.Not.Null);
-            Assert.That(foundEndpointMonitoring.DailyThroughput.Count, Is.EqualTo(1));
-            Assert.That(foundEndpointMonitoring.UserIndicator, Is.EqualTo(userIndicator));
-        }
-
-        [Test]
-        public async Task Should_correctly_report_throughput_existence_for_X_days()
-        {
-            var endpointAudit = new Endpoint("Endpoint", ThroughputSource.Audit)
-            {
-                DailyThroughput =
-                [
-                    new EndpointDailyThroughput
-                    {
-                        DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-10),
-                        TotalThroughput = 50
-                    }
-                ]
-            };
-            await DataStore.RecordEndpointThroughput(endpointAudit.Id, endpointAudit.DailyThroughput);
-
-            Assert.That(await DataStore.IsThereThroughputForLastXDays(5), Is.False);
-            Assert.That(await DataStore.IsThereThroughputForLastXDays(20), Is.True);
-        }
+        Assert.That(await DataStore.IsThereThroughputForLastXDays(timeFrameToCheck), expectedValue ? Is.True : Is.False);
     }
 }

--- a/src/Particular.ThroughputCollector.Persistence.Tests/PersistenceTestFixture.cs
+++ b/src/Particular.ThroughputCollector.Persistence.Tests/PersistenceTestFixture.cs
@@ -1,52 +1,28 @@
-﻿namespace Particular.ThroughputCollector.Persistence.Tests
+﻿namespace Particular.ThroughputCollector.Persistence.Tests;
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+[TestFixture]
+abstract class PersistenceTestFixture
 {
-    using System;
-    using System.Threading.Tasks;
-    using NUnit.Framework;
+    public Action<PersistenceSettings> SetSettings = _ => { };
 
-    [TestFixture]
-    abstract class PersistenceTestFixture
+    [SetUp]
+    public virtual Task Setup()
     {
-        public Action<PersistenceSettings> SetSettings = _ => { };
+        configuration = new PersistenceTestsConfiguration();
 
-        [SetUp]
-        public virtual Task Setup()
-        {
-            configuration = new PersistenceTestsConfiguration();
-
-            return configuration.Configure(SetSettings);
-        }
-
-        [TearDown]
-        public virtual Task Cleanup()
-        {
-            return configuration?.Cleanup();
-        }
-
-        //protected string GetManifestPath()
-        //{
-        //    var currentFolder = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
-
-        //    while (currentFolder != null)
-        //    {
-        //        var file = currentFolder.EnumerateFiles("*.sln", SearchOption.TopDirectoryOnly)
-        //            .SingleOrDefault();
-
-        //        if (file != null)
-        //        {
-        //            return Path.Combine(file.Directory.FullName, $"Particular.ThroughputCollector.Persistence.{PersisterName}", "persistence.manifest");
-        //        }
-
-        //        currentFolder = currentFolder.Parent;
-        //    }
-
-        //    throw new Exception($"Cannot find manifest folder for {PersisterName}");
-        //}
-
-        protected string PersisterName => configuration.Name;
-
-        protected IThroughputDataStore DataStore => configuration.ThroughputDataStore;
-
-        protected PersistenceTestsConfiguration configuration;
+        return configuration.Configure(SetSettings);
     }
+
+    [TearDown]
+    public virtual Task Cleanup() => configuration?.Cleanup();
+
+    protected string PersisterName => configuration.Name;
+
+    protected IThroughputDataStore DataStore => configuration.ThroughputDataStore;
+
+    protected PersistenceTestsConfiguration configuration;
 }

--- a/src/Particular.ThroughputCollector.Persistence/IThroughputDataStore.cs
+++ b/src/Particular.ThroughputCollector.Persistence/IThroughputDataStore.cs
@@ -15,11 +15,14 @@ public interface IThroughputDataStore
 
     Task SaveEndpoint(Endpoint endpoint, CancellationToken cancellationToken = default);
 
-    Task RecordEndpointThroughput(EndpointIdentifier id, IEnumerable<EndpointDailyThroughput> throughput, CancellationToken cancellationToken = default);
+    Task<IDictionary<string, IEnumerable<ThroughputData>>> GetEndpointThroughputByQueueName(IEnumerable<string> queueNames, CancellationToken cancellationToken = default);
+
+    Task RecordEndpointThroughput(string endpointName, ThroughputSource throughputSource, DateOnly date, long messageCount, CancellationToken cancellationToken = default) =>
+        RecordEndpointThroughput(endpointName, throughputSource, [new EndpointDailyThroughput(date, messageCount)], cancellationToken);
+
+    Task RecordEndpointThroughput(string endpointName, ThroughputSource throughputSource, IEnumerable<EndpointDailyThroughput> throughput, CancellationToken cancellationToken = default);
 
     Task UpdateUserIndicatorOnEndpoints(List<Endpoint> endpointsWithUserIndicator);
-
-    Task AppendEndpointThroughput(Endpoint endpoint);
 
     Task<bool> IsThereThroughputForLastXDays(int days);
 

--- a/src/Particular.ThroughputCollector.Persistence/PersistenceSettings.cs
+++ b/src/Particular.ThroughputCollector.Persistence/PersistenceSettings.cs
@@ -5,7 +5,5 @@ using System.Collections.Generic;
 
 public class PersistenceSettings()
 {
-    public HashSet<string> PlatformEndpointNames { get; } = [];
-
     public IDictionary<string, string> PersisterSpecificSettings { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Particular.ThroughputCollector.UnitTests/Infrastructure/DataStoreBuilder.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/Infrastructure/DataStoreBuilder.cs
@@ -1,0 +1,132 @@
+﻿namespace Particular.ThroughputCollector.UnitTests.Infrastructure;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Particular.ThroughputCollector.Contracts;
+using Particular.ThroughputCollector.Persistence;
+
+class DataStoreBuilder(IThroughputDataStore store)
+{
+    static readonly Random rng = new();
+
+    readonly List<Endpoint> endpoints = [];
+    readonly Dictionary<EndpointIdentifier, List<ThroughputData>> endpointThroughput = [];
+
+    public DataStoreBuilder AddEndpoint(string name = null, IEnumerable<ThroughputSource> sources = null)
+    {
+        var index = endpoints.Count;
+
+        sources ??= [ThroughputSource.None];
+        foreach (var source in sources)
+        {
+            endpoints.Add(CreateEndpoint(index, name, source));
+        }
+
+        return this;
+    }
+
+    public DataStoreBuilder ConfigureEndpoint(Action<Endpoint> configureEndpoint) => ConfigureEndpoint(null, configureEndpoint);
+
+    public DataStoreBuilder ConfigureEndpoint(ThroughputSource? source = null, Action<Endpoint> configureEndpoint = null)
+    {
+        Func<Endpoint, bool> predicate = source is null
+            ? endpoint => true
+            : endpoint => endpoint.Id.ThroughputSource == source.Value;
+
+        var endpoint = endpoints.LastOrDefault(predicate) ?? throw new InvalidOperationException($"Need to add an endpoint before calling {nameof(ConfigureEndpoint)}");
+
+        configureEndpoint?.Invoke(endpoint);
+
+        return this;
+    }
+
+    public DataStoreBuilder WithThroughput(ThroughputSource? source = null, DateOnly? startDate = null, int? days = null, IList<long> data = null)
+    {
+        var endpoint = endpoints.LastOrDefault() ?? throw new InvalidOperationException($"Need to add an endpoint before calling {nameof(WithThroughput)}");
+
+        if (source is not null)
+        {
+            var endpointForSource = endpoints.SingleOrDefault(e => e.Id.Name == endpoint.Id.Name && e.Id.ThroughputSource == source);
+            if (endpointForSource is null)
+            {
+                endpointForSource = new Endpoint(endpoint.Id.Name, source.Value) { SanitizedName = endpoint.SanitizedName };
+                endpoints.Add(endpointForSource);
+            }
+
+            endpoint = endpointForSource;
+        }
+
+        source ??= endpoint.Id.ThroughputSource;
+        if (endpoints.SingleOrDefault(e => e.Id.Name == endpoint.Id.Name && e.Id.ThroughputSource == source) == null)
+        {
+            throw new InvalidOperationException($"Need to add endpoint {endpoint.Id.Name}:{source} before calling {nameof(WithThroughput)}");
+        }
+
+        var idForThroughput = new EndpointIdentifier(endpoint.Id.Name, source.Value);
+
+        var throughput = CreateThroughput(source.Value, startDate, days, data);
+
+        if (endpointThroughput.TryGetValue(idForThroughput, out var throughputList))
+        {
+            throughputList.Add(throughput);
+        }
+        else
+        {
+            endpointThroughput.Add(idForThroughput, [throughput]);
+        }
+
+        return this;
+    }
+
+    public async Task Build()
+    {
+        foreach (var endpoint in endpoints)
+        {
+            await store.SaveEndpoint(endpoint);
+        };
+
+        foreach (var (endpointId, throughputList) in endpointThroughput)
+        {
+            foreach (var throughput in throughputList)
+            {
+                await store.RecordEndpointThroughput(endpointId.Name, throughput.ThroughputSource, throughput.Select(entry => new EndpointDailyThroughput(entry.Key, entry.Value)));
+            }
+        }
+    }
+
+    static Endpoint CreateEndpoint(int index, string name = null, ThroughputSource source = ThroughputSource.None)
+    {
+        string endpointName = name ?? $"Endpoint{index}";
+
+        return new Endpoint(endpointName, source)
+        {
+            SanitizedName = endpointName
+        };
+    }
+
+    protected static ThroughputData CreateThroughput(ThroughputSource source, DateOnly? startDate = null, int? days = null, IList<long> data = null)
+    {
+        var numberOfThroughputEntries = days is not null && data is not null
+            ? Math.Max(days.Value, data.Count)
+            : days ?? data?.Count ?? 1;
+
+        if (startDate == null)
+        {
+            startDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-numberOfThroughputEntries);
+        }
+
+        var throughput = Enumerable.Range(0, numberOfThroughputEntries)
+            .Select(i =>
+            {
+                var messageCount = data is not null && i < data.Count
+                    ? data[i]
+                    : rng.Next(100);
+
+                return new EndpointDailyThroughput(startDate.Value.AddDays(i), messageCount);
+            });
+
+        return new ThroughputData(throughput) { ThroughputSource = source };
+    }
+}

--- a/src/Particular.ThroughputCollector.UnitTests/Infrastructure/DataStoreBuilder.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/Infrastructure/DataStoreBuilder.cs
@@ -98,7 +98,7 @@ class DataStoreBuilder(IThroughputDataStore store)
 
     static Endpoint CreateEndpoint(int index, string name = null, ThroughputSource source = ThroughputSource.None)
     {
-        string endpointName = name ?? $"Endpoint{index}";
+        string endpointName = name ?? $"Endpoint{index + 1}";
 
         return new Endpoint(endpointName, source)
         {

--- a/src/Particular.ThroughputCollector.UnitTests/Infrastructure/ThroughputDataStoreExtensions.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/Infrastructure/ThroughputDataStoreExtensions.cs
@@ -1,0 +1,8 @@
+﻿namespace Particular.ThroughputCollector.UnitTests.Infrastructure;
+
+using Particular.ThroughputCollector.Persistence;
+
+static class ThroughputDataStoreExtensions
+{
+    public static DataStoreBuilder CreateBuilder(this IThroughputDataStore dataStore) => new(dataStore);
+}

--- a/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_EnvironmentData_Tests.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_EnvironmentData_Tests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Particular.ThroughputCollector.UnitTests;
 
-using System;
 using System.Collections.Generic;
-
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Particular.ThroughputCollector.Contracts;
@@ -22,14 +20,17 @@ class ThroughputCollector_Report_EnvironmentData_Tests : ThroughputCollectorTest
     [Test]
     public async Task Should_set_audit_flag_to_false_when_no_audit_data()
     {
-        EndpointsWithThroughputFromBrokerOnly.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .Build();
 
+        // Act
         var report = await ThroughputCollector.GenerateThroughputReport([], "");
 
+        // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.EnvironmentData, Is.Not.Null, $"Environment data missing from the report");
         Assert.That(report.ReportData.EnvironmentData.ContainsKey(EnvironmentData.AuditEnabled.ToString()), Is.True, $"AuditEnabled missing from Environment data");
@@ -39,14 +40,24 @@ class ThroughputCollector_Report_EnvironmentData_Tests : ThroughputCollectorTest
     [Test]
     public async Task Should_set_audit_flag_to_true_when_audit_data_exists()
     {
-        EndpointsWithThroughputFromBrokerAndMonitoringAndAudit.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Monitoring])
+                .WithThroughput(ThroughputSource.Broker, days: 2)
+                .WithThroughput(ThroughputSource.Monitoring, days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Audit])
+                .WithThroughput(ThroughputSource.Broker, days: 2)
+                .WithThroughput(ThroughputSource.Audit, days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Monitoring, ThroughputSource.Audit])
+                .WithThroughput(ThroughputSource.Broker, days: 2)
+                .WithThroughput(ThroughputSource.Monitoring, days: 2)
+                .WithThroughput(ThroughputSource.Audit, days: 2)
+            .Build();
 
+        // Act
         var report = await ThroughputCollector.GenerateThroughputReport([], "");
 
+        // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.EnvironmentData, Is.Not.Null, $"Environment data missing from the report");
         Assert.That(report.ReportData.EnvironmentData.ContainsKey(EnvironmentData.AuditEnabled.ToString()), Is.True, $"AuditEnabled missing from Environment data");
@@ -56,14 +67,17 @@ class ThroughputCollector_Report_EnvironmentData_Tests : ThroughputCollectorTest
     [Test]
     public async Task Should_set_monitoring_flag_to_false_when_no_audit_data()
     {
-        EndpointsWithThroughputFromBrokerOnly.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .Build();
 
+        // Act
         var report = await ThroughputCollector.GenerateThroughputReport([], "");
 
+        // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.EnvironmentData, Is.Not.Null, $"Environment data missing from the report");
         Assert.That(report.ReportData.EnvironmentData.ContainsKey(EnvironmentData.MonitoringEnabled.ToString()), Is.True, $"MonitoringEnabled missing from Environment data");
@@ -73,14 +87,24 @@ class ThroughputCollector_Report_EnvironmentData_Tests : ThroughputCollectorTest
     [Test]
     public async Task Should_set_monitoring_flag_to_true_when_audit_data_exists()
     {
-        EndpointsWithThroughputFromBrokerAndMonitoringAndAudit.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Monitoring])
+                .WithThroughput(ThroughputSource.Broker, days: 2)
+                .WithThroughput(ThroughputSource.Monitoring, days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Audit])
+                .WithThroughput(ThroughputSource.Broker, days: 2)
+                .WithThroughput(ThroughputSource.Audit, days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Monitoring, ThroughputSource.Audit])
+                .WithThroughput(ThroughputSource.Broker, days: 2)
+                .WithThroughput(ThroughputSource.Monitoring, days: 2)
+                .WithThroughput(ThroughputSource.Audit, days: 2)
+            .Build();
 
+        // Act
         var report = await ThroughputCollector.GenerateThroughputReport([], "");
 
+        // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.EnvironmentData, Is.Not.Null, $"Environment data missing from the report");
         Assert.That(report.ReportData.EnvironmentData.ContainsKey(EnvironmentData.MonitoringEnabled.ToString()), Is.True, $"MonitoringEnabled missing from Environment data");
@@ -90,15 +114,25 @@ class ThroughputCollector_Report_EnvironmentData_Tests : ThroughputCollectorTest
     [Test]
     public async Task Should_set_sp_version_if_provided()
     {
-        EndpointsWithThroughputFromBrokerAndMonitoringAndAudit.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Monitoring])
+                .WithThroughput(ThroughputSource.Broker, days: 2)
+                .WithThroughput(ThroughputSource.Monitoring, days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Audit])
+                .WithThroughput(ThroughputSource.Broker, days: 2)
+                .WithThroughput(ThroughputSource.Audit, days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Monitoring, ThroughputSource.Audit])
+                .WithThroughput(ThroughputSource.Broker, days: 2)
+                .WithThroughput(ThroughputSource.Monitoring, days: 2)
+                .WithThroughput(ThroughputSource.Audit, days: 2)
+            .Build();
 
+        // Act
         var spVersion = "5.1";
         var report = await ThroughputCollector.GenerateThroughputReport([], spVersion);
 
+        // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.ServicePulseVersion, Is.Not.Null, $"ServicePulseVersion missing from the report");
         Assert.That(report.ReportData.ServicePulseVersion, Is.EqualTo(spVersion), $"ServicePulseVersion should be {spVersion}");
@@ -107,11 +141,12 @@ class ThroughputCollector_Report_EnvironmentData_Tests : ThroughputCollectorTest
     [Test]
     public async Task Should_include_broker_data_in_report()
     {
-        EndpointsWithThroughputFromBrokerOnly.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .Build();
 
         var version = "1.2";
         var scopeType = "testingScope";
@@ -121,8 +156,10 @@ class ThroughputCollector_Report_EnvironmentData_Tests : ThroughputCollectorTest
         };
         await DataStore.SaveBrokerData(broker, scopeType, brokerData);
 
+        // Act
         var report = await ThroughputCollector.GenerateThroughputReport([], "");
 
+        // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.EnvironmentData, Is.Not.Null, $"Missing EnvironmentData from report");
         Assert.That(report.ReportData.ScopeType, Is.Not.Null, $"Missing ScopeType from report");
@@ -130,22 +167,4 @@ class ThroughputCollector_Report_EnvironmentData_Tests : ThroughputCollectorTest
         Assert.That(report.ReportData.EnvironmentData.ContainsKey(EnvironmentData.Version.ToString()), Is.True, $"Missing EnvironmentData.Version from report");
         Assert.That(report.ReportData.EnvironmentData[EnvironmentData.Version.ToString()], Is.EqualTo(version), $"Incorrect EnvironmentData.Version on report");
     }
-
-    readonly List<Endpoint> EndpointsWithThroughputFromBrokerOnly =
-    [
-        new Endpoint("Endpoint1", ThroughputSource.Broker) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 50 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 55 }] },
-        new Endpoint("Endpoint2", ThroughputSource.Broker) { SanitizedName = "Endpoint2", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 60 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 65 }] },
-        new Endpoint("Endpoint3", ThroughputSource.Broker) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 75 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 50 }] }
-    ];
-
-    readonly List<Endpoint> EndpointsWithThroughputFromBrokerAndMonitoringAndAudit =
-    [
-        new Endpoint("Endpoint1", ThroughputSource.Broker) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 50 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 55 }] },
-        new Endpoint("Endpoint1", ThroughputSource.Monitoring) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 60 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 65 }] },
-        new Endpoint("Endpoint2", ThroughputSource.Broker) { SanitizedName = "Endpoint2", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 60 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 65 }] },
-        new Endpoint("Endpoint2", ThroughputSource.Audit) { SanitizedName = "Endpoint2", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 61 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 64 }] },
-        new Endpoint("Endpoint3", ThroughputSource.Broker) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 50 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 57 }] },
-        new Endpoint("Endpoint3", ThroughputSource.Monitoring) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 40 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 45 }] },
-        new Endpoint("Endpoint3", ThroughputSource.Audit) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 42 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 47 }] }
-    ];
 }

--- a/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_EnvironmentData_Tests.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_EnvironmentData_Tests.cs
@@ -65,7 +65,7 @@ class ThroughputCollector_Report_EnvironmentData_Tests : ThroughputCollectorTest
     }
 
     [Test]
-    public async Task Should_set_monitoring_flag_to_false_when_no_audit_data()
+    public async Task Should_set_monitoring_flag_to_false_when_no_monitoring_data()
     {
         // Arrange
         await DataStore.CreateBuilder()
@@ -85,7 +85,7 @@ class ThroughputCollector_Report_EnvironmentData_Tests : ThroughputCollectorTest
     }
 
     [Test]
-    public async Task Should_set_monitoring_flag_to_true_when_audit_data_exists()
+    public async Task Should_set_monitoring_flag_to_true_when_monitoring_data_exists()
     {
         // Arrange
         await DataStore.CreateBuilder()

--- a/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_Masking_Tests.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_Masking_Tests.cs
@@ -1,7 +1,5 @@
 ﻿namespace Particular.ThroughputCollector.UnitTests;
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -22,14 +20,17 @@ class ThroughputCollector_Report_Masking_Tests : ThroughputCollectorTestFixture
     [Test]
     public async Task Should_mask_endpoint_names_when_mask_provided()
     {
-        EndpointsWithThroughputFromBrokerOnly.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .Build();
 
+        // Act
         var report = await ThroughputCollector.GenerateThroughputReport(["Endpoint1"], "");
 
+        // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.TotalQueues, Is.EqualTo(3), $"Invalid TotalQueues on report");
         Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint1"), Is.Null, $"QueueName not masked on report");
@@ -41,14 +42,17 @@ class ThroughputCollector_Report_Masking_Tests : ThroughputCollectorTestFixture
     [Test]
     public async Task Should_not_mask_endpoint_names_when_no_mask_provided()
     {
-        EndpointsWithThroughputFromBrokerOnly.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .Build();
 
+        // Act
         var report = await ThroughputCollector.GenerateThroughputReport([], "");
 
+        // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.TotalQueues, Is.EqualTo(3), $"Invalid TotalQueues on report");
         Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName.Contains("REDACTED")), Is.Null, $"QueueNames should not be masked on report");
@@ -56,11 +60,4 @@ class ThroughputCollector_Report_Masking_Tests : ThroughputCollectorTestFixture
         Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint2"), Is.Not.Null, $"QueueName Endpoint2 not found on report");
         Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint3"), Is.Not.Null, $"QueueName Endpoint2 not found on report");
     }
-
-    readonly List<Endpoint> EndpointsWithThroughputFromBrokerOnly =
-    [
-        new Endpoint("Endpoint1", ThroughputSource.Broker) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 50 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 55 }] },
-        new Endpoint("Endpoint2", ThroughputSource.Broker) { SanitizedName = "Endpoint2", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 60 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 65 }] },
-        new Endpoint("Endpoint3", ThroughputSource.Broker) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 75 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 50 }] }
-    ];
 }

--- a/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_Masking_Tests.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_Masking_Tests.cs
@@ -22,9 +22,9 @@ class ThroughputCollector_Report_Masking_Tests : ThroughputCollectorTestFixture
     {
         // Arrange
         await DataStore.CreateBuilder()
-            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
-            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
-            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint("Endpoint2", sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint("Endpoint3", sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
             .Build();
 
         // Act
@@ -44,9 +44,9 @@ class ThroughputCollector_Report_Masking_Tests : ThroughputCollectorTestFixture
     {
         // Arrange
         await DataStore.CreateBuilder()
-            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
-            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
-            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint("Endpoint2", sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint("Endpoint3", sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
             .Build();
 
         // Act

--- a/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
@@ -49,7 +49,7 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
         await DataStore.CreateBuilder()
             .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker])
             .ConfigureEndpoint(endpoint => endpoint.UserIndicator = UserIndicator.NServicebusEndpoint.ToString()).WithThroughput(days: 2)
-            .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker])
+            .AddEndpoint("Endpoint2", sources: [ThroughputSource.Broker])
             .ConfigureEndpoint(endpoint => endpoint.UserIndicator = UserIndicator.NServicebusEndpointNoLongerInUse.ToString()).WithThroughput(days: 2)
             .AddEndpoint("Endpoint3", sources: [ThroughputSource.Broker])
             .ConfigureEndpoint(endpoint => endpoint.UserIndicator = UserIndicator.NServicebusEndpointSendOnly.ToString()).WithThroughput(days: 2)

--- a/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
@@ -38,7 +38,7 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
         // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.Queues.Count, Is.EqualTo(3), $"Incorrect number of endpoints in throughput report");
-        Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint3")?.DailyThroughputFromBroker?.Length, Is.EqualTo(0), $"Incorrect number of endpoints in throughput report");
+        Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint3")?.DailyThroughputFromBroker?.Length, Is.EqualTo(0), $"Daily throughput should not be included for Endpoint3");
     }
 
     [Test]
@@ -62,10 +62,10 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
         // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.Queues.Count, Is.EqualTo(4), $"Incorrect number of endpoints in throughput report");
-        Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint1")?.DailyThroughputFromBroker?.Length, Is.EqualTo(2), $"Incorrect number of endpoints in throughput report");
-        Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint2")?.DailyThroughputFromBroker?.Length, Is.EqualTo(2), $"Incorrect number of endpoints in throughput report");
-        Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint3")?.DailyThroughputFromBroker?.Length, Is.EqualTo(2), $"Incorrect number of endpoints in throughput report");
-        Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint4")?.DailyThroughputFromBroker?.Length, Is.EqualTo(2), $"Incorrect number of endpoints in throughput report");
+        Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint1")?.DailyThroughputFromBroker?.Length, Is.EqualTo(2), $"Daily throughput should be included for Endpoint1");
+        Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint2")?.DailyThroughputFromBroker?.Length, Is.EqualTo(2), $"Daily throughput should be included for Endpoint2");
+        Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint3")?.DailyThroughputFromBroker?.Length, Is.EqualTo(2), $"Daily throughput should be included for Endpoint3");
+        Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint4")?.DailyThroughputFromBroker?.Length, Is.EqualTo(2), $"Daily throughput should be included for Endpoint4");
     }
 
     [TestCase(ThroughputSource.Audit)]
@@ -129,8 +129,8 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
         Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint2").Throughput, Is.EqualTo(65), $"Incorrect Throughput recorded for Endpoint2");
         Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint3").Throughput, Is.EqualTo(75), $"Incorrect Throughput recorded for Endpoint3");
 
-        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(195), $"Incorrect TotalThroughput recorded for Endpoint1");
-        Assert.That(report.ReportData.TotalQueues, Is.EqualTo(3), $"Incorrect TotalQueues recorded for Endpoint1");
+        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(195), $"Incorrect TotalThroughput recorded");
+        Assert.That(report.ReportData.TotalQueues, Is.EqualTo(3), $"Incorrect TotalQueues recorded");
     }
 
     [Test]
@@ -161,8 +161,8 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
         Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint2").Throughput, Is.EqualTo(65), $"Incorrect Throughput recorded for Endpoint2");
         Assert.That(report.ReportData.Queues.FirstOrDefault(w => w.QueueName == "Endpoint3").Throughput, Is.EqualTo(57), $"Incorrect Throughput recorded for Endpoint3");
 
-        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(187), $"Incorrect TotalThroughput recorded for Endpoint1");
-        Assert.That(report.ReportData.TotalQueues, Is.EqualTo(3), $"Incorrect TotalQueues recorded for Endpoint1");
+        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(187), $"Incorrect TotalThroughput recorded");
+        Assert.That(report.ReportData.TotalQueues, Is.EqualTo(3), $"Incorrect TotalQueues recorde");
     }
 
     [Test]
@@ -179,8 +179,8 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
         Assert.That(report.ReportData.Queues.Count, Is.EqualTo(1), "Invalid number of endpoints in throughput report");
         Assert.That(report.ReportData.Queues[0].Throughput, Is.EqualTo(0), $"Incorrect Throughput recorded for {report.ReportData.Queues[0].QueueName}");
 
-        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(0), $"Incorrect TotalThroughput recorded for Endpoint1");
-        Assert.That(report.ReportData.TotalQueues, Is.EqualTo(1), $"Incorrect TotalQueues recorded for Endpoint1");
+        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(0), $"Incorrect TotalThroughput recorded");
+        Assert.That(report.ReportData.TotalQueues, Is.EqualTo(1), $"Incorrect TotalQueues recorded");
     }
 
     [Test]
@@ -208,7 +208,7 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
         //even though the names are different, we should have matched on the sanitized name and hence displayed max throughput from the 2 endpoints
         Assert.That(report.ReportData.Queues[0].Throughput, Is.EqualTo(75), $"Incorrect Throughput recorded for Endpoint1");
 
-        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(75), $"Incorrect TotalThroughput recorded for Endpoint1");
-        Assert.That(report.ReportData.TotalQueues, Is.EqualTo(1), $"Incorrect TotalQueues recorded for Endpoint1");
+        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(75), $"Incorrect TotalThroughput recorded");
+        Assert.That(report.ReportData.TotalQueues, Is.EqualTo(1), $"Incorrect TotalQueues recorded");
     }
 }

--- a/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
@@ -1,7 +1,6 @@
 ﻿namespace Particular.ThroughputCollector.UnitTests;
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;

--- a/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_ThroughputSummary_Tests.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_ThroughputSummary_Tests.cs
@@ -27,9 +27,12 @@ class ThroughputCollector_ThroughputSummary_Tests : ThroughputCollectorTestFixtu
             .AddEndpoint().WithThroughput(days: 2)
             .AddEndpoint().WithThroughput(days: 2)
             .AddEndpoint().WithThroughput(days: 2)
-            .AddEndpoint("Particular.ServiceControl").WithThroughput(days: 2)
-            .AddEndpoint("audit").WithThroughput(days: 2)
-            .AddEndpoint("error").WithThroughput(days: 2)
+            .AddEndpoint("Particular.ServiceControl")
+            .ConfigureEndpoint(endpoint => endpoint.EndpointIndicators = [EndpointIndicator.PlatformEndpoint.ToString()]).WithThroughput(days: 2)
+            .AddEndpoint("audit")
+            .ConfigureEndpoint(endpoint => endpoint.EndpointIndicators = [EndpointIndicator.PlatformEndpoint.ToString()]).WithThroughput(days: 2)
+            .AddEndpoint("error")
+            .ConfigureEndpoint(endpoint => endpoint.EndpointIndicators = [EndpointIndicator.PlatformEndpoint.ToString()]).WithThroughput(days: 2)
             .Build();
 
         // Act

--- a/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_ThroughputSummary_Tests.cs
+++ b/src/Particular.ThroughputCollector.UnitTests/ThroughputCollector/ThroughputCollector_ThroughputSummary_Tests.cs
@@ -1,7 +1,5 @@
 ﻿namespace Particular.ThroughputCollector.UnitTests;
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -12,6 +10,7 @@ using Particular.ThroughputCollector.UnitTests.Infrastructure;
 class ThroughputCollector_ThroughputSummary_Tests : ThroughputCollectorTestFixture
 {
     readonly Broker broker = Broker.AzureServiceBus;
+
     public override Task Setup()
     {
         SetThroughputSettings = s => s.Broker = broker;
@@ -23,35 +22,40 @@ class ThroughputCollector_ThroughputSummary_Tests : ThroughputCollectorTestFixtu
     [Test]
     public async Task Should_remove_audit_error_and_servicecontrol_queue_from_summary()
     {
-        EndpointsWithThroughputFromBrokerOnly.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
-        await DataStore.SaveEndpoint(ErrorEndpoint);
-        await DataStore.RecordEndpointThroughput(ErrorEndpoint.Id, ErrorEndpoint.DailyThroughput);
-        await DataStore.SaveEndpoint(AuditEndpoint);
-        await DataStore.RecordEndpointThroughput(AuditEndpoint.Id, AuditEndpoint.DailyThroughput);
-        await DataStore.SaveEndpoint(ServiceControlEndpoint);
-        await DataStore.RecordEndpointThroughput(ServiceControlEndpoint.Id, ServiceControlEndpoint.DailyThroughput);
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint().WithThroughput(days: 2)
+            .AddEndpoint().WithThroughput(days: 2)
+            .AddEndpoint().WithThroughput(days: 2)
+            .AddEndpoint("Particular.ServiceControl").WithThroughput(days: 2)
+            .AddEndpoint("audit").WithThroughput(days: 2)
+            .AddEndpoint("error").WithThroughput(days: 2)
+            .Build();
 
+        // Act
         var summary = await ThroughputCollector.GetThroughputSummary();
 
+        // Assert
         Assert.That(summary, Is.Not.Null);
         Assert.That(summary.Count, Is.EqualTo(3), $"Incorrect number of endpoints in throughput summary");
-
     }
-    [Test]
-    public async Task Should_return_correct_number_of_endpoints_in_summary_when_only_one_source_of_throughput()
-    {
-        EndpointsWithThroughputFromBrokerOnly.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
 
+    [TestCase(ThroughputSource.Audit)]
+    [TestCase(ThroughputSource.Broker)]
+    [TestCase(ThroughputSource.Monitoring)]
+    public async Task Should_return_correct_number_of_endpoints_in_summary_when_only_one_source_of_throughput(ThroughputSource source)
+    {
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint(sources: [source]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [source]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [source]).WithThroughput(days: 2)
+            .Build();
+
+        // Act
         var summary = await ThroughputCollector.GetThroughputSummary();
 
+        // Assert
         Assert.That(summary, Is.Not.Null);
         Assert.That(summary.Count, Is.EqualTo(3), $"Incorrect number of endpoints in throughput summary");
     }
@@ -59,49 +63,66 @@ class ThroughputCollector_ThroughputSummary_Tests : ThroughputCollectorTestFixtu
     [Test]
     public async Task Should_return_correct_number_of_endpoints_in_summary_when_multiple_sources_of_throughput()
     {
-        EndpointsWithThroughputFromBrokerAndMonitoring.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Monitoring]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker]).WithThroughput(days: 2)
+            .AddEndpoint(sources: [ThroughputSource.Broker, ThroughputSource.Monitoring]).WithThroughput(days: 2)
+            .Build();
 
+        // Act
         var summary = await ThroughputCollector.GetThroughputSummary();
 
+        // Assert
         Assert.That(summary, Is.Not.Null);
         Assert.That(summary.Count, Is.EqualTo(3), $"Incorrect number of endpoints in throughput summary");
     }
 
-    [Test]
-    public async Task Should_return_correct_max_throughput_in_summary_when_data_only_from_one_source()
+    [TestCase(ThroughputSource.Audit)]
+    [TestCase(ThroughputSource.Broker)]
+    [TestCase(ThroughputSource.Monitoring)]
+    public async Task Should_return_correct_max_throughput_in_summary_when_data_only_from_one_source(ThroughputSource source)
     {
-        EndpointsWithThroughputFromBrokerOnly.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint("Endpoint1", sources: [source]).WithThroughput(data: [50, 55])
+            .AddEndpoint("Endpoint2", sources: [source]).WithThroughput(data: [60, 65])
+            .AddEndpoint("Endpoint3", sources: [source]).WithThroughput(data: [75, 50])
+            .Build();
 
+        // Act
         var summary = await ThroughputCollector.GetThroughputSummary();
 
+        // Assert
         Assert.That(summary, Is.Not.Null);
-        Assert.That(summary.Count, Is.EqualTo(3));
+        Assert.That(summary.Count, Is.EqualTo(3), $"Incorrect number of endpoints in throughput summary");
 
-        Assert.That(summary.FirstOrDefault(w => w.Name == "Endpoint1").MaxDailyThroughput, Is.EqualTo(55), $"Incorrect MaxDailyThroughput recorded for Endpoint1");
-        Assert.That(summary.FirstOrDefault(w => w.Name == "Endpoint2").MaxDailyThroughput, Is.EqualTo(65), $"Incorrect MaxDailyThroughput recorded for Endpoint2");
-        Assert.That(summary.FirstOrDefault(w => w.Name == "Endpoint3").MaxDailyThroughput, Is.EqualTo(75), $"Incorrect MaxDailyThroughput recorded for Endpoint3");
-
+        Assert.That(summary.Single(w => w.Name == "Endpoint1").MaxDailyThroughput, Is.EqualTo(55), $"Incorrect MaxDailyThroughput recorded for Endpoint1");
+        Assert.That(summary.Single(w => w.Name == "Endpoint2").MaxDailyThroughput, Is.EqualTo(65), $"Incorrect MaxDailyThroughput recorded for Endpoint2");
+        Assert.That(summary.Single(w => w.Name == "Endpoint3").MaxDailyThroughput, Is.EqualTo(75), $"Incorrect MaxDailyThroughput recorded for Endpoint3");
     }
 
     [Test]
     public async Task Should_return_correct_max_throughput_in_summary_when_multiple_sources()
     {
-        EndpointsWithThroughputFromBrokerAndMonitoringAndAudit.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker, ThroughputSource.Monitoring])
+                .WithThroughput(ThroughputSource.Broker, data: [50, 55])
+                .WithThroughput(ThroughputSource.Monitoring, data: [60, 65])
+            .AddEndpoint("Endpoint2", sources: [ThroughputSource.Broker, ThroughputSource.Audit])
+                .WithThroughput(ThroughputSource.Broker, data: [60, 65])
+                .WithThroughput(ThroughputSource.Audit, data: [61, 64])
+            .AddEndpoint("Endpoint3", sources: [ThroughputSource.Broker, ThroughputSource.Monitoring, ThroughputSource.Audit])
+                .WithThroughput(ThroughputSource.Broker, data: [50, 57])
+                .WithThroughput(ThroughputSource.Monitoring, data: [40, 45])
+                .WithThroughput(ThroughputSource.Audit, data: [42, 47])
+            .Build();
 
+        // Act
         var summary = await ThroughputCollector.GetThroughputSummary();
 
+        // Assert
         Assert.That(summary, Is.Not.Null);
         Assert.That(summary.Count, Is.EqualTo(3));
 
@@ -113,10 +134,13 @@ class ThroughputCollector_ThroughputSummary_Tests : ThroughputCollectorTestFixtu
     [Test]
     public async Task Should_return_correct_max_throughput_in_summary_when_endpoint_has_no_throughput()
     {
-        EndpointsWithNoThroughput.ForEach(e => DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput));
+        // Arrange
+        await DataStore.CreateBuilder().AddEndpoint().Build();
 
+        // Act
         var summary = await ThroughputCollector.GetThroughputSummary();
 
+        // Assert
         Assert.That(summary, Is.Not.Null);
         Assert.That(summary.Count, Is.EqualTo(1), "Invalid number of endpoints in throughput summary");
         Assert.That(summary[0].MaxDailyThroughput, Is.EqualTo(0), $"Incorrect MaxDailyThroughput recorded for {summary[0].Name}");
@@ -125,14 +149,19 @@ class ThroughputCollector_ThroughputSummary_Tests : ThroughputCollectorTestFixtu
     [Test]
     public async Task Should_return_correct_max_throughput_in_summary_when_data_from_multiple_sources_and_name_is_different()
     {
-        EndpointsWithDifferentNamesButSameSanitizedNames.ForEach(async e =>
-        {
-            await DataStore.SaveEndpoint(e);
-            await DataStore.RecordEndpointThroughput(e.Id, e.DailyThroughput);
-        });
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker])
+                .WithThroughput(data: [50, 75])
+            .AddEndpoint("Endpoint1_", sources: [ThroughputSource.Audit])
+            .ConfigureEndpoint(endpoint => endpoint.SanitizedName = "Endpoint1")
+                .WithThroughput(data: [60, 65])
+            .Build();
 
+        // Act
         var summary = await ThroughputCollector.GetThroughputSummary();
 
+        // Assert
         Assert.That(summary, Is.Not.Null);
         Assert.That(summary.Count, Is.EqualTo(1));
 
@@ -142,47 +171,4 @@ class ThroughputCollector_ThroughputSummary_Tests : ThroughputCollectorTestFixtu
         //even though the names are different, we should have matched on the sanitized name and hence displayed max throughput from the 2 endpoints
         Assert.That(summary[0].MaxDailyThroughput, Is.EqualTo(75), $"Incorrect MaxDailyThroughput recorded for Endpoint1");
     }
-
-
-    readonly List<Endpoint> EndpointsWithNoThroughput =
-    [
-        new Endpoint("Endpoint1", ThroughputSource.Audit) { SanitizedName = "Endpoint1" },
-    ];
-
-    readonly List<Endpoint> EndpointsWithThroughputFromBrokerOnly =
-    [
-        new Endpoint("Endpoint1", ThroughputSource.Broker) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 50 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 55 }] },
-        new Endpoint("Endpoint2", ThroughputSource.Broker) { SanitizedName = "Endpoint2", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 60 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 65 }] },
-        new Endpoint("Endpoint3", ThroughputSource.Broker) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 75 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 50 }] }
-    ];
-
-    readonly List<Endpoint> EndpointsWithThroughputFromBrokerAndMonitoring =
-    [
-        new Endpoint("Endpoint1", ThroughputSource.Broker) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 50 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 55 }] },
-        new Endpoint("Endpoint1", ThroughputSource.Monitoring) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 60 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 65 }] },
-        new Endpoint("Endpoint2", ThroughputSource.Broker) { SanitizedName = "Endpoint2", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 60 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 65 }] },
-        new Endpoint("Endpoint3", ThroughputSource.Broker) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 50 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 55 }] },
-        new Endpoint("Endpoint1", ThroughputSource.Monitoring) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 40 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 45 }] }
-    ];
-
-    readonly List<Endpoint> EndpointsWithThroughputFromBrokerAndMonitoringAndAudit =
-    [
-        new Endpoint("Endpoint1", ThroughputSource.Broker) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 50 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 55 }] },
-        new Endpoint("Endpoint1", ThroughputSource.Monitoring) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 60 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 65 }] },
-        new Endpoint("Endpoint2", ThroughputSource.Broker) { SanitizedName = "Endpoint2", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 60 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 65 }] },
-        new Endpoint("Endpoint2", ThroughputSource.Audit) { SanitizedName = "Endpoint2", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 61 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 64 }] },
-        new Endpoint("Endpoint3", ThroughputSource.Broker) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 50 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 57 }] },
-        new Endpoint("Endpoint3", ThroughputSource.Monitoring) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 40 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 45 }] },
-        new Endpoint("Endpoint3", ThroughputSource.Audit) { SanitizedName = "Endpoint3", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 42 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 47 }] }
-    ];
-
-    readonly List<Endpoint> EndpointsWithDifferentNamesButSameSanitizedNames =
-    [
-        new Endpoint("Endpoint1", ThroughputSource.Broker) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 50 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 75 }] },
-        new Endpoint("Endpoint1_", ThroughputSource.Audit) { SanitizedName = "Endpoint1", DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 60 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 65 }] },
-    ];
-
-    readonly Endpoint ServiceControlEndpoint = new("Particular.ServiceControl", ThroughputSource.Broker) { SanitizedName = "Particular.ServiceControl", EndpointIndicators = [EndpointIndicator.PlatformEndpoint.ToString()], DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 500 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 600 }] };
-    readonly Endpoint AuditEndpoint = new("audit", ThroughputSource.Broker) { SanitizedName = "audit", EndpointIndicators = [EndpointIndicator.PlatformEndpoint.ToString()], DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 500 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 600 }] };
-    readonly Endpoint ErrorEndpoint = new("error", ThroughputSource.Broker) { SanitizedName = "error", EndpointIndicators = [EndpointIndicator.PlatformEndpoint.ToString()], DailyThroughput = [new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1), TotalThroughput = 500 }, new EndpointDailyThroughput { DateUTC = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), TotalThroughput = 600 }] };
 }

--- a/src/Particular.ThroughputCollector/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
+++ b/src/Particular.ThroughputCollector/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
@@ -73,7 +73,7 @@ internal class BrokerThroughputCollectorHostedService(
                 endpoint = new Endpoint(endpointId)
                 {
                     Scope = queueName.Scope,
-                    EndpointIndicators = queueName.EndpointIndicators.ToArray()
+                    EndpointIndicators = [.. queueName.EndpointIndicators]
                 };
 
                 await dataStore.SaveEndpoint(endpoint, stoppingToken);
@@ -84,7 +84,7 @@ internal class BrokerThroughputCollectorHostedService(
                 ? defaultStartDate
                 : endpoint.LastCollectedDate;
 
-            await foreach (var queueThroughput in throughputQuery.GetThroughputPerDay(queueName, startDate, stoppingToken))
+            await foreach (var queueThroughput in brokerThroughputQuery.GetThroughputPerDay(queueName, startDate, stoppingToken))
             {
                 await dataStore.RecordEndpointThroughput(queueName.QueueName, ThroughputSource.Broker, queueThroughput.DateUTC, queueThroughput.TotalThroughput, stoppingToken);
             }

--- a/src/Particular.ThroughputCollector/IThroughputCollector.cs
+++ b/src/Particular.ThroughputCollector/IThroughputCollector.cs
@@ -4,11 +4,11 @@
 
     public interface IThroughputCollector
     {
-        Task<List<EndpointThroughputSummary>> GetThroughputSummary();
+        Task<List<EndpointThroughputSummary>> GetThroughputSummary(CancellationToken cancellationToken = default);
         Task UpdateUserIndicatorsOnEndpoints(List<EndpointThroughputSummary> endpointsThroughputSummary);
         Task<ThroughputConnectionSettings> GetThroughputConnectionSettingsInformation();
         Task<ConnectionTestResults> TestConnectionSettings(CancellationToken cancellationToken = default);
-        Task<SignedReport> GenerateThroughputReport(string[] masks, string spVersion);
+        Task<SignedReport> GenerateThroughputReport(string[] masks, string spVersion, CancellationToken cancellationToken = default);
         Task<ReportGenerationState> GetReportGenerationState();
     }
 }

--- a/src/Particular.ThroughputCollector/MonitoringThroughput/MonitoringThroughputFeature.cs
+++ b/src/Particular.ThroughputCollector/MonitoringThroughput/MonitoringThroughputFeature.cs
@@ -71,13 +71,9 @@ class MonitoringThroughputFeature : Feature
 
                     if (e.Throughput > 0)
                     {
-                        var endpointThroughput = new EndpointDailyThroughput
-                        {
-                            DateUTC = DateOnly.FromDateTime(message.EndDateTime),
-                            TotalThroughput = e.Throughput
-                        };
+                        var endpointThroughput = new EndpointDailyThroughput(DateOnly.FromDateTime(message.EndDateTime), e.Throughput);
 
-                        await dataStore.RecordEndpointThroughput(endpoint.Id, [endpointThroughput], cancellationToken);
+                        await dataStore.RecordEndpointThroughput(e.Name, ThroughputSource.Monitoring, [endpointThroughput], cancellationToken);
                     }
                 });
             }

--- a/src/Particular.ThroughputCollector/ServiceCollectionExtensions.cs
+++ b/src/Particular.ThroughputCollector/ServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ static class ServiceCollectionExtensions
     /// It is possible for multiple different hosts to be created by Service Control and its associated test infrastructure,
     /// which means AddPersistence can be called multiple times and potentially with different persistence types
     /// </remarks>
-    public static IServiceCollection AddPersistence(this IServiceCollection services, string persistenceType, Action<PersistenceSettings>? configureSettings = null)
+    public static IServiceCollection AddPersistence(this IServiceCollection services, string persistenceType)
     {
         if (PersistenceTypes.Count == 0)
         {
@@ -25,7 +25,6 @@ static class ServiceCollectionExtensions
 
         var persistenceConfiguration = PersistenceConfigurationFactory.LoadPersistenceConfiguration(persistenceType);
         var persistenceSettings = persistenceConfiguration.BuildPersistenceSettings();
-        configureSettings?.Invoke(persistenceSettings);
         services.AddSingleton(persistenceSettings);
 
         var persistence = persistenceConfiguration.Create(persistenceSettings);

--- a/src/Particular.ThroughputCollector/ThroughputCollector.cs
+++ b/src/Particular.ThroughputCollector/ThroughputCollector.cs
@@ -1,196 +1,212 @@
-﻿namespace Particular.ThroughputCollector
+﻿namespace Particular.ThroughputCollector;
+
+using AuditThroughput;
+using Contracts;
+using Persistence;
+using ServiceControl.Transports;
+using Shared;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using QueueThroughput = Contracts.QueueThroughput;
+
+public class ThroughputCollector(IThroughputDataStore dataStore, ThroughputSettings throughputSettings, AuditQuery auditQuery, IBrokerThroughputQuery? throughputQuery = null)
+    : IThroughputCollector
 {
-    using AuditThroughput;
-    using Contracts;
-    using Persistence;
-    using ServiceControl.Transports;
-    using Shared;
-    using QueueThroughput = Contracts.QueueThroughput;
-
-    public class ThroughputCollector(IThroughputDataStore dataStore, ThroughputSettings throughputSettings, AuditQuery auditQuery, IBrokerThroughputQuery? throughputQuery = null)
-        : IThroughputCollector
+    public async Task<ThroughputConnectionSettings> GetThroughputConnectionSettingsInformation()
     {
-        public async Task<ThroughputConnectionSettings> GetThroughputConnectionSettingsInformation()
+        var throughputConnectionSettings = new ThroughputConnectionSettings
         {
-            var throughputConnectionSettings = new ThroughputConnectionSettings
-            {
-                Broker = throughputSettings.Broker,
-                Settings = throughputSettings.Broker != Broker.None
-                    ? throughputQuery?.Settings.Select(pair => new ThroughputConnectionSetting(pair.Key, pair.Description)).ToList() ?? []
-                    : ServiceControlSettings.GetServiceControlConnectionSettings()
-            };
-            return await Task.FromResult(throughputConnectionSettings);
-        }
-
-        public async Task<ConnectionTestResults> TestConnectionSettings(CancellationToken cancellationToken = default)
-        {
-            var tasks = new List<Task>();
-            var brokerTask = Task.FromResult(new ConnectionSettingsTestResult { ConnectionSuccessful = false, ConnectionErrorMessages = [] });
-
-            if (throughputQuery != null)
-            {
-                brokerTask = throughputQuery.TestConnection(cancellationToken).ContinueWith(task => new ConnectionSettingsTestResult { ConnectionSuccessful = task.Result.Success, ConnectionErrorMessages = task.Result.Errors }, cancellationToken);
-                tasks.Add(brokerTask);
-            }
-            var auditTask = auditQuery.TestAuditConnection(cancellationToken);
-
-            await Task.WhenAll(tasks);
-
-            var connectionTestResults = new ConnectionTestResults(throughputSettings.Broker, auditTask.Result, new ConnectionSettingsTestResult(), brokerTask.Result);
-
-            return await Task.FromResult(connectionTestResults);
-        }
-
-        public async Task UpdateUserIndicatorsOnEndpoints(List<EndpointThroughputSummary> endpointThroughputs)
-        {
-            await dataStore.UpdateUserIndicatorOnEndpoints(endpointThroughputs.Select(e =>
-                new Endpoint(e.Name, ThroughputSource.None)
-                {
-                    SanitizedName = e.Name,
-                    UserIndicator = e.UserIndicator,
-                }).ToList());
-
-            await Task.CompletedTask;
-        }
-
-        public async Task<List<EndpointThroughputSummary>> GetThroughputSummary()
-        {
-            var endpoints = await dataStore.GetAllEndpoints(false);
-            var endpointSummaries = new List<EndpointThroughputSummary>();
-
-            //group endpoints by sanitized name - so to group throughput recorded from broker, audit and monitoring
-            foreach (var endpoint in endpoints.GroupBy(g => g.SanitizedName))
-            {
-                var endpointSummary = new EndpointThroughputSummary
-                {
-                    //want to display the endpoint name to the user if it's different to the sanitized endpoint name
-                    Name = endpoint.Any(w => w.Id.Name != w.SanitizedName) ? endpoint.First(w => w.Id.Name != w.SanitizedName).Id.Name : endpoint.Key,
-                    UserIndicator = UserIndicator(endpoint) ?? string.Empty,
-                    IsKnownEndpoint = IsKnownEndpoint(endpoint),
-                    MaxDailyThroughput = MaxDailyThroughput(endpoint) ?? 0
-                };
-
-                endpointSummaries.Add(endpointSummary);
-            }
-
-            return await Task.FromResult(endpointSummaries);
-        }
-
-        public async Task<ReportGenerationState> GetReportGenerationState()
-        {
-            var reportGenerationState = new ReportGenerationState
-            {
-                Broker = throughputSettings.Broker,
-                ReportCanBeGenerated = await dataStore.IsThereThroughputForLastXDays(30)
-            };
-
-            return reportGenerationState;
-        }
-
-        public async Task<SignedReport> GenerateThroughputReport(string[] masks, string spVersion)
-        {
-            CreateMasks(masks);
-
-            var endpoints = await dataStore.GetAllEndpoints(false);
-            var endpointThroughputs = new List<QueueThroughput>();
-            List<string> ignoredQueueNames = [];
-
-            //group endpoints by sanitized name - so to group throughput recorded from broker, audit and monitoring
-            foreach (var endpoint in endpoints.GroupBy(g => g.SanitizedName))
-            {
-                //want to display the endpoint name if it's different to the sanitized endpoint name
-                var queueName = endpoint.Any(w => w.Id.Name != w.SanitizedName) ? endpoint.First(w => w.Id.Name != w.SanitizedName).Id.Name : endpoint.Key;
-
-                //get all data that we have, including daily values
-                var endpointThroghput = new QueueThroughput
-                {
-                    QueueName = Mask(queueName),
-                    UserIndicator = UserIndicator(endpoint) ?? string.Empty,
-                    EndpointIndicators = EndpointIndicators(endpoint) ?? [],
-                    NoDataOrSendOnly = NoDataOrSendOnly(endpoint),
-                    Scope = EndpointScope(endpoint) ?? "",
-                    Throughput = MaxDailyThroughput(endpoint) ?? 0,
-                    DailyThroughputFromAudit = AuditThroughput(endpoint) ?? [],
-                    DailyThroughputFromMonitoring = MonitoringThroughput(endpoint) ?? [],
-                    DailyThroughputFromBroker = BrokerThroughput(endpoint) ?? []
-                };
-
-                endpointThroughputs.Add(endpointThroghput);
-            }
-
-            var brokerData = await dataStore.GetBrokerData(throughputSettings.Broker);
-            var yesterday = DateTime.UtcNow.Date.AddDays(-1);
-            var report = new Report
-            {
-                EndTime = new DateTimeOffset(yesterday, TimeSpan.Zero),
-                CustomerName = throughputSettings.CustomerName, //who the license is registeredTo
-                ReportMethod = "NA",
-                ScopeType = brokerData?.ScopeType ?? "",
-                Prefix = null,
-                MessageTransport = throughputQuery?.MessageTransport ?? throughputSettings.TransportType,
-                ToolVersion = "V3", //ensure we check for this on the other side - ie that we can process V3
-                ServiceControlVersion = throughputSettings.ServiceControlVersion,
-                ServicePulseVersion = spVersion,
-                IgnoredQueues = ignoredQueueNames?.ToArray() ?? [],
-                Queues = endpointThroughputs.ToArray(),
-                TotalQueues = endpointThroughputs.Count(),
-                TotalThroughput = endpointThroughputs.Sum(q => q.Throughput ?? 0),
-                EnvironmentData = brokerData?.Data ?? []
-            };
-
-            //this will be the date of the first throughput that we have received
-            var firstAuditThroughputDate = endpointThroughputs.SelectMany(w => w.DailyThroughputFromAudit).MinBy(m => m.DateUTC)?.DateUTC.ToDateTime(TimeOnly.MinValue) ?? yesterday.AddDays(-1);
-            var firstMonitoringThroughputDate = endpointThroughputs.SelectMany(w => w.DailyThroughputFromMonitoring).MinBy(m => m.DateUTC)?.DateUTC.ToDateTime(TimeOnly.MinValue) ?? yesterday.AddDays(-1);
-            var firstBrokerThroughputDate = endpointThroughputs.SelectMany(w => w.DailyThroughputFromBroker).MinBy(m => m.DateUTC)?.DateUTC.ToDateTime(TimeOnly.MinValue) ?? yesterday.AddDays(-1);
-            report.StartTime = new DateTimeOffset(new[] { firstAuditThroughputDate, firstMonitoringThroughputDate, firstBrokerThroughputDate }.Min(), TimeSpan.Zero);
-            report.ReportDuration = report.EndTime - report.StartTime;
-
-            report.EnvironmentData.Add(EnvironmentData.AuditEnabled.ToString(), endpoints.Any(a => a.Id.ThroughputSource == ThroughputSource.Audit && a.DailyThroughput?.Count > 0).ToString());
-            report.EnvironmentData.Add(EnvironmentData.MonitoringEnabled.ToString(), endpoints.Any(a => a.Id.ThroughputSource == ThroughputSource.Monitoring && a.DailyThroughput?.Count > 0).ToString());
-
-            var throughputReport = new SignedReport() { ReportData = report, Signature = Signature.SignReport(report) };
-            return await Task.FromResult(throughputReport);
-        }
-
-        void CreateMasks(string[] wordsToMask)
-        {
-            var number = 0;
-            masks = wordsToMask
-                .Select(mask =>
-                {
-                    number++;
-                    return (mask, $"REDACTED{number}");
-                })
-                .ToArray();
-        }
-
-        string Mask(string stringToMask)
-        {
-            foreach (var (mask, replacement) in masks)
-            {
-                stringToMask = stringToMask.Replace(mask, replacement, StringComparison.OrdinalIgnoreCase);
-            }
-
-            return stringToMask;
-        }
-
-        string? UserIndicator(IGrouping<string, Endpoint> endpoint) => endpoint.FirstOrDefault(s => !string.IsNullOrEmpty(s.UserIndicator))?.UserIndicator;
-
-        string? EndpointScope(IGrouping<string, Endpoint> endpoint) => endpoint.FirstOrDefault(s => !string.IsNullOrEmpty(s.Scope))?.Scope;
-        bool IsKnownEndpoint(IGrouping<string, Endpoint> endpoint) => endpoint.Any(s => s.EndpointIndicators != null && s.EndpointIndicators.Contains(EndpointIndicator.KnownEndpoint.ToString()));
-        //bool IsPlatformEndpoint(IGrouping<string, Endpoint> endpoint) => endpoint.Any(s => s.EndpointIndicators != null && s.EndpointIndicators.Contains(EndpointIndicator.PlatformEndpoint.ToString()));
-
-        bool NoDataOrSendOnly(IGrouping<string, Endpoint> endpoint) => endpoint.All(a => a.DailyThroughput.Sum(s => s.TotalThroughput) == 0);
-        string[]? EndpointIndicators(IGrouping<string, Endpoint> endpoint) => endpoint.Where(w => w.EndpointIndicators?.Any() == true)?.SelectMany(s => s.EndpointIndicators)?.Distinct()?.ToArray();
-        EndpointDailyThroughput[]? AuditThroughput(IGrouping<string, Endpoint> endpoint) => endpoint.Where(w => w.Id.ThroughputSource == ThroughputSource.Audit)?.SelectMany(s => s.DailyThroughput)?.ToArray();
-        EndpointDailyThroughput[]? MonitoringThroughput(IGrouping<string, Endpoint> endpoint) => endpoint.Where(w => w.Id.ThroughputSource == ThroughputSource.Monitoring)?.SelectMany(s => s.DailyThroughput)?.ToArray();
-        EndpointDailyThroughput[]? BrokerThroughput(IGrouping<string, Endpoint> endpoint) => endpoint.Where(w => w.Id.ThroughputSource == ThroughputSource.Broker && (string.IsNullOrEmpty(w.UserIndicator) || !w.UserIndicator.Equals(Contracts.UserIndicator.NotNServicebusEndpoint.ToString(), StringComparison.OrdinalIgnoreCase)))?.SelectMany(s => s.DailyThroughput)?.ToArray();
-
-        //get the max throughput recorded for the endpoints - shouldn't matter where it comes from (ie broker or service control)
-        long? MaxDailyThroughput(IGrouping<string, Endpoint> endpoint) => endpoint.Where(w => w.DailyThroughput != null).SelectMany(s => s.DailyThroughput).MaxBy(m => m.TotalThroughput)?.TotalThroughput;
-
-        //bool ThroughputExistsForThisPeriod(IGrouping<string, Endpoint> endpoint, int days) => endpoint.Where(w => w.DailyThroughput != null).SelectMany(s => s.DailyThroughput).Any(m => m.DateUTC <= DateTime.UtcNow && m.DateUTC >= DateTime.UtcNow.AddDays(-days));
-
-        (string Mask, string Replacement)[] masks = [];
+            Broker = throughputSettings.Broker,
+            Settings = throughputSettings.Broker != Broker.None
+                ? throughputQuery?.Settings.Select(pair => new ThroughputConnectionSetting(pair.Key, pair.Description)).ToList() ?? []
+                : ServiceControlSettings.GetServiceControlConnectionSettings()
+        };
+        return await Task.FromResult(throughputConnectionSettings);
     }
+
+    public async Task<ConnectionTestResults> TestConnectionSettings(CancellationToken cancellationToken = default)
+    {
+        var tasks = new List<Task>();
+        var brokerTask = Task.FromResult(new ConnectionSettingsTestResult { ConnectionSuccessful = false, ConnectionErrorMessages = [] });
+
+        if (throughputQuery != null)
+        {
+            brokerTask = throughputQuery.TestConnection(cancellationToken).ContinueWith(task => new ConnectionSettingsTestResult { ConnectionSuccessful = task.Result.Success, ConnectionErrorMessages = task.Result.Errors }, cancellationToken);
+            tasks.Add(brokerTask);
+        }
+
+        var auditTask = auditQuery.TestAuditConnection(cancellationToken);
+        tasks.Add(auditTask);
+
+        await Task.WhenAll(tasks);
+
+        var connectionTestResults = new ConnectionTestResults(throughputSettings.Broker, auditTask.Result, new ConnectionSettingsTestResult(), brokerTask.Result);
+
+        return await Task.FromResult(connectionTestResults);
+    }
+
+    public async Task UpdateUserIndicatorsOnEndpoints(List<EndpointThroughputSummary> endpointThroughputs)
+    {
+        await dataStore.UpdateUserIndicatorOnEndpoints(endpointThroughputs.Select(e =>
+            new Endpoint(e.Name, ThroughputSource.None)
+            {
+                SanitizedName = e.Name,
+                UserIndicator = e.UserIndicator,
+            }).ToList());
+
+        await Task.CompletedTask;
+    }
+
+    public async Task<List<EndpointThroughputSummary>> GetThroughputSummary(CancellationToken cancellationToken = default)
+    {
+        var endpoints = (await dataStore.GetAllEndpoints(false, cancellationToken)).ToList();
+        var queueNames = endpoints.Select(endpoint => endpoint.SanitizedName).Distinct();
+        var endpointThroughputPerQueue = await dataStore.GetEndpointThroughputByQueueName(queueNames, cancellationToken);
+        var endpointSummaries = new List<EndpointThroughputSummary>();
+
+        //group endpoints by sanitized name - so to group throughput recorded from broker, audit and monitoring
+        foreach (var endpointGroupPerQueue in endpoints.GroupBy(g => g.SanitizedName))
+        {
+            if (!endpointThroughputPerQueue.TryGetValue(endpointGroupPerQueue.Key, out var data))
+            {
+                data = [];
+            }
+
+            var endpointSummary = new EndpointThroughputSummary
+            {
+                //want to display the endpoint name to the user if it's different to the sanitized endpoint name
+                Name = endpointGroupPerQueue.FirstOrDefault(endpoint => endpoint.Id.Name != endpoint.SanitizedName)?.Id.Name ?? endpointGroupPerQueue.Key,
+                UserIndicator = UserIndicator(endpointGroupPerQueue) ?? string.Empty,
+                IsKnownEndpoint = IsKnownEndpoint(endpointGroupPerQueue),
+                MaxDailyThroughput = data.Max(),
+            };
+
+            endpointSummaries.Add(endpointSummary);
+        }
+
+        return endpointSummaries;
+    }
+
+    public async Task<ReportGenerationState> GetReportGenerationState()
+    {
+        var reportGenerationState = new ReportGenerationState
+        {
+            Broker = throughputSettings.Broker,
+            ReportCanBeGenerated = await dataStore.IsThereThroughputForLastXDays(30)
+        };
+
+        return reportGenerationState;
+    }
+
+    public async Task<SignedReport> GenerateThroughputReport(string[] masks, string spVersion, CancellationToken cancellationToken)
+    {
+        CreateMasks(masks);
+
+        var endpoints = await dataStore.GetAllEndpoints(false, cancellationToken);
+        var queueNames = endpoints.Select(endpoint => endpoint.SanitizedName).Distinct();
+        var endpointThroughputPerQueue = await dataStore.GetEndpointThroughputByQueueName(queueNames, cancellationToken);
+        var queueThroughputs = new List<Contracts.QueueThroughput>();
+        List<string> ignoredQueueNames = [];
+
+        //group endpoints by sanitized name - so to group throughput recorded from broker, audit and monitoring
+        foreach (var endpointGroupPerQueue in endpoints.GroupBy(g => g.SanitizedName))
+        {
+            //want to display the endpoint name if it's different to the sanitized endpoint name
+            var endpointName = endpointGroupPerQueue.FirstOrDefault(endpoint => endpoint.Id.Name != endpoint.SanitizedName)?.Id.Name ?? endpointGroupPerQueue.Key;
+
+            if (!endpointThroughputPerQueue.TryGetValue(endpointGroupPerQueue.Key, out var data))
+            {
+                data = [];
+            }
+
+            var throughputData = data.ToList();
+
+            //get all data that we have, including daily values
+            var queueThroughput = new Contracts.QueueThroughput
+            {
+                QueueName = Mask(endpointName),
+                UserIndicator = UserIndicator(endpointGroupPerQueue) ?? string.Empty,
+                EndpointIndicators = EndpointIndicators(endpointGroupPerQueue) ?? [],
+                NoDataOrSendOnly = throughputData.Sum() == 0,
+                Scope = EndpointScope(endpointGroupPerQueue) ?? "",
+                Throughput = throughputData.Max(),
+                DailyThroughputFromAudit = throughputData.FromSource(ThroughputSource.Audit).ToArray(),
+                DailyThroughputFromMonitoring = throughputData.FromSource(ThroughputSource.Monitoring).ToArray(),
+                DailyThroughputFromBroker = throughputData.FromSource(ThroughputSource.Broker).ToArray()
+            };
+
+            queueThroughputs.Add(queueThroughput);
+        }
+
+        var brokerData = await dataStore.GetBrokerData(throughputSettings.Broker);
+        var yesterday = DateTime.UtcNow.Date.AddDays(-1);
+        var report = new Report
+        {
+            EndTime = new DateTimeOffset(yesterday, TimeSpan.Zero),
+            CustomerName = throughputSettings.CustomerName, //who the license is registeredTo
+            ReportMethod = "NA",
+            ScopeType = brokerData?.ScopeType ?? "",
+            Prefix = null,
+            MessageTransport = throughputQuery?.MessageTransport ?? throughputSettings.TransportType,
+            ToolVersion = "V3", //ensure we check for this on the other side - ie that we can process V3
+            ServiceControlVersion = throughputSettings.ServiceControlVersion,
+            ServicePulseVersion = spVersion,
+            IgnoredQueues = [.. ignoredQueueNames],
+            Queues = [.. queueThroughputs],
+            TotalQueues = queueThroughputs.Count,
+            TotalThroughput = queueThroughputs.Sum(q => q.Throughput ?? 0),
+            EnvironmentData = brokerData?.Data ?? []
+        };
+
+        var auditThroughput = queueThroughputs.SelectMany(w => w.DailyThroughputFromAudit);
+        var monitoringThroughput = queueThroughputs.SelectMany(w => w.DailyThroughputFromMonitoring);
+        var brokerThroughput = queueThroughputs.SelectMany(w => w.DailyThroughputFromBroker);
+
+        //this will be the date of the first throughput that we have received
+        var firstAuditThroughputDate = auditThroughput.Any() ? auditThroughput.MinBy(m => m.DateUTC).DateUTC.ToDateTime(TimeOnly.MinValue) : yesterday.AddDays(-1);
+        var firstMonitoringThroughputDate = monitoringThroughput.Any() ? monitoringThroughput.MinBy(m => m.DateUTC).DateUTC.ToDateTime(TimeOnly.MinValue) : yesterday.AddDays(-1);
+        var firstBrokerThroughputDate = brokerThroughput.Any() ? auditThroughput.MinBy(m => m.DateUTC).DateUTC.ToDateTime(TimeOnly.MinValue) : yesterday.AddDays(-1);
+        report.StartTime = new DateTimeOffset(new[] { firstAuditThroughputDate, firstMonitoringThroughputDate, firstBrokerThroughputDate }.Min(), TimeSpan.Zero);
+        report.ReportDuration = report.EndTime - report.StartTime;
+
+        report.EnvironmentData.Add(EnvironmentData.AuditEnabled.ToString(), endpointThroughputPerQueue.HasDataFromSource(ThroughputSource.Audit).ToString());
+        report.EnvironmentData.Add(EnvironmentData.MonitoringEnabled.ToString(), endpointThroughputPerQueue.HasDataFromSource(ThroughputSource.Monitoring).ToString());
+
+        var throughputReport = new SignedReport() { ReportData = report, Signature = Signature.SignReport(report) };
+        return throughputReport;
+    }
+
+    void CreateMasks(string[] wordsToMask)
+    {
+        var number = 0;
+        masks = wordsToMask
+            .Select(mask =>
+            {
+                number++;
+                return (mask, $"REDACTED{number}");
+            })
+            .ToArray();
+    }
+
+    string Mask(string stringToMask)
+    {
+        foreach (var (mask, replacement) in masks)
+        {
+            stringToMask = stringToMask.Replace(mask, replacement, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return stringToMask;
+    }
+
+    static string GetSignature() => string.Empty; //TODO
+
+    static string? UserIndicator(IGrouping<string, Endpoint> endpoint) => endpoint.FirstOrDefault(s => !string.IsNullOrEmpty(s.UserIndicator))?.UserIndicator;
+
+    static string? EndpointScope(IGrouping<string, Endpoint> endpoint) => endpoint.FirstOrDefault(s => !string.IsNullOrEmpty(s.Scope))?.Scope;
+
+    bool IsKnownEndpoint(IGrouping<string, Endpoint> endpoint) => endpoint.Any(s => s.EndpointIndicators != null && s.EndpointIndicators.Contains(EndpointIndicator.KnownEndpoint.ToString()));
+    //bool IsPlatformEndpoint(IGrouping<string, Endpoint> endpoint) => endpoint.Any(s => s.EndpointIndicators != null && s.EndpointIndicators.Contains(EndpointIndicator.PlatformEndpoint.ToString()));
+
+    string[]? EndpointIndicators(IGrouping<string, Endpoint> endpoint) => endpoint.Where(w => w.EndpointIndicators?.Any() == true)?.SelectMany(s => s.EndpointIndicators)?.Distinct()?.ToArray();
+    (string Mask, string Replacement)[] masks = [];
 }

--- a/src/Particular.ThroughputCollector/ThroughputCollector.cs
+++ b/src/Particular.ThroughputCollector/ThroughputCollector.cs
@@ -201,8 +201,6 @@ public class ThroughputCollector(IThroughputDataStore dataStore, ThroughputSetti
         return stringToMask;
     }
 
-    static string GetSignature() => string.Empty; //TODO
-
     static string? UserIndicator(IGrouping<string, Endpoint> endpoint) => endpoint.FirstOrDefault(s => !string.IsNullOrEmpty(s.UserIndicator))?.UserIndicator;
 
     static string? EndpointScope(IGrouping<string, Endpoint> endpoint) => endpoint.FirstOrDefault(s => !string.IsNullOrEmpty(s.Scope))?.Scope;

--- a/src/Particular.ThroughputCollector/ThroughputCollectorHostBuilderExtensions.cs
+++ b/src/Particular.ThroughputCollector/ThroughputCollectorHostBuilderExtensions.cs
@@ -53,7 +53,7 @@ public static class ThroughputCollectorHostBuilderExtensions
             services.AddHostedService<BrokerThroughputCollectorHostedService>();
         }
 
-        hostBuilder.AddThroughputCollectorPersistence(persistenceType, errorQueue, serviceControlQueue);
+        hostBuilder.AddThroughputCollectorPersistence(persistenceType);
 
         if (throughputQueryProvider != null)
         {
@@ -75,20 +75,9 @@ public static class ThroughputCollectorHostBuilderExtensions
         }
     }
 
-    public static IHostApplicationBuilder AddThroughputCollectorPersistence(this IHostApplicationBuilder hostBuilder, string persistenceType, string? errorQueue = null, string? serviceControlQueue = null)
+    public static IHostApplicationBuilder AddThroughputCollectorPersistence(this IHostApplicationBuilder hostBuilder, string persistenceType)
     {
-        hostBuilder.Services.AddPersistence(persistenceType, settings =>
-        {
-            if (!string.IsNullOrEmpty(errorQueue))
-            {
-                settings.PlatformEndpointNames.Add(errorQueue);
-            }
-
-            if (!string.IsNullOrEmpty(serviceControlQueue))
-            {
-                settings.PlatformEndpointNames.Add(serviceControlQueue);
-            }
-        });
+        hostBuilder.Services.AddPersistence(persistenceType);
 
         return hostBuilder;
     }

--- a/src/Particular.ThroughputCollector/ThroughputCollectorHostBuilderExtensions.cs
+++ b/src/Particular.ThroughputCollector/ThroughputCollectorHostBuilderExtensions.cs
@@ -53,7 +53,7 @@ public static class ThroughputCollectorHostBuilderExtensions
             services.AddHostedService<BrokerThroughputCollectorHostedService>();
         }
 
-        hostBuilder.AddThroughputCollectorPersistence(persistenceType);
+        hostBuilder.AddThroughputCollectorPersistence(persistenceType, errorQueue, serviceControlQueue);
 
         if (throughputQueryProvider != null)
         {

--- a/src/Particular.ThroughputCollector/ThroughputDataExtensions.cs
+++ b/src/Particular.ThroughputCollector/ThroughputDataExtensions.cs
@@ -1,0 +1,21 @@
+﻿namespace Particular.ThroughputCollector;
+
+using System.Linq;
+using Particular.ThroughputCollector.Contracts;
+
+static class ThroughputDataExtensions
+{
+    public static IEnumerable<EndpointDailyThroughput> FromSource(this IEnumerable<ThroughputData> throughputs, ThroughputSource source) => throughputs
+        .SingleOrDefault(td => td.ThroughputSource == source)?
+        .Select(kvp => new EndpointDailyThroughput(kvp.Key, kvp.Value)) ?? [];
+
+    public static long Sum(this IEnumerable<ThroughputData> throughputs) => throughputs.SelectMany(t => t).Sum(kvp => kvp.Value);
+
+    public static long Max(this IEnumerable<ThroughputData> throughputs) =>
+        throughputs.Any()
+            ? throughputs.SelectMany(t => t).Max(kvp => kvp.Value)
+            : 0;
+
+    public static bool HasDataFromSource(this IDictionary<string, IEnumerable<ThroughputData>> throughputPerQueue, ThroughputSource source) =>
+        throughputPerQueue.Any(queueName => queueName.Value.Any(data => data.ThroughputSource == source && data.Count > 0));
+}

--- a/src/Particular.ThroughputCollector/WebApi/ThroughputController.cs
+++ b/src/Particular.ThroughputCollector/WebApi/ThroughputController.cs
@@ -16,9 +16,9 @@
 
         [Route("throughput/endpoints")]
         [HttpGet]
-        public async Task<List<EndpointThroughputSummary>> GetEndpointThroughput(CancellationToken cancellationToken)
+        public async Task<List<EndpointThroughputSummary>> GetEndpointThroughput(CancellationToken token)
         {
-            return await throughputCollector.GetThroughputSummary(cancellationToken);
+            return await throughputCollector.GetThroughputSummary(token);
         }
 
         [Route("throughput/endpoints/update")]
@@ -41,7 +41,7 @@
         public async Task<FileContentResult> GetThroughputReportFile(string[]? mask, CancellationToken token)
         {
             var report = await throughputCollector.GenerateThroughputReport(
-                mask ?? [], 
+                mask ?? [],
                 Request.Headers.TryGetValue("Particular-ServicePulse-Version", out var value) ? value.ToString() : "Unknown",
                 token);
 

--- a/src/Particular.ThroughputCollector/WebApi/ThroughputController.cs
+++ b/src/Particular.ThroughputCollector/WebApi/ThroughputController.cs
@@ -16,9 +16,9 @@
 
         [Route("throughput/endpoints")]
         [HttpGet]
-        public async Task<List<EndpointThroughputSummary>> GetEndpointThroughput(CancellationToken token)
+        public async Task<List<EndpointThroughputSummary>> GetEndpointThroughput(CancellationToken cancellationToken)
         {
-            return await throughputCollector.GetThroughputSummary();
+            return await throughputCollector.GetThroughputSummary(cancellationToken);
         }
 
         [Route("throughput/endpoints/update")]
@@ -40,7 +40,11 @@
         [HttpGet]
         public async Task<FileContentResult> GetThroughputReportFile(string[]? mask, CancellationToken token)
         {
-            var report = await throughputCollector.GenerateThroughputReport(mask ?? [], Request.Headers.TryGetValue("Particular-ServicePulse-Version", out var value) ? value.ToString() : "Unknown");
+            var report = await throughputCollector.GenerateThroughputReport(
+                mask ?? [], 
+                Request.Headers.TryGetValue("Particular-ServicePulse-Version", out var value) ? value.ToString() : "Unknown",
+                token);
+
             var options = new JsonSerializerOptions
             {
                 WriteIndented = true,

--- a/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
+++ b/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
@@ -32,6 +32,10 @@ namespace ServiceControl.Transports
         System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken);
         System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken);
         void Initialise(System.Collections.Frozen.FrozenDictionary<string, string> settings);
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Success",
+                "Errors"})]
+        System.Threading.Tasks.Task<System.ValueTuple<bool, System.Collections.Generic.List<string>>> TestConnection(System.Threading.CancellationToken cancellationToken);
     }
     public interface IProvideQueueLength
     {

--- a/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
+++ b/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
@@ -29,7 +29,6 @@ namespace ServiceControl.Transports
         string MessageTransport { get; }
         string? ScopeType { get; }
         ServiceControl.Transports.KeyDescriptionPair[] Settings { get; }
-        bool SupportsHistoricalMetrics { get; }
         System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken);
         System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken);
         void Initialise(System.Collections.Frozen.FrozenDictionary<string, string> settings);

--- a/src/ServiceControl.Transports/IBrokerThroughputQuery.cs
+++ b/src/ServiceControl.Transports/IBrokerThroughputQuery.cs
@@ -25,7 +25,6 @@ public interface IBrokerThroughputQuery
     Dictionary<string, string> Data { get; }
     string MessageTransport { get; }
     string? ScopeType { get; }
-    bool SupportsHistoricalMetrics { get; }
     KeyDescriptionPair[] Settings { get; }
     Task<(bool Success, List<string> Errors)> TestConnection(CancellationToken cancellationToken);
 }


### PR DESCRIPTION
The endpoint's throughput is now separate to the endpoint definition itself.

Recording throughput is always an "append" operation, i.e. if a value already exists for a date, then the new value is added to the existing value.

Refactored tests to attempt to show test "arrangement" inline with the test to make it easier to know what a test's data looks like just by reading the test.  Also attempted to have test arrangement only specify values required for the test, and abstract away other values that aren't of interest for that test.