### PR TITLE
Switch to readonly dictionary instead

### DIFF
--- a/src/Particular.LicensingComponent.UnitTests/AuditThroughputCollectorHostedService_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/AuditThroughputCollectorHostedService_Tests.cs
@@ -1,8 +1,8 @@
 ﻿namespace Particular.LicensingComponent.UnitTests;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -308,7 +308,7 @@ class AuditThroughputCollectorHostedService_Tests : ThroughputCollectorTestFixtu
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialise(FrozenDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialise(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/AuditThroughputCollectorHostedService_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/AuditThroughputCollectorHostedService_Tests.cs
@@ -308,7 +308,7 @@ class AuditThroughputCollectorHostedService_Tests : ThroughputCollectorTestFixtu
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialise(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialize(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/AuditThroughputCollectorHostedService_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/AuditThroughputCollectorHostedService_Tests.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -308,7 +308,7 @@ class AuditThroughputCollectorHostedService_Tests : ThroughputCollectorTestFixtu
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialize(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialize(ReadOnlyDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/BrokerThroughputCollectorHostedServiceTests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/BrokerThroughputCollectorHostedServiceTests.cs
@@ -2,7 +2,7 @@ namespace Particular.LicensingComponent.UnitTests;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -130,7 +130,7 @@ class BrokerThroughputCollectorHostedServiceTests
             return false;
         }
 
-        public void Initialize(ImmutableDictionary<string, string> settings)
+        public void Initialize(ReadOnlyDictionary<string, string> settings)
         {
         }
 
@@ -179,7 +179,7 @@ class BrokerThroughputCollectorHostedServiceTests
             return false;
         }
 
-        public void Initialize(ImmutableDictionary<string, string> settings)
+        public void Initialize(ReadOnlyDictionary<string, string> settings)
         {
         }
 
@@ -224,7 +224,7 @@ class BrokerThroughputCollectorHostedServiceTests
             return false;
         }
 
-        public void Initialize(ImmutableDictionary<string, string> settings)
+        public void Initialize(ReadOnlyDictionary<string, string> settings)
         {
         }
 

--- a/src/Particular.LicensingComponent.UnitTests/BrokerThroughputCollectorHostedServiceTests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/BrokerThroughputCollectorHostedServiceTests.cs
@@ -1,8 +1,8 @@
 namespace Particular.LicensingComponent.UnitTests;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -130,7 +130,7 @@ class BrokerThroughputCollectorHostedServiceTests
             return false;
         }
 
-        public void Initialise(FrozenDictionary<string, string> settings)
+        public void Initialise(ImmutableDictionary<string, string> settings)
         {
         }
 
@@ -179,7 +179,7 @@ class BrokerThroughputCollectorHostedServiceTests
             return false;
         }
 
-        public void Initialise(FrozenDictionary<string, string> settings)
+        public void Initialise(ImmutableDictionary<string, string> settings)
         {
         }
 
@@ -224,7 +224,7 @@ class BrokerThroughputCollectorHostedServiceTests
             return false;
         }
 
-        public void Initialise(FrozenDictionary<string, string> settings)
+        public void Initialise(ImmutableDictionary<string, string> settings)
         {
         }
 

--- a/src/Particular.LicensingComponent.UnitTests/BrokerThroughputCollectorHostedServiceTests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/BrokerThroughputCollectorHostedServiceTests.cs
@@ -130,7 +130,7 @@ class BrokerThroughputCollectorHostedServiceTests
             return false;
         }
 
-        public void Initialise(ImmutableDictionary<string, string> settings)
+        public void Initialize(ImmutableDictionary<string, string> settings)
         {
         }
 
@@ -179,7 +179,7 @@ class BrokerThroughputCollectorHostedServiceTests
             return false;
         }
 
-        public void Initialise(ImmutableDictionary<string, string> settings)
+        public void Initialize(ImmutableDictionary<string, string> settings)
         {
         }
 
@@ -224,7 +224,7 @@ class BrokerThroughputCollectorHostedServiceTests
             return false;
         }
 
-        public void Initialise(ImmutableDictionary<string, string> settings)
+        public void Initialize(ImmutableDictionary<string, string> settings)
         {
         }
 

