### PR TITLE
Fix Connection controllers response serialization casing

### DIFF
--- a/src/ServiceControl.Audit/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Audit/Connection/ConnectionController.cs
@@ -24,7 +24,7 @@ namespace ServiceControl.Audit.Connection
                         Enabled = true,
                         SagaAuditQueue = settings.AuditQueue,
                     }
-                }, new JsonSerializerOptions());
+                }, JsonSerializerOptions.Default);
     }
 
     public class ConnectionDetails

--- a/src/ServiceControl.Audit/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Audit/Connection/ConnectionController.cs
@@ -17,8 +17,11 @@ namespace ServiceControl.Audit.Connection
             new JsonResult(
                 new ConnectionDetails
                 {
-                    MessageAudit =
-                        new MessageAuditConnectionDetails { Enabled = true, AuditQueue = settings.AuditQueue },
+                    MessageAudit = new MessageAuditConnectionDetails
+                    {
+                        Enabled = true,
+                        AuditQueue = settings.AuditQueue
+                    },
                     SagaAudit = new SagaAuditConnectionDetails
                     {
                         Enabled = true,
@@ -31,7 +34,6 @@ namespace ServiceControl.Audit.Connection
     {
         public MessageAuditConnectionDetails MessageAudit { get; set; }
         public SagaAuditConnectionDetails SagaAudit { get; set; }
-
     }
 
     // HINT: This should match the type in the PlatformConnector package

--- a/src/ServiceControl.Audit/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Audit/Connection/ConnectionController.cs
@@ -8,27 +8,23 @@ namespace ServiceControl.Audit.Connection
     [Route("api")]
     public class ConnectionController(Settings settings) : ControllerBase
     {
+        // This controller doesn't use the default serialization settings because
+        // ServicePulse and the Platform Connector Plugin expect the connection
+        // details the be serialized and formatted in a specific way
         [Route("connection")]
         [HttpGet]
-        public IActionResult GetConnectionDetails()
-        {
-            var connectionDetails = new ConnectionDetails
-            {
-                MessageAudit = new MessageAuditConnectionDetails
+        public IActionResult GetConnectionDetails() =>
+            new JsonResult(
+                new ConnectionDetails
                 {
-                    Enabled = true,
-                    AuditQueue = settings.AuditQueue
-                },
-                SagaAudit = new SagaAuditConnectionDetails
-                {
-                    Enabled = true,
-                    SagaAuditQueue = settings.AuditQueue,
-                }
-            };
-            // by default snake case is used for serialization so we take care of explicitly serializing here
-            var content = JsonSerializer.Serialize(connectionDetails);
-            return Content(content, "application/json");
-        }
+                    MessageAudit =
+                        new MessageAuditConnectionDetails { Enabled = true, AuditQueue = settings.AuditQueue },
+                    SagaAudit = new SagaAuditConnectionDetails
+                    {
+                        Enabled = true,
+                        SagaAuditQueue = settings.AuditQueue,
+                    }
+                }, new JsonSerializerOptions());
     }
 
     public class ConnectionDetails

--- a/src/ServiceControl.Monitoring.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.approved.txt
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.approved.txt
@@ -1,0 +1,9 @@
+{
+  "Metrics": {
+    "Enabled": true,
+    "MetricsQueue": "Particular.Monitoring",
+    "Interval": "00:00:01",
+    "InstanceId": "uniqueInstanceId",
+    "TimeToLive": "00:02:00"
+  }
+}

--- a/src/ServiceControl.Monitoring.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.approved.txt
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.approved.txt
@@ -2,8 +2,6 @@
   "Metrics": {
     "Enabled": true,
     "MetricsQueue": "Particular.Monitoring",
-    "Interval": "00:00:01",
-    "InstanceId": "uniqueInstanceId",
-    "TimeToLive": "00:02:00"
+    "Interval": "00:00:01"
   }
 }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/PlatformConnectionTests.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/PlatformConnectionTests.cs
@@ -1,0 +1,40 @@
+namespace ServiceControl.Monitoring.AcceptanceTests.Tests
+{
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using AcceptanceTesting.EndpointTemplates;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+    using Particular.Approvals;
+    using ServiceControl.AcceptanceTesting;
+
+
+    class PlatformConnectionTests : AcceptanceTest
+    {
+        [Test]
+        public async Task ExposesConnectionDetails()
+        {
+            var config = await Define<MyContext>()
+                .WithEndpoint<MyEndpoint>()
+                .Done(async x =>
+                {
+                    var result = await this.GetRaw("/connection");
+                    x.Connection = await result.Content.ReadAsStringAsync();
+                    return true;
+                })
+                .Run();
+
+            Approver.Verify(JsonSerializer.Deserialize<object>(config.Connection));
+        }
+
+        class MyEndpoint : EndpointConfigurationBuilder
+        {
+            public MyEndpoint() => EndpointSetup<DefaultServerWithoutAudit>();
+        }
+
+        class MyContext : ScenarioContext
+        {
+            public string Connection { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.Monitoring.AcceptanceTests/ServiceControl.Monitoring.AcceptanceTests.csproj
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/ServiceControl.Monitoring.AcceptanceTests.csproj
@@ -21,6 +21,11 @@
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Particular.Approvals" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="ApprovalFiles\" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Monitoring.AcceptanceTests/ServiceControl.Monitoring.AcceptanceTests.csproj
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/ServiceControl.Monitoring.AcceptanceTests.csproj
@@ -24,8 +24,4 @@
     <PackageReference Include="Particular.Approvals" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="ApprovalFiles\" />
-  </ItemGroup>
-
 </Project>

--- a/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Monitoring.Connection
 {
     using System;
+    using System.Text.Json.Serialization;
     using Microsoft.AspNetCore.Mvc;
     using NServiceBus;
 
@@ -23,8 +24,12 @@
                 }
             };
 
+        // Backward compatibility reason:
+        // to make it so that the latest ServicePulse can talk to ServiceControl 5.0.5
+        // the Metrics property must be serialized PascalCase 
         public class ConnectionDetails
         {
+            [JsonPropertyName("Metrics")]
             public MetricsConnectionDetails Metrics { get; set; }
         }
 

--- a/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
@@ -22,7 +22,7 @@
                     MetricsQueue = mainInputQueue,
                     Interval = defaultInterval
                 }
-            }, new JsonSerializerOptions());
+            }, JsonSerializerOptions.Default);
 
         // ServicePulse expects as result an object with a Metrics root property
         class ConnectionDetails

