### PR TITLE
Ignore prerelease tags when calculating latest version

### DIFF
--- a/.github/actions/validate-version/action.yml
+++ b/.github/actions/validate-version/action.yml
@@ -59,6 +59,7 @@ runs:
         $releasedVersions = $releases |
             where Draft -eq $false |
             where Prerelease -eq $false |
+            where Name -match '^\d+\.\d+\.\d+$' |  # Ignore prerelease tags
             select -ExpandProperty tag_name
 
         $latestVersion = $releasedVersions |


### PR DESCRIPTION
GitHub releases are not marked as Prerelease for prelease tags, so another filter is needed to get only versions that can be parsed as System.Version entities in the publish script.