### PR TITLE
Installer upgrade behavior more resilient when files are in use and locked

### DIFF
--- a/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
+++ b/src/ServiceControl.Config/Framework/Modules/InstallerModule.cs
@@ -125,6 +125,14 @@ namespace ServiceControl.Config.Framework.Modules
                 progress.Report(currentStep++, totalSteps, "Upgrading Files...");
                 instance.UpgradeFiles(ZipInfo.ResourceName);
             }
+            catch (Exception e)
+            {
+                return new ReportCard
+                {
+                    Errors = { e.Message },
+                    Status = Status.Failed
+                };
+            }
             finally
             {
                 progress.Report(currentStep++, totalSteps, "Restoring app.config...");
@@ -317,6 +325,14 @@ namespace ServiceControl.Config.Framework.Modules
             {
                 progress.Report(2, 5, "Upgrading Files...");
                 instance.UpgradeFiles(ZipInfo.ResourceName);
+            }
+            catch (Exception e)
+            {
+                return new ReportCard
+                {
+                    Errors = { e.Message },
+                    Status = Status.Failed
+                };
             }
             finally
             {

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -114,7 +114,6 @@ namespace ServiceControlInstaller.Engine.FileSystem
                     var relativePath = srcFile.Substring(srcDir.Length + 1);
                     var destFile = Path.Combine(destDir, relativePath);
                     var destFileDir = Path.GetDirectoryName(destFile);
-                    Trace.WriteLine($"Cloning {srcFile} to {destFile}");
                     Directory.CreateDirectory(destFileDir);
                     File.Copy(srcFile, destFile);
                 }

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -24,32 +24,26 @@ namespace ServiceControlInstaller.Engine.FileSystem
             }
 
             var originalPath = path;
-
-            // Move folder to ensure no files are in use so that it is less likely that we corrupt the folder
-            // when still in use
-
             var pathToDelete = path + "$";
 
-            RunWithRetries(() => di.MoveTo(pathToDelete));
-
-            path = pathToDelete;
             try
             {
+                // Move folder to ensure no files are in use so that it is less likely that we corrupt the folder
+                // when still in use
+                RunWithRetries(() => di.MoveTo(pathToDelete));
+                path = pathToDelete;
                 DeleteDirectoryInternal(path, recursive, contentsOnly, excludes);
+
+                if (contentsOnly)
+                {
+                    di.MoveTo(originalPath);
+                }
             }
             catch (Exception ex)
             {
                 throw new($"Failure during folder {(contentsOnly ? "cleanup" : "removal")}. Remaining folder content is available at: {path}", ex);
             }
-            finally
-            {
-                // Intentionally not moving back in a finally as folder is likely corrupted
-            }
-
-            if (contentsOnly)
-            {
-                di.MoveTo(originalPath);
-            }
+            // Intentionally not moving back in a finally as folder is likely corrupted
         }
 
         static void DeleteDirectoryInternal(string path, bool recursive, bool contentsOnly, params string[] excludes)

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -81,8 +81,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
 
                 RunWithRetries(() =>
                 {
-                    fi.Attributes &= ~FileAttributes.ReadOnly;
-                    fi.Attributes &= ~FileAttributes.System;
+                    fi.Attributes &= ~(FileAttributes.ReadOnly | FileAttributes.System);
                     fi.Delete();
                 });
             }
@@ -94,8 +93,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
 
             RunWithRetries(() =>
             {
-                di.Attributes &= ~FileAttributes.ReadOnly;
-                di.Attributes &= ~FileAttributes.System;
+                di.Attributes &= ~(FileAttributes.ReadOnly | FileAttributes.System);
                 di.Delete();
             });
             di.Delete();

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace ServiceControlInstaller.Engine.FileSystem
 {
     using System;
@@ -97,6 +99,30 @@ namespace ServiceControlInstaller.Engine.FileSystem
                 di.Delete();
             });
         }
