### PR TITLE
Add TargetArch property to set RID

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -29,8 +29,11 @@
     <InstanceName Include="Particular.ServiceControl.Monitoring" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(WindowsSelfContained)' == 'true'">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  <PropertyGroup>
+    <RuntimeIdentifier Condition="'$(WindowsSelfContained)' == 'true'">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetArch)' == 'amd64'">linux-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetArch)' == 'arm'">linux-arm</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetArch)' == 'arm64'">linux-arm64</RuntimeIdentifier>
   </PropertyGroup>
 
   <!-- workaround for https://github.com/microsoft/MSBuildSdks/issues/477 -->

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /
 ENV CI=true
 
 COPY . .
-RUN dotnet build src/ServiceControl.Audit/ServiceControl.Audit.csproj --configuration Release -graph --arch $TARGETARCH
+RUN dotnet build src/ServiceControl.Audit/ServiceControl.Audit.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
 
 
 # Runtime image

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /
 ENV CI=true
 
 COPY . .
-RUN dotnet build src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj --configuration Release -graph --arch $TARGETARCH
+RUN dotnet build src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
 
 
 # Runtime image

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /
 ENV CI=true
 
 COPY . .
-RUN dotnet build src/ServiceControl/ServiceControl.csproj --configuration Release -graph --arch $TARGETARCH
+RUN dotnet build src/ServiceControl/ServiceControl.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
 
 
 # Runtime image


### PR DESCRIPTION
This PR adds a `TargetArch` MSBuild property that used to pass in the docker `TARGETARCH` value, enabling that value to set the `RuntimeIdentifier` in the Custom.Build.props file.

Before making this change, the artifacts built in the docker images would have both a RID-specific and a RID-agnostic version, resulting in two copies of everything.

This is fixed by setting the `RuntimeIdentifier`in the Custom.Build.props file, which makes it set for every project.