### PR TITLE
Restore SetupMode = None, make all args ENV vars

### DIFF
--- a/src/ServiceControl.RavenDB/Dockerfile
+++ b/src/ServiceControl.RavenDB/Dockerfile
@@ -4,7 +4,9 @@ FROM ravendb/ravendb:$BASETAG AS ravendb
 
 COPY src/ServiceControl.RavenDB/RavenLicense.json /opt/RavenDB/servicecontrol-license.json
 
-ENV RAVEN_ARGS='--License.Eula.Accepted=true --License.Path=/opt/RavenDB/servicecontrol-license.json'
+ENV RAVEN_License_Eula_Accepted=true \
+    RAVEN_License_Path=/opt/RavenDB/servicecontrol-license.json \
+    RAVEN_Setup_Mode=None
 
 LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
       org.opencontainers.image.authors="Particular Software" \

--- a/src/ServiceControl.UnitTests/Infrastructure/DockerfileTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/DockerfileTests.cs
@@ -1,0 +1,20 @@
+﻿namespace ServiceControl.UnitTests.Infrastructure
+{
+    using System.IO;
+    using System.Text.RegularExpressions;
+    using NUnit.Framework;
+
+    public class DockerfileTests
+    {
+        [Test]
+        public void DontUseRavenArgs()
+        {
+            var srcDir = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", ".."));
+            var ravenContainerDockerfilePath = Path.Combine(srcDir, "ServiceControl.RavenDB", "Dockerfile");
+            var contents = File.ReadAllText(ravenContainerDockerfilePath);
+            var setsRavenArgs = Regex.IsMatch(contents, @"RAVEN_ARGS=", RegexOptions.IgnoreCase);
+
+            Assert.That(setsRavenArgs, Is.False, "Our Dockerfile should not set RAVEN_ARGS to anything, and leave that entirely to the end user. Instead, replace any --Setting.Name=value with an env var RAVEN_Setting_Name=value.");
+        }
+    }
+}


### PR DESCRIPTION
Goes back to SetupMode = None, which can be overridden by setting runtime ENV of RAVEN_Setup_Mode=Initial

Also splits RAVEN_ARGS into being set by 2 ENV vars, because a user overwriting RAVEN_ARGS would clobber both, thus we should avoid ever setting RAVEN_ARGS at the Dockerfile level and leave that solely for the end user.