### PR TITLE
Retries and integration messages fails to deserialize on older MSMQ endpoints

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="NServiceBus.Testing" Version="9.0.0" />
     <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="4.0.1" />
     <PackageVersion Include="NServiceBus.Transport.AzureStorageQueues" Version="13.0.0" />
-    <PackageVersion Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.0" />
+    <PackageVersion Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.1" />
     <PackageVersion Include="NServiceBus.Transport.SqlServer" Version="8.0.0" />
     <PackageVersion Include="NuGet.Versioning" Version="6.10.0" />
     <PackageVersion Include="NUnit" Version="3.14.0" />


### PR DESCRIPTION
Version 3.0.0 of the MSMQ source package emits a BOM into the message headers, this causes older versions of transports not expecting a BOM to throw when attempting to deserializer message headers:

```
2024-05-24 09:50:35.097 WARN  Message '7e47b130-25e6-4b43-baf0-2339b773687a\105607' has corrupted headers
System.InvalidOperationException: There is an error in XML document (1, 1). ---> System.Xml.XmlException: Data at the root level is invalid. Line 1, position 1.
   at System.Xml.XmlTextReaderImpl.Throw(Exception e)
   at System.Xml.XmlTextReaderImpl.ParseRootLevelWhitespace()
   at System.Xml.XmlTextReaderImpl.ParseDocumentContent()
   at System.Xml.XmlReader.MoveToContent()
   at Microsoft.Xml.Serialization.GeneratedAssembly.XmlSerializationReaderList1.Read3_ArrayOfHeaderInfo()
   --- End of inner exception stack trace ---
   at System.Xml.Serialization.XmlSerializer.Deserialize(XmlReader xmlReader, String encodingStyle, XmlDeserializationEvents events)
   at NServiceBus.Transport.Msmq.MsmqUtilities.DeserializeMessageHeaders(Message m)
   at NServiceBus.Transport.Msmq.MsmqUtilities.ExtractHeaders(Message msmqMessage)
   at NServiceBus.Transport.Msmq.ReceiveStrategy.TryExtractHeaders(Message message, Dictionary`2& headers)
```

### Root cause

These versions were using `Encoding.UTF8.GetString` to get the data to deserialize via `XmlReader` which can't handle a BOM.
### ServiceControl versions affected

This issue was introduced in https://github.com/Particular/ServiceControl/releases/tag/5.2.0 since that is the first version that uses the source package for MSMQ.

### NServiceBus versions affected

- NServiceBus v7.X when NServiceBus.Transport.Msmq v1.0.X is used (later versions does not have the issue)
- NServiceBus v6.X (msmq bundled in core)
- NServiceBus v5.X (msmq bundled in core)

See https://github.com/Particular/NServiceBus.Transport.Msmq/pull/711 for more details