--- a/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
+++ b/src/ServiceControl.Monitoring/Connection/ConnectionController.cs
@@ -1,7 +1,7 @@
 ﻿namespace ServiceControl.Monitoring.Connection
 {
     using System;
-    using System.Text.Json.Serialization;
+    using System.Text.Json;
     using Microsoft.AspNetCore.Mvc;
     using NServiceBus;
 
@@ -13,8 +13,8 @@
 
         [Route("connection")]
         [HttpGet]
-        public ActionResult<ConnectionDetails> GetConnectionDetails() =>
-            new ConnectionDetails
+        public IActionResult GetConnectionDetails() =>
+            new JsonResult(new ConnectionDetails
             {
                 Metrics = new MetricsConnectionDetails
                 {
@@ -22,19 +22,16 @@
                     MetricsQueue = mainInputQueue,
                     Interval = defaultInterval
                 }
-            };
+            }, new JsonSerializerOptions());
 
-        // Backward compatibility reason:
-        // to make it so that the latest ServicePulse can talk to ServiceControl 5.0.5
-        // the Metrics property must be serialized PascalCase 
-        public class ConnectionDetails
+        // ServicePulse expects as result an object with a Metrics root property
+        class ConnectionDetails
         {
-            [JsonPropertyName("Metrics")]
             public MetricsConnectionDetails Metrics { get; set; }
         }
 
         // HINT: This should match the type in the PlatformConnector package
