### PR TITLE
SagaAudit Timespan parsing fallback to "g" format in cases where "c" is not enough to stay compatible with previous versions

### DIFF
--- a/src/ServiceControl.Audit.UnitTests/SagaAudit/CustomTimeSpanConverterTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/SagaAudit/CustomTimeSpanConverterTests.cs
@@ -1,0 +1,72 @@
+namespace ServiceControl.Audit.UnitTests.SagaAudit
+{
+    using NUnit.Framework;
+    using ServiceControl.SagaAudit;
+    using JsonSerializer = System.Text.Json.JsonSerializer;
+
+    [TestFixture]
+    public class CustomTimeSpanConverterTests
+    {
+        [Theory]
+        [TestCase("2:0:00:00")]
+        [TestCase("1:00:00")]
+        [TestCase("1")]
+        [TestCase("10")]
+        [TestCase("00:01")]
+        [TestCase("0:00:02")]
+        [TestCase("0:00:00.0000001")]
+        [TestCase("0:00:00.0000010")]
+        [TestCase("0:00:00.0000100")]
+        [TestCase("0:00:00.0001000")]
+        [TestCase("0:00:00.0010000")]
+        [TestCase("0:00:00.0100000")]
+        [TestCase("0:00:00.1000000")]
+        [TestCase("23:59:59")]
+        [TestCase("\\u002D23:59:59")]
+        [TestCase("\\u0032\\u0033\\u003A\\u0035\\u0039\\u003A\\u0035\\u0039")]
+        [TestCase("23:59:59.9")]
+        [TestCase("23:59:59.9999999")]
+        [TestCase("9999999.23:59:59.9999999")]
+        [TestCase("-9999999.23:59:59.9999999")]
+        [TestCase("10675199.02:48:05.4775807")] // TimeSpan.MaxValue
+        [TestCase("-10675199.02:48:05.4775808")] // TimeSpan.MinValue
+        public void Should_not_throw_on_valid_timespans(string timespan)
+        {
+            string json = $$"""
+                            {
+                                "ResultingMessages": [
+                                    {
+                                        "DeliveryAt": null,
+                                        "DeliveryDelay": "{{timespan}}"
+                                    }
+                                ]
+                            }
+                            """;
+
+            Assert.DoesNotThrow(() =>
+            {
+                JsonSerializer.Deserialize(json, SagaAuditMessagesSerializationContext.Default.SagaUpdatedMessage);
+            });
+        }
+
+        [Test]
+        public void Should_not_throw_on_null()
+        {
+            string json = """
+                          {
+                              "ResultingMessages": [
+                                  {
+                                      "DeliveryAt": null,
+                                      "DeliveryDelay":null
+                                  }
+                              ]
+                          }
+                          """;
+
+            Assert.DoesNotThrow(() =>
+            {
+                JsonSerializer.Deserialize(json, SagaAuditMessagesSerializationContext.Default.SagaUpdatedMessage);
+            });
+        }
+    }
+}

