### PR TITLE
Reference RavenDB.Embedded package in PlatformSample

### DIFF
--- a/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
+++ b/src/Particular.PlatformSample.ServiceControl/Particular.PlatformSample.ServiceControl.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <Description>Particular ServiceControl binaries for use by Particular.PlatformSample. Not intended for use outside of Particular.PlatformSample.</Description>
     <PackageProjectUrl>https://docs.particular.net/servicecontrol/</PackageProjectUrl>
     <NoWarn>$(NoWarn);NU5100;NU5118</NoWarn>
@@ -13,6 +12,10 @@
 
   <ItemGroup Label="Needed for build ordering">
     <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RavenDB.Embedded" PrivateAssets="none" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow-up to #4051

This PR adds a RavenDB.Embedded package reference to Particular.PlatformSample.ServiceControl so that it will bring in whatever version of RavenDB is being referenced by ServiceControl when the package is built.

https://github.com/Particular/Particular.PlatformSample/pull/375 has been updated to use this version of RavenRB instead of directly referencing itself.