+        
+        public static void CloneDirectory(string srcDir, string destDir, params string[] excludes)
+        {
+            Directory.CreateDirectory(destDir);
+            
+            var files = Directory.EnumerateFiles(srcDir, "*", SearchOption.AllDirectories);
+            
+            foreach (var srcFile in files)
+            {
+                var filename = Path.GetFileName(srcFile);
+               
+                var isMatch = excludes.Any(p => string.Equals(p, filename, StringComparison.OrdinalIgnoreCase)); 
+
+                if (isMatch)
+                {
+                    var relativePath = srcFile.Substring(srcDir.Length+1);
+                    var destFile = Path.Combine(destDir, relativePath);
+                    var destFileDir = Path.GetDirectoryName(destFile);
+                    Trace.WriteLine($"Cloning {srcFile} to {destFile}");
+                    Directory.CreateDirectory(destFileDir);
+                    File.Copy(srcFile, destFile);
+                }
+            }
+        }        
 
         public static void CreateDirectoryAndSetAcl(string path, FileSystemAccessRule accessRule)
         {

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -28,11 +28,21 @@ namespace ServiceControlInstaller.Engine.FileSystem
             // Move folder to ensure no files are in use so that it is less likely that we corrupt the folder
             // when still in use
 
-            var pathToDelete= path + "$";
+            var pathToDelete = path + "$";
             di.MoveTo(pathToDelete);
             path = pathToDelete;
-
-            DeleteDirectoryInternal(path, recursive, contentsOnly, excludes);
+            try
+            {
+                DeleteDirectoryInternal(path, recursive, contentsOnly, excludes);
+            }
+            catch (Exception ex)
+            {
+                throw new($"Failure during folder {(contentsOnly ? "cleanup" : "removal")}. Remaining folder content is available at: {path}", ex);
+            }
+            finally
+            {
+                // Intentionally not moving back in a finally as folder is likely corrupted
+            }
 
             if (contentsOnly)
             {
@@ -40,7 +50,6 @@ namespace ServiceControlInstaller.Engine.FileSystem
                 return;
             }
 
-            // Intentionally not moving back in a finally as folder is likely corrupted
         }
 
         static void DeleteDirectoryInternal(string path, bool recursive, bool contentsOnly, params string[] excludes)

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -129,7 +129,6 @@ namespace ServiceControlInstaller.Engine.FileSystem
 
         static void RunWithRetries(Action action)
         {
-            // Try
             var attempts = 10;
             while (true)
             {

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -96,7 +96,6 @@ namespace ServiceControlInstaller.Engine.FileSystem
                 di.Attributes &= ~(FileAttributes.ReadOnly | FileAttributes.System);
                 di.Delete();
             });
-            di.Delete();
         }
 
         public static void CreateDirectoryAndSetAcl(string path, FileSystemAccessRule accessRule)

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -24,14 +24,33 @@ namespace ServiceControlInstaller.Engine.FileSystem
             }
 
             var originalPath = path;
-            var originalAttributes = di.Attributes;
 
             // Move folder to ensure no files are in use so that it is less likely that we corrupt the folder
             // when still in use
 
-            var pathToDelete = path + "$";
+            var pathToDelete= path + "$";
             di.MoveTo(pathToDelete);
             path = pathToDelete;
+
+            DeleteDirectoryInternal(path, recursive, contentsOnly, excludes);
+
+            if (contentsOnly)
+            {
+                di.MoveTo(originalPath);
+                return;
+            }
+
+            // Intentionally not moving back in a finally as folder is likely corrupted
+        }
+
+        static void DeleteDirectoryInternal(string path, bool recursive, bool contentsOnly, params string[] excludes)
+        {
+            var di = new DirectoryInfo(path);
+
+            if (!di.Exists)
+            {
+                return;
+            }
 
             if (recursive)
             {
@@ -43,7 +62,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
                         continue;
                     }
 
-                    DeleteDirectory(s, true, false, excludes);
+                    DeleteDirectoryInternal(s, true, false, excludes);
                 }
             }
 