--- a/src/ServiceControl.Audit.UnitTests/SagaAudit/CustomTimeSpanConverterTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/SagaAudit/CustomTimeSpanConverterTests.cs
@@ -7,27 +7,63 @@ namespace ServiceControl.Audit.UnitTests.SagaAudit
     [TestFixture]
     public class CustomTimeSpanConverterTests
     {
-        [Theory]
-        [TestCase("2:0:00:00")]
-        [TestCase("1:00:00")]
-        [TestCase("1")]
-        [TestCase("10")]
-        [TestCase("00:01")]
-        [TestCase("0:00:02")]
-        [TestCase("0:00:00.0000001")]
-        [TestCase("0:00:00.0000010")]
-        [TestCase("0:00:00.0000100")]
-        [TestCase("0:00:00.0001000")]
-        [TestCase("0:00:00.0010000")]
-        [TestCase("0:00:00.0100000")]
-        [TestCase("0:00:00.1000000")]
-        [TestCase("23:59:59")]
-        [TestCase("\\u002D23:59:59")]
-        [TestCase("\\u0032\\u0033\\u003A\\u0035\\u0039\\u003A\\u0035\\u0039")]
-        [TestCase("23:59:59.9")]
-        [TestCase("23:59:59.9999999")]
-        [TestCase("9999999.23:59:59.9999999")]
-        [TestCase("-9999999.23:59:59.9999999")]
+        [Test]
+        // Days, Hours, Minutes, and Seconds
+        [TestCase("1:0:00:00")] // 1 day, 0 hours, 0 minutes, 0 seconds
+        [TestCase("2:0:00:00")] // 2 days, 0 hours, 0 minutes, 0 seconds
+        [TestCase("3:5:6:7.890")] // 3 days, 5 hours, 6 minutes, 7 seconds, with milliseconds
+        [TestCase("1:02:03")] // 1 hour, 2 minutes, 3 seconds
+        [TestCase("0:00:00")] // Zero TimeSpan
+        [TestCase("1.0:00:00")] // 1 day, 0 hours, 0 minutes, 0 seconds
+        [TestCase("1.23:59:59")] // 1 day, 23 hours, 59 minutes, 59 seconds
+        [TestCase("10.12:30:45")] // 10 days, 12 hours, 30 minutes, 45 seconds
+
+        // Milliseconds and Ticks
+        [TestCase("0:00:00.123")] // 123 milliseconds
+        [TestCase("0:00:00.9999999")] // 9999999 ticks
+        [TestCase("0:00:00.1")] // 1 tenth of a second
+        [TestCase("1.0:00:00.1234567")] // 1 day, 0 hours, 0 minutes, 0 seconds, with fractional seconds
+
+        // Single Time Components
+        [TestCase("1:00:00")] // 1 hour, 0 minutes, 0 seconds
+        [TestCase("1:2:3")] // 1 hour, 2 minutes, 3 seconds without leading zeros
+        [TestCase("0:1:1")] // Zero hours with 1 minute and 1 second
+        [TestCase("1:1:1.123")] // 1 hour, 1 minute, 1 second with milliseconds
+        [TestCase("0:0:0.1")] // 1 tenth of a second
+        [TestCase("1:2:3.456")] // 1 hour, 2 minutes, 3 seconds with milliseconds
+        [TestCase("12:34:56.789")] // 12 hours, 34 minutes, 56 seconds with milliseconds
+        [TestCase("0:59:59")] // 59 minutes, 59 seconds
+        [TestCase("0:0:0.999")] // 999 milliseconds
+        [TestCase("6:30:0")] // 6 hours, 30 minutes
+
+        // Whole Days
+        [TestCase("1")] // 1 day
+        [TestCase("10")] // 10 days
+
+        // Minutes and Seconds
+        [TestCase("00:01")] // 1 minute
+        [TestCase("0:00:02")] // 2 seconds
+
+        // Small Fractions of a Second
+        [TestCase("0:00:00.0000001")] // 1 tick
+        [TestCase("0:00:00.0000010")] // 10 ticks
+        [TestCase("0:00:00.0000100")] // 100 ticks
+        [TestCase("0:00:00.0001000")] // 1000 ticks
+        [TestCase("0:00:00.0010000")] // 10000 ticks (1 millisecond)
+        [TestCase("0:00:00.0100000")] // 100000 ticks (10 milliseconds)
+        [TestCase("0:00:00.1000000")] // 1000000 ticks (100 milliseconds)
+
+        // Large Time Values & Special chars
+        [TestCase("23:59:59")] // 23 hours, 59 minutes, 59 seconds
+        [TestCase("\\u002D23:59:59")] // -23 hours, 59 minutes, 59 seconds (Unicode escape for minus sign)
+        [TestCase(
+            "\\u0032\\u0033\\u003A\\u0035\\u0039\\u003A\\u0035\\u0039")] // "23:59:59" with Unicode escape sequences for digits and colon
+        [TestCase("23:59:59.9")] // 23 hours, 59 minutes, 59 seconds, with 900 milliseconds
+        [TestCase("23:59:59.9999999")] // 23 hours, 59 minutes, 59 seconds, with 9999999 ticks
+        [TestCase("9999999.23:59:59.9999999")] // 9999999 days, 23 hours, 59 minutes, 59 seconds, with 9999999 ticks
+        [TestCase("-9999999.23:59:59.9999999")] // -9999999 days, 23 hours, 59 minutes, 59 seconds, with 9999999 ticks
+
+        // Max and Min TimeSpan Values
         [TestCase("10675199.02:48:05.4775807")] // TimeSpan.MaxValue
         [TestCase("-10675199.02:48:05.4775808")] // TimeSpan.MinValue
         public void Should_not_throw_on_valid_timespans(string timespan)

--- a/src/ServiceControl.SagaAudit/CustomTimeSpanConverter.cs
+++ b/src/ServiceControl.SagaAudit/CustomTimeSpanConverter.cs
@@ -18,7 +18,6 @@ namespace ServiceControl.SagaAudit
     /// <remarks>Using this code outside this specific use case here is probably a very bad idea. Be warned.</remarks>
     sealed class CustomTimeSpanConverter : JsonConverter<TimeSpan>
     {
-        // we allow the short format "g" too which has a minimum of 7 chars. .NET Requires min 8 chars
         const int MinimumTimeSpanFormatLength = 1; // d
         const int MaximumTimeSpanFormatLength = 26; // -dddddddd.hh:mm:ss.fffffff
         const int MaxExpansionFactorWhileEscaping = 6;
@@ -57,10 +56,9 @@ namespace ServiceControl.SagaAudit
                 ThrowFormatException();
             }
 
-            // Ut8Parser.TryParse also handles short format "g" which has a minimum of 7 chars independent of the format identifier
+            // Ut8Parser.TryParse also handles some short format "g" cases which has a minimum of 1 chars independent of the format identifier
             if (!Utf8Parser.TryParse(source, out TimeSpan parsedTimeSpan, out int bytesConsumed, 'c') || source.Length != bytesConsumed)
             {
-                // Fallback to reading the "g" format
                 ThrowFormatException();
             }
 

--- a/src/ServiceControl.SagaAudit/CustomTimeSpanConverter.cs
+++ b/src/ServiceControl.SagaAudit/CustomTimeSpanConverter.cs
@@ -19,7 +19,7 @@ namespace ServiceControl.SagaAudit
     sealed class CustomTimeSpanConverter : JsonConverter<TimeSpan>
     {
         // we allow the short format "g" too which has a minimum of 7 chars. .NET Requires min 8 chars
-        const int MinimumTimeSpanFormatLength = 7; // hh:mm:ss or h:mm:ss
+        const int MinimumTimeSpanFormatLength = 1; // d
         const int MaximumTimeSpanFormatLength = 26; // -dddddddd.hh:mm:ss.fffffff
         const int MaxExpansionFactorWhileEscaping = 6;
 
@@ -60,6 +60,7 @@ namespace ServiceControl.SagaAudit
             // Ut8Parser.TryParse also handles short format "g" which has a minimum of 7 chars independent of the format identifier
             if (!Utf8Parser.TryParse(source, out TimeSpan parsedTimeSpan, out int bytesConsumed, 'c') || source.Length != bytesConsumed)
             {
+                // Fallback to reading the "g" format
                 ThrowFormatException();
             }
 

--- a/src/ServiceControl.SagaAudit/CustomTimeSpanConverter.cs
+++ b/src/ServiceControl.SagaAudit/CustomTimeSpanConverter.cs
@@ -57,7 +57,9 @@ namespace ServiceControl.SagaAudit
             }
 
             // Ut8Parser.TryParse also handles some short format "g" cases which has a minimum of 1 chars independent of the format identifier
-            if (!Utf8Parser.TryParse(source, out TimeSpan parsedTimeSpan, out int bytesConsumed, 'c') || source.Length != bytesConsumed)
+            if ((!Utf8Parser.TryParse(source, out TimeSpan parsedTimeSpan, out int bytesConsumed, 'c') || source.Length != bytesConsumed) &&
+                // Otherwise we fall back to read with the short format "g" directly since that is what the SagaAudit plugin used to stay backward compatible
+                (!Utf8Parser.TryParse(source, out parsedTimeSpan, out bytesConsumed, 'g') || source.Length != bytesConsumed))
             {
                 ThrowFormatException();
             }


### PR DESCRIPTION
Follow through on https://github.com/Particular/ServiceControl/pull/4142 since we covered more edge cases that weren't covered with the "c" format restrictions being lifted I have added a fallback to parsing with the "g" format should the "c" format parsing return false.

This should make the code compliant hopefully all cases that came from the previous plugin versions [using custom timespan formatting ](https://github.com/Particular/NServiceBus.SagaAudit/blob/release-4.0/src/NServiceBus.SagaAudit/MessageSerializationStrategy.cs#L36-L40)

This needs to be back ported to 5.2