### PR TITLE
Moved assembly loading code into PersistenceFactory

### DIFF
--- a/src/Particular.ThroughputCollector.Persistence.Tests/PersistenceManifestLibraryTests.cs
+++ b/src/Particular.ThroughputCollector.Persistence.Tests/PersistenceManifestLibraryTests.cs
@@ -14,7 +14,7 @@
         [Test]
         public void Should_find_persistence_type_by_name()
         {
-            var _persistenceType = PersistenceManifestLibrary.Find(persistenceName)?.TypeName;
+            var _persistenceType = PersistenceManifestLibrary.Find(persistenceName).TypeName;
 
             Assert.That(_persistenceType, Is.EqualTo(persistenceType));
         }
@@ -22,7 +22,7 @@
         [Test]
         public void Should_find_persistence_type_by_type()
         {
-            var _persistenceType = PersistenceManifestLibrary.Find(persistenceType)?.TypeName;
+            var _persistenceType = PersistenceManifestLibrary.Find(persistenceType).TypeName;
 
             Assert.That(_persistenceType, Is.EqualTo(persistenceType));
         }
@@ -30,7 +30,7 @@
         [Test]
         public void Should_find_persistence_type_folder_by_name()
         {
-            var _persistenceTypeFolder = PersistenceManifestLibrary.Find(persistenceType)?.Location;
+            var _persistenceTypeFolder = PersistenceManifestLibrary.Find(persistenceType).Location;
 
             Assert.That(_persistenceTypeFolder, Is.Not.Null);
         }
@@ -38,7 +38,7 @@
         [Test]
         public void Should_find_persistence_type_folder_by_type()
         {
-            var _persistenceTypeFolder = PersistenceManifestLibrary.Find(persistenceType)?.Location;
+            var _persistenceTypeFolder = PersistenceManifestLibrary.Find(persistenceType).Location;
 
             Assert.That(_persistenceTypeFolder, Is.Not.Null);
         }

--- a/src/Particular.ThroughputCollector.Persistence/PersistenceManifest.cs
+++ b/src/Particular.ThroughputCollector.Persistence/PersistenceManifest.cs
@@ -101,14 +101,22 @@ public static class PersistenceManifestLibrary
         return Path.GetDirectoryName(assemblyLocation);
     }
 
-    public static PersistenceManifest? Find(string persistenceType)
+    public static PersistenceManifest Find(string persistenceType)
     {
         if (persistenceType == null)
         {
             throw new Exception("No persistenceType has been configured. Either provide a Type or Name in the PersistenceType setting.");
         }
 
-        return PersistenceManifests.FirstOrDefault(w => w.IsMatch(persistenceType));
+        var persistence = PersistenceManifests.FirstOrDefault(w => w.IsMatch(persistenceType));
+        if (persistence == null)
+        {
+            throw new InvalidOperationException($"No persistence manifest found for persistenceType {persistenceType} in ThroughputCollector");
+        }
+        else
+        {
+            return persistence;
+        }
     }
 
     static readonly ILog logger = LogManager.GetLogger(typeof(PersistenceManifestLibrary));

--- a/src/Particular.ThroughputCollector.Persistence/ServiceCollectionExtensions.cs
+++ b/src/Particular.ThroughputCollector.Persistence/ServiceCollectionExtensions.cs
@@ -1,11 +1,10 @@
-﻿namespace Particular.ThroughputCollector;
+﻿namespace Particular.ThroughputCollector.Persistence;
 
 using Microsoft.Extensions.DependencyInjection;
-using Particular.ThroughputCollector.Persistence;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddPersistence(this IServiceCollection services, IPersistenceConfiguration persistenceConfiguration)
+    public static IServiceCollection AddThroughputPersistence(this IServiceCollection services, IPersistenceConfiguration persistenceConfiguration)
     {
         var persistenceSettings = persistenceConfiguration.BuildPersistenceSettings();
         var persistence = persistenceConfiguration.Create(persistenceSettings);

--- a/src/ServiceControl/Licensing/ThroughputComponent.cs
+++ b/src/ServiceControl/Licensing/ThroughputComponent.cs
@@ -40,6 +40,6 @@ class ThroughputComponent : ServiceControlComponent
     {
         var componentPersistenceManifest = ThroughputPersistence.PersistenceManifestLibrary.Find(PersistenceManifestLibrary.GetName(settings.PersistenceType));
 
-        services.AddThroughputPersistence(PersistenceFactory.LoadComponentPersistence(settings, componentPersistenceManifest.AssemblyPath, componentPersistenceManifest.TypeName) as ThroughputPersistence.IPersistenceConfiguration);
+        services.AddThroughputPersistence(PersistenceFactory.LoadComponentPersistence<ThroughputPersistence.IPersistenceConfiguration>(settings, componentPersistenceManifest.AssemblyPath, componentPersistenceManifest.TypeName));
     }
 }

--- a/src/ServiceControl/Persistence/PersistenceFactory.cs
+++ b/src/ServiceControl/Persistence/PersistenceFactory.cs
@@ -55,7 +55,7 @@ namespace ServiceControl.Persistence
                 : loadContext;
         }
 
-        public static object LoadComponentPersistence(Settings settings, string componentPersistenceAssemblyPath, string componentPersistenceType)
+        public static T LoadComponentPersistence<T>(Settings settings, string componentPersistenceAssemblyPath, string componentPersistenceType)
         {
             if (!loadedComponentPersisters.Contains(componentPersistenceType))
             {
@@ -83,7 +83,12 @@ namespace ServiceControl.Persistence
             ?? throw new InvalidOperationException($"Could not load type '{componentPersistenceType}' for requested persistence type '{hostPersistenceManifest.Name}' from '{loadContext.Name}' load context");
 
             loadedComponentPersisters.Add(componentPersistenceType);
-            return Activator.CreateInstance(type);
+            if (Activator.CreateInstance(type) is not T typedComponentPersistence)
+            {
+                throw new InvalidOperationException($"{componentPersistenceType} is not of type {typeof(T).Name}");
+            }
+
+            return typedComponentPersistence;
         }
     }
 }


### PR DESCRIPTION
Moved the loading code out of the component to make it cleaner, and this way other components can easier load their persistence into the service.