@@ -63,8 +82,6 @@ namespace ServiceControlInstaller.Engine.FileSystem
 
             if (contentsOnly)
             {
-                di.MoveTo(originalPath);
-                di.Attributes = originalAttributes;
                 return;
             }
 

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace ServiceControlInstaller.Engine.FileSystem
 {
     using System;
@@ -8,6 +6,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
     using System.Reflection;
     using System.Security.AccessControl;
     using Ionic.Zip;
+    using System.Diagnostics;
 
     static class FileUtils
     {
@@ -99,22 +98,20 @@ namespace ServiceControlInstaller.Engine.FileSystem
                 di.Delete();
             });
         }
-        
+
         public static void CloneDirectory(string srcDir, string destDir, params string[] excludes)
         {
             Directory.CreateDirectory(destDir);
-            
             var files = Directory.EnumerateFiles(srcDir, "*", SearchOption.AllDirectories);
-            
+
             foreach (var srcFile in files)
             {
                 var filename = Path.GetFileName(srcFile);
-               
-                var isMatch = excludes.Any(p => string.Equals(p, filename, StringComparison.OrdinalIgnoreCase)); 
+                var isMatch = excludes.Any(p => string.Equals(p, filename, StringComparison.OrdinalIgnoreCase));
 
                 if (isMatch)
                 {
-                    var relativePath = srcFile.Substring(srcDir.Length+1);
+                    var relativePath = srcFile.Substring(srcDir.Length + 1);
                     var destFile = Path.Combine(destDir, relativePath);
                     var destFileDir = Path.GetDirectoryName(destFile);
                     Trace.WriteLine($"Cloning {srcFile} to {destFile}");
@@ -122,7 +119,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
                     File.Copy(srcFile, destFile);
                 }
             }
-        }        
+        }
 
         public static void CreateDirectoryAndSetAcl(string path, FileSystemAccessRule accessRule)
         {

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -99,7 +99,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
             });
         }
 
-        public static void CloneDirectory(string srcDir, string destDir, params string[] excludes)
+        public static void CloneDirectory(string srcDir, string destDir, params string[] includes)
         {
             Directory.CreateDirectory(destDir);
             var files = Directory.EnumerateFiles(srcDir, "*", SearchOption.AllDirectories);
@@ -107,7 +107,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
             foreach (var srcFile in files)
             {
                 var filename = Path.GetFileName(srcFile);
-                var isMatch = excludes.Any(p => string.Equals(p, filename, StringComparison.OrdinalIgnoreCase));
+                var isMatch = includes.Any(p => string.Equals(p, filename, StringComparison.OrdinalIgnoreCase));
 
                 if (isMatch)
                 {

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -49,7 +49,6 @@ namespace ServiceControlInstaller.Engine.FileSystem
                 di.MoveTo(originalPath);
                 return;
             }
-
         }
 
         static void DeleteDirectoryInternal(string path, bool recursive, bool contentsOnly, params string[] excludes)

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -159,8 +159,9 @@ namespace ServiceControlInstaller.Engine.FileSystem
                     action();
                     break;
                 }
