### PR TITLE
Only allow env files to drop namespace on 3 app namespaces

### DIFF
--- a/src/ServiceControl.Configuration/EnvironmentVariableSettingsReader.cs
+++ b/src/ServiceControl.Configuration/EnvironmentVariableSettingsReader.cs
@@ -2,7 +2,6 @@ namespace ServiceControl.Configuration;
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using static ValueConverter;
 
@@ -29,21 +28,28 @@ static partial class EnvironmentVariableSettingsReader
 
     static IEnumerable<string> GetFullKeyOptions(SettingsRootNamespace settingsNamespace, string name)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            yield return $"{settingsNamespace}/{name}";
-        }
-
         var regex = SeparatorsRegex();
 
         var namespacedKey = regex.Replace($"{settingsNamespace}_{name}", "_");
         yield return namespacedKey.ToUpperInvariant();
         yield return namespacedKey;
 
-        var nameOnly = regex.Replace(name, "_");
-        yield return nameOnly.ToUpperInvariant();
-        yield return nameOnly;
+        // The 3 app namespaces can be loaded from env vars without the namespace, so settings like TransportType can be
+        // shared between all instances in a container .env file. Settings in all other namespaces must be fully specified.
+        if (CanSetWithoutNamespaceList.Contains(settingsNamespace))
+        {
+            var nameOnly = regex.Replace(name, "_");
+            yield return nameOnly.ToUpperInvariant();
+            yield return nameOnly;
+        }
     }
+
+    static readonly HashSet<SettingsRootNamespace> CanSetWithoutNamespaceList =
+    [
+        new SettingsRootNamespace("ServiceControl"),
+        new SettingsRootNamespace("ServiceControl.Audit"),
+        new SettingsRootNamespace("Monitoring")
+    ];
 
     [GeneratedRegex(@"[\./]")]
     private static partial Regex SeparatorsRegex();


### PR DESCRIPTION
All other namespaces, such as Throughput component related, must be fully specified to avoid settings clobbering each other.

Also, no app.config style env vars allowed, must use POSIX_STYLE