### PR TITLE
Licensing cleanup, round 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,5 @@ jobs:
         uses: Particular/run-tests-action@v1.7.0
         env:
           ServiceControl_TESTS_FILTER: ${{ matrix.test-category }}
-          ServiceControl_LicenseText: ${{ secrets.LICENSETEXT }}
-          ServiceControl_Audit_LicenseText: ${{ secrets.LICENSETEXT }}
-          Monitoring_LicenseText: ${{ secrets.LICENSETEXT }}
+          PARTICULARSOFTWARE_LICENSE: ${{ secrets.LICENSETEXT }}
           AZURE_ACI_CREDENTIALS: ${{ secrets.AZURE_ACI_CREDENTIALS }}

--- a/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
@@ -125,8 +125,6 @@
             //If any changes have been made to settings, this may break the embedded config in that project, which may need to be updated.
             var settings = CreateTestSettings();
 
-            settings.LicenseFileText = null;
-
             Approver.Verify(settings);
         }
 

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -21,7 +21,6 @@
   "ForwardAuditMessages": false,
   "IngestAuditMessages": true,
   "AuditLogQueue": "audit.log",
-  "LicenseFileText": null,
   "AuditRetentionPeriod": "30.00:00:00",
   "MaxBodySizeToStore": 102400,
   "ServiceName": "Particular.ServiceControl.Audit",

--- a/src/ServiceControl.Audit/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Audit/HostApplicationBuilderExtensions.cs
@@ -33,11 +33,6 @@ static class HostApplicationBuilderExtensions
 
         RecordStartup(settings, configuration, persistenceConfiguration);
 
-        if (!string.IsNullOrWhiteSpace(settings.LicenseFileText))
-        {
-            configuration.License(settings.LicenseFileText);
-        }
-
         builder.Logging.ClearProviders();
         builder.Logging.AddNLog();
         builder.Logging.SetMinimumLevel(settings.LoggingSettings.ToHostLogLevel());

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -35,8 +35,6 @@
 
             LoadAuditQueueInformation();
 
-            TryLoadLicenseFromConfig();
-
             ForwardAuditMessages = GetForwardAuditMessages();
             AuditRetentionPeriod = GetAuditRetentionPeriod();
 
@@ -131,8 +129,6 @@
         public bool IngestAuditMessages { get; set; } = true;
 
         public string AuditLogQueue { get; set; }
-
-        public string LicenseFileText { get; set; }
 
         public TimeSpan AuditRetentionPeriod { get; }
 
@@ -281,8 +277,6 @@
             var machine = address.Substring(atIndex + 1);
             return $"{queue}.log@{machine}";
         }
-
-        void TryLoadLicenseFromConfig() => LicenseFileText = SettingsReader.Read<string>(SettingsRootNamespace, "LicenseText");
 
         // logger is intentionally not static to prevent it from being initialized before LoggingConfigurator.ConfigureLogging has been called
         readonly ILog logger = LogManager.GetLogger(typeof(Settings));

--- a/src/ServiceControl.Monitoring.UnitTests/API/SettingsTests.cs
+++ b/src/ServiceControl.Monitoring.UnitTests/API/SettingsTests.cs
@@ -8,10 +8,7 @@
         [Test]
         public void PlatformSampleSettings()
         {
-            var settings = new Settings
-            {
-                LicenseFileText = null
-            };
+            var settings = new Settings();
 
             Approver.Verify(settings);
         }

--- a/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
@@ -19,6 +19,5 @@
   "SkipQueueCreation": false,
   "RootUrl": "http://localhost:9999/",
   "MaximumConcurrencyLevel": 32,
-  "LicenseFileText": null,
   "ServiceControlThroughputDataQueue": "ServiceControl.ThroughputData"
 }