-                catch (IOException) when (--attempts > 0)
+                catch (IOException ex) when (--attempts > 0)
                 {
+                    Trace.WriteLine($"ServiceControlInstaller.Engine.FileSystem.FileUtils::RunWithRetries Action failed, {attempts} attempts remaining. Reason: {ex.Message} ({ex.GetType().FullName})");
                     // Yes, Task.Delay would be better but would require all calls to be async
                     // and in 99.9% this sleep will not hit 
                     System.Threading.Thread.Sleep(100);

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -163,7 +163,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
                 }
                 catch (IOException ex) when (--attempts > 0)
                 {
-                    Trace.WriteLine($"ServiceControlInstaller.Engine.FileSystem.FileUtils::RunWithRetries Action failed, {attempts} attempts remaining. Reason: {ex.Message} ({ex.GetType().FullName})");
+                    Debug.WriteLine($"ServiceControlInstaller.Engine.FileSystem.FileUtils::RunWithRetries Action failed, {attempts} attempts remaining. Reason: {ex.Message} ({ex.GetType().FullName})");
                     // Yes, Task.Delay would be better but would require all calls to be async
                     // and in 99.9% this sleep will not hit 
                     Thread.Sleep(100);

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -1,12 +1,13 @@
 namespace ServiceControlInstaller.Engine.FileSystem
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Reflection;
     using System.Security.AccessControl;
+    using System.Threading;
     using Ionic.Zip;
-    using System.Diagnostics;
 
     static class FileUtils
     {
@@ -25,7 +26,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
             }
 
             var originalPath = path;
-            var pathToDelete = path + "." + DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            string pathToDelete = path + Path.GetRandomFileName();
 
             try
             {
@@ -163,7 +164,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
                     Trace.WriteLine($"ServiceControlInstaller.Engine.FileSystem.FileUtils::RunWithRetries Action failed, {attempts} attempts remaining. Reason: {ex.Message} ({ex.GetType().FullName})");
                     // Yes, Task.Delay would be better but would require all calls to be async
                     // and in 99.9% this sleep will not hit 
-                    System.Threading.Thread.Sleep(100);
+                    Thread.Sleep(100);
                 }
             }
         }

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -25,7 +25,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
             }
 
             var originalPath = path;
-            var pathToDelete = path + "$";
+            var pathToDelete = path + "." + DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
             try
             {

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -26,6 +26,8 @@ namespace ServiceControlInstaller.Engine.FileSystem
             }
 
             var originalPath = path;
+
+            // ADD randomness to path, not replacing folder name so that it can still be identified
             string pathToDelete = path + Path.GetRandomFileName();
 
             try

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -183,7 +183,7 @@
 
             // Prepare
             FileUtils.DeleteDirectory(newPath, true, false);
-            Prepare(zipFilePat, newPath);
+            Prepare(zipFilePath, newPath);
 
             // Swap
             MoveCurrentToOld(newPath, oldPath);

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -241,7 +241,7 @@
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Unable to cleanup {oldPath}. Reason: {ex.Message} ({ex.GetType().FullName})");
+                Trace.WriteLine($"ServiceControlInstaller.Engine.Instances.BaseService::PurgeOld Unable to cleanup {oldPath}. Reason: {ex.Message} ({ex.GetType().FullName})");
                 // Ignore, did our best. Unfortunately no context to report a warning
             }
         }

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -175,7 +175,7 @@
         public abstract void Reload();
 
 
-        public void UpgradeFiles(string zipFilePat)
+        public void UpgradeFiles(string zipFilePath)
         {
             // Do NOT use a TEMP folder as that could be on another drive and moving that will require first copying files.
             var newPath = InstallPath + ".new";

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -239,8 +239,9 @@
             {
                 FileUtils.DeleteDirectory(oldPath, true, false);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Trace.WriteLine($"Unable to cleanup {oldPath}. Reason: {ex.Message} ({ex.GetType().FullName})");
                 // Ignore, did our best. Unfortunately no context to report a warning
             }
         }

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -241,7 +241,7 @@
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"ServiceControlInstaller.Engine.Instances.BaseService::PurgeOld Unable to cleanup {oldPath}. Reason: {ex.Message} ({ex.GetType().FullName})");
+                Debug.WriteLine($"ServiceControlInstaller.Engine.Instances.BaseService::PurgeOld Unable to cleanup {oldPath}. Reason: {ex.Message} ({ex.GetType().FullName})");
                 // Ignore, did our best. Unfortunately no context to report a warning
             }
         }

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -227,7 +227,7 @@
                 }
                 catch (Exception ex2)
                 {
-                    throw new($"Error while making new version active but unsuccessful in restoring previous version.\n\nManually restore '{oldPath}' to '{InstallPath}' to repair instance.", ex2);
+                    throw new($"Error while making new version active and unsuccessful in restoring previous version.\n\nManually restore '{oldPath}' to '{InstallPath}' to repair instance.", ex2);
                 }
             }
         }

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -4,6 +4,7 @@
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Runtime;
     using System.ServiceProcess;
     using System.Threading;
     using Engine;
