### PR TITLE
Align the default db path to other default values

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_critical_storage_threshold_reached.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_critical_storage_threshold_reached.cs
@@ -37,6 +37,7 @@
                     }, (_, __) =>
                     {
                         PersisterSettings.MinimumStorageLeftRequiredForIngestion = 100;
+                        PersisterSettings.DatabasePath = TestContext.CurrentContext.TestDirectory;
                         return Task.CompletedTask;
                     })
                     .When(context =>
@@ -66,6 +67,7 @@
                     }, (session, context) =>
                     {
                         PersisterSettings.MinimumStorageLeftRequiredForIngestion = 100;
+                        PersisterSettings.DatabasePath = TestContext.CurrentContext.TestDirectory;
                         return Task.CompletedTask;
                     })
                     .When(context =>

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -34,7 +34,7 @@
             {
                 ConnectionString = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ConnectionStringKey),
                 DatabaseName = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabaseNameKey, RavenPersisterSettings.DatabaseNameDefault),
-                DatabasePath = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.DatabasePathKey),
+                DatabasePath = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.DatabasePathKey, DefaultDatabaseLocation()),
                 DatabaseMaintenancePort = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabaseMaintenancePortKey, RavenPersisterSettings.DatabaseMaintenancePortDefault),
                 ExpirationProcessTimerInSeconds = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.ExpirationProcessTimerInSecondsKey, 600),
                 MinimumStorageLeftRequiredForIngestion = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.MinimumStorageLeftRequiredForIngestionKey, CheckMinimumStorageRequiredForIngestion.MinimumStorageLeftRequiredForIngestionDefault),
@@ -52,6 +52,14 @@
             CheckFreeDiskSpace.Validate(settings);
             CheckMinimumStorageRequiredForIngestion.Validate(settings);
             return settings;
+        }
+
+        // SC installer always populates DBPath in app.config on installation/change/upgrade so this will only be used when
+        // debugging or if the entry is removed manually. In those circumstances default to the folder containing the exe
+        static string DefaultDatabaseLocation()
+        {
+            var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+            return Path.Combine(Path.GetDirectoryName(assemblyLocation), ".db");
         }
 
         // SC installer always populates LogPath in app.config on installation/change/upgrade so this will only be used when

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -34,7 +34,7 @@
             {
                 ConnectionString = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ConnectionStringKey),
                 DatabaseName = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabaseNameKey, RavenPersisterSettings.DatabaseNameDefault),
-                DatabasePath = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.DatabasePathKey, DefaultDatabaseLocation()),
+                DatabasePath = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabasePathKey, DefaultDatabaseLocation()),
                 DatabaseMaintenancePort = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabaseMaintenancePortKey, RavenPersisterSettings.DatabaseMaintenancePortDefault),
                 ExpirationProcessTimerInSeconds = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.ExpirationProcessTimerInSecondsKey, 600),
                 MinimumStorageLeftRequiredForIngestion = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.MinimumStorageLeftRequiredForIngestionKey, CheckMinimumStorageRequiredForIngestion.MinimumStorageLeftRequiredForIngestionDefault),

--- a/src/ServiceControl/Persistence/PersistenceFactory.cs
+++ b/src/ServiceControl/Persistence/PersistenceFactory.cs
@@ -2,8 +2,6 @@ namespace ServiceControl.Persistence
 {
     using System;
     using System.IO;
-    using System.Reflection;
-    using Configuration;
     using ServiceBus.Management.Infrastructure.Settings;
 
     static class PersistenceFactory
@@ -14,9 +12,7 @@ namespace ServiceControl.Persistence
 
             //HINT: This is false when executed from acceptance tests
             settings.PersisterSpecificSettings ??= persistenceConfiguration.CreateSettings(Settings.SettingsRootNamespace);
-
             settings.PersisterSpecificSettings.MaintenanceMode = maintenanceMode;
-            settings.PersisterSpecificSettings.DatabasePath = BuildDataBasePath();
 
             var persistence = persistenceConfiguration.Create(settings.PersisterSpecificSettings);
             return persistence;
@@ -37,16 +33,6 @@ namespace ServiceControl.Persistence
             {
                 throw new Exception($"Could not load persistence customization type {settings.PersistenceType}.", e);
             }
-        }
-
-        static string BuildDataBasePath()
-        {
-            // SC installer always populates DBPath in app.config on installation/change/upgrade so this will only be used when
-            // debugging or if the entry is removed manually. In those circumstances default to the folder containing the exe
-            var assemblyLocation = Assembly.GetExecutingAssembly().Location;
-            var defaultPath = Path.Combine(Path.GetDirectoryName(assemblyLocation), ".db");
-
-            return SettingsReader.Read(Settings.SettingsRootNamespace, "DbPath", defaultPath);
         }
     }
 }


### PR DESCRIPTION
When loading settings, for some values like DbPath and LogPath, ServiceControl uses default values if nothing can be found in the user's settings.

This PR aligns the way the default DbPath is generated to the way other default settings, like log path, are generated