### PR TITLE
CustomTimeSpanConverter to stay compatible with previous version of the saga audit plugin that used SimpleJson and a custom converter

### DIFF
--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -214,7 +214,7 @@
             try
             {
                 using var stream = new ReadOnlyStream(context.Body);
-                SagaUpdatedMessage message = JsonSerializer.Deserialize<SagaUpdatedMessage>(stream);
+                SagaUpdatedMessage message = JsonSerializer.Deserialize(stream, SagaAuditMessagesSerializationContext.Default.SagaUpdatedMessage);
 
                 var sagaSnapshot = SagaSnapshotFactory.Create(message);
 

--- a/src/ServiceControl.SagaAudit/CustomTimeSpanConverter.cs
+++ b/src/ServiceControl.SagaAudit/CustomTimeSpanConverter.cs
@@ -57,15 +57,8 @@ namespace ServiceControl.SagaAudit
                 ThrowFormatException();
             }
 
-            // check for the most common path first which is quite likely going to succeed
-            var result = Utf8Parser.TryParse(source, out TimeSpan parsedTimeSpan, out int bytesConsumed, 'c');
-            if (!result)
-            {
-                // For backward compatibility with the v4 versions of the audit plugin
-                result = Utf8Parser.TryParse(source, out parsedTimeSpan, out bytesConsumed, 'g');
-            }
-
-            if (!result || source.Length != bytesConsumed)
+            // Ut8Parser.TryParse also handles short format "g" which has a minimum of 7 chars independent of the format identifier
+            if (!Utf8Parser.TryParse(source, out TimeSpan parsedTimeSpan, out int bytesConsumed, 'c') || source.Length != bytesConsumed)
             {
                 ThrowFormatException();
             }

--- a/src/ServiceControl.SagaAudit/CustomTimeSpanConverter.cs
+++ b/src/ServiceControl.SagaAudit/CustomTimeSpanConverter.cs
@@ -1,0 +1,97 @@
+namespace ServiceControl.SagaAudit
+{
+    using System;
+    using System.Buffers.Text;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.CompilerServices;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// The custom converter is needed to handle the TimeSpan format used by the audit plugin. Versions before v5.0.0
+    /// used SimpleJson and had special handling for TimeSpan. TimeSpan got converted into the "g" representation which may not start with a trailing zero
+    /// The new audit plugin uses System.Text.Json which always uses the "c" format for TimeSpan. The "c" format always starts with a trailing zero.
+    ///
+    /// At the time of writing this code was adopted from NET TimeSpanConverter which unfortunately is internal
+    /// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs#L31
+    /// </summary>
+    /// <remarks>Using this code outside this specific use case here is probably a very bad idea. Be warned.</remarks>
+    sealed class CustomTimeSpanConverter : JsonConverter<TimeSpan>
+    {
+        // we allow the short format "g" too which has a minimum of 7 chars. .NET Requires min 8 chars
+        const int MinimumTimeSpanFormatLength = 7; // hh:mm:ss or h:mm:ss
+        const int MaximumTimeSpanFormatLength = 26; // -dddddddd.hh:mm:ss.fffffff
+        const int MaxExpansionFactorWhileEscaping = 6;
+
+        const int MaximumEscapedTimeSpanFormatLength = MaxExpansionFactorWhileEscaping * MaximumTimeSpanFormatLength;
+
+        public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                ThrowInvalidOperationException_ExpectedString(reader.TokenType);
+            }
+
+            if (!IsInRangeInclusive(ValueLength(ref reader), MinimumTimeSpanFormatLength,
+                    MaximumEscapedTimeSpanFormatLength))
+            {
+                ThrowFormatException();
+            }
+
+            scoped ReadOnlySpan<byte> source;
+            if (!reader.HasValueSequence && !reader.ValueIsEscaped)
+            {
+                source = reader.ValueSpan;
+            }
+            else
+            {
+                Span<byte> stackSpan = stackalloc byte[MaximumEscapedTimeSpanFormatLength];
+                var bytesWritten = reader.CopyString(stackSpan);
+                source = stackSpan[..bytesWritten];
+            }
+
+            byte firstChar = source[0];
+            if (!IsDigit(firstChar) && firstChar != '-')
+            {
+                // Note: Utf8Parser.TryParse allows for leading whitespace so we need to exclude that case here.
+                ThrowFormatException();
+            }
+
+            // check for the most common path first which is quite likely going to succeed
+            var result = Utf8Parser.TryParse(source, out TimeSpan parsedTimeSpan, out int bytesConsumed, 'c');
+            if (!result)
+            {
+                // For backward compatibility with the v4 versions of the audit plugin
+                result = Utf8Parser.TryParse(source, out parsedTimeSpan, out bytesConsumed, 'g');
+            }
+
+            if (!result || source.Length != bytesConsumed)
+            {
+                ThrowFormatException();
+            }
+
+            return parsedTimeSpan;
+        }
+
+        int ValueLength(ref Utf8JsonReader reader) => reader.HasValueSequence
+            ? checked((int)reader.ValueSequence.Length)
+            : reader.ValueSpan.Length;
+
+        static bool IsDigit(byte value) => (uint)(value - '0') <= '9' - '0';
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static bool IsInRangeInclusive(int value, int lowerBound, int upperBound)
+            => (uint)(value - lowerBound) <= (uint)(upperBound - lowerBound);
+
+        [DoesNotReturn]
+        static void ThrowInvalidOperationException_ExpectedString(JsonTokenType tokenType) =>
+            throw new InvalidOperationException($"The provided token type '{tokenType}' is not a string");
+
+        [DoesNotReturn]
+        static void ThrowFormatException() =>
+            throw new FormatException($"The input string was not in a correct Timespan format");
+
+        public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options) =>
+            throw new NotImplementedException("The custom timespan converter was intended to be used only to deserialize SagaUpdateMessages but never to serialize them.");
+    }
+}

