### PR TITLE
Add container image annotations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,12 +181,12 @@ jobs:
           docker buildx build --push --tag ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }} `
               --file src/${{ matrix.project }}/Dockerfile `
               --build-arg VERSION=${{ env.MinVerVersion }} `
-              --annotation="manifest,index:org.opencontainers.image.title=${{ matrix.name }}" `
-              --annotation="manifest,index:org.opencontainers.image.authors=Particular Software" `
-              --annotation="manifest,index:org.opencontainers.image.vendor=Particular Software" `
-              --annotation="manifest,index:org.opencontainers.image.version=${{ env.MinVerVersion }}" `
-              --annotation="manifest,index:org.opencontainers.image.source=https://github.com/Particular/ServiceControl" `
-              --annotation="manifest,index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" `
+              --annotation "manifest,index:org.opencontainers.image.title=${{ matrix.name }}" `
+              --annotation "manifest,index:org.opencontainers.image.authors=Particular Software" `
+              --annotation "manifest,index:org.opencontainers.image.vendor=Particular Software" `
+              --annotation "manifest,index:org.opencontainers.image.version=${{ env.MinVerVersion }}" `
+              --annotation "manifest,index:org.opencontainers.image.source=https://github.com/Particular/ServiceControl" `
+              --annotation "manifest,index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" `
               --platform linux/arm64,linux/arm,linux/amd64 .
           docker buildx imagetools inspect ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }}
   db-containers:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
         include:
           - name: servicecontrol
             project: ServiceControl
-            description: ServiceControl primary instance
+            description: ServiceControl error instance
           - name: servicecontrol-audit
             project: ServiceControl.Audit
             description: ServiceControl audit instance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,15 +178,15 @@ jobs:
         env:
           TAG_NAME: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || env.MinVerVersion }}
         run: |
-          docker buildx build --push --tag ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }} `
-              --file src/${{ matrix.project }}/Dockerfile `
-              --build-arg VERSION=${{ env.MinVerVersion }} `
-              --annotation "manifest,index:org.opencontainers.image.title=${{ matrix.name }}" `
-              --annotation "manifest,index:org.opencontainers.image.authors=Particular Software" `
-              --annotation "manifest,index:org.opencontainers.image.vendor=Particular Software" `
-              --annotation "manifest,index:org.opencontainers.image.version=${{ env.MinVerVersion }}" `
-              --annotation "manifest,index:org.opencontainers.image.source=https://github.com/Particular/ServiceControl" `
-              --annotation "manifest,index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" `
+          docker buildx build --push --tag ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }} \
+              --file src/${{ matrix.project }}/Dockerfile \
+              --build-arg VERSION=${{ env.MinVerVersion }} \
+              --annotation "manifest,index:org.opencontainers.image.title=${{ matrix.name }}" \
+              --annotation "manifest,index:org.opencontainers.image.authors=Particular Software" \
+              --annotation "manifest,index:org.opencontainers.image.vendor=Particular Software" \
+              --annotation "manifest,index:org.opencontainers.image.version=${{ env.MinVerVersion }}" \
+              --annotation "manifest,index:org.opencontainers.image.source=https://github.com/Particular/ServiceControl" \
+              --annotation "manifest,index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" \
               --platform linux/arm64,linux/arm,linux/amd64 .
           docker buildx imagetools inspect ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }}
   db-containers:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,16 @@ jobs:
         env:
           TAG_NAME: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || env.MinVerVersion }}
         run: |