@@ -172,5 +173,25 @@
         }
 
         public abstract void Reload();
+
+
+        public void UpgradeFiles(string zipFilePat)
+        {
+            var newPath = InstallPath + ".new";
+            var oldPath = InstallPath + ".old";
+
+            // Prepare
+            FileUtils.DeleteDirectory(newPath, true, false);
+            Prepare(zipFilePat, newPath);
+
+            //Swap
+            Directory.Move(InstallPath, oldPath);
+            Directory.Move(newPath, InstallPath);
+
+            // Clean
+            FileUtils.DeleteDirectory(oldPath, true, false);
+        }
+
+        protected abstract void Prepare(string zipFilePath, string destDir);
     }
 }

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -177,6 +177,7 @@
 
         public void UpgradeFiles(string zipFilePat)
         {
+            // Do NOT use a TEMP folder as that could be on another drive and moving that will require first copying files.
             var newPath = InstallPath + ".new";
             var oldPath = InstallPath + ".old";
 

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -244,25 +244,11 @@
             }
         }
 
-        public void UpgradeFiles(string zipFilePath)
+        protected override void Prepare(string zipFilePath, string destDir)
         {
-            var newPath = InstallPath + ".new";
-            var oldPath = InstallPath + ".old";
-
-            // Cleanup previous prep folder
-            FileUtils.DeleteDirectory(newPath, true, false);
-
-            // Prepare new version
-            FileUtils.CloneDirectory(InstallPath, newPath, "license", $"{Constants.MonitoringExe}.config");
-            FileUtils.UnzipToSubdirectory(zipFilePath, newPath);
-            FileUtils.UnzipToSubdirectory("InstanceShared.zip", newPath);
-
-            // Swap versions
-            Directory.Move(InstallPath, oldPath);
-            Directory.Move(newPath, InstallPath);
-
-            // Delete old version
-            FileUtils.DeleteDirectory(oldPath, true, false);
+            FileUtils.CloneDirectory(InstallPath, destDir, "license", $"{Constants.MonitoringExe}.config");
+            FileUtils.UnzipToSubdirectory(zipFilePath, destDir);
+            FileUtils.UnzipToSubdirectory("InstanceShared.zip", destDir);
         }
 
         public void RestoreAppConfig(string sourcePath)

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -246,9 +246,23 @@
 
         public void UpgradeFiles(string zipFilePath)
         {
-            FileUtils.DeleteDirectory(InstallPath, true, true, "license", $"{Constants.MonitoringExe}.config");
-            FileUtils.UnzipToSubdirectory(zipFilePath, InstallPath);
-            FileUtils.UnzipToSubdirectory("InstanceShared.zip", InstallPath);
+            var newPath = InstallPath + ".new";
+            var oldPath = InstallPath + ".old";
+
+            // Cleanup previous prep folder
+            FileUtils.DeleteDirectory(newPath, true, false);
+
+            // Prepare new version
+            FileUtils.CloneDirectory(InstallPath, newPath, "license", $"{Constants.MonitoringExe}.config");
+            FileUtils.UnzipToSubdirectory(zipFilePath, newPath);
+            FileUtils.UnzipToSubdirectory("InstanceShared.zip", newPath);
+
+            // Swap versions
+            Directory.Move(InstallPath, oldPath);
+            Directory.Move(newPath, InstallPath);
+
+            // Delete old version
+            FileUtils.DeleteDirectory(oldPath, true, false);
         }
 
         public void RestoreAppConfig(string sourcePath)

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
@@ -104,10 +104,25 @@ namespace ServiceControlInstaller.Engine.Instances
 
         public override void UpgradeFiles(string zipResourceName)
         {
-            FileUtils.DeleteDirectory(InstallPath, true, true, "license", $"{Constants.ServiceControlAuditExe}.config");
-            FileUtils.UnzipToSubdirectory(zipResourceName, InstallPath);
-            FileUtils.UnzipToSubdirectory("InstanceShared.zip", InstallPath);
-            FileUtils.UnzipToSubdirectory("RavenDBServer.zip", Path.Combine(InstallPath, "Persisters", "RavenDB", "RavenDBServer"));
+            var newPath = InstallPath + ".new";
+            var oldPath = InstallPath + ".old";
+
+            // Cleanup previous prep folder
+            FileUtils.DeleteDirectory(newPath, true, false);
+
+            // Prepare new version
+            FileUtils.CloneDirectory(InstallPath, newPath, "license", $"{Constants.ServiceControlAuditExe}.config");
+            FileUtils.UnzipToSubdirectory(zipResourceName, newPath);
+            FileUtils.UnzipToSubdirectory("InstanceShared.zip", newPath);
+            FileUtils.UnzipToSubdirectory("RavenDBServer.zip", Path.Combine(newPath, "Persisters", "RavenDB", "RavenDBServer"));
+
+            // Swap versions
+            Directory.Move(InstallPath, oldPath);
+            Directory.Move(newPath, InstallPath);
+
+            // Delete old version
+            FileUtils.DeleteDirectory(oldPath, true, false);
+            
         }
 
         protected override IEnumerable<string> GetPersistencePathsToCleanUp()

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
@@ -102,27 +102,12 @@ namespace ServiceControlInstaller.Engine.Instances
             QueueCreation.RunQueueCreation(this);
         }
 
