### PR TITLE
Licensing cleanup

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
@@ -3,7 +3,6 @@
     using System.Collections.Generic;
     using System.Runtime.InteropServices;
     using System.Threading.Tasks;
-    using LicenseManagement;
     using Microsoft.Extensions.Hosting;
     using NServiceBus.Logging;
     using Settings;
@@ -14,12 +13,6 @@
         public override async Task Execute(HostArguments args, Settings settings)
         {
             settings.SkipQueueCreation = args.SkipQueueCreation;
-
-            // Validate license:
-            if (!ValidateLicense(settings))
-            {
-                return;
-            }
 
             if (settings.IngestAuditMessages)
             {
@@ -55,35 +48,6 @@
             using var host = hostBuilder.Build();
             await host.StartAsync();
             await host.StopAsync();
-        }
-
-        bool ValidateLicense(Settings settings)
-        {
-            if (!string.IsNullOrWhiteSpace(settings.LicenseFileText))
-            {
-                if (!LicenseManager.IsLicenseValidForServiceControlInit(settings.LicenseFileText, out var errorMessageForLicenseText))
-                {
-                    Logger.Error(errorMessageForLicenseText);
-                    return false;
-                }
-
-                if (!LicenseManager.TryImportLicenseFromText(settings.LicenseFileText, out var importErrorMessage))
-                {
-                    Logger.Error(importErrorMessage);
-                    return false;
-                }
-            }
-            else
-            {
-                var license = LicenseManager.FindLicense();
-                if (!LicenseManager.IsLicenseValidForServiceControlInit(license, out var errorMessageForFoundLicense))
-                {
-                    Logger.Error(errorMessageForFoundLicense);
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         static readonly ILog Logger = LogManager.GetLogger<SetupCommand>();

--- a/src/ServiceControl.Monitoring/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/SetupCommand.cs
@@ -1,7 +1,6 @@
 namespace ServiceControl.Monitoring
 {
     using System.Threading.Tasks;
-    using LicenseManagement;
     using NServiceBus.Logging;
     using Transports;
 
@@ -9,11 +8,6 @@ namespace ServiceControl.Monitoring
     {
         public override Task Execute(Settings settings)
         {
-            if (!ValidateLicense(settings))
-            {
-                return Task.CompletedTask;
-            }
-
             if (settings.SkipQueueCreation)
             {
                 Logger.Info("Skipping queue creation");
@@ -24,35 +18,6 @@ namespace ServiceControl.Monitoring
             transportSettings.ErrorQueue = settings.ErrorQueue;
             var transportCustomization = TransportFactory.Create(transportSettings);
             return transportCustomization.ProvisionQueues(transportSettings, []);
-        }
-
-        bool ValidateLicense(Settings settings)
-        {
-            if (!string.IsNullOrWhiteSpace(settings.LicenseFileText))
-            {
-                if (!LicenseManager.IsLicenseValidForServiceControlInit(settings.LicenseFileText, out var errorMessageForLicenseText))
-                {
-                    Logger.Error(errorMessageForLicenseText);
-                    return false;
-                }
-
-                if (!LicenseManager.TryImportLicenseFromText(settings.LicenseFileText, out var importErrorMessage))
-                {
-                    Logger.Error(importErrorMessage);
-                    return false;
-                }
-            }
-            else
-            {
-                var license = LicenseManager.FindLicense();
-                if (!LicenseManager.IsLicenseValidForServiceControlInit(license, out var errorMessageForFoundLicense))
-                {
-                    Logger.Error(errorMessageForFoundLicense);
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         static readonly ILog Logger = LogManager.GetLogger<SetupCommand>();

--- a/src/ServiceControl/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/SetupCommand.cs
@@ -2,7 +2,6 @@
 {
     using System.Runtime.InteropServices;
     using System.Threading.Tasks;
-    using LicenseManagement;
     using Microsoft.Extensions.Hosting;
     using NServiceBus.Logging;
     using Particular.ServiceControl;
@@ -16,12 +15,6 @@
         public override async Task Execute(HostArguments args, Settings settings)
         {
             settings.SkipQueueCreation = args.SkipQueueCreation;
-
-            // Validate license:
-            if (!ValidateLicense(settings))
-            {
-                return;
-            }
 
             var hostBuilder = Host.CreateApplicationBuilder();
             hostBuilder.AddServiceControlInstallers(settings);
@@ -56,35 +49,6 @@
             }
 
             await host.StopAsync();
-        }
-
-        static bool ValidateLicense(Settings settings)
-        {
-            if (!string.IsNullOrWhiteSpace(settings.LicenseFileText))
-            {
-                if (!LicenseManager.IsLicenseValidForServiceControlInit(settings.LicenseFileText, out var errorMessageForLicenseText))
-                {
-                    Logger.Error(errorMessageForLicenseText);
-                    return false;
-                }
-
-                if (!LicenseManager.TryImportLicenseFromText(settings.LicenseFileText, out var importErrorMessage))
-                {
-                    Logger.Error(importErrorMessage);
-                    return false;
-                }
-            }
-            else
-            {
-                var license = LicenseManager.FindLicense();
-                if (!LicenseManager.IsLicenseValidForServiceControlInit(license, out var errorMessageForFoundLicense))
-                {
-                    Logger.Error(errorMessageForFoundLicense);
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         static readonly ILog Logger = LogManager.GetLogger<SetupCommand>();


### PR DESCRIPTION
This PR cleans up how ServiceControl handles licenses in the following ways:

- Setup commands no longer validate license files or attempt to copy license information to disk. It is assumed that when an instance starts, a valid license is has been provided in the standard locations. This is already true for the current deployment methods (SCMU and PowerShell) and a license will need to be provided for containers.
- The `LicenseManager` code that was used solely for the Setup commands has now been removed.
- There was custom code that duplicating the existing license validation code, so that has been changed to replace the custom code with the standard validation path.