-        public class MetricsConnectionDetails
+        class MetricsConnectionDetails
         {
             public bool Enabled { get; set; }
             public string MetricsQueue { get; set; }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.approved.txt
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ApprovalFiles/PlatformConnectionTests.ExposesConnectionDetails.approved.txt
@@ -1,5 +1,5 @@
 {
-  "Settings": {
+  "settings": {
     "Heartbeats": {
       "Enabled": true,
       "HeartbeatsQueue": "Particular.ServiceControl",
@@ -20,5 +20,5 @@
       "CustomChecksQueue": "Particular.ServiceControl"
     }
   },
-  "Errors": []
+  "errors": []
 }

--- a/src/ServiceControl/Connection/ConnectionController.cs
+++ b/src/ServiceControl/Connection/ConnectionController.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceControl.Connection
 {
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Text.Json;
     using System.Text.Json.Serialization;
@@ -19,18 +18,18 @@
         public async Task<IActionResult> GetConnectionDetails()
         {
             var platformConnectionDetails = await builder.BuildPlatformConnection();
-            return new JsonResult(new ConnectionDetails(platformConnectionDetails.ToDictionary(), platformConnectionDetails.Errors), JsonSerializerOptions.Default);
+            return new JsonResult(new ConnectionDetails(new Dictionary<string, object>(platformConnectionDetails.ToDictionary()), [.. platformConnectionDetails.Errors]), JsonSerializerOptions.Default);
         }
 
         // The Settings and Errors properties are serialized as settings and errors
         // because ServicePulse expects them te be lowercase 
-        class ConnectionDetails(IDictionary<string, object> settings, ConcurrentBag<string> errors)
+        class ConnectionDetails(Dictionary<string, object> settings, List<string> errors)
         {
             [JsonPropertyName("settings")]
-            public IDictionary<string, object> Settings { get; init; } = settings;
+            public Dictionary<string, object> Settings { get; init; } = settings;
 
             [JsonPropertyName("errors")]
-            public ConcurrentBag<string> Errors { get; init; } = errors;
+            public List<string> Errors { get; init; } = errors;
         }
     }
 }

--- a/src/ServiceControl/Connection/ConnectionController.cs
+++ b/src/ServiceControl/Connection/ConnectionController.cs
@@ -19,7 +19,7 @@
         public async Task<IActionResult> GetConnectionDetails()
         {
             var platformConnectionDetails = await builder.BuildPlatformConnection();
-            return new JsonResult(new ConnectionDetails(platformConnectionDetails.ToDictionary(), platformConnectionDetails.Errors), new JsonSerializerOptions());
+            return new JsonResult(new ConnectionDetails(platformConnectionDetails.ToDictionary(), platformConnectionDetails.Errors), JsonSerializerOptions.Default);
         }
 
         // The Settings and Errors properties are serialized as settings and errors

--- a/src/ServiceControl/Connection/PlatformConnectionDetails.cs
+++ b/src/ServiceControl/Connection/PlatformConnectionDetails.cs
@@ -2,11 +2,10 @@
 {
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Text.Json;
 
     public class PlatformConnectionDetails
     {
-        readonly ConcurrentDictionary<string, object> values = new ConcurrentDictionary<string, object>();
+        readonly ConcurrentDictionary<string, object> values = new();
 
         public void Add(string key, object value)
         {


### PR DESCRIPTION
For backward compatibility reasons, the ServiceControl monitoring connection details `Metrics` property must be serialized PascalCase so that the latest ServicePulse can talk to ServiceControl 5.0.5. For the same reason, the ServiceControl primary connection details `settings` and `errors` properties must be camelCase.

- [x] Fix the comments
- [x] An approval test that validates what the Monitoring instance returns is missing
- [x] Validate what the Platform Connection plugin expects ([Platform Connection schema](https://docs.particular.net/platform/json-schema))
- [x] Validate the Json serialization settings of the various instances