-        public override void UpgradeFiles(string zipResourceName)
+        protected override void Prepare(string zipResourceName, string destDir)
         {
-            var newPath = InstallPath + ".new";
-            var oldPath = InstallPath + ".old";
-
-            // Cleanup previous prep folder
-            FileUtils.DeleteDirectory(newPath, true, false);
-
-            // Prepare new version
-            FileUtils.CloneDirectory(InstallPath, newPath, "license", $"{Constants.ServiceControlAuditExe}.config");
-            FileUtils.UnzipToSubdirectory(zipResourceName, newPath);
-            FileUtils.UnzipToSubdirectory("InstanceShared.zip", newPath);
-            FileUtils.UnzipToSubdirectory("RavenDBServer.zip", Path.Combine(newPath, "Persisters", "RavenDB", "RavenDBServer"));
-
-            // Swap versions
-            Directory.Move(InstallPath, oldPath);
-            Directory.Move(newPath, InstallPath);
-
-            // Delete old version
-            FileUtils.DeleteDirectory(oldPath, true, false);
-            
+            FileUtils.CloneDirectory(InstallPath, destDir, "license", $"{Constants.ServiceControlAuditExe}.config");
+            FileUtils.UnzipToSubdirectory(zipResourceName, destDir);
+            FileUtils.UnzipToSubdirectory("InstanceShared.zip", destDir);
+            FileUtils.UnzipToSubdirectory("RavenDBServer.zip", Path.Combine(destDir, "Persisters", "RavenDB", "RavenDBServer"));
         }
 
         protected override IEnumerable<string> GetPersistencePathsToCleanUp()

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
@@ -383,8 +383,6 @@ namespace ServiceControlInstaller.Engine.Instances
             AppConfig.Save();
         }
 
-        public abstract void UpgradeFiles(string zipResourceName);
-
         public abstract void RunQueueCreation();
 
         public void SetupInstance()

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -192,26 +192,12 @@ namespace ServiceControlInstaller.Engine.Instances
             }
         }
 
