### PR TITLE
Update RabbitQuery to only look at the current configured SC virtualhost

### DIFF
--- a/src/Particular.LicensingComponent.Persistence.InMemory/InMemoryLicensingDataStore.cs
+++ b/src/Particular.LicensingComponent.Persistence.InMemory/InMemoryLicensingDataStore.cs
@@ -28,7 +28,13 @@ public class InMemoryLicensingDataStore : ILicensingDataStore
 
     public Task<Endpoint?> GetEndpoint(EndpointIdentifier id, CancellationToken cancellationToken)
     {
-        endpoints.TryGetValue(id, out var endpoint);
+        if (endpoints.TryGetValue(id, out var endpoint))
+        {
+            if (allThroughput.TryGetValue(id, out var endpointThroughput))
+            {
+                endpoint.LastCollectedDate = endpointThroughput.LastOrDefault().Key;
+            }
+        }
         return Task.FromResult(endpoint);
     }
 

--- a/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
@@ -103,7 +103,7 @@ public class BrokerThroughputCollectorHostedService(
             var defaultStartDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime).AddDays(-30);
             var startDate = endpoint.LastCollectedDate < defaultStartDate
                 ? defaultStartDate
-                : endpoint.LastCollectedDate;
+                : endpoint.LastCollectedDate.AddDays(1);
 
             await foreach (var queueThroughput in brokerThroughputQuery.GetThroughputPerDay(queueName, startDate, stoppingToken))
             {


### PR DESCRIPTION
I have included two fixes in this PR

- Fix for Rabbit to only look at the VirtualHost of the configured SC instance
- Fix for both ASQ and ASB to skip the last collected date.