### PR TITLE
Set MinVerAutoIncrement to patch on `release-5.3` branch

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <MinVerMinimumMajorMinor>5.2</MinVerMinimumMajorMinor>
-    <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+    <MinVerAutoIncrement>patch</MinVerAutoIncrement>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This is done after the first tag on the branch.