### PR TITLE
Workaround for Rider 2024.1.2 to debug `PublishSingleFile` builds

### DIFF
--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -7,7 +7,7 @@
     <ApplicationIcon>App.ico</ApplicationIcon>
     <UseWpf>true</UseWpf>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <PublishSingleFile>true</PublishSingleFile>
+    <PublishSingleFile Condition="'$(Configuration)' == 'Release'">true</PublishSingleFile><!-- Rider cannot debug PublishSingleFile builds -->
     <SelfContained>true</SelfContained>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>


### PR DESCRIPTION
Rider 2024.1.2 cannot debug `PublishSingleFile`  builds. Workaround applied that is listed at:

- https://youtrack.jetbrains.com/issue/RIDER-56918/