### PR TITLE
Updated to Azure.Identity and Microsoft.Identity.Client

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,7 +7,7 @@
 
   <ItemGroup Label="Versions for direct package references">
     <PackageVersion Include="Autofac" Version="8.0.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.11.3" />
+    <PackageVersion Include="Azure.Identity" Version="1.11.4" />
     <PackageVersion Include="ByteSize" Version="2.1.2" />
     <PackageVersion Include="Caliburn.Micro" Version="4.0.212" />
     <PackageVersion Include="DotNetZip" Version="1.16.0" />
@@ -69,7 +69,7 @@
   <ItemGroup Label="Versions to pin transitive references">
     <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.5" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.61.0" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.61.3" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.5" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
Updated to Azure.Identity 1.11.4 and Microsoft.Identity.Client 4.61.3 to resolve medium level vulnerability

- https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/security/dependabot/5