### PR TITLE
Clean up GitHub container registry

### DIFF
--- a/.github/workflows/clean-ghcr.yml
+++ b/.github/workflows/clean-ghcr.yml
@@ -11,7 +11,33 @@ jobs:
       - name: ServiceControl PRs
         uses: snok/container-retention-policy@v2.2.1
         with:
-          image-names: servicecontrol*
+          image-names: servicecontrol
+          filter-tags: pr-*
+          filter-include-untagged: true
+          cut-off: A week ago UTC
+          timestamp-to-use: updated_at
+          account-type: org
+          org-name: particular
+          token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token
+          dry-run: true
+      - name: Audit PRs
+        uses: snok/container-retention-policy@v2.2.1
+        with:
+          image-names: servicecontrol-audit
+          filter-tags: pr-*
+          filter-include-untagged: true
+          cut-off: A week ago UTC
+          timestamp-to-use: updated_at
+          account-type: org
+          org-name: particular
+          token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token
+          dry-run: true
+      - name: Monitoring PRs
+        uses: snok/container-retention-policy@v2.2.1
+        with:
+          image-names: servicecontrol-monitoring
           filter-tags: pr-*
           filter-include-untagged: true
           cut-off: A week ago UTC

--- a/.github/workflows/clean-ghcr.yml
+++ b/.github/workflows/clean-ghcr.yml
@@ -8,11 +8,10 @@ jobs:
     name: Delete unused containers
     runs-on: ubuntu-latest
     steps:
-      - name: Delete PR containers
-        id: prs
+      - name: ServiceControl PRs
         uses: snok/container-retention-policy@v2.2.1
         with:
-          image-names: servicecontrol
+          image-names: servicecontrol*
           filter-tags: pr-*
           filter-include-untagged: true
           cut-off: A week ago UTC
@@ -22,9 +21,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
           dry-run: true
-      - name: Outputs
-        run: |
-          echo "Deleted: ${{ steps.prs.outputs.deleted }}"
-          echo "Failed: ${{ steps.prs.outputs.failed }}"
           
     

--- a/.github/workflows/clean-ghcr.yml
+++ b/.github/workflows/clean-ghcr.yml
@@ -20,7 +20,7 @@ jobs:
           org-name: particular
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
-          dry-run: true
+          dry-run: false
       - name: Audit PRs
         uses: snok/container-retention-policy@v2.2.1
         with:
@@ -33,7 +33,7 @@ jobs:
           org-name: particular
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
-          dry-run: true
+          dry-run: false
       - name: Monitoring PRs
         uses: snok/container-retention-policy@v2.2.1
         with:
@@ -46,6 +46,6 @@ jobs:
           org-name: particular
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
-          dry-run: true
+          dry-run: false
           
     

--- a/.github/workflows/clean-ghcr.yml
+++ b/.github/workflows/clean-ghcr.yml
@@ -8,11 +8,11 @@ jobs:
     name: Delete unused containers
     runs-on: ubuntu-latest
     steps:
-      - name: ServiceControl PRs
+      - name: ServiceControl images
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol
-          filter-tags: pr-*
+          filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
           cut-off: A week ago UTC
           timestamp-to-use: updated_at
@@ -21,11 +21,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
           dry-run: false
-      - name: Audit PRs
+      - name: Audit images
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol-audit
-          filter-tags: pr-*
+          filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
           cut-off: A week ago UTC
           timestamp-to-use: updated_at
@@ -34,11 +34,24 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
           dry-run: false
-      - name: Monitoring PRs
+      - name: Monitoring images
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol-monitoring
-          filter-tags: pr-*
+          filter-tags: pr-*, *-alpha.*
+          filter-include-untagged: true
+          cut-off: A week ago UTC
+          timestamp-to-use: updated_at
+          account-type: org
+          org-name: particular
+          token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token
+          dry-run: false
+      - name: RavenDB images
+        uses: snok/container-retention-policy@v2.2.1
+        with:
+          image-names: servicecontrol-monitoring
+          filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
           cut-off: A week ago UTC
           timestamp-to-use: updated_at

--- a/.github/workflows/clean-ghcr.yml
+++ b/.github/workflows/clean-ghcr.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ServiceControl images
-        id: primary
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol
@@ -22,8 +21,19 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
           dry-run: false
