### PR TITLE
Fix metrics serialization

### DIFF
--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_queue_length_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_queue_length_data.cs
@@ -82,8 +82,7 @@
                          return false;
                      }
 
-                     // Metric names are fixed names and therefore are not following the casing rules of the chosen serializer
-                     if (monitoredEndpointDetails.Digest.Metrics.TryGetValue("QueueLength", out var queueLength) && queueLength.Average == 0.0)
+                     if (monitoredEndpointDetails.Digest.Metrics.TryGetValue("queueLength", out var queueLength) && queueLength.Average == 0.0)
                      {
                          return false;
                      }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_retries_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_retries_data.cs
@@ -27,7 +27,7 @@
                 {
                     var result = await this.TryGetMany<MonitoredEndpoint>("/monitored-endpoints?history=1");
 
-                    metricReported = result.HasResult && result.Items[0].Metrics.TryGetValue("Retries", out var retries) && retries.Average > 0;
+                    metricReported = result.HasResult && result.Items[0].Metrics.TryGetValue("retries", out var retries) && retries.Average > 0;
 
                     if (metricReported)
                     {

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_timings_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_timings_data.cs
@@ -23,7 +23,7 @@
                 {
                     var result = await this.TryGetMany<MonitoredEndpoint>("/monitored-endpoints?history=1");
 
-                    metricReported = result.HasResult && result.Items[0].Metrics.TryGetValue("ProcessingTime", out var processingTime) && processingTime?.Average > 0;
+                    metricReported = result.HasResult && result.Items[0].Metrics.TryGetValue("processingTime", out var processingTime) && processingTime?.Average > 0;
 
                     return metricReported;
                 })

--- a/src/ServiceControl.Monitoring/Infrastructure/WebApi/SerializerOptions.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/WebApi/SerializerOptions.cs
@@ -12,6 +12,7 @@ public static class SerializerOptions
         options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
         options.WriteIndented = false;
         options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
         options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
         return options;
     }


### PR DESCRIPTION
These were dictionary keys and were not covered by the default serialization options

Before:

![image](https://github.com/Particular/ServiceControl/assets/124014/2c46c2c4-0abe-43b8-b369-98515feb2a89)

After:

![image](https://github.com/Particular/ServiceControl/assets/124014/37a98813-1b45-4d29-816d-cd78b72651e3)