-          docker buildx build --push --tag ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }} --file src/${{ matrix.project }}/Dockerfile --build-arg VERSION=${{ env.MinVerVersion }} --platform linux/arm64,linux/arm,linux/amd64 --annotation="org.opencontainers.image.source=https://github.com/Particular/ServiceControl" .
+          docker buildx build --push --tag ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }} `
+              --file src/${{ matrix.project }}/Dockerfile `
+              --build-arg VERSION=${{ env.MinVerVersion }} `
+              --annotation="manifest,index:org.opencontainers.image.title=${{ matrix.name }}" `
+              --annotation="manifest,index:org.opencontainers.image.authors=Particular Software" `
+              --annotation="manifest,index:org.opencontainers.image.vendor=Particular Software" `
+              --annotation="manifest,index:org.opencontainers.image.version=${{ env.MinVerVersion }}" `
+              --annotation="manifest,index:org.opencontainers.image.source=https://github.com/Particular/ServiceControl" `
+              --annotation="manifest,index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" `
+              --platform linux/arm64,linux/arm,linux/amd64 .
           docker buildx imagetools inspect ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }}
   db-containers:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,12 +181,17 @@ jobs:
           docker buildx build --push --tag ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }} \
               --file src/${{ matrix.project }}/Dockerfile \
               --build-arg VERSION=${{ env.MinVerVersion }} \
-              --annotation "manifest,index:org.opencontainers.image.title=${{ matrix.name }}" \
-              --annotation "manifest,index:org.opencontainers.image.authors=Particular Software" \
-              --annotation "manifest,index:org.opencontainers.image.vendor=Particular Software" \
-              --annotation "manifest,index:org.opencontainers.image.version=${{ env.MinVerVersion }}" \
-              --annotation "manifest,index:org.opencontainers.image.source=https://github.com/Particular/ServiceControl" \
-              --annotation "manifest,index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" \
+              --annotation "index,manifest:org.opencontainers.image.title=${{ matrix.name }}" \
+              --annotation "org.opencontainers.image.description=Plain description" \
+              --annotation "manifest:org.opencontainers.image.description=Manifest description" \
+              --annotation "index:org.opencontainers.image.description=Index description" \
+              --annotation "manifest-descriptor:org.opencontainers.image.description=Manifest descriptor description" \
+              --annotation "index-descriptor:org.opencontainers.image.description=Index descriptor description" \
+              --annotation "index,manifest:org.opencontainers.image.authors=Particular Software" \
+              --annotation "index,manifest:org.opencontainers.image.vendor=Particular Software" \
+              --annotation "index,manifest:org.opencontainers.image.version=${{ env.MinVerVersion }}" \
+              --annotation "index,manifest:org.opencontainers.image.source=https://github.com/Particular/ServiceControl" \
+              --annotation "index,manifest:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" \
               --platform linux/arm64,linux/arm,linux/amd64 .
           docker buildx imagetools inspect ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }}
   db-containers:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
         env:
           TAG_NAME: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || env.MinVerVersion }}
         run: |
-          docker buildx build --push --tag ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }} --file src/${{ matrix.project }}/Dockerfile --build-arg VERSION=${{ env.MinVerVersion }} --platform linux/arm64,linux/arm,linux/amd64 .
+          docker buildx build --push --tag ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }} --file src/${{ matrix.project }}/Dockerfile --build-arg VERSION=${{ env.MinVerVersion }} --platform linux/arm64,linux/arm,linux/amd64 --annotation="org.opencontainers.image.source=https://github.com/Particular/ServiceControl" .
           docker buildx imagetools inspect ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }}
   db-containers:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,7 @@ jobs:
               --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}/tree/${{ github.sha }}" \
               --annotation "index:org.opencontainers.image.url=https://hub.docker.com/r/particular/${{ matrix.name }}" \
               --annotation "index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" \
-              --annotation "index:org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/sdk:8.0" \
+              --annotation "index:org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0" \
               --platform linux/arm64,linux/arm,linux/amd64 .
           docker buildx imagetools inspect ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }}
   db-containers:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,11 +187,14 @@ jobs:
               --annotation "index:org.opencontainers.image.title=${{ matrix.name }}" \
               --annotation "index:org.opencontainers.image.description=${{ matrix.description }}" \
               --annotation "index:org.opencontainers.image.created=$(date '+%FT%TZ')" \
+              --annotation "index:org.opencontainers.image.revision=${{ github.sha }}" \
               --annotation "index:org.opencontainers.image.authors=Particular Software" \
               --annotation "index:org.opencontainers.image.vendor=Particular Software" \
               --annotation "index:org.opencontainers.image.version=${{ env.MinVerVersion }}" \
-              --annotation "index:org.opencontainers.image.source=https://github.com/Particular/ServiceControl" \
+              --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}/tree/${{ github.sha }}" \
+              --annotation "index:org.opencontainers.image.url=https://hub.docker.com/r/particular/${{ matrix.name }}" \
               --annotation "index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" \
+              --annotation "index:org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/sdk:8.0" \
               --platform linux/arm64,linux/arm,linux/amd64 .
           docker buildx imagetools inspect ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }}
   db-containers:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,10 +151,13 @@ jobs:
         include:
           - name: servicecontrol
             project: ServiceControl
+            description: ServiceControl primary instance
           - name: servicecontrol-audit
             project: ServiceControl.Audit
+            description: ServiceControl audit instance
           - name: servicecontrol-monitoring
             project: ServiceControl.Monitoring
+            description: ServiceControl monitoring instance
       fail-fast: false
     steps:
       - name: Check for secrets
@@ -181,17 +184,14 @@ jobs:
           docker buildx build --push --tag ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }} \
               --file src/${{ matrix.project }}/Dockerfile \
               --build-arg VERSION=${{ env.MinVerVersion }} \
-              --annotation "index,manifest:org.opencontainers.image.title=${{ matrix.name }}" \
-              --annotation "org.opencontainers.image.description=Plain description" \
-              --annotation "manifest:org.opencontainers.image.description=Manifest description" \
-              --annotation "index:org.opencontainers.image.description=Index description" \
-              --annotation "manifest-descriptor:org.opencontainers.image.description=Manifest descriptor description" \
-              --annotation "index-descriptor:org.opencontainers.image.description=Index descriptor description" \
-              --annotation "index,manifest:org.opencontainers.image.authors=Particular Software" \
-              --annotation "index,manifest:org.opencontainers.image.vendor=Particular Software" \
-              --annotation "index,manifest:org.opencontainers.image.version=${{ env.MinVerVersion }}" \
-              --annotation "index,manifest:org.opencontainers.image.source=https://github.com/Particular/ServiceControl" \
-              --annotation "index,manifest:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" \
+              --annotation "index:org.opencontainers.image.title=${{ matrix.name }}" \
+              --annotation "index:org.opencontainers.image.description=${{ matrix.description }}" \
+              --annotation "index:org.opencontainers.image.created=$(date '+%FT%TZ')" \
+              --annotation "index:org.opencontainers.image.authors=Particular Software" \
+              --annotation "index:org.opencontainers.image.vendor=Particular Software" \
+              --annotation "index:org.opencontainers.image.version=${{ env.MinVerVersion }}" \
+              --annotation "index:org.opencontainers.image.source=https://github.com/Particular/ServiceControl" \
+              --annotation "index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" \
               --platform linux/arm64,linux/arm,linux/amd64 .
           docker buildx imagetools inspect ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }}
   db-containers:


### PR DESCRIPTION
Fills out the annotations at the index (top-most) level. Since Docker Hub doesn't appear to support displaying any of these yet, this just a first "good-enough" pass.

The resulting annotations from `docker buildx imagetools inspect` are:

```json
  "annotations": {
    "org.opencontainers.image.authors": "Particular Software",
    "org.opencontainers.image.base.name": "mcr.microsoft.com/dotnet/aspnet:8.0",
    "org.opencontainers.image.created": "2024-06-19T17:40:18Z",
    "org.opencontainers.image.description": "ServiceControl primary instance",
    "org.opencontainers.image.documentation": "https://docs.particular.net/servicecontrol/",
    "org.opencontainers.image.revision": "7e2e444ac98ed35bfc45cb14defc8277211f4592",
    "org.opencontainers.image.source": "https://github.com/Particular/ServiceControl/tree/7e2e444ac98ed35bfc45cb14defc8277211f4592",
    "org.opencontainers.image.title": "servicecontrol",
    "org.opencontainers.image.url": "https://hub.docker.com/r/particular/servicecontrol",
    "org.opencontainers.image.vendor": "Particular Software",
    "org.opencontainers.image.version": "5.2.1-alpha.0.51"
  }
```