-        public override void UpgradeFiles(string zipFilePath)
+        protected override void Prepare(string zipFilePath, string destDir)
         {
-            var newPath = InstallPath + ".new";
-            var oldPath = InstallPath + ".old";
-
-            // Cleanup previous prep folder
-            FileUtils.DeleteDirectory(newPath, true, false);
-
-            // Prepare new version
-            FileUtils.CloneDirectory(InstallPath, newPath, "license", $"{Constants.ServiceControlExe}.config");
-            FileUtils.UnzipToSubdirectory(zipFilePath, newPath);
-            FileUtils.UnzipToSubdirectory("InstanceShared.zip", newPath);
-            FileUtils.UnzipToSubdirectory("RavenDBServer.zip", Path.Combine(newPath, "Persisters", "RavenDB", "RavenDBServer"));
-
-            // Swap versions
-            Directory.Move(InstallPath, oldPath);
-            Directory.Move(newPath, InstallPath);
-
-            // Delete old version
-            FileUtils.DeleteDirectory(oldPath, true, false);
+            FileUtils.CloneDirectory(InstallPath, destDir, "license", $"{Constants.ServiceControlExe}.config");
+            FileUtils.UnzipToSubdirectory(zipFilePath, destDir);
+            FileUtils.UnzipToSubdirectory("InstanceShared.zip", destDir);
+            FileUtils.UnzipToSubdirectory("RavenDBServer.zip", Path.Combine(destDir, "Persisters", "RavenDB", "RavenDBServer"));
         }
 
         protected override IEnumerable<string> GetPersistencePathsToCleanUp()

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -194,10 +194,24 @@ namespace ServiceControlInstaller.Engine.Instances
 
         public override void UpgradeFiles(string zipFilePath)
         {
-            FileUtils.DeleteDirectory(InstallPath, true, true, "license", $"{Constants.ServiceControlExe}.config");
-            FileUtils.UnzipToSubdirectory(zipFilePath, InstallPath);
-            FileUtils.UnzipToSubdirectory("InstanceShared.zip", InstallPath);
-            FileUtils.UnzipToSubdirectory("RavenDBServer.zip", Path.Combine(InstallPath, "Persisters", "RavenDB", "RavenDBServer"));
+            var newPath = InstallPath + ".new";
+            var oldPath = InstallPath + ".old";
+
+            // Cleanup previous prep folder
+            FileUtils.DeleteDirectory(newPath, true, false);
+
+            // Prepare new version
+            FileUtils.CloneDirectory(InstallPath, newPath, "license", $"{Constants.ServiceControlExe}.config");
+            FileUtils.UnzipToSubdirectory(zipFilePath, newPath);
+            FileUtils.UnzipToSubdirectory("InstanceShared.zip", newPath);
+            FileUtils.UnzipToSubdirectory("RavenDBServer.zip", Path.Combine(newPath, "Persisters", "RavenDB", "RavenDBServer"));
+
+            // Swap versions
+            Directory.Move(InstallPath, oldPath);
+            Directory.Move(newPath, InstallPath);
+
+            // Delete old version
+            FileUtils.DeleteDirectory(oldPath, true, false);
         }
 
         protected override IEnumerable<string> GetPersistencePathsToCleanUp()


### PR DESCRIPTION
It frequently happens that for unknown reasons files are still in use which result in errors like the following:

```txt
The process cannot access the file 'H:\ServiceControl\servicecontrol-test-monitoring\bin\System.Transactions.Local.dll' because it is being used by another process.
```

This change improves the installer logic when upgrading instances by first preparing the new version in a new folder and when that completes swap the folder of the current instance for the folder of the new instance. This resolves most if not all issues around files that are locked or in use.

It also makes the folder delete operation more resilient against very short lock that can be caused because the instance although reporting stopped in Windows Service Control Manager to still be running for a very little time or because a virusscanner locks a file or any other reason for a file to be in use. 


Summarized:

1. Installer upgrade first prepares folder, then swaps current/new folder. Previously immediately updated files in existing folder.
2. Retries file operations when failing with an `IOException` 10x with a 100ms sleep to allow for short file locks
3. Renames (move to the same parent folder with different name) the folder which only passes when there are no files in use/locked

This is tested with all 3 monitor types by upgrading 5.2.4 to 5.3.0-alpha.0.30 from the build server.