--- a/src/ServiceControl.SagaAudit/Messages/SagaChangeOutput.cs
+++ b/src/ServiceControl.SagaAudit/Messages/SagaChangeOutput.cs
@@ -1,13 +1,17 @@
 namespace ServiceControl.EndpointPlugin.Messages.SagaState
 {
     using System;
+    using System.Text.Json.Serialization;
     using NServiceBus;
+    using SagaAudit;
 
     public class SagaChangeOutput : ICommand
     {
         public string MessageType { get; set; }
         public DateTime TimeSent { get; set; }
         public DateTime? DeliveryAt { get; set; }
+        // See the description of the converter why this is required
+        [JsonConverter(typeof(CustomTimeSpanConverter))]
         public TimeSpan? DeliveryDelay { get; set; }
         public string Destination { get; set; }
         public string ResultingMessageId { get; set; }

--- a/src/ServiceControl.SagaAudit/Messages/SagaUpdatedMessage.cs
+++ b/src/ServiceControl.SagaAudit/Messages/SagaUpdatedMessage.cs
@@ -6,15 +6,10 @@
 
     public class SagaUpdatedMessage : IMessage
     {
-        public SagaUpdatedMessage()
-        {
-            ResultingMessages = [];
-        }
-
         public string SagaState { get; set; }
         public Guid SagaId { get; set; }
         public SagaChangeInitiator Initiator { get; set; }
-        public List<SagaChangeOutput> ResultingMessages { get; set; }
+        public List<SagaChangeOutput> ResultingMessages { get; set; } = [];
         public string Endpoint { get; set; }
         public bool IsNew { get; set; }
         public bool IsCompleted { get; set; }

--- a/src/ServiceControl.SagaAudit/SagaAuditMessagesSerializationContext.cs
+++ b/src/ServiceControl.SagaAudit/SagaAuditMessagesSerializationContext.cs
@@ -1,0 +1,10 @@
+namespace ServiceControl.SagaAudit
+{
+    using System.Text.Json.Serialization;
+    using EndpointPlugin.Messages.SagaState;
+
+    [JsonSerializable(typeof(SagaChangeInitiator))]
+    [JsonSerializable(typeof(SagaChangeOutput))]
+    [JsonSerializable(typeof(SagaUpdatedMessage))]
+    public partial class SagaAuditMessagesSerializationContext : JsonSerializerContext;
+}

--- a/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
@@ -1,6 +1,7 @@
 namespace ServiceBus.Management.Infrastructure
 {
     using System;
+    using System.Text.Json;
     using NServiceBus;
     using NServiceBus.Configuration.AdvancedExtensibility;
     using ServiceControl.ExternalIntegrations;
@@ -8,6 +9,7 @@ namespace ServiceBus.Management.Infrastructure
     using ServiceControl.Infrastructure.Subscriptions;
     using ServiceControl.Notifications.Email;
     using ServiceControl.Operations;
+    using ServiceControl.SagaAudit;
     using ServiceControl.Transports;
 
     static class NServiceBusFactory
@@ -44,7 +46,14 @@ namespace ServiceBus.Management.Infrastructure
             recoverability.CustomPolicy(SendEmailNotificationHandler.RecoverabilityPolicy);
 
             configuration.UsePersistence<ServiceControlSubscriptionPersistence, StorageType.Subscriptions>();
-            configuration.UseSerialization<SystemJsonSerializer>();
+            var serializer = configuration.UseSerialization<SystemJsonSerializer>();
+            serializer.Options(new JsonSerializerOptions
+            {
+                TypeInfoResolverChain =
+                {
+                    SagaAuditMessagesSerializationContext.Default
+                }
+            });
 
             configuration.LimitMessageProcessingConcurrencyTo(settings.MaximumConcurrencyLevel);
 

--- a/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl/Infrastructure/NServiceBusFactory.cs
@@ -2,6 +2,7 @@ namespace ServiceBus.Management.Infrastructure
 {
     using System;
     using System.Text.Json;
+    using System.Text.Json.Serialization.Metadata;
     using NServiceBus;
     using NServiceBus.Configuration.AdvancedExtensibility;
     using ServiceControl.ExternalIntegrations;
@@ -51,7 +52,9 @@ namespace ServiceBus.Management.Infrastructure
             {
                 TypeInfoResolverChain =
                 {
-                    SagaAuditMessagesSerializationContext.Default
+                    SagaAuditMessagesSerializationContext.Default,
+                    // This is required until we move all known message types over to source generated contexts
+                    new DefaultJsonTypeInfoResolver()
                 }
             });
 

--- a/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
+++ b/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
@@ -37,6 +37,11 @@
 
         async Task RefreshAuditQueue()
         {
+            if (nextAuditQueueNameRefresh > DateTime.UtcNow)
+            {
+                return;
+            }
+
             await semaphore.WaitAsync();
             try
             {

--- a/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
+++ b/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
@@ -11,18 +11,12 @@
     using ServiceControl.Infrastructure;
     using ServiceControl.Persistence;
 
-    class SagaUpdatedHandler : IHandleMessages<SagaUpdatedMessage>
+    class SagaUpdatedHandler(ISagaAuditDataStore sagaAuditStore, IPlatformConnectionBuilder connectionBuilder)
+        : IHandleMessages<SagaUpdatedMessage>
     {
-        public SagaUpdatedHandler(ISagaAuditDataStore sagaAuditStore, IPlatformConnectionBuilder connectionBuilder)
-        {
-            this.sagaAuditStore = sagaAuditStore;
-            this.connectionBuilder = connectionBuilder;
-        }
-
         public async Task Handle(SagaUpdatedMessage message, IMessageHandlerContext context)
         {
             var sagaSnapshot = SagaSnapshotFactory.Create(message);
-
             var supportedByDataStore = await sagaAuditStore.StoreSnapshot(sagaSnapshot);
 
             if (!supportedByDataStore)
@@ -72,9 +66,6 @@
                 semaphore.Release();
             }
         }
-
-        readonly ISagaAuditDataStore sagaAuditStore;
-        readonly IPlatformConnectionBuilder connectionBuilder;
 
         static string auditQueueName;
         static DateTime nextAuditQueueNameRefresh;


### PR DESCRIPTION
The SagaAudit plugin has previously used SimpleJson and [had a custom implementation for TimeSpan that converted TimeSpan values into the short format ('g')](https://github.com/Particular/NServiceBus.SagaAudit/blob/release-4.0/src/NServiceBus.SagaAudit/MessageSerializationStrategy.cs#L36-L40). The behavior of this is that instead of constantly writing the 'c' format like `hh:mm:ss` (8 chars) it writes in certain circumstances `h:mm:ss` (7 chars). 

Newtonsoft.Json can send and receive the 7 or the 8 chars format. 
System.Text.Json only handles the 8 chars format. More details in https://github.com/dotnet/runtime/issues/100538

The changes in the Audit plugin make sense and given only new instances of ServiceControl that use System.Text.Json are affected, we have decided to implement a custom timespan converter for this very specific case to make deserializing `SagaUpdatedMessage` more relaxed.

I have also included parts of the spike of https://github.com/Particular/ServiceControl/pull/4086 into this PR to source gen the type information.