### PR TITLE
Bump version to 5.4

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MinVerMinimumMajorMinor>5.2</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>5.4</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR bumps the version on `master` up to 5.4 manually since the `release-5.3` branch has been created in a way that will mean the `5.3.0` tag will not be visible to `master`.