### PR TITLE
Reproduction of issue, not being able to find type

### DIFF
--- a/src/ProjectReferences.Persisters.Primary.props
+++ b/src/ProjectReferences.Persisters.Primary.props
@@ -2,6 +2,7 @@
 
   <ItemGroup Label="Persisters">
     <ProjectReference Include="..\ServiceControl.Persistence.RavenDB\ServiceControl.Persistence.RavenDB.csproj" ReferenceOutputAssembly="false" Private="false" />
+    <ProjectReference Include="..\ServiceControl.Persistence.RavenDB.NewFeature\ServiceControl.Persistence.RavenDB.NewFeature.csproj" ReferenceOutputAssembly="false" Private="false"/>
   </ItemGroup>
 
 </Project>

--- a/src/ProjectReferences.Persisters.Primary.props
+++ b/src/ProjectReferences.Persisters.Primary.props
@@ -2,7 +2,6 @@
 
   <ItemGroup Label="Persisters">
     <ProjectReference Include="..\ServiceControl.Persistence.RavenDB\ServiceControl.Persistence.RavenDB.csproj" ReferenceOutputAssembly="false" Private="false" />
-    <ProjectReference Include="..\ServiceControl.Persistence.RavenDB.NewFeature\ServiceControl.Persistence.RavenDB.NewFeature.csproj" ReferenceOutputAssembly="false" Private="false"/>
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Persistence.NewFeature/INewFeatureDataStore.cs
+++ b/src/ServiceControl.Persistence.NewFeature/INewFeatureDataStore.cs
@@ -1,0 +1,6 @@
+namespace ServiceControl.Persistence.NewFeature;
+
+public interface INewFeatureDataStore
+{
+    string SayHello();
+}

--- a/src/ServiceControl.Persistence.NewFeature/ServiceControl.Persistence.NewFeature.csproj
+++ b/src/ServiceControl.Persistence.NewFeature/ServiceControl.Persistence.NewFeature.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/ServiceControl.Persistence.RavenDB.NewFeature/.editorconfig
+++ b/src/ServiceControl.Persistence.RavenDB.NewFeature/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# Justification: ServiceControl app has no synchronization context
+dotnet_diagnostic.CA2007.severity = none

--- a/src/ServiceControl.Persistence.RavenDB.NewFeature/RavenNewFeatureDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB.NewFeature/RavenNewFeatureDataStore.cs
@@ -1,0 +1,8 @@
+﻿namespace ServiceControl.Persistence.RavenDB.NewFeature;
+
+using Persistence.NewFeature;
+
+public class RavenNewFeatureDataStore : INewFeatureDataStore
+{
+    public string SayHello() => "hello";
+}

--- a/src/ServiceControl.Persistence.RavenDB.NewFeature/ServiceControl.Persistence.RavenDB.NewFeature.csproj
+++ b/src/ServiceControl.Persistence.RavenDB.NewFeature/ServiceControl.Persistence.RavenDB.NewFeature.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.Persistence.NewFeature\ServiceControl.Persistence.NewFeature.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
@@ -12,7 +12,9 @@
     using Persistence.Recoverability;
     using Recoverability;
     using SagaAudit;
+    using ServiceControl.CustomChecks;
     using ServiceControl.Infrastructure.RavenDB.Subscriptions;
+    using ServiceControl.Persistence.RavenDB.CustomChecks;
     using ServiceControl.Recoverability;
     using UnitOfWork;
 
@@ -47,10 +49,10 @@
             services.AddSingleton<IExternalIntegrationRequestsDataStore>(p => p.GetRequiredService<ExternalIntegrationRequestsDataStore>());
             services.AddHostedService(p => p.GetRequiredService<ExternalIntegrationRequestsDataStore>());
 
-            //services.AddCustomCheck<CheckRavenDBIndexErrors>();
-            //services.AddCustomCheck<CheckRavenDBIndexLag>();
-            //services.AddCustomCheck<CheckFreeDiskSpace>();
-            //services.AddCustomCheck<CheckMinimumStorageRequiredForIngestion>();
+            services.AddCustomCheck<CheckRavenDBIndexErrors>();
+            services.AddCustomCheck<CheckRavenDBIndexLag>();
+            services.AddCustomCheck<CheckFreeDiskSpace>();
+            services.AddCustomCheck<CheckMinimumStorageRequiredForIngestion>();
 
             services.AddSingleton<OperationsManager>();
 
