### PR TITLE
Add missing required headers to the primary and the monitoring instances

### DIFF
--- a/src/ServiceControl.Monitoring/WebApplicationExtensions.cs
+++ b/src/ServiceControl.Monitoring/WebApplicationExtensions.cs
@@ -12,7 +12,7 @@ public static class WebApplicationExtensions
         {
             policyBuilder.AllowAnyOrigin();
             policyBuilder.WithExposedHeaders(["ETag", "Last-Modified", "Link", "Total-Count", "X-Particular-Version"]);
-            policyBuilder.WithHeaders(["Origin", "X-Requested-With", "Content-Type", "Accept"]);
+            policyBuilder.WithHeaders(["Origin", "X-Requested-With", "Content-Type", "Accept", "Particular-ServicePulse-Version"]);
             policyBuilder.WithMethods(["POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH"]);
         });
 

--- a/src/ServiceControl/Infrastructure/WebApi/Cors.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/Cors.cs
@@ -10,7 +10,7 @@
 
             builder.AllowAnyOrigin();
             builder.WithExposedHeaders(["ETag", "Last-Modified", "Link", "Total-Count", "X-Particular-Version"]);
-            builder.WithHeaders(["Origin", "X-Requested-With", "Content-Type", "Accept"]);
+            builder.WithHeaders(["Origin", "X-Requested-With", "Content-Type", "Accept", "Particular-ServicePulse-Version"]);
             builder.WithMethods(["POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD"]);
 
             return builder.Build();


### PR DESCRIPTION
When installing on Windows, CORS policy kicks in (it doesn't happen when running from the command line or debugging). ServicePulse sends a `Particular-ServicePulse-Version` header that needs to be explicitly allowed.

> Access to fetch at 'http://localhost:33333/api/' from origin 'http://localhost:1331' has been blocked by CORS policy: Request header field particular-servicepulse-version is not allowed by Access-Control-Allow-Headers in preflight response.

<img width="542" alt="image" src="https://github.com/Particular/ServiceControl/assets/1325611/6a636218-f375-47b4-a248-fbb567dd95fc">
