### PR TITLE
Retried messages and ServiceControl integration messages cannot be handled by older MSMQ endpoints

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="NServiceBus.Testing" Version="9.0.0" />
     <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="4.0.1" />
     <PackageVersion Include="NServiceBus.Transport.AzureStorageQueues" Version="13.0.0" />
-    <PackageVersion Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.0" />
+    <PackageVersion Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.1" />
     <PackageVersion Include="NServiceBus.Transport.SqlServer" Version="8.0.0" />
     <PackageVersion Include="NuGet.Versioning" Version="6.9.1" />
     <PackageVersion Include="NUnit" Version="3.14.0" />


### PR DESCRIPTION
Backport of https://github.com/Particular/ServiceControl/pull/4196