--- a/src/Particular.LicensingComponent.UnitTests/Infrastructure/FakeBrokerThroughputQuery.cs
+++ b/src/Particular.LicensingComponent.UnitTests/Infrastructure/FakeBrokerThroughputQuery.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using ServiceControl.Transports.BrokerThroughput;
@@ -24,7 +24,7 @@ class FakeBrokerThroughputQuery : IBrokerThroughputQuery
         CancellationToken cancellationToken) => throw new NotImplementedException();
 
     public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-    public void Initialize(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
+    public void Initialize(ReadOnlyDictionary<string, string> settings) => throw new NotImplementedException();
 
     public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
         CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/Infrastructure/FakeBrokerThroughputQuery.cs
+++ b/src/Particular.LicensingComponent.UnitTests/Infrastructure/FakeBrokerThroughputQuery.cs
@@ -24,7 +24,7 @@ class FakeBrokerThroughputQuery : IBrokerThroughputQuery
         CancellationToken cancellationToken) => throw new NotImplementedException();
 
     public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-    public void Initialise(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
+    public void Initialize(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
 
     public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
         CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/Infrastructure/FakeBrokerThroughputQuery.cs
+++ b/src/Particular.LicensingComponent.UnitTests/Infrastructure/FakeBrokerThroughputQuery.cs
@@ -1,8 +1,8 @@
 ﻿namespace Particular.LicensingComponent.UnitTests.Infrastructure;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using ServiceControl.Transports.BrokerThroughput;
@@ -24,7 +24,7 @@ class FakeBrokerThroughputQuery : IBrokerThroughputQuery
         CancellationToken cancellationToken) => throw new NotImplementedException();
 
     public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-    public void Initialise(FrozenDictionary<string, string> settings) => throw new NotImplementedException();
+    public void Initialise(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
 
     public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
         CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/MonitoringService_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/MonitoringService_Tests.cs
@@ -2,7 +2,7 @@ namespace Particular.LicensingComponent.UnitTests;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -162,7 +162,7 @@ class MonitoringService_Tests : ThroughputCollectorTestFixture
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialize(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialize(ReadOnlyDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/MonitoringService_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/MonitoringService_Tests.cs
@@ -1,8 +1,8 @@
 namespace Particular.LicensingComponent.UnitTests;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -162,7 +162,7 @@ class MonitoringService_Tests : ThroughputCollectorTestFixture
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialise(FrozenDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialise(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/MonitoringService_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/MonitoringService_Tests.cs
@@ -162,7 +162,7 @@ class MonitoringService_Tests : ThroughputCollectorTestFixture
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialise(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialize(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_SanitizedNameGrouping_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_SanitizedNameGrouping_Tests.cs
@@ -1,8 +1,8 @@
 ﻿namespace Particular.LicensingComponent.UnitTests;
 
-using System.Collections.Frozen;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -133,7 +133,7 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialise(FrozenDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialise(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();
@@ -160,7 +160,7 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialise(FrozenDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialise(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_SanitizedNameGrouping_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_SanitizedNameGrouping_Tests.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -133,7 +133,7 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialize(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialize(ReadOnlyDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();
@@ -160,7 +160,7 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialize(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialize(ReadOnlyDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_SanitizedNameGrouping_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_SanitizedNameGrouping_Tests.cs
@@ -133,7 +133,7 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialise(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialize(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();
@@ -160,7 +160,7 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
             CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool HasInitialisationErrors(out string errorMessage) => throw new NotImplementedException();
-        public void Initialise(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
+        public void Initialize(ImmutableDictionary<string, string> settings) => throw new NotImplementedException();
 
         public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
             CancellationToken cancellationToken) => throw new NotImplementedException();

--- a/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
@@ -26,7 +26,7 @@ public class BrokerThroughputCollectorHostedService(
             => brokerKeys.Select(pair => KeyValuePair.Create(pair.Key, SettingsReader.Read<string>(ThroughputSettings.SettingsNamespace, pair.Key)))
                 .Where(pair => !string.IsNullOrEmpty(pair.Value)).ToImmutableDictionary();
 
-        brokerThroughputQuery.Initialise(LoadBrokerSettingValues(brokerThroughputQuery.Settings));
+        brokerThroughputQuery.Initialize(LoadBrokerSettingValues(brokerThroughputQuery.Settings));
 
         if (brokerThroughputQuery.HasInitialisationErrors(out var errorMessage))
         {

--- a/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
@@ -1,7 +1,6 @@
 namespace Particular.LicensingComponent.BrokerThroughput;
 
-using System.Collections.Frozen;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using Contracts;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -22,9 +21,9 @@ public class BrokerThroughputCollectorHostedService(
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        static ImmutableDictionary<string, string> LoadBrokerSettingValues(IEnumerable<KeyDescriptionPair> brokerKeys)
-            => brokerKeys.Select(pair => KeyValuePair.Create(pair.Key, SettingsReader.Read<string>(ThroughputSettings.SettingsNamespace, pair.Key)))
-                .Where(pair => !string.IsNullOrEmpty(pair.Value)).ToImmutableDictionary();
+        static ReadOnlyDictionary<string, string> LoadBrokerSettingValues(IEnumerable<KeyDescriptionPair> brokerKeys)
+            => new(brokerKeys.Select(pair => KeyValuePair.Create(pair.Key, SettingsReader.Read<string>(ThroughputSettings.SettingsNamespace, pair.Key)))
+                .Where(pair => !string.IsNullOrEmpty(pair.Value)).ToDictionary());
 
         brokerThroughputQuery.Initialize(LoadBrokerSettingValues(brokerThroughputQuery.Settings));
 

--- a/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
@@ -1,6 +1,7 @@
 namespace Particular.LicensingComponent.BrokerThroughput;
 
 using System.Collections.Frozen;
+using System.Collections.Immutable;
 using Contracts;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -21,11 +22,9 @@ public class BrokerThroughputCollectorHostedService(
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        static FrozenDictionary<string, string> LoadBrokerSettingValues(IEnumerable<KeyDescriptionPair> brokerKeys)
-        {
-            return brokerKeys.Select(pair => KeyValuePair.Create(pair.Key, SettingsReader.Read<string>(ThroughputSettings.SettingsNamespace, pair.Key)))
-                .Where(pair => !string.IsNullOrEmpty(pair.Value)).ToFrozenDictionary(key => key.Key, key => key.Value);
-        }
+        static ImmutableDictionary<string, string> LoadBrokerSettingValues(IEnumerable<KeyDescriptionPair> brokerKeys)
+            => brokerKeys.Select(pair => KeyValuePair.Create(pair.Key, SettingsReader.Read<string>(ThroughputSettings.SettingsNamespace, pair.Key)))
+                .Where(pair => !string.IsNullOrEmpty(pair.Value)).ToImmutableDictionary();
 
         brokerThroughputQuery.Initialise(LoadBrokerSettingValues(brokerThroughputQuery.Settings));
 

--- a/src/ServiceControl.Transports.ASBS.Tests/AzureQueryTests.cs
+++ b/src/ServiceControl.Transports.ASBS.Tests/AzureQueryTests.cs
@@ -1,8 +1,8 @@
 namespace ServiceControl.Transport.Tests;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -44,7 +44,7 @@ class AzureQueryTests : TransportTestFixture
 
         transportSettings.ConnectionString =
             "Endpoint=sb://testmenow.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=xxxxxxxxxxxxx";
-        query.Initialise(FrozenDictionary<string, string>.Empty);
+        query.Initialise(ImmutableDictionary<string, string>.Empty);
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -63,7 +63,7 @@ class AzureQueryTests : TransportTestFixture
 
         string serviceBusName = query.ExtractServiceBusName();
         Dictionary<string, string> dictionary = GetSettings();
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsTrue(success);
@@ -91,7 +91,7 @@ class AzureQueryTests : TransportTestFixture
             { AzureQuery.AzureServiceBusSettings.TenantId, "not valid" },
             { AzureQuery.AzureServiceBusSettings.SubscriptionId, "not valid" }
         };
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -114,7 +114,7 @@ class AzureQueryTests : TransportTestFixture
             { AzureQuery.AzureServiceBusSettings.TenantId, Guid.Empty.ToString() },
             { AzureQuery.AzureServiceBusSettings.SubscriptionId, "not valid" }
         };
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -132,7 +132,7 @@ class AzureQueryTests : TransportTestFixture
 
         Dictionary<string, string> dictionary = GetSettings();
         dictionary[AzureQuery.AzureServiceBusSettings.ClientId] = "not valid";
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -155,7 +155,7 @@ class AzureQueryTests : TransportTestFixture
 
         Dictionary<string, string> dictionary = GetSettings();
         dictionary[AzureQuery.AzureServiceBusSettings.ClientSecret] = "not valid";
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, _) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsFalse(success);
@@ -175,7 +175,7 @@ class AzureQueryTests : TransportTestFixture
 
         Dictionary<string, string> dictionary = GetSettings();
 
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.ASBS.Tests/AzureQueryTests.cs
+++ b/src/ServiceControl.Transports.ASBS.Tests/AzureQueryTests.cs
@@ -2,7 +2,7 @@ namespace ServiceControl.Transport.Tests;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -44,7 +44,7 @@ class AzureQueryTests : TransportTestFixture
 
         transportSettings.ConnectionString =
             "Endpoint=sb://testmenow.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=xxxxxxxxxxxxx";
-        query.Initialize(ImmutableDictionary<string, string>.Empty);
+        query.Initialize(ReadOnlyDictionary<string, string>.Empty);
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -63,7 +63,7 @@ class AzureQueryTests : TransportTestFixture
 
         string serviceBusName = query.ExtractServiceBusName();
         Dictionary<string, string> dictionary = GetSettings();
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsTrue(success);
@@ -91,7 +91,7 @@ class AzureQueryTests : TransportTestFixture
             { AzureQuery.AzureServiceBusSettings.TenantId, "not valid" },
             { AzureQuery.AzureServiceBusSettings.SubscriptionId, "not valid" }
         };
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -114,7 +114,7 @@ class AzureQueryTests : TransportTestFixture
             { AzureQuery.AzureServiceBusSettings.TenantId, Guid.Empty.ToString() },
             { AzureQuery.AzureServiceBusSettings.SubscriptionId, "not valid" }
         };
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -132,7 +132,7 @@ class AzureQueryTests : TransportTestFixture
 
         Dictionary<string, string> dictionary = GetSettings();
         dictionary[AzureQuery.AzureServiceBusSettings.ClientId] = "not valid";
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -155,7 +155,7 @@ class AzureQueryTests : TransportTestFixture
 
         Dictionary<string, string> dictionary = GetSettings();
         dictionary[AzureQuery.AzureServiceBusSettings.ClientSecret] = "not valid";
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, List<string> errors, _) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsFalse(success);
@@ -175,7 +175,7 @@ class AzureQueryTests : TransportTestFixture
 
         Dictionary<string, string> dictionary = GetSettings();
 
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.ASBS.Tests/AzureQueryTests.cs
+++ b/src/ServiceControl.Transports.ASBS.Tests/AzureQueryTests.cs
@@ -44,7 +44,7 @@ class AzureQueryTests : TransportTestFixture
 
         transportSettings.ConnectionString =
             "Endpoint=sb://testmenow.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=xxxxxxxxxxxxx";
-        query.Initialise(ImmutableDictionary<string, string>.Empty);
+        query.Initialize(ImmutableDictionary<string, string>.Empty);
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -63,7 +63,7 @@ class AzureQueryTests : TransportTestFixture
 
         string serviceBusName = query.ExtractServiceBusName();
         Dictionary<string, string> dictionary = GetSettings();
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsTrue(success);
@@ -91,7 +91,7 @@ class AzureQueryTests : TransportTestFixture
             { AzureQuery.AzureServiceBusSettings.TenantId, "not valid" },
             { AzureQuery.AzureServiceBusSettings.SubscriptionId, "not valid" }
         };
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -114,7 +114,7 @@ class AzureQueryTests : TransportTestFixture
             { AzureQuery.AzureServiceBusSettings.TenantId, Guid.Empty.ToString() },
             { AzureQuery.AzureServiceBusSettings.SubscriptionId, "not valid" }
         };
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -132,7 +132,7 @@ class AzureQueryTests : TransportTestFixture
 
         Dictionary<string, string> dictionary = GetSettings();
         dictionary[AzureQuery.AzureServiceBusSettings.ClientId] = "not valid";
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -155,7 +155,7 @@ class AzureQueryTests : TransportTestFixture
 
         Dictionary<string, string> dictionary = GetSettings();
         dictionary[AzureQuery.AzureServiceBusSettings.ClientSecret] = "not valid";
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, _) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsFalse(success);
@@ -175,7 +175,7 @@ class AzureQueryTests : TransportTestFixture
 
         Dictionary<string, string> dictionary = GetSettings();
 
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.ASBS/AzureQuery.cs
+++ b/src/ServiceControl.Transports.ASBS/AzureQuery.cs
@@ -2,8 +2,8 @@
 namespace ServiceControl.Transports.ASBS;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -28,7 +28,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
     ArmClient? armClient;
     string? resourceId;
 
-    protected override void InitialiseCore(FrozenDictionary<string, string> settings)
+    protected override void InitialiseCore(ImmutableDictionary<string, string> settings)
     {
         ConnectionSettings? connectionSettings = ConnectionStringParser.Parse(transportSettings.ConnectionString);
         bool usingManagedIdentity =

--- a/src/ServiceControl.Transports.ASBS/AzureQuery.cs
+++ b/src/ServiceControl.Transports.ASBS/AzureQuery.cs
@@ -3,7 +3,7 @@ namespace ServiceControl.Transports.ASBS;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -28,7 +28,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
     ArmClient? armClient;
     string? resourceId;
 
-    protected override void InitializeCore(ImmutableDictionary<string, string> settings)
+    protected override void InitializeCore(ReadOnlyDictionary<string, string> settings)
     {
         ConnectionSettings? connectionSettings = ConnectionStringParser.Parse(transportSettings.ConnectionString);
         bool usingManagedIdentity =

--- a/src/ServiceControl.Transports.ASBS/AzureQuery.cs
+++ b/src/ServiceControl.Transports.ASBS/AzureQuery.cs
@@ -28,7 +28,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
     ArmClient? armClient;
     string? resourceId;
 
-    protected override void InitialiseCore(ImmutableDictionary<string, string> settings)
+    protected override void InitializeCore(ImmutableDictionary<string, string> settings)
     {
         ConnectionSettings? connectionSettings = ConnectionStringParser.Parse(transportSettings.ConnectionString);
         bool usingManagedIdentity =

--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQQuery.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQQuery.cs
@@ -3,7 +3,7 @@ namespace ServiceControl.Transports.RabbitMQ;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -39,7 +39,7 @@ public class RabbitMQQuery : BrokerThroughputQuery
         connectionConfiguration = ConnectionConfiguration.Create(transportSettings.ConnectionString, string.Empty);
     }
 
-    protected override void InitializeCore(ImmutableDictionary<string, string> settings)
+    protected override void InitializeCore(ReadOnlyDictionary<string, string> settings)
     {
         if (!settings.TryGetValue(RabbitMQSettings.UserName, out string? username) ||
             string.IsNullOrEmpty(username))

--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQQuery.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQQuery.cs
@@ -39,7 +39,7 @@ public class RabbitMQQuery : BrokerThroughputQuery
         connectionConfiguration = ConnectionConfiguration.Create(transportSettings.ConnectionString, string.Empty);
     }
 
-    protected override void InitialiseCore(ImmutableDictionary<string, string> settings)
+    protected override void InitializeCore(ImmutableDictionary<string, string> settings)
     {
         if (!settings.TryGetValue(RabbitMQSettings.UserName, out string? username) ||
             string.IsNullOrEmpty(username))

--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQQuery.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQQuery.cs
@@ -2,8 +2,8 @@
 namespace ServiceControl.Transports.RabbitMQ;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -39,7 +39,7 @@ public class RabbitMQQuery : BrokerThroughputQuery
         connectionConfiguration = ConnectionConfiguration.Create(transportSettings.ConnectionString, string.Empty);
     }
 
-    protected override void InitialiseCore(FrozenDictionary<string, string> settings)
+    protected override void InitialiseCore(ImmutableDictionary<string, string> settings)
     {
         if (!settings.TryGetValue(RabbitMQSettings.UserName, out string? username) ||
             string.IsNullOrEmpty(username))

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/RabbitMQQueryTests.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/RabbitMQQueryTests.cs
@@ -32,7 +32,7 @@ class RabbitMQQueryTests : TransportTestFixture
         string[] additionalQueues = Enumerable.Range(1, 10).Select(i => $"myqueue{i}").ToArray();
         await configuration.TransportCustomization.ProvisionQueues(transportSettings, additionalQueues);
 
-        query.Initialise(ImmutableDictionary<string, string>.Empty);
+        query.Initialize(ImmutableDictionary<string, string>.Empty);
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/RabbitMQQueryTests.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/RabbitMQQueryTests.cs
@@ -1,8 +1,8 @@
 namespace ServiceControl.Transport.Tests;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,8 +32,7 @@ class RabbitMQQueryTests : TransportTestFixture
         string[] additionalQueues = Enumerable.Range(1, 10).Select(i => $"myqueue{i}").ToArray();
         await configuration.TransportCustomization.ProvisionQueues(transportSettings, additionalQueues);
 
-        var dictionary = new Dictionary<string, string>();
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(ImmutableDictionary<string, string>.Empty);
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/RabbitMQQueryTests.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/RabbitMQQueryTests.cs
@@ -2,7 +2,7 @@ namespace ServiceControl.Transport.Tests;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,7 +32,7 @@ class RabbitMQQueryTests : TransportTestFixture
         string[] additionalQueues = Enumerable.Range(1, 10).Select(i => $"myqueue{i}").ToArray();
         await configuration.TransportCustomization.ProvisionQueues(transportSettings, additionalQueues);
 
-        query.Initialize(ImmutableDictionary<string, string>.Empty);
+        query.Initialize(ReadOnlyDictionary<string, string>.Empty);
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/RabbitMQQueryTests.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/RabbitMQQueryTests.cs
@@ -44,7 +44,7 @@ class RabbitMQQueryTests : TransportTestFixture
         {
             { RabbitMQQuery.RabbitMQSettings.API, "http://localhost:12345" }
         };
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsFalse(success);
@@ -58,7 +58,7 @@ class RabbitMQQueryTests : TransportTestFixture
     {
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        query.Initialise(ImmutableDictionary<string, string>.Empty);
+        query.Initialize(ImmutableDictionary<string, string>.Empty);
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsTrue(success);
@@ -83,7 +83,7 @@ class RabbitMQQueryTests : TransportTestFixture
 
         await CreateTestQueue(transportSettings.EndpointName);
 
-        query.Initialise(ImmutableDictionary<string, string>.Empty);
+        query.Initialize(ImmutableDictionary<string, string>.Empty);
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/RabbitMQQueryTests.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/RabbitMQQueryTests.cs
@@ -1,8 +1,8 @@
 namespace ServiceControl.Transport.Tests;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -44,7 +44,7 @@ class RabbitMQQueryTests : TransportTestFixture
         {
             { RabbitMQQuery.RabbitMQSettings.API, "http://localhost:12345" }
         };
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsFalse(success);
@@ -58,8 +58,7 @@ class RabbitMQQueryTests : TransportTestFixture
     {
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        var dictionary = new Dictionary<string, string>();
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(ImmutableDictionary<string, string>.Empty);
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsTrue(success);
@@ -84,8 +83,7 @@ class RabbitMQQueryTests : TransportTestFixture
 
         await CreateTestQueue(transportSettings.EndpointName);
 
-        var dictionary = new Dictionary<string, string>();
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(ImmutableDictionary<string, string>.Empty);
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/RabbitMQQueryTests.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/RabbitMQQueryTests.cs
@@ -2,7 +2,7 @@ namespace ServiceControl.Transport.Tests;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -44,7 +44,7 @@ class RabbitMQQueryTests : TransportTestFixture
         {
             { RabbitMQQuery.RabbitMQSettings.API, "http://localhost:12345" }
         };
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsFalse(success);
@@ -58,7 +58,7 @@ class RabbitMQQueryTests : TransportTestFixture
     {
         using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        query.Initialize(ImmutableDictionary<string, string>.Empty);
+        query.Initialize(ReadOnlyDictionary<string, string>.Empty);
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsTrue(success);
@@ -83,7 +83,7 @@ class RabbitMQQueryTests : TransportTestFixture
 
         await CreateTestQueue(transportSettings.EndpointName);
 
-        query.Initialize(ImmutableDictionary<string, string>.Empty);
+        query.Initialize(ReadOnlyDictionary<string, string>.Empty);
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.SQS.Tests/AmazonSQSQueryTests.cs
+++ b/src/ServiceControl.Transports.SQS.Tests/AmazonSQSQueryTests.cs
@@ -1,8 +1,8 @@
 namespace ServiceControl.Transport.Tests;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,7 +46,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             { AmazonSQSQuery.AmazonSQSSettings.SecretKey, "not_valid" },
             { AmazonSQSQuery.AmazonSQSSettings.Region, "us-east-1" }
         };
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -66,7 +66,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             { AmazonSQSQuery.AmazonSQSSettings.AccessKey, "valid" },
             { AmazonSQSQuery.AmazonSQSSettings.SecretKey, "valid" }
         };
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -86,7 +86,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             { AmazonSQSQuery.AmazonSQSSettings.AccessKey, "valid" },
             { AmazonSQSQuery.AmazonSQSSettings.SecretKey, "valid" }
         };
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Approver.Verify(diagnostics);
@@ -120,7 +120,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             dictionary.Add(AmazonSQSQuery.AmazonSQSSettings.Region, connectionString.Region);
         }
 
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
 
         await Task.Delay(TimeSpan.FromMinutes(2), token);
 

--- a/src/ServiceControl.Transports.SQS.Tests/AmazonSQSQueryTests.cs
+++ b/src/ServiceControl.Transports.SQS.Tests/AmazonSQSQueryTests.cs
@@ -46,7 +46,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             { AmazonSQSQuery.AmazonSQSSettings.SecretKey, "not_valid" },
             { AmazonSQSQuery.AmazonSQSSettings.Region, "us-east-1" }
         };
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -66,7 +66,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             { AmazonSQSQuery.AmazonSQSSettings.AccessKey, "valid" },
             { AmazonSQSQuery.AmazonSQSSettings.SecretKey, "valid" }
         };
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -86,7 +86,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             { AmazonSQSQuery.AmazonSQSSettings.AccessKey, "valid" },
             { AmazonSQSQuery.AmazonSQSSettings.SecretKey, "valid" }
         };
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Approver.Verify(diagnostics);
@@ -120,7 +120,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             dictionary.Add(AmazonSQSQuery.AmazonSQSSettings.Region, connectionString.Region);
         }
 
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
 
         await Task.Delay(TimeSpan.FromMinutes(2), token);
 

--- a/src/ServiceControl.Transports.SQS.Tests/AmazonSQSQueryTests.cs
+++ b/src/ServiceControl.Transports.SQS.Tests/AmazonSQSQueryTests.cs
@@ -2,7 +2,7 @@ namespace ServiceControl.Transport.Tests;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,7 +46,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             { AmazonSQSQuery.AmazonSQSSettings.SecretKey, "not_valid" },
             { AmazonSQSQuery.AmazonSQSSettings.Region, "us-east-1" }
         };
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -66,7 +66,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             { AmazonSQSQuery.AmazonSQSSettings.AccessKey, "valid" },
             { AmazonSQSQuery.AmazonSQSSettings.SecretKey, "valid" }
         };
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -86,7 +86,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             { AmazonSQSQuery.AmazonSQSSettings.AccessKey, "valid" },
             { AmazonSQSQuery.AmazonSQSSettings.SecretKey, "valid" }
         };
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Approver.Verify(diagnostics);
@@ -120,7 +120,7 @@ class AmazonSQSQueryTests : TransportTestFixture
             dictionary.Add(AmazonSQSQuery.AmazonSQSSettings.Region, connectionString.Region);
         }
 
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
 
         await Task.Delay(TimeSpan.FromMinutes(2), token);
 

--- a/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
+++ b/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
@@ -3,7 +3,7 @@ namespace ServiceControl.Transports.SQS;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -26,7 +26,7 @@ public class AmazonSQSQuery(ILogger<AmazonSQSQuery> logger, TimeProvider timePro
     AmazonSQSClient? sqs;
     string? prefix;
 
-    protected override void InitializeCore(ImmutableDictionary<string, string> settings)
+    protected override void InitializeCore(ReadOnlyDictionary<string, string> settings)
     {
         var sqsConnectionString = new SQSTransportConnectionString(transportSettings.ConnectionString);
         AWSCredentials credentials = FallbackCredentialsFactory.GetCredentials();

--- a/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
+++ b/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
@@ -26,7 +26,7 @@ public class AmazonSQSQuery(ILogger<AmazonSQSQuery> logger, TimeProvider timePro
     AmazonSQSClient? sqs;
     string? prefix;
 
-    protected override void InitialiseCore(ImmutableDictionary<string, string> settings)
+    protected override void InitializeCore(ImmutableDictionary<string, string> settings)
     {
         var sqsConnectionString = new SQSTransportConnectionString(transportSettings.ConnectionString);
         AWSCredentials credentials = FallbackCredentialsFactory.GetCredentials();

--- a/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
+++ b/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
@@ -2,8 +2,8 @@
 namespace ServiceControl.Transports.SQS;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -26,7 +26,7 @@ public class AmazonSQSQuery(ILogger<AmazonSQSQuery> logger, TimeProvider timePro
     AmazonSQSClient? sqs;
     string? prefix;
 
-    protected override void InitialiseCore(FrozenDictionary<string, string> settings)
+    protected override void InitialiseCore(ImmutableDictionary<string, string> settings)
     {
         var sqsConnectionString = new SQSTransportConnectionString(transportSettings.ConnectionString);
         AWSCredentials credentials = FallbackCredentialsFactory.GetCredentials();

--- a/src/ServiceControl.Transports.SqlServer.Tests/SqlServerQueryTests.cs
+++ b/src/ServiceControl.Transports.SqlServer.Tests/SqlServerQueryTests.cs
@@ -2,7 +2,7 @@ namespace ServiceControl.Transport.Tests;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -45,7 +45,7 @@ class SqlServerQueryTests : TransportTestFixture
         {
             { SqlServerQuery.SqlServerSettings.ConnectionString, "not valid" }
         };
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -64,7 +64,7 @@ class SqlServerQueryTests : TransportTestFixture
             { SqlServerQuery.SqlServerSettings.ConnectionString, configuration.ConnectionString },
             { SqlServerQuery.SqlServerSettings.AdditionalCatalogs, "not_here" }
         };
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -83,7 +83,7 @@ class SqlServerQueryTests : TransportTestFixture
         {
             { SqlServerQuery.SqlServerSettings.ConnectionString, configuration.ConnectionString }
         };
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsTrue(success);
@@ -103,7 +103,7 @@ class SqlServerQueryTests : TransportTestFixture
 
         await CreateTestQueue(transportSettings.EndpointName);
 
-        query.Initialize(dictionary.ToImmutableDictionary());
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.SqlServer.Tests/SqlServerQueryTests.cs
+++ b/src/ServiceControl.Transports.SqlServer.Tests/SqlServerQueryTests.cs
@@ -45,7 +45,7 @@ class SqlServerQueryTests : TransportTestFixture
         {
             { SqlServerQuery.SqlServerSettings.ConnectionString, "not valid" }
         };
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -64,7 +64,7 @@ class SqlServerQueryTests : TransportTestFixture
             { SqlServerQuery.SqlServerSettings.ConnectionString, configuration.ConnectionString },
             { SqlServerQuery.SqlServerSettings.AdditionalCatalogs, "not_here" }
         };
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -83,7 +83,7 @@ class SqlServerQueryTests : TransportTestFixture
         {
             { SqlServerQuery.SqlServerSettings.ConnectionString, configuration.ConnectionString }
         };
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsTrue(success);
@@ -103,7 +103,7 @@ class SqlServerQueryTests : TransportTestFixture
 
         await CreateTestQueue(transportSettings.EndpointName);
 
-        query.Initialise(dictionary.ToImmutableDictionary());
+        query.Initialize(dictionary.ToImmutableDictionary());
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.SqlServer.Tests/SqlServerQueryTests.cs
+++ b/src/ServiceControl.Transports.SqlServer.Tests/SqlServerQueryTests.cs
@@ -1,8 +1,8 @@
 namespace ServiceControl.Transport.Tests;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -45,7 +45,7 @@ class SqlServerQueryTests : TransportTestFixture
         {
             { SqlServerQuery.SqlServerSettings.ConnectionString, "not valid" }
         };
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -64,7 +64,7 @@ class SqlServerQueryTests : TransportTestFixture
             { SqlServerQuery.SqlServerSettings.ConnectionString, configuration.ConnectionString },
             { SqlServerQuery.SqlServerSettings.AdditionalCatalogs, "not_here" }
         };
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, List<string> errors, string diagnostics) =
             await query.TestConnection(cancellationTokenSource.Token);
 
@@ -83,7 +83,7 @@ class SqlServerQueryTests : TransportTestFixture
         {
             { SqlServerQuery.SqlServerSettings.ConnectionString, configuration.ConnectionString }
         };
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsTrue(success);
@@ -103,7 +103,7 @@ class SqlServerQueryTests : TransportTestFixture
 
         await CreateTestQueue(transportSettings.EndpointName);
 
-        query.Initialise(dictionary.ToFrozenDictionary());
+        query.Initialise(dictionary.ToImmutableDictionary());
 
         var queueNames = new List<IBrokerQueue>();
         await foreach (IBrokerQueue queueName in query.GetQueueNames(token))

--- a/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
@@ -19,7 +19,7 @@ public class SqlServerQuery(
 {
     readonly List<DatabaseDetails> databases = [];
 
-    protected override void InitialiseCore(ImmutableDictionary<string, string> settings)
+    protected override void InitializeCore(ImmutableDictionary<string, string> settings)
     {
         if (!settings.TryGetValue(SqlServerSettings.ConnectionString, out string? connectionString))
         {

--- a/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
@@ -2,8 +2,8 @@
 namespace ServiceControl.Transports.SqlServer;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -19,7 +19,7 @@ public class SqlServerQuery(
 {
     readonly List<DatabaseDetails> databases = [];
 
-    protected override void InitialiseCore(FrozenDictionary<string, string> settings)
+    protected override void InitialiseCore(ImmutableDictionary<string, string> settings)
     {
         if (!settings.TryGetValue(SqlServerSettings.ConnectionString, out string? connectionString))
         {

--- a/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
@@ -3,7 +3,7 @@ namespace ServiceControl.Transports.SqlServer;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -19,7 +19,7 @@ public class SqlServerQuery(
 {
     readonly List<DatabaseDetails> databases = [];
 
-    protected override void InitializeCore(ImmutableDictionary<string, string> settings)
+    protected override void InitializeCore(ReadOnlyDictionary<string, string> settings)
     {
         if (!settings.TryGetValue(SqlServerSettings.ConnectionString, out string? connectionString))
         {

--- a/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
+++ b/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
@@ -112,8 +112,8 @@ namespace ServiceControl.Transports.BrokerThroughput
         public abstract System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken);
         public abstract System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.BrokerThroughput.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken);
         public bool HasInitialisationErrors(out string errorMessage) { }
-        public void Initialise(System.Collections.Frozen.FrozenDictionary<string, string> settings) { }
-        protected abstract void InitialiseCore(System.Collections.Frozen.FrozenDictionary<string, string> settings);
+        public void Initialise(System.Collections.Immutable.ImmutableDictionary<string, string> settings) { }
+        protected abstract void InitialiseCore(System.Collections.Immutable.ImmutableDictionary<string, string> settings);
         public virtual string SanitizeEndpointName(string endpointName) { }
         public virtual string SanitizedEndpointNameCleanser(string endpointName) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
+++ b/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
@@ -112,8 +112,8 @@ namespace ServiceControl.Transports.BrokerThroughput
         public abstract System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken);
         public abstract System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.BrokerThroughput.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken);
         public bool HasInitialisationErrors(out string errorMessage) { }
-        public void Initialise(System.Collections.Immutable.ImmutableDictionary<string, string> settings) { }
-        protected abstract void InitialiseCore(System.Collections.Immutable.ImmutableDictionary<string, string> settings);
+        public void Initialize(System.Collections.Immutable.ImmutableDictionary<string, string> settings) { }
+        protected abstract void InitializeCore(System.Collections.Immutable.ImmutableDictionary<string, string> settings);
         public virtual string SanitizeEndpointName(string endpointName) { }
         public virtual string SanitizedEndpointNameCleanser(string endpointName) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
@@ -150,7 +150,7 @@ namespace ServiceControl.Transports.BrokerThroughput
         System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken);
         System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.BrokerThroughput.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken);
         bool HasInitialisationErrors(out string errorMessage);
-        void Initialise(System.Collections.Frozen.FrozenDictionary<string, string> settings);
+        void Initialize(System.Collections.Immutable.ImmutableDictionary<string, string> settings);
         string SanitizeEndpointName(string endpointName);
         string SanitizedEndpointNameCleanser(string endpointName);
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
+++ b/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
@@ -112,8 +112,8 @@ namespace ServiceControl.Transports.BrokerThroughput
         public abstract System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken);
         public abstract System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.BrokerThroughput.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken);
         public bool HasInitialisationErrors(out string errorMessage) { }
-        public void Initialize(System.Collections.Immutable.ImmutableDictionary<string, string> settings) { }
-        protected abstract void InitializeCore(System.Collections.Immutable.ImmutableDictionary<string, string> settings);
+        public void Initialize(System.Collections.ObjectModel.ReadOnlyDictionary<string, string> settings) { }
+        protected abstract void InitializeCore(System.Collections.ObjectModel.ReadOnlyDictionary<string, string> settings);
         public virtual string SanitizeEndpointName(string endpointName) { }
         public virtual string SanitizedEndpointNameCleanser(string endpointName) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
@@ -150,7 +150,7 @@ namespace ServiceControl.Transports.BrokerThroughput
         System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken);
         System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.BrokerThroughput.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken);
         bool HasInitialisationErrors(out string errorMessage);
-        void Initialize(System.Collections.Immutable.ImmutableDictionary<string, string> settings);
+        void Initialize(System.Collections.ObjectModel.ReadOnlyDictionary<string, string> settings);
         string SanitizeEndpointName(string endpointName);
         string SanitizedEndpointNameCleanser(string endpointName);
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {

--- a/src/ServiceControl.Transports/BrokerThroughput/BrokerThroughputQuery.cs
+++ b/src/ServiceControl.Transports/BrokerThroughput/BrokerThroughputQuery.cs
@@ -28,14 +28,14 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
         return true;
     }
 
-    public void Initialise(ImmutableDictionary<string, string> settings)
+    public void Initialize(ImmutableDictionary<string, string> settings)
     {
         InitialiseErrors.Clear();
         Diagnostics.Clear();
 
         try
         {
-            InitialiseCore(settings);
+            InitializeCore(settings);
         }
         catch (Exception e)
         {
@@ -44,7 +44,7 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
         }
     }
 
-    protected abstract void InitialiseCore(ImmutableDictionary<string, string> settings);
+    protected abstract void InitializeCore(ImmutableDictionary<string, string> settings);
 
     public abstract IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue, DateOnly startDate,
         CancellationToken cancellationToken);

--- a/src/ServiceControl.Transports/BrokerThroughput/BrokerThroughputQuery.cs
+++ b/src/ServiceControl.Transports/BrokerThroughput/BrokerThroughputQuery.cs
@@ -3,7 +3,7 @@ namespace ServiceControl.Transports.BrokerThroughput;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,7 +28,7 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
         return true;
     }
 
-    public void Initialize(ImmutableDictionary<string, string> settings)
+    public void Initialize(ReadOnlyDictionary<string, string> settings)
     {
         InitialiseErrors.Clear();
         Diagnostics.Clear();
@@ -44,7 +44,7 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
         }
     }
 
-    protected abstract void InitializeCore(ImmutableDictionary<string, string> settings);
+    protected abstract void InitializeCore(ReadOnlyDictionary<string, string> settings);
 
     public abstract IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue, DateOnly startDate,
         CancellationToken cancellationToken);

--- a/src/ServiceControl.Transports/BrokerThroughput/BrokerThroughputQuery.cs
+++ b/src/ServiceControl.Transports/BrokerThroughput/BrokerThroughputQuery.cs
@@ -2,8 +2,8 @@
 namespace ServiceControl.Transports.BrokerThroughput;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,7 +28,7 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
         return true;
     }
 
-    public void Initialise(FrozenDictionary<string, string> settings)
+    public void Initialise(ImmutableDictionary<string, string> settings)
     {
         InitialiseErrors.Clear();
         Diagnostics.Clear();
@@ -44,7 +44,7 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
         }
     }
 
-    protected abstract void InitialiseCore(FrozenDictionary<string, string> settings);
+    protected abstract void InitialiseCore(ImmutableDictionary<string, string> settings);
 
     public abstract IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue, DateOnly startDate,
         CancellationToken cancellationToken);

--- a/src/ServiceControl.Transports/BrokerThroughput/IBrokerThroughputQuery.cs
+++ b/src/ServiceControl.Transports/BrokerThroughput/IBrokerThroughputQuery.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 public interface IBrokerThroughputQuery
 {
     bool HasInitialisationErrors(out string errorMessage);
-    void Initialise(ImmutableDictionary<string, string> settings);
+    void Initialize(ImmutableDictionary<string, string> settings);
     IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue, DateOnly startDate,
         CancellationToken cancellationToken);
     IAsyncEnumerable<IBrokerQueue> GetQueueNames(CancellationToken cancellationToken);

--- a/src/ServiceControl.Transports/BrokerThroughput/IBrokerThroughputQuery.cs
+++ b/src/ServiceControl.Transports/BrokerThroughput/IBrokerThroughputQuery.cs
@@ -2,15 +2,15 @@
 namespace ServiceControl.Transports.BrokerThroughput;
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
 public interface IBrokerThroughputQuery
 {
     bool HasInitialisationErrors(out string errorMessage);
-    void Initialise(FrozenDictionary<string, string> settings);
+    void Initialise(ImmutableDictionary<string, string> settings);
     IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue, DateOnly startDate,
         CancellationToken cancellationToken);
     IAsyncEnumerable<IBrokerQueue> GetQueueNames(CancellationToken cancellationToken);

--- a/src/ServiceControl.Transports/BrokerThroughput/IBrokerThroughputQuery.cs
+++ b/src/ServiceControl.Transports/BrokerThroughput/IBrokerThroughputQuery.cs
@@ -3,14 +3,14 @@ namespace ServiceControl.Transports.BrokerThroughput;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 
 public interface IBrokerThroughputQuery
 {
     bool HasInitialisationErrors(out string errorMessage);
-    void Initialize(ImmutableDictionary<string, string> settings);
+    void Initialize(ReadOnlyDictionary<string, string> settings);
     IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue, DateOnly startDate,
         CancellationToken cancellationToken);
     IAsyncEnumerable<IBrokerQueue> GetQueueNames(CancellationToken cancellationToken);


### PR DESCRIPTION
By looking at the usage of the dictionary it feels to me it is not worth the overhead. Frozen collections in general can take multiple miliseconds to initialize and that overhead is only worth taking when you actually read from those many many times. By having had a quick look at the usage of the settings in the queries it looks like we usually extract concrete information from the settings in the initialization path and then use that stored state to do the runtime operations. So effectively the frozen dictionary is not read on the hot path over and over again. 