### PR TITLE
Reduce size of production artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4.0.0
         with:
-          dotnet-version: |
-            8.0.x
-            7.0.x
+          dotnet-version: 8.0.x
       - name: Download RavenDB Server
         shell: pwsh
         run: ./tools/download-ravendb-server.ps1

--- a/src/ServiceControl.Audit.Persistence.InMemory/ServiceControl.Audit.Persistence.InMemory.csproj
+++ b/src/ServiceControl.Audit.Persistence.InMemory/ServiceControl.Audit.Persistence.InMemory.csproj
@@ -16,8 +16,4 @@
     <None Update="persistence.manifest" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Artifact Include="$(OutputPath)" DestinationFolder="$(ArtifactsPath)Particular.ServiceControl.Audit\Persisters\InMemory" />
-  </ItemGroup>
-
 </Project>

--- a/src/ServiceControl.Transports.Msmq/ServiceControl.Transports.Msmq.csproj
+++ b/src/ServiceControl.Transports.Msmq/ServiceControl.Transports.Msmq.csproj
@@ -21,7 +21,7 @@
     <None Update="transport.manifest" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith(linux)) == false">
     <Artifact Include="$(OutputPath)" DestinationFolder="@(InstanceName->'$(ArtifactsPath)%(Identity)\Transports\MSMQ')" />
   </ItemGroup>
 

--- a/src/ServiceControlInstaller.Engine.UnitTests/ApprovalFiles/PersistenceManifestTests.ApproveAuditInstanceManifests.approved.txt
+++ b/src/ServiceControlInstaller.Engine.UnitTests/ApprovalFiles/PersistenceManifestTests.ApproveAuditInstanceManifests.approved.txt
@@ -1,5 +1,4 @@
 [
-  "InMemory: In-memory",
   "RavenDB: RavenDB",
   "RavenDB35: RavenDB 3.5 (Legacy)"
 ]

--- a/src/ServiceControlInstaller.Packaging.UnitTests/AuditDeploymentPackageTests.cs
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/AuditDeploymentPackageTests.cs
@@ -17,8 +17,7 @@ namespace Tests
         {
             var expectedPersisters = new[] {
                 "RavenDB35", // Still must exist, as Raven35 persistence.manifest file must be available for SCMU to understand old versions
-                "RavenDB",
-                "InMemory"
+                "RavenDB"
             };
 
             var persisters = deploymentPackage.DeploymentUnits.Where(u => u.Category == "Persisters");


### PR DESCRIPTION
This PR makes the following changes:

- MSMQ artifacts are not created when building with a Linux RuntimeIdentifier. This prevents the Linux container builds from including the MSMQ transport bits.
- Audit in-memory persistence is not production option, so we should not be creating artifacts for it

It also includes a bit of cleanup to the CI file, removing .NET 7 now RavenDB no longer requires it.