+      - name: Test untagged
+        uses: snok/container-retention-policy@v2.2.1
+        with:
+          image-names: servicecontrol
+          untagged-only: true
+          cut-off: 3 days ago UTC
+          timestamp-to-use: updated_at
+          account-type: org
+          org-name: particular
+          token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token
+          dry-run: false
       - name: Audit images
-        id: audit
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol-audit
@@ -37,7 +47,6 @@ jobs:
           token-type: github-token
           dry-run: false
       - name: Monitoring images
-        id: monitoring
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol-monitoring
@@ -51,7 +60,6 @@ jobs:
           token-type: github-token
           dry-run: false
       - name: RavenDB images
-        id: raven
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol-ravendb
@@ -64,18 +72,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
           dry-run: false
-      - name: Results
-        run: |
-          echo "Removed images:"
-          echo "  - servicecontrol: ${{ steps.primary.outputs.deleted }}"
-          echo "  - servicecontrol-audit: ${{ steps.audit.outputs.deleted }}"
-          echo "  - servicecontrol-monitoring: ${{ steps.monitoring.outputs.deleted }}"
-          echo "  - servicecontrol-ravendb: ${{ steps.raven.outputs.deleted }}"
-          echo ""
-          echo "Failures:"
-          echo "  - servicecontrol: ${{ steps.primary.outputs.failed }}"
-          echo "  - servicecontrol-audit: ${{ steps.audit.outputs.failed }}"
-          echo "  - servicecontrol-monitoring: ${{ steps.monitoring.outputs.failed }}"
-          echo "  - servicecontrol-ravendb: ${{ steps.raven.outputs.failed }}"
-          
-    

--- a/.github/workflows/clean-ghcr.yml
+++ b/.github/workflows/clean-ghcr.yml
@@ -1,0 +1,30 @@
+name: Cleanup GitHub Container Registry
+on:
+  #schedule:
+  #  - cron: "0 0 * * *" # Midnight UTC daily
+  pull_request:
+jobs:
+  clean:
+    name: Delete unused containers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete PR containers
+        id: prs
+        uses: snok/container-retention-policy@v2.2.1
+        with:
+          image-names: servicecontrol
+          filter-tags: pr-*
+          filter-include-untagged: true
+          cut-off: A week ago UTC
+          timestamp-to-use: updated_at
+          account-type: org
+          org-name: particular
+          token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token
+          dry-run: true
+      - name: Outputs
+        run: |
+          echo "Deleted: ${{ steps.prs.outputs.deleted }}"
+          echo "Failed: ${{ steps.prs.outputs.failed }}"
+          
+    

--- a/.github/workflows/clean-ghcr.yml
+++ b/.github/workflows/clean-ghcr.yml
@@ -1,8 +1,8 @@
 name: Cleanup GitHub Container Registry
 on:
-  #schedule:
-  #  - cron: "0 0 * * *" # Midnight UTC daily
-  pull_request:
+  schedule:
+    - cron: "0 0 * * *" # Midnight UTC daily
+  workflow_dispatch:
 jobs:
   clean:
     name: Delete unused containers

--- a/.github/workflows/clean-ghcr.yml
+++ b/.github/workflows/clean-ghcr.yml
@@ -9,12 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ServiceControl images
+        id: primary
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol
           filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
-          cut-off: A week ago UTC
+          cut-off: 3 days ago UTC
           timestamp-to-use: updated_at
           account-type: org
           org-name: particular
@@ -22,12 +23,13 @@ jobs:
           token-type: github-token
           dry-run: false
       - name: Audit images
+        id: audit
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol-audit
           filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
-          cut-off: A week ago UTC
+          cut-off: 3 days ago UTC
           timestamp-to-use: updated_at
           account-type: org
           org-name: particular
@@ -35,12 +37,13 @@ jobs:
           token-type: github-token
           dry-run: false
       - name: Monitoring images
+        id: monitoring
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol-monitoring
           filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
-          cut-off: A week ago UTC
+          cut-off: 3 days ago UTC
           timestamp-to-use: updated_at
           account-type: org
           org-name: particular
@@ -48,17 +51,31 @@ jobs:
           token-type: github-token
           dry-run: false
       - name: RavenDB images
+        id: raven
         uses: snok/container-retention-policy@v2.2.1
         with:
