### PR TITLE
Change the monitoring status to report as "active" when throughput exists, even if just for today - 5.4

### DIFF
--- a/src/Particular.LicensingComponent.Persistence.InMemory/InMemoryLicensingDataStore.cs
+++ b/src/Particular.LicensingComponent.Persistence.InMemory/InMemoryLicensingDataStore.cs
@@ -128,10 +128,15 @@ public class InMemoryLicensingDataStore : ILicensingDataStore
             t => t.Key >= DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-days) &&
                  t.Key <= DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1))));
 
-    public async Task<bool> IsThereThroughputForLastXDaysForSource(int days, ThroughputSource throughputSource, CancellationToken cancellationToken) => await Task.FromResult(
-        allThroughput.Any(endpointThroughput => endpointThroughput.Key.ThroughputSource == throughputSource && endpointThroughput.Value.Any(
-            t => t.Key >= DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-days) &&
-                 t.Key <= DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1))));
+    public async Task<bool> IsThereThroughputForLastXDaysForSource(int days, ThroughputSource throughputSource, bool includeToday, CancellationToken cancellationToken)
+    {
+        var endDate = includeToday ? DateOnly.FromDateTime(DateTime.UtcNow) : DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1);
+
+        return await Task.FromResult(
+            allThroughput.Any(
+                endpointThroughput => endpointThroughput.Key.ThroughputSource == throughputSource &&
+                endpointThroughput.Value.Any(t => t.Key >= DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-days) && t.Key <= endDate)));
+    }
 
     List<Endpoint> GetAllConnectedEndpoints(string name) => endpoints.Where(w => w.SanitizedName == name).ToList();
 

--- a/src/Particular.LicensingComponent.Persistence/ILicensingDataStore.cs
+++ b/src/Particular.LicensingComponent.Persistence/ILicensingDataStore.cs
@@ -25,7 +25,7 @@ public interface ILicensingDataStore
     Task UpdateUserIndicatorOnEndpoints(List<UpdateUserIndicator> userIndicatorUpdates, CancellationToken cancellationToken);
 
     Task<bool> IsThereThroughputForLastXDays(int days, CancellationToken cancellationToken);
-    Task<bool> IsThereThroughputForLastXDaysForSource(int days, ThroughputSource throughputSource, CancellationToken cancellationToken);
+    Task<bool> IsThereThroughputForLastXDaysForSource(int days, ThroughputSource throughputSource, bool includeToday, CancellationToken cancellationToken);
 
     Task<BrokerMetadata> GetBrokerMetadata(CancellationToken cancellationToken);
 

--- a/src/Particular.LicensingComponent/MonitoringThroughput/MonitoringService.cs
+++ b/src/Particular.LicensingComponent/MonitoringThroughput/MonitoringService.cs
@@ -52,7 +52,7 @@ public class MonitoringService(ILicensingDataStore dataStore, IBrokerThroughputQ
         var connectionTestResult = new ConnectionSettingsTestResult { ConnectionSuccessful = true };
 
         var diagnostics = new StringBuilder();
-        if (await dataStore.IsThereThroughputForLastXDaysForSource(30, ThroughputSource.Monitoring, cancellationToken))
+        if (await dataStore.IsThereThroughputForLastXDaysForSource(30, ThroughputSource.Monitoring, true, cancellationToken))
         {
             diagnostics.AppendLine("Throughput from Monitoring recorded in the last 30 days");
         }

--- a/src/ServiceControl.Persistence.Tests/Throughput/EndpointsTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Throughput/EndpointsTests.cs
@@ -179,10 +179,12 @@ class EndpointsTests : PersistenceTestBase
         Assert.That(await LicensingDataStore.IsThereThroughputForLastXDays(timeFrameToCheck, default), expectedValue ? Is.True : Is.False);
     }
 
-    [TestCase(10, 5, ThroughputSource.Monitoring, ThroughputSource.Monitoring, false)]
-    [TestCase(10, 20, ThroughputSource.Monitoring, ThroughputSource.Monitoring, true)]
-    [TestCase(10, 20, ThroughputSource.Audit, ThroughputSource.Monitoring, false)]
-    public async Task Should_correctly_report_throughput_existence_for_X_days_for_specific_source(int daysSinceLastThroughputEntry, int timeFrameToCheck, ThroughputSource throughputSourceToRecord, ThroughputSource throughputSourceToCheck, bool expectedValue)
+    [TestCase(10, 5, ThroughputSource.Monitoring, ThroughputSource.Monitoring, false, false)]
+    [TestCase(10, 20, ThroughputSource.Monitoring, ThroughputSource.Monitoring, false, true)]
+    [TestCase(10, 20, ThroughputSource.Audit, ThroughputSource.Monitoring, false, false)]
+    [TestCase(0, 5, ThroughputSource.Monitoring, ThroughputSource.Monitoring, false, false)]
+    [TestCase(0, 5, ThroughputSource.Monitoring, ThroughputSource.Monitoring, true, true)]
+    public async Task Should_correctly_report_throughput_existence_for_X_days_for_specific_source(int daysSinceLastThroughputEntry, int timeFrameToCheck, ThroughputSource throughputSourceToRecord, ThroughputSource throughputSourceToCheck, bool includeToday, bool expectedValue)
     {
         // Arrange
         var endpointAudit = new Endpoint("Endpoint", throughputSourceToRecord);
@@ -195,6 +197,6 @@ class EndpointsTests : PersistenceTestBase
             50,
             default);
 
-        Assert.That(await LicensingDataStore.IsThereThroughputForLastXDaysForSource(timeFrameToCheck, throughputSourceToCheck, default), expectedValue ? Is.True : Is.False);
+        Assert.That(await LicensingDataStore.IsThereThroughputForLastXDaysForSource(timeFrameToCheck, throughputSourceToCheck, includeToday, default), expectedValue ? Is.True : Is.False);
     }
 }


### PR DESCRIPTION
Cheery picked from https://github.com/Particular/ServiceControl/pull/4294

Previously this is following the same rules as for "can report be generated", which returns false if only data for today exists, since it may be incomplete.