### PR TITLE
Remove portable command line option

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
@@ -45,11 +45,6 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
                         ];
                         executionMode = ExecutionMode.Maintenance;
                     }
-                },
-                {
-                    "p|portable",
-                    @"Internal use - runs as a console app, even non-interactively",
-                    s => { Portable = true; }
                 }
             };
 
@@ -75,20 +70,6 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
                     "skip-queue-creation",
                     @"Skip queue creation during install/update",
                     s => { SkipQueueCreation = true; }
-                },
-                {
-                    "p|portable",
-                    @"Runs as a console app, even non-interactively",
-                    s => { Portable = true; }
-                }
-            };
-
-            var externalUnitTestRunnerOptions = new OptionSet
-            {
-                {
-                    "p|portable",
-                    @"Runs as a console app, even non-interactively",
-                    s => { Portable = true; }
                 }
             };
 
@@ -126,7 +107,6 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
                 }
 
                 defaultOptions.Parse(args);
-                externalUnitTestRunnerOptions.Parse(args);
             }
             catch (Exception e)
             {
@@ -138,9 +118,11 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
         public List<Type> Commands { get; private set; }
 
         public bool Help { get; set; }
+
         public string ServiceName { get; set; }
+
         public string Username { get; set; }
-        public bool Portable { get; set; }
+
         public bool SkipQueueCreation { get; set; }
 
         public void PrintUsage()

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
@@ -3,7 +3,6 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Reflection;
     using Commands;
     using Configuration;
@@ -15,10 +14,7 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
         {
             if (SettingsReader.Read<bool>(Settings.SettingsRootNamespace, "MaintenanceMode"))
             {
-                args = args.Concat(new[]
-                {
-                    "-m"
-                }).ToArray();
+                args = [.. args, "-m"];
             }
 
             var executionMode = ExecutionMode.Run;

--- a/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
@@ -7,7 +7,6 @@
     },
     "LogPath": "C:\\Logs"
   },
-  "Portable": false,
   "ServiceName": "Particular.Monitoring",
   "TransportType": "NServiceBus.ServiceControlLearningTransport, ServiceControl.Transports.LearningTransport",
   "ConnectionString": null,

--- a/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
@@ -30,15 +30,6 @@
                     "skip-queue-creation",
                     "Skip queue creation during install/update",
                     s => overrides.Add(settings => settings.SkipQueueCreation = true)
-                },
-                {
-                    "portable",
-                    "Force running as a console application",
-                    s => overrides.Add(settings =>
-                    {
-                            Portable = true;
-                            settings.Portable = true;
-                    })
                 }
             };
 
@@ -55,8 +46,6 @@
                     break;
             }
         }
-
-        public bool Portable { get; set; }
 
         public List<Type> Commands { get; } = [];
 

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -53,8 +53,6 @@ namespace ServiceControl.Monitoring
 
         public LoggingSettings LoggingSettings { get; }
 
-        public bool Portable { get; set; } = false;
-
         public string ServiceName { get; set; } = DEFAULT_ENDPOINT_NAME;
 
         public string TransportType { get; set; }

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -3,7 +3,6 @@ namespace Particular.ServiceControl.Hosting
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Reflection;
     using global::ServiceControl.Configuration;
     using global::ServiceControl.Hosting.Commands;
@@ -15,10 +14,7 @@ namespace Particular.ServiceControl.Hosting
         {
             if (SettingsReader.Read<bool>(Settings.SettingsRootNamespace, "MaintenanceMode"))
             {
-                args = args.Concat(new[]
-                {
-                    "-m"
-                }).ToArray();
+                args = [.. args, "-m"];
             }
 
             var executionMode = ExecutionMode.Run;

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -45,11 +45,6 @@ namespace Particular.ServiceControl.Hosting
                         ];
                         executionMode = ExecutionMode.Maintenance;
                     }
-                },
-                {
-                    "p|portable",
-                    @"Runs as a console app, even non-interactively",
-                    s => { Portable = true; }
                 }
             };
 
@@ -75,20 +70,6 @@ namespace Particular.ServiceControl.Hosting
                     "skip-queue-creation",
                     @"Skip queue creation during install/update",
                     s => { SkipQueueCreation = true; }
-                },
-                {
-                    "p|portable",
-                    @"Runs as a console app, even non-interactively",
-                    s => { Portable = true; }
-                }
-            };
-
-            var externalUnitTestRunnerOptions = new OptionSet
-            {
-                {
-                    "p|portable",
-                    @"Runs as a console app, even non-interactively",
-                    s => { Portable = true; }
                 }
             };
 
@@ -126,7 +107,6 @@ namespace Particular.ServiceControl.Hosting
                 }
 
                 defaultOptions.Parse(args);
-                externalUnitTestRunnerOptions.Parse(args);
             }
             catch (Exception e)
             {
@@ -138,9 +118,11 @@ namespace Particular.ServiceControl.Hosting
         public List<Type> Commands { get; private set; }
 
         public bool Help { get; set; }
+
         public string ServiceName { get; set; }
+
         public string Username { get; set; }
-        public bool Portable { get; set; }
+
         public bool SkipQueueCreation { get; set; }
 
         public void PrintUsage()


### PR DESCRIPTION
The `portable` option is completely vestigial now, so this PR just finishes the clean up and removes it.