### PR TITLE
Remove the Particular-ServicePulse-Version header

### DIFF
--- a/src/ServiceControl.Monitoring/WebApplicationExtensions.cs
+++ b/src/ServiceControl.Monitoring/WebApplicationExtensions.cs
@@ -12,7 +12,7 @@ public static class WebApplicationExtensions
         {
             policyBuilder.AllowAnyOrigin();
             policyBuilder.WithExposedHeaders(["ETag", "Last-Modified", "Link", "Total-Count", "X-Particular-Version"]);
-            policyBuilder.WithHeaders(["Origin", "X-Requested-With", "Content-Type", "Accept", "Particular-ServicePulse-Version"]);
+            policyBuilder.WithHeaders(["Origin", "X-Requested-With", "Content-Type", "Accept"]);
             policyBuilder.WithMethods(["POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH"]);
         });
 

--- a/src/ServiceControl/Infrastructure/WebApi/Cors.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/Cors.cs
@@ -10,7 +10,7 @@
 
             builder.AllowAnyOrigin();
             builder.WithExposedHeaders(["ETag", "Last-Modified", "Link", "Total-Count", "X-Particular-Version"]);
-            builder.WithHeaders(["Origin", "X-Requested-With", "Content-Type", "Accept", "Particular-ServicePulse-Version"]);
+            builder.WithHeaders(["Origin", "X-Requested-With", "Content-Type", "Accept"]);
             builder.WithMethods(["POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD"]);
 
             return builder.Build();


### PR DESCRIPTION
After discussing the various options, it seems a better approach for ServicePulse to share its version with ServiceControl is to use a modified user agent string that any ServiceControl controller can extract and parse.