### PR TITLE
DocumentStore and SessionProvider async and order independent

### DIFF
--- a/src/ServiceControl.AcceptanceTests.RavenDB/Recoverability/MessageFailures/FailedErrorsController.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/Recoverability/MessageFailures/FailedErrorsController.cs
@@ -20,13 +20,13 @@
     {
         [Route("failederrors/count")]
         [HttpGet]
-        public async Task<FailedErrorsCountReponse> GetFailedErrorsCount()
+        public async Task<FailedErrorsCountReponse> GetFailedErrorsCount(CancellationToken cancellationToken)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query =
                 session.Query<FailedErrorImport, FailedErrorImportIndex>().Statistics(out var stats);
 
-            var count = await query.CountAsync();
+            var count = await query.CountAsync(cancellationToken);
 
             Response.WithEtag(stats.ResultEtag.ToString());
 

--- a/src/ServiceControl.AcceptanceTests.RavenDB/Recoverability/MessageFailures/FailedMessageRetriesController.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/Recoverability/MessageFailures/FailedMessageRetriesController.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.AcceptanceTests.RavenDB.Recoverability.MessageFailures
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Infrastructure.WebApi;
     using Microsoft.AspNetCore.Mvc;
@@ -18,10 +19,10 @@
     {
         [Route("failedmessageretries/count")]
         [HttpGet]
-        public async Task<FailedMessageRetriesCountReponse> GetFailedMessageRetriesCount()
+        public async Task<FailedMessageRetriesCountReponse> GetFailedMessageRetriesCount(CancellationToken cancellationToken)
         {
-            using var session = sessionProvider.OpenSession();
-            await session.Query<FailedMessageRetry>().Statistics(out var stats).ToListAsync();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
+            await session.Query<FailedMessageRetry>().Statistics(out var stats).ToListAsync(cancellationToken);
 
             Response.WithEtag(stats.ResultEtag.ToString());
 

--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditIngestionUnitOfWorkFactory.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditIngestionUnitOfWorkFactory.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Audit.Persistence.InMemory
 {
+    using System.Threading.Tasks;
     using ServiceControl.Audit.Auditing.BodyStorage;
     using ServiceControl.Audit.Persistence.UnitOfWork;
 
@@ -11,10 +12,10 @@
             bodyStorageEnricher = new BodyStorageEnricher(bodyStorage, settings);
         }
 
-        public IAuditIngestionUnitOfWork StartNew(int batchSize)
+        public ValueTask<IAuditIngestionUnitOfWork> StartNew(int batchSize)
         {
             //The batchSize argument is ignored: the in-memory storage implementation doesn't support batching.
-            return new InMemoryAuditIngestionUnitOfWork(dataStore, bodyStorageEnricher);
+            return new ValueTask<IAuditIngestionUnitOfWork>(new InMemoryAuditIngestionUnitOfWork(dataStore, bodyStorageEnricher));
         }
 
         public bool CanIngestMore() => true;

--- a/src/ServiceControl.Audit.Persistence.RavenDB/CustomChecks/CheckRavenDBIndexLag.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/CustomChecks/CheckRavenDBIndexLag.cs
@@ -14,7 +14,7 @@
     {
         public override async Task<CheckResult> PerformCheck(CancellationToken cancellationToken = default)
         {
-            var store = documentStoreProvider.GetDocumentStore();
+            var store = await documentStoreProvider.GetDocumentStore(cancellationToken);
             var statistics = await store.Maintenance.SendAsync(new GetStatisticsOperation(), cancellationToken);
             var indexes = statistics.Indexes.OrderBy(x => x.Name).ToArray();
 

--- a/src/ServiceControl.Audit.Persistence.RavenDB/IRavenDocumentStoreProvider.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/IRavenDocumentStoreProvider.cs
@@ -1,9 +1,11 @@
 ﻿namespace ServiceControl.Audit.Persistence.RavenDB
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Raven.Client.Documents;
 
     interface IRavenDocumentStoreProvider
     {
-        IDocumentStore GetDocumentStore();
+        ValueTask<IDocumentStore> GetDocumentStore(CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/IRavenSessionProvider.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/IRavenSessionProvider.cs
@@ -1,9 +1,13 @@
-﻿namespace ServiceControl.Audit.Persistence.RavenDB
+﻿#nullable enable
+
+namespace ServiceControl.Audit.Persistence.RavenDB
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Raven.Client.Documents.Session;
 
     interface IRavenSessionProvider
     {
-        IAsyncDocumentSession OpenSession();
+        ValueTask<IAsyncDocumentSession> OpenSession(SessionOptions? options = default, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenAttachmentsBodyStorage.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenAttachmentsBodyStorage.cs
@@ -24,7 +24,7 @@
 
         public async Task<StreamResult> TryFetch(string bodyId)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var result = await session.Advanced.Attachments.GetAsync($"MessageBodies/{bodyId}", "body");
 
             if (result == null)

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenAuditDataStore.cs
@@ -21,7 +21,7 @@
     {
         public async Task<QueryResult<SagaHistory>> QuerySagaHistoryById(Guid input)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var sagaHistory = await
                 session.Query<SagaHistory, SagaDetailsIndex>()
                     .Statistics(out var stats)
@@ -32,7 +32,7 @@
 
         public async Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
                 .Statistics(out var stats)
                 .IncludeSystemMessagesWhere(includeSystemMessages)
@@ -46,7 +46,7 @@
 
         public async Task<QueryResult<IList<MessagesView>>> QueryMessages(string searchParam, PagingInfo pagingInfo, SortInfo sortInfo)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
                 .Statistics(out var stats)
                 .Search(x => x.Query, searchParam)
@@ -60,7 +60,7 @@
 
         public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
                 .Statistics(out var stats)
                 .Search(x => x.Query, keyword)
@@ -75,7 +75,7 @@
 
         public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
                 .Statistics(out var stats)
                 .IncludeSystemMessagesWhere(includeSystemMessages)
@@ -90,7 +90,7 @@
 
         public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByConversationId(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
                 .Statistics(out var stats)
                 .Where(m => m.ConversationId == conversationId)
@@ -104,7 +104,7 @@
 
         public async Task<MessageBodyView> GetMessageBody(string messageId)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var result = await session.Advanced.Attachments.GetAsync(messageId, "body");
 
             if (result == null)
@@ -122,7 +122,7 @@
 
         public async Task<QueryResult<IList<KnownEndpointsView>>> QueryKnownEndpoints()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var endpoints = await session.Advanced.LoadStartingWithAsync<KnownEndpoint>(KnownEndpoint.CollectionName, pageSize: 1024);
 
             var knownEndpoints = endpoints
@@ -146,7 +146,7 @@
         {
             var indexName = GetIndexName(isFullTextSearchEnabled);
 
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             // Maximum should really be 31 queries if there are 30 days of audit data, but default limit is 30
             session.Advanced.MaxNumberOfRequestsPerSession = 40;
 

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenFailedAuditStorage.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenFailedAuditStorage.cs
@@ -14,7 +14,7 @@
     {
         public async Task SaveFailedAuditImport(FailedAuditImport message)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             await session.StoreAsync(message);
             await session.SaveChangesAsync();
         }
@@ -23,7 +23,7 @@
             Func<FailedTransportMessage, Func<CancellationToken, Task>, CancellationToken, Task> onMessage,
             CancellationToken cancellationToken)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = session.Query<FailedAuditImport, FailedAuditImportIndex>();
 
             IAsyncEnumerator<StreamResult<FailedAuditImport>> stream = default;
@@ -57,7 +57,7 @@
 
         public async Task<int> GetFailedAuditsCount()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             return await session.Query<FailedAuditImport, FailedAuditImportIndex>()
                 .CountAsync();
         }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenSessionProvider.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenSessionProvider.cs
@@ -1,11 +1,17 @@
-﻿namespace ServiceControl.Audit.Persistence.RavenDB
+﻿#nullable enable
+
+namespace ServiceControl.Audit.Persistence.RavenDB
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Raven.Client.Documents.Session;
 
     class RavenSessionProvider(IRavenDocumentStoreProvider documentStoreProvider) : IRavenSessionProvider
     {
-        public IAsyncDocumentSession OpenSession() =>
-            documentStoreProvider.GetDocumentStore()
-                .OpenAsyncSession();
+        public async ValueTask<IAsyncDocumentSession> OpenSession(SessionOptions? options = default, CancellationToken cancellationToken = default)
+        {
+            var documentStore = await documentStoreProvider.GetDocumentStore(cancellationToken);
+            return documentStore.OpenAsyncSession(options ?? new SessionOptions());
+        }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/UnitOfWork/RavenAuditUnitOfWorkFactory.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/UnitOfWork/RavenAuditUnitOfWorkFactory.cs
@@ -1,7 +1,7 @@
 ﻿namespace ServiceControl.Audit.Persistence.RavenDB.UnitOfWork
 {
-    using System;
     using System.Threading;
+    using System.Threading.Tasks;
     using Persistence.UnitOfWork;
     using Raven.Client.Documents.BulkInsert;
     using RavenDB;
@@ -13,10 +13,10 @@
         MinimumRequiredStorageState customCheckState)
         : IAuditIngestionUnitOfWorkFactory
     {
-        public IAuditIngestionUnitOfWork StartNew(int batchSize)
+        public async ValueTask<IAuditIngestionUnitOfWork> StartNew(int batchSize)
         {
             var timedCancellationSource = new CancellationTokenSource(databaseConfiguration.BulkInsertCommitTimeout);
-            var bulkInsert = documentStoreProvider.GetDocumentStore()
+            var bulkInsert = (await documentStoreProvider.GetDocumentStore(timedCancellationSource.Token))
                 .BulkInsert(new BulkInsertOptions { SkipOverwriteIfUnchanged = true, }, timedCancellationSource.Token);
 
             return new RavenAuditIngestionUnitOfWork(

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/PersistenceTestsConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/PersistenceTestsConfiguration.cs
@@ -82,7 +82,7 @@
             FailedAuditStorage = host.Services.GetRequiredService<IFailedAuditStorage>();
 
             var documentStoreProvider = host.Services.GetRequiredService<IRavenDocumentStoreProvider>();
-            DocumentStore = documentStoreProvider.GetDocumentStore();
+            DocumentStore = await documentStoreProvider.GetDocumentStore();
             var bulkInsert = DocumentStore.BulkInsert(
                 options: new BulkInsertOptions { SkipOverwriteIfUnchanged = true, });
 

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/RetentionTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/RetentionTests.cs
@@ -133,7 +133,7 @@
 
         async Task IngestProcessedMessagesAudits(params ProcessedMessage[] processedMessages)
         {
-            var unitOfWork = StartAuditUnitOfWork(processedMessages.Length);
+            var unitOfWork = await StartAuditUnitOfWork(processedMessages.Length);
             foreach (var processedMessage in processedMessages)
             {
                 await unitOfWork.RecordProcessedMessage(processedMessage);
@@ -144,7 +144,7 @@
 
         async Task IngestKnownEndpoints(params KnownEndpoint[] knownEndpoints)
         {
-            var unitOfWork = StartAuditUnitOfWork(knownEndpoints.Length);
+            var unitOfWork = await StartAuditUnitOfWork(knownEndpoints.Length);
             foreach (var knownEndpoint in knownEndpoints)
             {
                 await unitOfWork.RecordKnownEndpoint(knownEndpoint);
@@ -155,7 +155,7 @@
 
         async Task IngestSagaAudits(params SagaSnapshot[] snapshots)
         {
-            var unitOfWork = StartAuditUnitOfWork(snapshots.Length);
+            var unitOfWork = await StartAuditUnitOfWork(snapshots.Length);
             foreach (var snapshot in snapshots)
             {
                 await unitOfWork.RecordSagaSnapshot(snapshot);

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SagaDetailsIndexTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SagaDetailsIndexTests.cs
@@ -111,7 +111,7 @@
 
         async Task IngestSagaAudits(params SagaSnapshot[] snapshots)
         {
-            var unitOfWork = StartAuditUnitOfWork(snapshots.Length);
+            var unitOfWork = await StartAuditUnitOfWork(snapshots.Length);
             foreach (var snapshot in snapshots)
             {
                 await unitOfWork.RecordSagaSnapshot(snapshot);

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SagaHistoryIndexTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/SagaHistoryIndexTests.cs
@@ -43,7 +43,7 @@
 
         async Task IngestSagaAudits(params SagaSnapshot[] snapshots)
         {
-            var unitOfWork = StartAuditUnitOfWork(snapshots.Length);
+            var unitOfWork = await StartAuditUnitOfWork(snapshots.Length);
             foreach (var snapshot in snapshots)
             {
                 await unitOfWork.RecordSagaSnapshot(snapshot);

--- a/src/ServiceControl.Audit.Persistence.Tests/AuditCountingTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/AuditCountingTests.cs
@@ -104,7 +104,7 @@
 
         async Task IngestProcessedMessagesAudits(params ProcessedMessage[] processedMessages)
         {
-            var unitOfWork = StartAuditUnitOfWork(processedMessages.Length);
+            var unitOfWork = await StartAuditUnitOfWork(processedMessages.Length);
             foreach (var processedMessage in processedMessages)
             {
                 await unitOfWork.RecordProcessedMessage(processedMessage);

--- a/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
@@ -81,7 +81,7 @@
         public async Task Can_roundtrip_message_body()
         {
             string expectedContentType = "text/xml";
-            var unitOfWork = AuditIngestionUnitOfWorkFactory.StartNew(1);
+            var unitOfWork = await StartAuditUnitOfWork(1);
 
             var body = new byte[100];
             Random.Shared.NextBytes(body);
@@ -113,7 +113,7 @@
         [Test]
         public async Task Does_respect_max_message_body()
         {
-            var unitOfWork = AuditIngestionUnitOfWorkFactory.StartNew(1);
+            var unitOfWork = await StartAuditUnitOfWork(1);
 
             var body = new byte[MAX_BODY_SIZE + 1000];
             Random.Shared.NextBytes(body);
@@ -136,7 +136,7 @@
         [Test]
         public async Task Deduplicates_messages_in_same_batch()
         {
-            var unitOfWork = AuditIngestionUnitOfWorkFactory.StartNew(1);
+            var unitOfWork = await StartAuditUnitOfWork(1);
             var messageId = "duplicatedId";
             var processingEndpoint = "endpoint";
             var processingStarted = DateTime.UtcNow;
@@ -163,12 +163,12 @@
             var processingStarted = DateTime.UtcNow;
 
             var processedMessage = MakeMessage(messageId: messageId, processingEndpoint: processingEndpoint, processingStarted: processingStarted);
-            var unitOfWork1 = AuditIngestionUnitOfWorkFactory.StartNew(1);
+            var unitOfWork1 = await StartAuditUnitOfWork(1);
             await unitOfWork1.RecordProcessedMessage(processedMessage);
             await unitOfWork1.DisposeAsync();
 
             var duplicatedMessage = MakeMessage(messageId: messageId, processingEndpoint: processingEndpoint, processingStarted: processingStarted);
-            var unitOfWork2 = AuditIngestionUnitOfWorkFactory.StartNew(1);
+            var unitOfWork2 = await StartAuditUnitOfWork(1);
             await unitOfWork2.RecordProcessedMessage(duplicatedMessage);
             await unitOfWork2.DisposeAsync();
 
@@ -182,7 +182,7 @@
         [Test]
         public async Task Does_not_deduplicate_with_different_processing_started_header()
         {
-            var unitOfWork = AuditIngestionUnitOfWorkFactory.StartNew(1);
+            var unitOfWork = await StartAuditUnitOfWork(1);
             var messageId = "duplicatedId";
             var processingEndpoint = "endpoint";
             var processingStarted = DateTime.UtcNow;
@@ -264,7 +264,7 @@
 
         async Task IngestProcessedMessagesAudits(params ProcessedMessage[] processedMessages)
         {
-            var unitOfWork = StartAuditUnitOfWork(processedMessages.Length);
+            var unitOfWork = await StartAuditUnitOfWork(processedMessages.Length);
             foreach (var processedMessage in processedMessages)
             {
                 await unitOfWork.RecordProcessedMessage(processedMessage);

--- a/src/ServiceControl.Audit.Persistence.Tests/KnownEndpointsTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/KnownEndpointsTests.cs
@@ -53,7 +53,7 @@
 
         async Task IngestKnownEndpoints(params KnownEndpoint[] knownEndpoints)
         {
-            var unitOfWork = StartAuditUnitOfWork(knownEndpoints.Length);
+            var unitOfWork = await StartAuditUnitOfWork(knownEndpoints.Length);
             foreach (var knownEndpoint in knownEndpoints)
             {
                 await unitOfWork.RecordKnownEndpoint(knownEndpoint);

--- a/src/ServiceControl.Audit.Persistence.Tests/PersistenceTestFixture.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/PersistenceTestFixture.cs
@@ -58,7 +58,7 @@
         protected IAuditIngestionUnitOfWorkFactory AuditIngestionUnitOfWorkFactory =>
             configuration.AuditIngestionUnitOfWorkFactory;
 
-        protected IAuditIngestionUnitOfWork StartAuditUnitOfWork(int batchSize) =>
+        protected ValueTask<IAuditIngestionUnitOfWork> StartAuditUnitOfWork(int batchSize) =>
             AuditIngestionUnitOfWorkFactory.StartNew(batchSize);
 
         protected IServiceProvider ServiceProvider => configuration.ServiceProvider;

--- a/src/ServiceControl.Audit.Persistence.Tests/SagaHistoryTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/SagaHistoryTests.cs
@@ -58,7 +58,7 @@
 
         async Task IngestSagaAudits(params SagaSnapshot[] snapshots)
         {
-            var unitOfWork = StartAuditUnitOfWork(snapshots.Length);
+            var unitOfWork = await StartAuditUnitOfWork(snapshots.Length);
             foreach (var snapshot in snapshots)
             {
                 await unitOfWork.RecordSagaSnapshot(snapshot);

--- a/src/ServiceControl.Audit.Persistence/UnitOfWork/IAuditIngestionUnitOfWorkFactory.cs
+++ b/src/ServiceControl.Audit.Persistence/UnitOfWork/IAuditIngestionUnitOfWorkFactory.cs
@@ -1,8 +1,10 @@
 ﻿namespace ServiceControl.Audit.Persistence.UnitOfWork
 {
+    using System.Threading.Tasks;
+
     public interface IAuditIngestionUnitOfWorkFactory
     {
-        IAuditIngestionUnitOfWork StartNew(int batchSize); //Throws if not enough space or some other problem preventing from writing data
+        ValueTask<IAuditIngestionUnitOfWork> StartNew(int batchSize); //Throws if not enough space or some other problem preventing from writing data
         bool CanIngestMore();
     }
 }

--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -53,7 +53,7 @@
             {
 
                 // deliberately not using the using statement because we dispose async explicitly
-                unitOfWork = unitOfWorkFactory.StartNew(contexts.Count);
+                unitOfWork = await unitOfWorkFactory.StartNew(contexts.Count);
                 var inserts = new List<Task>(contexts.Count);
                 foreach (var context in contexts)
                 {

--- a/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckRavenDBIndexErrors.cs
+++ b/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckRavenDBIndexErrors.cs
@@ -14,7 +14,7 @@
     {
         public override async Task<CheckResult> PerformCheck(CancellationToken cancellationToken = default)
         {
-            var documentStore = documentStoreProvider.GetDocumentStore();
+            var documentStore = await documentStoreProvider.GetDocumentStore(cancellationToken);
             var response = await documentStore.Maintenance.SendAsync(new GetIndexErrorsOperation(), cancellationToken);
 
             // Filter response as RavenDB5+ will return entries without errors

--- a/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckRavenDBIndexLag.cs
+++ b/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckRavenDBIndexLag.cs
@@ -15,7 +15,7 @@
     {
         public override async Task<CheckResult> PerformCheck(CancellationToken cancellationToken = default)
         {
-            var documentStore = documentStoreProvider.GetDocumentStore();
+            var documentStore = await documentStoreProvider.GetDocumentStore(cancellationToken);
             var statistics = await documentStore.Maintenance.SendAsync(new GetStatisticsOperation(), cancellationToken);
             var indexes = statistics.Indexes.OrderBy(x => x.Name).ToArray();
 

--- a/src/ServiceControl.Persistence.RavenDB/EventLogDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/EventLogDataStore.cs
@@ -10,14 +10,14 @@
     {
         public async Task Add(EventLogItem logItem)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             await session.StoreAsync(logItem);
             await session.SaveChangesAsync();
         }
 
         public async Task<(IList<EventLogItem>, int, string)> GetEventLogItems(PagingInfo pagingInfo)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var results = await session
                 .Query<EventLogItem>()
                 .Statistics(out var stats)

--- a/src/ServiceControl.Persistence.RavenDB/FailedErrorImportDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/FailedErrorImportDataStore.cs
@@ -15,7 +15,7 @@
         {
             var succeeded = 0;
             var failed = 0;
-            using (var session = sessionProvider.OpenSession())
+            using (var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken))
             {
                 var query = session.Query<FailedErrorImport, FailedErrorImportIndex>();
                 await using var stream = await session.Advanced.StreamAsync(query, cancellationToken);
@@ -57,7 +57,7 @@
 
         public async Task<bool> QueryContainsFailedImports()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var query = session.Query<FailedErrorImport, FailedErrorImportIndex>();
             await using var ie = await session.Advanced.StreamAsync(query);
             return await ie.MoveNextAsync();

--- a/src/ServiceControl.Persistence.RavenDB/FailedMessageViewIndexNotifications.cs
+++ b/src/ServiceControl.Persistence.RavenDB/FailedMessageViewIndexNotifications.cs
@@ -28,7 +28,7 @@
 
         async Task UpdatedCount()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var failedUnresolvedMessageCount = await session
                 .Query<FailedMessage, FailedMessageViewIndex>()
                 .CountAsync(p => p.Status == FailedMessageStatus.Unresolved);
@@ -72,14 +72,13 @@
             subscription?.Dispose();
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
-            var documentStore = documentStoreProvider.GetDocumentStore();
+            var documentStore = await documentStoreProvider.GetDocumentStore(cancellationToken);
             subscription = documentStore
                 .Changes()
                 .ForIndex(new FailedMessageViewIndex().IndexName)
                 .Subscribe(d => OnNext());
-            return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)

--- a/src/ServiceControl.Persistence.RavenDB/IRavenDocumentStoreProvider.cs
+++ b/src/ServiceControl.Persistence.RavenDB/IRavenDocumentStoreProvider.cs
@@ -1,9 +1,13 @@
+#nullable enable
+
 namespace ServiceControl.Persistence.RavenDB
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Raven.Client.Documents;
 
     interface IRavenDocumentStoreProvider
     {
-        IDocumentStore GetDocumentStore();
+        ValueTask<IDocumentStore> GetDocumentStore(CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/IRavenPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/IRavenPersistenceLifecycle.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace ServiceControl.Persistence.RavenDB
 {
     using System.Threading;

--- a/src/ServiceControl.Persistence.RavenDB/IRavenSessionProvider.cs
+++ b/src/ServiceControl.Persistence.RavenDB/IRavenSessionProvider.cs
@@ -2,10 +2,12 @@
 
 namespace ServiceControl.Persistence.RavenDB
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Raven.Client.Documents.Session;
 
     public interface IRavenSessionProvider
     {
-        IAsyncDocumentSession OpenSession(SessionOptions? options = default);
+        ValueTask<IAsyncDocumentSession> OpenSession(SessionOptions? options = default, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/Infrastructure/Subscriptions/RavenSubscriptionStorage.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Infrastructure/Subscriptions/RavenSubscriptionStorage.cs
@@ -43,7 +43,7 @@
 
         public async Task Initialize()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var primeSubscriptions = await LoadSubscriptions(session) ?? await MigrateSubscriptions(session, localClient);
 
             await SetSubscriptions(primeSubscriptions);
@@ -148,7 +148,7 @@
 
         async Task SaveSubscriptions()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             await session.StoreAsync(subscriptions, Subscriptions.SingleDocumentId);
             UpdateLookup();
             await session.SaveChangesAsync();

--- a/src/ServiceControl.Persistence.RavenDB/MessageRedirects/MessageRedirectsDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/MessageRedirects/MessageRedirectsDataStore.cs
@@ -7,7 +7,7 @@
     {
         public async Task<MessageRedirectsCollection> GetOrCreate()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var redirects = await session.LoadAsync<MessageRedirectsCollection>(DefaultId);
 
             if (redirects != null)
@@ -23,7 +23,7 @@
 
         public async Task Save(MessageRedirectsCollection redirects)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             await session.StoreAsync(redirects, redirects.ETag, DefaultId);
             await session.SaveChangesAsync();
         }

--- a/src/ServiceControl.Persistence.RavenDB/QueueAddressStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/QueueAddressStore.cs
@@ -12,7 +12,7 @@
     {
         public async Task<QueryResult<IList<QueueAddress>>> GetAddresses(PagingInfo pagingInfo)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var addresses = await session
                 .Query<QueueAddress, QueueAddressIndex>()
                 .Statistics(out var stats)
@@ -25,7 +25,7 @@
 
         public async Task<QueryResult<IList<QueueAddress>>> GetAddressesBySearchTerm(string search, PagingInfo pagingInfo)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var failedMessageQueues = await session
                     .Query<QueueAddress, QueueAddressIndex>()
                     .Statistics(out var stats)

--- a/src/ServiceControl.Persistence.RavenDB/RavenAttachmentsBodyStorage.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenAttachmentsBodyStorage.cs
@@ -15,7 +15,7 @@
 
         public async Task<MessageBodyStreamResult> TryFetch(string bodyId)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
 
             // BodyId could be a MessageID or a UniqueID, but if a UniqueID then it will be a DeterministicGuid of MessageID and endpoint name and be Guid-parseable
             // This is preferred, then we know we're getting the correct message body that is attached to the FailedMessage document

--- a/src/ServiceControl.Persistence.RavenDB/RavenCustomCheckDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenCustomCheckDataStore.cs
@@ -18,7 +18,7 @@
             var status = CheckStateChange.Unchanged;
             var id = MakeId(detail.GetDeterministicId());
 
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var customCheck = await session.LoadAsync<CustomCheck>(id);
 
             if (customCheck == null ||
@@ -46,7 +46,7 @@
 
         public async Task<QueryResult<IList<CustomCheck>>> GetStats(PagingInfo paging, string status = null)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var query =
                 session.Query<CustomCheck, CustomChecksIndex>().Statistics(out var stats);
 
@@ -62,13 +62,13 @@
         public async Task DeleteCustomCheck(Guid id)
         {
             var documentId = MakeId(id);
-            using var session = sessionProvider.OpenSession(new SessionOptions { NoTracking = true, NoCaching = true });
+            using var session = await sessionProvider.OpenSession(new SessionOptions { NoTracking = true, NoCaching = true });
             await session.Advanced.RequestExecutor.ExecuteAsync(new DeleteDocumentCommand(documentId, null), session.Advanced.Context);
         }
 
         public async Task<int> GetNumberOfFailedChecks()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var failedCustomCheckCount = await session.Query<CustomCheck, CustomChecksIndex>().CountAsync(p => p.Status == Status.Fail);
 
             return failedCustomCheckCount;

--- a/src/ServiceControl.Persistence.RavenDB/RavenMonitoringDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenMonitoringDataStore.cs
@@ -16,7 +16,7 @@
             var id = endpoint.GetDeterministicId();
             var docId = MakeDocumentId(id);
 
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
 
             var knownEndpoint = await session.LoadAsync<KnownEndpoint>(docId);
 
@@ -42,7 +42,7 @@
             var id = endpoint.GetDeterministicId();
             var docId = MakeDocumentId(id);
 
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
 
             var knownEndpoint = await session.LoadAsync<KnownEndpoint>(docId);
 
@@ -70,7 +70,7 @@
             var id = endpoint.GetDeterministicId();
             var docId = MakeDocumentId(id);
 
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
 
             var knownEndpoint = await session.LoadAsync<KnownEndpoint>(docId);
 
@@ -84,7 +84,7 @@
 
         public async Task WarmupMonitoringFromPersistence(IEndpointInstanceMonitoring endpointInstanceMonitoring)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             await using var endpointsEnumerator = await session.Advanced.StreamAsync(session.Query<KnownEndpoint, KnownEndpointIndex>());
 
             while (await endpointsEnumerator.MoveNextAsync())
@@ -97,14 +97,14 @@
 
         public async Task Delete(Guid endpointId)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             session.Delete(MakeDocumentId(endpointId));
             await session.SaveChangesAsync();
         }
 
         public async Task<IReadOnlyList<KnownEndpoint>> GetAllKnownEndpoints()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
 
             var knownEndpoints = await session.Query<KnownEndpoint, KnownEndpointIndex>()
                 .ToListAsync();

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceLifecycleHostedService.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceLifecycleHostedService.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace ServiceControl.Persistence.RavenDB
 {
     using System.Threading;

--- a/src/ServiceControl.Persistence.RavenDB/RavenSessionProvider.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenSessionProvider.cs
@@ -2,12 +2,16 @@
 
 namespace ServiceControl.Persistence.RavenDB
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Raven.Client.Documents.Session;
 
     class RavenSessionProvider(IRavenDocumentStoreProvider documentStoreProvider) : IRavenSessionProvider
     {
-        public IAsyncDocumentSession OpenSession(SessionOptions? options = default) =>
-            documentStoreProvider.GetDocumentStore()
-                .OpenAsyncSession(options ?? new SessionOptions());
+        public async ValueTask<IAsyncDocumentSession> OpenSession(SessionOptions? options = default, CancellationToken cancellationToken = default)
+        {
+            var documentStore = await documentStoreProvider.GetDocumentStore(cancellationToken);
+            return documentStore.OpenAsyncSession(options ?? new SessionOptions());
+        }
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/ArchiveDocumentManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/ArchiveDocumentManager.cs
@@ -110,7 +110,7 @@
 
         public async Task<bool> WaitForIndexUpdateOfArchiveOperation(IRavenSessionProvider sessionProvider, string requestId, TimeSpan timeToWait)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var indexQuery = session.Query<FailureGroupMessageView>(new FailedMessages_ByGroup().IndexName)
                 .Customize(x => x.WaitForNonStaleResults(timeToWait));
 
@@ -134,7 +134,7 @@
 
         public async Task RemoveArchiveOperation(IRavenSessionProvider sessionProvider, ArchiveOperation archiveOperation)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             session.Advanced.Defer(new DeleteCommandData(archiveOperation.Id, null));
             await session.SaveChangesAsync();
 

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/MessageArchiver.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/MessageArchiver.cs
@@ -37,7 +37,7 @@
             logger.Info($"Archiving of {groupId} started");
             ArchiveOperation archiveOperation;
 
-            using (var session = sessionProvider.OpenSession())
+            using (var session = await sessionProvider.OpenSession())
             {
                 session.Advanced.UseOptimisticConcurrency = true; // Ensure 2 messages don't split the same operation into batches at once
 
@@ -64,7 +64,7 @@
 
             while (archiveOperation.CurrentBatch < archiveOperation.NumberOfBatches)
             {
-                using (var batchSession = sessionProvider.OpenSession())
+                using (var batchSession = await sessionProvider.OpenSession())
                 {
                     var nextBatch = await archiveDocumentManager.GetArchiveBatch(batchSession, archiveOperation.Id, archiveOperation.CurrentBatch);
                     if (nextBatch == null)
@@ -129,7 +129,7 @@
             logger.Info($"Unarchiving of {groupId} started");
             UnarchiveOperation unarchiveOperation;
 
-            using (var session = sessionProvider.OpenSession())
+            using (var session = await sessionProvider.OpenSession())
             {
                 session.Advanced.UseOptimisticConcurrency = true; // Ensure 2 messages don't split the same operation into batches at once
 
@@ -157,7 +157,7 @@
 
             while (unarchiveOperation.CurrentBatch < unarchiveOperation.NumberOfBatches)
             {
-                using var batchSession = sessionProvider.OpenSession();
+                using var batchSession = await sessionProvider.OpenSession();
                 var nextBatch = await unarchiveDocumentManager.GetUnarchiveBatch(batchSession, unarchiveOperation.Id, unarchiveOperation.CurrentBatch);
                 if (nextBatch == null)
                 {

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/UnarchiveDocumentManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/UnarchiveDocumentManager.cs
@@ -113,7 +113,7 @@
 
         public async Task<bool> WaitForIndexUpdateOfUnarchiveOperation(IRavenSessionProvider sessionProvider, string requestId, TimeSpan timeToWait)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var indexQuery = session.Query<FailureGroupMessageView>(new FailedMessages_ByGroup().IndexName)
                 .Customize(x => x.WaitForNonStaleResults(timeToWait));
 
@@ -140,7 +140,7 @@
 
         public async Task RemoveUnarchiveOperation(IRavenSessionProvider sessionProvider, UnarchiveOperation unarchiveOperation)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             session.Advanced.Defer(new DeleteCommandData(unarchiveOperation.Id, null));
             await session.SaveChangesAsync();
         }

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/GroupsDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/GroupsDataStore.cs
@@ -13,7 +13,7 @@
     {
         public async Task<IList<FailureGroupView>> GetFailureGroupsByClassifier(string classifier, string classifierFilter)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var query = Queryable.Where(session.Query<FailureGroupView, FailureGroupsViewIndex>(), v => v.Type == classifier);
 
             if (!string.IsNullOrWhiteSpace(classifierFilter))
@@ -39,7 +39,7 @@
 
         public async Task<RetryBatch> GetCurrentForwardingBatch()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var nowForwarding = await session.Include<RetryBatchNowForwarding, RetryBatch>(r => r.RetryBatchId)
                 .LoadAsync<RetryBatchNowForwarding>(RetryBatchNowForwarding.Id);
 

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/RetryHistoryDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/RetryHistoryDataStore.cs
@@ -8,7 +8,7 @@
     {
         public async Task<RetryHistory> GetRetryHistory()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var id = RetryHistory.MakeId();
             var retryHistory = await session.LoadAsync<RetryHistory>(id);
 
@@ -20,7 +20,7 @@
         public async Task RecordRetryOperationCompleted(string requestId, RetryType retryType, DateTime startTime, DateTime completionTime,
             string originator, string classifier, bool messageFailed, int numberOfMessagesProcessed, DateTime lastProcessed, int retryHistoryDepth)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var retryHistory = await session.LoadAsync<RetryHistory>(RetryHistory.MakeId()) ?? RetryHistory.CreateNew();
 
             retryHistory.AddToUnacknowledged(new UnacknowledgedRetryOperation
@@ -53,7 +53,7 @@
 
         public async Task<bool> AcknowledgeRetryGroup(string groupId)
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             var retryHistory = await session.LoadAsync<RetryHistory>(RetryHistory.MakeId());
             if (retryHistory != null)
             {

--- a/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenIngestionUnitOfWork.cs
@@ -24,7 +24,7 @@
 
         public override async Task Complete()
         {
-            using var session = sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession();
             // not really interested in the batch results since a batch is atomic
             session.Advanced.Defer(commands.ToArray());
             await session.SaveChangesAsync();

--- a/src/ServiceControl.Persistence.RavenDB/WaitHandleExtensions.cs
+++ b/src/ServiceControl.Persistence.RavenDB/WaitHandleExtensions.cs
@@ -27,7 +27,7 @@ namespace ServiceBus.Management.Infrastructure.Extensions
             finally
             {
                 registeredHandle?.Unregister(null);
-                tokenRegistration.Dispose();
+                await tokenRegistration.DisposeAsync();
             }
         }
 

--- a/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
+++ b/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
@@ -64,7 +64,7 @@ public abstract class PersistenceTestBase
         host = hostBuilder.Build();
         await host.StartAsync();
 
-        DocumentStore = host.Services.GetRequiredService<IRavenDocumentStoreProvider>().GetDocumentStore();
+        DocumentStore = await host.Services.GetRequiredService<IRavenDocumentStoreProvider>().GetDocumentStore();
         SessionProvider = host.Services.GetRequiredService<IRavenSessionProvider>();
 
         CompleteDatabaseOperation();


### PR DESCRIPTION
This change makes it possible to safely retrieve the document store or a document session without running into ordering problems. Due to the interfaces returning value tasks it is also less likely that someone accidentally tries to use the document store provider in a constructor to assign a field.

We have discussed the alternative of wrapping the document store but it turned out the synchronous nature of the document store interface would require us to come up with complicated synchronous synchronization logic until the embedded instance is started.