--- a/src/ServiceControl.Monitoring/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Monitoring/HostApplicationBuilderExtensions.cs
@@ -75,11 +75,6 @@ public static class HostApplicationBuilderExtensions
 
     static void ConfigureEndpoint(EndpointConfiguration config, Func<ICriticalErrorContext, CancellationToken, Task> onCriticalError, ITransportCustomization transportCustomization, TransportSettings transportSettings, Settings settings, IServiceCollection services)
     {
-        if (!string.IsNullOrWhiteSpace(settings.LicenseFileText))
-        {
-            config.License(settings.LicenseFileText);
-        }
-
         transportCustomization.CustomizeMonitoringEndpoint(config, transportSettings);
 
         var serviceControlThroughputDataQueue = settings.ServiceControlThroughputDataQueue;

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -16,8 +16,6 @@ namespace ServiceControl.Monitoring
         {
             LoggingSettings = loggingSettings ?? new(SettingsRootNamespace);
 
-            TryLoadLicenseFromConfig();
-
             TransportType = SettingsReader.Read<string>(SettingsRootNamespace, "TransportType");
 
             ConnectionString = GetConnectionString();
@@ -77,10 +75,7 @@ namespace ServiceControl.Monitoring
 
         public int MaximumConcurrencyLevel { get; set; }
 
-        public string LicenseFileText { get; set; }
         public string ServiceControlThroughputDataQueue { get; set; }
-
-        void TryLoadLicenseFromConfig() => LicenseFileText = SettingsReader.Read<string>(SettingsRootNamespace, "LicenseText");
 
         public TransportSettings ToTransportSettings()
         {

--- a/src/ServiceControl.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.UnitTests/API/APIApprovals.cs
@@ -131,10 +131,7 @@
         {
             //HINT: Particular.PlatformSample includes a parameterized version of the ServiceControl.exe.config file.
             //If any changes have been made to settings, this may break the embedded config in that project, which may need to be updated.
-            var settings = new Settings
-            {
-                LicenseFileText = null
-            };
+            var settings = new Settings();
 
             Approver.Verify(settings, RemoveDataStoreSettings);
         }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -21,7 +21,6 @@
   "StorageUrl": "http://localhost:8888/storage",
   "StagingQueue": "Particular.ServiceControl.staging",
   "Port": 8888,
-  "LicenseFileText": null,
   "PersisterSpecificSettings": null,
   "PrintMetrics": false,
   "Hostname": "localhost",

--- a/src/ServiceControl/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl/HostApplicationBuilderExtensions.cs
@@ -35,11 +35,6 @@ namespace Particular.ServiceControl
 
             RecordStartup(settings, configuration);
 
-            if (!string.IsNullOrWhiteSpace(settings.LicenseFileText))
-            {
-                configuration.License(settings.LicenseFileText);
-            }
-
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.UserInteractive && Debugger.IsAttached)
             {
                 EventSourceCreator.Create();

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -42,8 +42,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
             LoadErrorIngestionSettings();
 
-            TryLoadLicenseFromConfig();
-
             TransportConnectionString = GetConnectionString();
             TransportType = transportType ?? SettingsReader.Read<string>(SettingsRootNamespace, "TransportType");
             PersistenceType = persisterType ?? SettingsReader.Read<string>(SettingsRootNamespace, "PersistenceType");
@@ -136,8 +134,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public string StagingQueue => $"{ServiceName}.staging";
 
         public int Port { get; private set; }
-
-        public string LicenseFileText { get; set; }
 
         public PersistenceSettings PersisterSpecificSettings { get; set; }
 
@@ -415,8 +411,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
                 ErrorLogQueue = Subscope(ErrorQueue);
             }
         }
-
-        void TryLoadLicenseFromConfig() => LicenseFileText = SettingsReader.Read<string>(SettingsRootNamespace, "LicenseText");
 
         // logger is intentionally not static to prevent it from being initialized before LoggingConfigurator.ConfigureLogging has been called
         readonly ILog logger = LogManager.GetLogger(typeof(Settings));


### PR DESCRIPTION
Follow-up to #4253

This PR removes the code related to the now unneeded `LicenseText`/`LicenseFileText` setting.

It also changes the CI workflow to use the standard `PARTICULARSOFTWARE_LICENSE` environment variable to pass in a license when running tests.