### PR TITLE
Improve default logging settings

### DIFF
--- a/src/ServiceControl.Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Infrastructure/LoggingConfigurator.cs
@@ -9,7 +9,7 @@ namespace ServiceControl.Infrastructure
     using NLog.Targets;
     using NServiceBus.Extensions.Logging;
     using ServiceControl.Configuration;
-    using LogLevel = NLog.LogLevel;
+
     using LogManager = NServiceBus.Logging.LogManager;
 
     public static class LoggingConfigurator
@@ -45,14 +45,11 @@ namespace ServiceControl.Infrastructure
                 UseDefaultRowHighlightingRules = true
             };
 
-            // Always want to see license logging regardless of default logging level
-            nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget));
             // Defaults
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel, consoleTarget));
 
             if (!AppEnvironment.RunningInContainer)
             {
-                nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, fileTarget));
                 nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel, fileTarget));
             }
 

--- a/src/ServiceControl.Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Infrastructure/LoggingConfigurator.cs
@@ -45,7 +45,21 @@ namespace ServiceControl.Infrastructure
                 UseDefaultRowHighlightingRules = true
             };
 
-            // Defaults
+            var aspNetCoreRule = new LoggingRule()
+            {
+                LoggerNamePattern = "Microsoft.AspNetCore.*",
+                FinalMinLevel = LogLevel.Warn
+            };
+
+            var httpClientRule = new LoggingRule()
+            {
+                LoggerNamePattern = "System.Net.Http.HttpClient.*",
+                FinalMinLevel = LogLevel.Warn
+            };
+
+            nlogConfig.LoggingRules.Add(aspNetCoreRule);
+            nlogConfig.LoggingRules.Add(httpClientRule);
+
             nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel, consoleTarget));
 
             if (!AppEnvironment.RunningInContainer)

--- a/src/ServiceControl.Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Infrastructure/LoggingConfigurator.cs
@@ -48,7 +48,7 @@ namespace ServiceControl.Infrastructure
             // Always want to see license logging regardless of default logging level
             nlogConfig.LoggingRules.Add(new LoggingRule("Particular.ServiceControl.Licensing.*", LogLevel.Info, consoleTarget));
             // Defaults
-            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel < LogLevel.Info ? loggingSettings.LogLevel : LogLevel.Info, consoleTarget));
+            nlogConfig.LoggingRules.Add(new LoggingRule("*", loggingSettings.LogLevel, consoleTarget));
 
             if (!AppEnvironment.RunningInContainer)
             {


### PR DESCRIPTION
This PR makes the following changes related to logging:

- Console logging now respects the `LogLevel` setting. Previously, it was not possible to set it higher than `Info`.
- There was a rule to ensure license-related logs at `Info` or higher would always be logged, but looking through the current codebase, the only `Particular.ServiceControl.Licensing` logs are `Debug` or `Error`, so this rule doesn't seem to be doing anything.
- The `Microsoft.AspNetCore.*` and `System.Net.Http.HttpClient.*` logs are now always set to `Warn` or higher, cleaning up a lot of noise in the log files.