@@ -70,7 +72,7 @@
 
             // Forward saga audit messages and warn in ServiceControl 5, remove in 6
             services.AddSingleton<ISagaAuditDataStore, SagaAuditDeprecationDataStore>();
-            //services.AddCustomCheck<SagaAuditDestinationCustomCheck>();
+            services.AddCustomCheck<SagaAuditDestinationCustomCheck>();
             services.AddSingleton<SagaAuditDestinationCustomCheck.State>();
         }
 

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
@@ -1,20 +1,20 @@
 ﻿namespace ServiceControl.Persistence.RavenDB
 {
-    using CustomChecks;
+    using MessageFailures;
     using MessageRedirects;
     using Microsoft.Extensions.DependencyInjection;
+    using NewFeature;
     using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using Operations.BodyStorage;
+    using Operations.BodyStorage.RavenAttachments;
+    using Persistence.MessageRedirects;
+    using Persistence.NewFeature;
     using Persistence.Recoverability;
     using Recoverability;
-    using ServiceControl.CustomChecks;
+    using SagaAudit;
     using ServiceControl.Infrastructure.RavenDB.Subscriptions;
-    using ServiceControl.MessageFailures;
-    using ServiceControl.Operations.BodyStorage;
-    using ServiceControl.Operations.BodyStorage.RavenAttachments;
-    using ServiceControl.Persistence.MessageRedirects;
-    using ServiceControl.Persistence.UnitOfWork;
     using ServiceControl.Recoverability;
-    using ServiceControl.SagaAudit;
+    using UnitOfWork;
 
     class RavenPersistence(RavenPersisterSettings settings) : IPersistence
     {
@@ -26,6 +26,8 @@
             {
                 return;
             }
+
+            services.AddSingleton<INewFeatureDataStore, RavenNewFeatureDataStore>();
 
             services.AddSingleton<IServiceControlSubscriptionStorage, RavenSubscriptionStorage>();
             services.AddSingleton<ISubscriptionStorage>(p => p.GetRequiredService<IServiceControlSubscriptionStorage>());
@@ -45,10 +47,10 @@
             services.AddSingleton<IExternalIntegrationRequestsDataStore>(p => p.GetRequiredService<ExternalIntegrationRequestsDataStore>());
             services.AddHostedService(p => p.GetRequiredService<ExternalIntegrationRequestsDataStore>());
 
-            services.AddCustomCheck<CheckRavenDBIndexErrors>();
-            services.AddCustomCheck<CheckRavenDBIndexLag>();
-            services.AddCustomCheck<CheckFreeDiskSpace>();
-            services.AddCustomCheck<CheckMinimumStorageRequiredForIngestion>();
+            //services.AddCustomCheck<CheckRavenDBIndexErrors>();
+            //services.AddCustomCheck<CheckRavenDBIndexLag>();
+            //services.AddCustomCheck<CheckFreeDiskSpace>();
+            //services.AddCustomCheck<CheckMinimumStorageRequiredForIngestion>();
 
             services.AddSingleton<OperationsManager>();
 
@@ -68,7 +70,7 @@
 
             // Forward saga audit messages and warn in ServiceControl 5, remove in 6
             services.AddSingleton<ISagaAuditDataStore, SagaAuditDeprecationDataStore>();
-            services.AddCustomCheck<SagaAuditDestinationCustomCheck>();
+            //services.AddCustomCheck<SagaAuditDestinationCustomCheck>();
             services.AddSingleton<SagaAuditDestinationCustomCheck.State>();
         }
 

--- a/src/ServiceControl.Persistence.RavenDB/ServiceControl.Persistence.RavenDB.csproj
+++ b/src/ServiceControl.Persistence.RavenDB/ServiceControl.Persistence.RavenDB.csproj
@@ -12,6 +12,8 @@
     <ProjectReference Include="..\ServiceControl.Configuration\ServiceControl.Configuration.csproj" Private="false" ExcludeAssets="runtime" />
     <ProjectReference Include="..\ServiceControl.DomainEvents\ServiceControl.DomainEvents.csproj" Private="false" ExcludeAssets="runtime" />
     <ProjectReference Include="..\ServiceControl.Infrastructure\ServiceControl.Infrastructure.csproj" Private="false" ExcludeAssets="runtime" />
+    <ProjectReference Include="..\ServiceControl.Persistence.NewFeature\ServiceControl.Persistence.NewFeature.csproj"/>
+    <ProjectReference Include="..\ServiceControl.Persistence.RavenDB.NewFeature\ServiceControl.Persistence.RavenDB.NewFeature.csproj"/>
     <ProjectReference Include="..\ServiceControl.Persistence\ServiceControl.Persistence.csproj" Private="false" ExcludeAssets="runtime" />
   </ItemGroup>
 

--- a/src/ServiceControl.Persistence.RavenDB/ServiceControl.Persistence.RavenDB.csproj
+++ b/src/ServiceControl.Persistence.RavenDB/ServiceControl.Persistence.RavenDB.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\ServiceControl.Configuration\ServiceControl.Configuration.csproj" Private="false" ExcludeAssets="runtime" />
     <ProjectReference Include="..\ServiceControl.DomainEvents\ServiceControl.DomainEvents.csproj" Private="false" ExcludeAssets="runtime" />
     <ProjectReference Include="..\ServiceControl.Infrastructure\ServiceControl.Infrastructure.csproj" Private="false" ExcludeAssets="runtime" />
-    <ProjectReference Include="..\ServiceControl.Persistence.NewFeature\ServiceControl.Persistence.NewFeature.csproj"/>
+    <ProjectReference Include="..\ServiceControl.Persistence.NewFeature\ServiceControl.Persistence.NewFeature.csproj" Private="false" ExcludeAssets="runtime" />
     <ProjectReference Include="..\ServiceControl.Persistence.RavenDB.NewFeature\ServiceControl.Persistence.RavenDB.NewFeature.csproj"/>
     <ProjectReference Include="..\ServiceControl.Persistence\ServiceControl.Persistence.csproj" Private="false" ExcludeAssets="runtime" />
   </ItemGroup>

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -157,6 +157,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Transports.M
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.Transports.Msmq.Tests", "ServiceControl.Transports.Msmq.Tests\ServiceControl.Transports.Msmq.Tests.csproj", "{5F8E6C64-B505-4FF7-81CC-9161FBC198A8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Persistence.RavenDB.NewFeature", "ServiceControl.Persistence.RavenDB.NewFeature\ServiceControl.Persistence.RavenDB.NewFeature.csproj", "{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Persistence.NewFeature", "ServiceControl.Persistence.NewFeature\ServiceControl.Persistence.NewFeature.csproj", "{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -849,6 +853,30 @@ Global
 		{5F8E6C64-B505-4FF7-81CC-9161FBC198A8}.Release|x64.Build.0 = Release|Any CPU
 		{5F8E6C64-B505-4FF7-81CC-9161FBC198A8}.Release|x86.ActiveCfg = Release|Any CPU
 		{5F8E6C64-B505-4FF7-81CC-9161FBC198A8}.Release|x86.Build.0 = Release|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Debug|x64.Build.0 = Debug|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Debug|x86.Build.0 = Debug|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Release|x64.ActiveCfg = Release|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Release|x64.Build.0 = Release|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Release|x86.ActiveCfg = Release|Any CPU
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F}.Release|x86.Build.0 = Release|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Debug|x64.Build.0 = Debug|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Debug|x86.Build.0 = Debug|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Release|x64.ActiveCfg = Release|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Release|x64.Build.0 = Release|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Release|x86.ActiveCfg = Release|Any CPU
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -920,6 +948,8 @@ Global
 		{E067C14F-867B-4479-BC85-39F2AFAF25D0} = {E2249BAA-D9E9-4369-9C70-0E21C69A3E56}
 		{F04B9D2C-7E31-4697-BAE3-D3FFC5FBBDFE} = {A21A1A89-0B07-4E87-8E3C-41D9C280DCB8}
 		{5F8E6C64-B505-4FF7-81CC-9161FBC198A8} = {E0E45F22-35E3-4AD8-B09E-EFEA5A2F18EE}
+		{B6EB1C8C-C5D1-4BAB-96A9-32CECC44A18F} = {9B52418E-BF18-4D25-BE17-4B56D3FB1154}
+		{3EFC3B89-D22F-40C8-AAC3-30B67CA9E2B3} = {9B52418E-BF18-4D25-BE17-4B56D3FB1154}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3B9E5B72-F580-465A-A22C-2D2148AF4EB4}

--- a/src/ServiceControl/NewFeature/Web/NewFeatureController.cs
+++ b/src/ServiceControl/NewFeature/Web/NewFeatureController.cs
@@ -1,0 +1,17 @@
+namespace ServiceControl.NewFeature.Web;
+
+using Microsoft.AspNetCore.Mvc;
+using Persistence.NewFeature;
+
+[ApiController]
+[Route("api")]
+public class NewFeatureController(INewFeatureDataStore newFeatureDataStoreDataStore)
+    : ControllerBase
+{
+    [Route("new")]
+    [HttpGet]
+    public IActionResult New()
+    {
+        return Ok(newFeatureDataStoreDataStore.SayHello());
+    }
+}

--- a/src/ServiceControl/ServiceControl.csproj
+++ b/src/ServiceControl/ServiceControl.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\ServiceControl.Infrastructure.Metrics\ServiceControl.Infrastructure.Metrics.csproj" />
     <ProjectReference Include="..\ServiceControl.Infrastructure\ServiceControl.Infrastructure.csproj" />
     <ProjectReference Include="..\ServiceControl.LicenseManagement\ServiceControl.LicenseManagement.csproj" />
+    <ProjectReference Include="..\ServiceControl.Persistence.NewFeature\ServiceControl.Persistence.NewFeature.csproj"/>
     <ProjectReference Include="..\ServiceControl.Persistence\ServiceControl.Persistence.csproj" />
     <ProjectReference Include="..\ServiceControl.Transports\ServiceControl.Transports.csproj" />
   </ItemGroup>


### PR DESCRIPTION
@bording I am having an issue as part of [#tf-cs3601-enable-the-platform-report-on-endpoint](https://particularsoftware.slack.com/archives/C06CUKQ3668) that I believe is related to the latest changes to do with `AssemblyLoadContext`.

I have prepared this reproduction with hopefully the minimum changes required to replicate the problem.

I am adding a "new feature" to ServiceControl in this reproduction.
This feature includes a Controller/Action and a datastore that is implemented in RavenDB (though it is just hard coded).

The interface for this new datastore is declared in a different assembly. This is important because this is what makes it fail.

When you run this repro, go to http://localhost:33333/api/new, and you should see the following error in the console of SC:
```
2024-04-17 11:13:28.8356|22|Info|Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware|Duration: 7.6784ms
2024-04-17 11:13:28.8365|22|Error|Microsoft.AspNetCore.Server.Kestrel|Connection id "0HN2UFEBGQOD5", Request id "0HN2UFEBGQOD5:00000001": An unhandled exception was thrown by the application.|System.InvalidOperationException: Unable to resolve service for type 'ServiceControl.Persistence.NewFeature.INewFeatureDataStore' while attempting to activate 'ServiceControl.NewFeature.Web.NewFeatureController'.
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.ThrowHelperUnableToResolveService(Type type, Type requiredBy)
   at lambda_method354(Closure, IServiceProvider, Object[])
   at Microsoft.AspNetCore.Mvc.Controllers.ControllerFactoryProvider.<>c__DisplayClass6_0.<CreateControllerFactory>g__CreateController|0(ControllerContext controllerContext)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|20_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|7_0(Endpoint endpoint, Task requestTask, ILogger logger)
   at Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware.InvokeInternal(HttpContext context, HttpLoggingOptions options, HttpLoggingAttribute loggingAttribute, HttpLoggingFields loggingFields)
   at Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware.InvokeInternal(HttpContext context, HttpLoggingOptions options, HttpLoggingAttribute loggingAttribute, HttpLoggingFields loggingFields)
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.InvokeCore(HttpContext context)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
2024-04-17 11:13:28.8438|22|Info|Microsoft.AspNetCore.Hosting.Diagnostics|Request finished HTTP/1.1 GET http://localhost:33333/api/new - 500 0 - 34.8728ms
```

So the error reports that the datastore impl is not registered in the DI container, but as you can see in [`john/repro?expand=1`#diff-2cb2367956](https://github.com/Particular/ServiceControl/compare/john/repro?expand=1#diff-2cb236795654b0294fbb3c158993e3a855b75820eb9e849837409a647dbbba55R30), we are registering it.