-          image-names: servicecontrol-monitoring
+          image-names: servicecontrol-ravendb
           filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
-          cut-off: A week ago UTC
+          cut-off: 3 days ago UTC
           timestamp-to-use: updated_at
           account-type: org
           org-name: particular
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
           dry-run: false
+      - name: Results
+        run: |
+          echo "Removed images:"
+          echo "  - servicecontrol: ${{ steps.primary.outputs.deleted }}"
+          echo "  - servicecontrol-audit: ${{ steps.audit.outputs.deleted }}"
+          echo "  - servicecontrol-monitoring: ${{ steps.monitoring.outputs.deleted }}"
+          echo "  - servicecontrol-ravendb: ${{ steps.raven.outputs.deleted }}"
+          echo ""
+          echo "Failures:"
+          echo "  - servicecontrol: ${{ steps.primary.outputs.failed }}"
+          echo "  - servicecontrol-audit: ${{ steps.audit.outputs.failed }}"
+          echo "  - servicecontrol-monitoring: ${{ steps.monitoring.outputs.failed }}"
+          echo "  - servicecontrol-ravendb: ${{ steps.raven.outputs.failed }}"
           
     

--- a/.github/workflows/clean-ghcr.yml
+++ b/.github/workflows/clean-ghcr.yml
@@ -8,64 +8,100 @@ jobs:
     name: Delete unused containers
     runs-on: ubuntu-latest
     steps:
-      - name: ServiceControl images
+      - name: ServiceControl PRs/alphas
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol
           filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
-          cut-off: 3 days ago UTC
+          cut-off: 2 weeks ago UTC
           timestamp-to-use: updated_at
           account-type: org
           org-name: particular
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
           dry-run: false
-      - name: Test untagged
+      - name: ServiceControl untagged
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol
           untagged-only: true
-          cut-off: 3 days ago UTC
+          cut-off: 2 weeks ago UTC
           timestamp-to-use: updated_at
           account-type: org
           org-name: particular
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
           dry-run: false
-      - name: Audit images
+      - name: Audit PRs/alphas
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol-audit
           filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
-          cut-off: 3 days ago UTC
+          cut-off: 2 weeks ago UTC
           timestamp-to-use: updated_at
           account-type: org
           org-name: particular
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
           dry-run: false
-      - name: Monitoring images
+      - name: Audit untagged
+        uses: snok/container-retention-policy@v2.2.1
+        with:
+          image-names: servicecontrol-audit
+          untagged-only: true
+          cut-off: 2 weeks ago UTC
+          timestamp-to-use: updated_at
+          account-type: org
+          org-name: particular
+          token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token
+          dry-run: false
+      - name: Monitoring PRs/alphas
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol-monitoring
           filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
-          cut-off: 3 days ago UTC
+          cut-off: 2 weeks ago UTC
           timestamp-to-use: updated_at
           account-type: org
           org-name: particular
           token: ${{ secrets.GITHUB_TOKEN }}
           token-type: github-token
           dry-run: false
-      - name: RavenDB images
+      - name: Monitoring untagged
+        uses: snok/container-retention-policy@v2.2.1
+        with:
+          image-names: servicecontrol-monitoring
+          untagged-only: true
+          cut-off: 2 weeks ago UTC
+          timestamp-to-use: updated_at
+          account-type: org
+          org-name: particular
+          token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token
+          dry-run: false
+      - name: RavenDB PRs/alphas
         uses: snok/container-retention-policy@v2.2.1
         with:
           image-names: servicecontrol-ravendb
           filter-tags: pr-*, *-alpha.*
           filter-include-untagged: true
-          cut-off: 3 days ago UTC
+          cut-off: 2 weeks ago UTC
+          timestamp-to-use: updated_at
+          account-type: org
+          org-name: particular
+          token: ${{ secrets.GITHUB_TOKEN }}
+          token-type: github-token
+          dry-run: false
+      - name: RavenDB untagged
+        uses: snok/container-retention-policy@v2.2.1
+        with:
+          image-names: servicecontrol-ravendb
+          untagged-only: true
+          cut-off: 2 weeks ago UTC
           timestamp-to-use: updated_at
           account-type: org
           org-name: particular


### PR DESCRIPTION
Cleans staged containers for alphas and PR builds in the GitHub Container Registry that are older than 2 weeks.