### PR TITLE
Add InstanceName setting to control the Service/Endpoint/Queue name

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_a_custom_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_a_custom_check_fails.cs
@@ -41,7 +41,7 @@
 
         public class EndpointWithFailingCustomCheck : EndpointConfigurationBuilder
         {
-            public EndpointWithFailingCustomCheck() => EndpointSetup<DefaultServerWithoutAudit>(c => { c.ReportCustomChecksTo(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1)); });
+            public EndpointWithFailingCustomCheck() => EndpointSetup<DefaultServerWithoutAudit>(c => { c.ReportCustomChecksTo(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromSeconds(1)); });
 
             class FailingCustomCheck() : CustomCheck("MyCustomCheckId", "MyCategory")
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_a_periodic_custom_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_a_periodic_custom_check_fails.cs
@@ -121,7 +121,7 @@
 
         public class WithCustomCheck : EndpointConfigurationBuilder
         {
-            public WithCustomCheck() => EndpointSetup<DefaultServerWithoutAudit>(c => { c.ReportCustomChecksTo(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1)); });
+            public WithCustomCheck() => EndpointSetup<DefaultServerWithoutAudit>(c => { c.ReportCustomChecksTo(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromSeconds(1)); });
 
             class FailingCustomCheck(MyContext context)
                 : NServiceBus.CustomChecks.CustomCheck("MyCustomCheckId", "MyCategory", TimeSpan.FromSeconds(5))

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_critical_storage_threshold_reached.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_critical_storage_threshold_reached.cs
@@ -99,7 +99,7 @@
             public Sender() =>
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
-                    c.ReportCustomChecksTo(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1));
+                    c.ReportCustomChecksTo(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromSeconds(1));
                     c.NoRetries();
                 });
 

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_custom_check_events_are_triggered.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_custom_check_events_are_triggered.cs
@@ -41,7 +41,7 @@
 
         public class EndpointWithCustomCheck : EndpointConfigurationBuilder
         {
-            public EndpointWithCustomCheck() => EndpointSetup<DefaultServerWithoutAudit>(c => c.ReportCustomChecksTo(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1)));
+            public EndpointWithCustomCheck() => EndpointSetup<DefaultServerWithoutAudit>(c => c.ReportCustomChecksTo(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromSeconds(1)));
 
             public class EventuallyFailingCustomCheck()
                 : CustomCheck("EventuallyFailingCustomCheck", "Testing", TimeSpan.FromSeconds(1))

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_email_notifications_are_enabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_email_notifications_are_enabled.cs
@@ -84,7 +84,7 @@
 
         public class EndpointWithFailingCustomCheck : EndpointConfigurationBuilder
         {
-            public EndpointWithFailingCustomCheck() => EndpointSetup<DefaultServerWithoutAudit>(c => { c.ReportCustomChecksTo(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1)); });
+            public EndpointWithFailingCustomCheck() => EndpointSetup<DefaultServerWithoutAudit>(c => { c.ReportCustomChecksTo(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromSeconds(1)); });
 
             class FailingCustomCheck() : CustomCheck("MyCustomCheckId", "MyCategory")
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_reporting_custom_check_with_signalr.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_reporting_custom_check_with_signalr.cs
@@ -93,7 +93,7 @@
 
         class EndpointWithCustomCheck : EndpointConfigurationBuilder
         {
-            public EndpointWithCustomCheck() => EndpointSetup<DefaultServerWithoutAudit>(c => { c.ReportCustomChecksTo(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1)); });
+            public EndpointWithCustomCheck() => EndpointSetup<DefaultServerWithoutAudit>(c => { c.ReportCustomChecksTo(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromSeconds(1)); });
 
             public class EventuallyFailingCustomCheck()
                 : CustomCheck("EventuallyFailingCustomCheck", "Testing", TimeSpan.FromSeconds(1))

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_fails.cs
@@ -69,10 +69,10 @@
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_SERVICE_NAME);
+                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_INSTANCE_NAME);
                 }, publisherMetadata =>
                 {
-                    publisherMetadata.RegisterPublisherFor<CustomCheckFailed>(Settings.DEFAULT_SERVICE_NAME);
+                    publisherMetadata.RegisterPublisherFor<CustomCheckFailed>(Settings.DEFAULT_INSTANCE_NAME);
                 });
 
             public class CustomCheckFailedHandler(MyContext testContext) : IHandleMessages<CustomCheckFailed>

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_succeeds.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_succeeds.cs
@@ -64,10 +64,10 @@
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_SERVICE_NAME);
+                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_INSTANCE_NAME);
                 }, publisherMetadata =>
                 {
-                    publisherMetadata.RegisterPublisherFor<CustomCheckSucceeded>(Settings.DEFAULT_SERVICE_NAME);
+                    publisherMetadata.RegisterPublisherFor<CustomCheckSucceeded>(Settings.DEFAULT_INSTANCE_NAME);
                 });
 
             public class CustomCheckSucceededHandler(MyContext testContext) : IHandleMessages<CustomCheckSucceeded>

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_is_restored.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_is_restored.cs
@@ -64,8 +64,8 @@ namespace ServiceControl.AcceptanceTests.Monitoring.ExternalIntegration
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_SERVICE_NAME);
-                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<HeartbeatRestored>(Settings.DEFAULT_SERVICE_NAME); });
+                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_INSTANCE_NAME);
+                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<HeartbeatRestored>(Settings.DEFAULT_INSTANCE_NAME); });
 
             public class FailureHandler(MyContext testContext) : IHandleMessages<HeartbeatRestored>
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_loss_is_detected.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_loss_is_detected.cs
@@ -66,8 +66,8 @@ namespace ServiceControl.AcceptanceTests.Monitoring.ExternalIntegration
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_SERVICE_NAME);
-                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<HeartbeatStopped>(Settings.DEFAULT_SERVICE_NAME); });
+                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_INSTANCE_NAME);
+                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<HeartbeatStopped>(Settings.DEFAULT_INSTANCE_NAME); });
 
             public class FailureHandler(MyContext testContext) : IHandleMessages<HeartbeatStopped>
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_is_removed.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_is_removed.cs
@@ -61,7 +61,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
 
         public class StartingEndpoint : EndpointConfigurationBuilder
         {
-            public StartingEndpoint() => EndpointSetup<DefaultServerWithoutAudit>(c => c.SendHeartbeatTo(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromHours(1)));
+            public StartingEndpoint() => EndpointSetup<DefaultServerWithoutAudit>(c => c.SendHeartbeatTo(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromHours(1)));
         }
     }
 }

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_starts_up.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_starts_up.cs
@@ -42,7 +42,7 @@
             public StartingEndpoint() =>
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
-                    c.SendHeartbeatTo(Settings.DEFAULT_SERVICE_NAME);
+                    c.SendHeartbeatTo(Settings.DEFAULT_INSTANCE_NAME);
 
                     c.GetSettings().Set("ServiceControl.CustomHostIdentifier", hostIdentifier);
                     c.UniquelyIdentifyRunningInstance().UsingCustomIdentifier(hostIdentifier);

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_with_heartbeat_plugin_starts_up.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_with_heartbeat_plugin_starts_up.cs
@@ -58,7 +58,7 @@
 
         public class StartingEndpoint : EndpointConfigurationBuilder
         {
-            public StartingEndpoint() => EndpointSetup<DefaultServerWithoutAudit>(c => c.SendHeartbeatTo(Settings.DEFAULT_SERVICE_NAME));
+            public StartingEndpoint() => EndpointSetup<DefaultServerWithoutAudit>(c => c.SendHeartbeatTo(Settings.DEFAULT_INSTANCE_NAME));
         }
     }
 }

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_an_unmonitored_endpoint_is_marked_as_monitored.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_an_unmonitored_endpoint_is_marked_as_monitored.cs
@@ -33,7 +33,7 @@
                     var options = new SendOptions();
 
                     options.DoNotEnforceBestPractices();
-                    options.SetDestination(Settings.DEFAULT_SERVICE_NAME);
+                    options.SetDestination(Settings.DEFAULT_INSTANCE_NAME);
 
                     return bus.Send(new NewEndpointDetected
                     {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_unmonitored_endpoint_starts_to_sends_heartbeats.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_unmonitored_endpoint_starts_to_sends_heartbeats.cs
@@ -29,7 +29,7 @@
                     var options = new SendOptions();
 
                     options.DoNotEnforceBestPractices();
-                    options.SetDestination(Settings.DEFAULT_SERVICE_NAME);
+                    options.SetDestination(Settings.DEFAULT_INSTANCE_NAME);
 
                     return bus.Send(new NewEndpointDetected
                     {
@@ -81,7 +81,7 @@
 
         public class WithHeartbeat : EndpointConfigurationBuilder
         {
-            public WithHeartbeat() => EndpointSetup<DefaultServerWithoutAudit>(c => { c.SendHeartbeatTo(Settings.DEFAULT_SERVICE_NAME); }).CustomEndpointName(EndpointName);
+            public WithHeartbeat() => EndpointSetup<DefaultServerWithoutAudit>(c => { c.SendHeartbeatTo(Settings.DEFAULT_INSTANCE_NAME); }).CustomEndpointName(EndpointName);
         }
     }
 }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_archived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_archived.cs
@@ -60,8 +60,8 @@
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(FailedMessagesArchived).Assembly, Settings.DEFAULT_SERVICE_NAME);
-                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<FailedMessagesArchived>(Settings.DEFAULT_SERVICE_NAME); });
+                    routing.RouteToEndpoint(typeof(FailedMessagesArchived).Assembly, Settings.DEFAULT_INSTANCE_NAME);
+                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<FailedMessagesArchived>(Settings.DEFAULT_INSTANCE_NAME); });
 
             public class FailureHandler(Context testContext) : IHandleMessages<FailedMessagesArchived>
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_resolved_by_retry.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_resolved_by_retry.cs
@@ -58,8 +58,8 @@
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(FailedMessagesArchived).Assembly, Settings.DEFAULT_SERVICE_NAME);
-                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<FailedMessagesArchived>(Settings.DEFAULT_SERVICE_NAME); });
+                    routing.RouteToEndpoint(typeof(FailedMessagesArchived).Assembly, Settings.DEFAULT_INSTANCE_NAME);
+                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<FailedMessagesArchived>(Settings.DEFAULT_INSTANCE_NAME); });
 
             public class FailureHandler(Context testContext) : IHandleMessages<MessageFailureResolvedByRetry>
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_resolved_manually.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_resolved_manually.cs
@@ -69,8 +69,8 @@
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(MessageFailureResolvedManually).Assembly, Settings.DEFAULT_SERVICE_NAME);
-                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<MessageFailureResolvedManually>(Settings.DEFAULT_SERVICE_NAME); });
+                    routing.RouteToEndpoint(typeof(MessageFailureResolvedManually).Assembly, Settings.DEFAULT_INSTANCE_NAME);
+                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<MessageFailureResolvedManually>(Settings.DEFAULT_INSTANCE_NAME); });
 
             public class FailureHandler(Context testContext) : IHandleMessages<MessageFailureResolvedManually>
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_unarchived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_unarchived.cs
@@ -77,8 +77,8 @@
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(FailedMessagesUnArchived).Assembly, Settings.DEFAULT_SERVICE_NAME);
-                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<FailedMessagesUnArchived>(Settings.DEFAULT_SERVICE_NAME); });
+                    routing.RouteToEndpoint(typeof(FailedMessagesUnArchived).Assembly, Settings.DEFAULT_INSTANCE_NAME);
+                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<FailedMessagesUnArchived>(Settings.DEFAULT_INSTANCE_NAME); });
             }
 
             public class FailureHandler(Context testContext) : IHandleMessages<FailedMessagesUnArchived>

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_group_is_archived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_group_is_archived.cs
@@ -75,8 +75,8 @@
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(FailedMessagesArchived).Assembly, Settings.DEFAULT_SERVICE_NAME);
-                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<FailedMessagesArchived>(Settings.DEFAULT_SERVICE_NAME); });
+                    routing.RouteToEndpoint(typeof(FailedMessagesArchived).Assembly, Settings.DEFAULT_INSTANCE_NAME);
+                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<FailedMessagesArchived>(Settings.DEFAULT_INSTANCE_NAME); });
 
             public class FailureHandler(Context testContext) : IHandleMessages<FailedMessagesArchived>
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_message_has_failed_detected.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_message_has_failed_detected.cs
@@ -72,8 +72,8 @@
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_SERVICE_NAME);
-                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<MessageFailed>(Settings.DEFAULT_SERVICE_NAME); });
+                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_INSTANCE_NAME);
+                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<MessageFailed>(Settings.DEFAULT_INSTANCE_NAME); });
 
             public class FailureHandler(MyContext testContext) : IHandleMessages<MessageFailed>
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_encountered_an_error.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_encountered_an_error.cs
@@ -97,8 +97,8 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
                     var routing = c.ConfigureRouting();
-                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_SERVICE_NAME);
-                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<HeartbeatStopped>(Settings.DEFAULT_SERVICE_NAME); });
+                    routing.RouteToEndpoint(typeof(MessageFailed).Assembly, Settings.DEFAULT_INSTANCE_NAME);
+                }, publisherMetadata => { publisherMetadata.RegisterPublisherFor<HeartbeatStopped>(Settings.DEFAULT_INSTANCE_NAME); });
 
             public class FailureHandler(MyContext testContext) : IHandleMessages<HeartbeatStopped>
             {

--- a/src/ServiceControl.AcceptanceTests/RootControllerTests.cs
+++ b/src/ServiceControl.AcceptanceTests/RootControllerTests.cs
@@ -24,7 +24,7 @@
                     new RemoteInstanceSetting(settings.RootUrl),
                     new RemoteInstanceSetting(settings.RootUrl)
                 ];
-                serviceName = settings.ServiceName;
+                serviceName = settings.InstanceName;
                 baseAddress = settings.RootUrl;
             };
 

--- a/src/ServiceControl.AcceptanceTests/TestSupport/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/AcceptanceTest.cs
@@ -70,7 +70,7 @@ namespace ServiceControl.AcceptanceTests
         }
 
 #pragma warning disable IDE0060 // Remove unused parameter
-        protected void ExecuteWhen(Func<bool> execute, Func<IDomainEvents, Task> action, string instanceName = Settings.DEFAULT_SERVICE_NAME)
+        protected void ExecuteWhen(Func<bool> execute, Func<IDomainEvents, Task> action, string instanceName = Settings.DEFAULT_INSTANCE_NAME)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
             var timeout = TimeSpan.FromSeconds(1);

--- a/src/ServiceControl.AcceptanceTests/TestSupport/ReportSuccessfulRetryToServiceControl.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ReportSuccessfulRetryToServiceControl.cs
@@ -16,7 +16,7 @@
             if (context.MessageHeaders.TryGetValue("ServiceControl.Retry.UniqueMessageId", out var messageId))
             {
                 var options = new SendOptions();
-                options.SetDestination(Settings.DEFAULT_SERVICE_NAME);
+                options.SetDestination(Settings.DEFAULT_INSTANCE_NAME);
 
                 await context.Send(new MarkMessageFailureResolvedByRetry
                 {

--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -51,8 +51,9 @@
             Directory.CreateDirectory(logPath);
             var loggingSettings = new LoggingSettings(Settings.SettingsRootNamespace, defaultLevel: LogLevel.Debug, logPath: logPath);
 
-            var settings = new Settings(instanceName, transportToUse.TypeName, persistenceToUse.PersistenceType, loggingSettings, forwardErrorMessages: false, errorRetentionPeriod: TimeSpan.FromDays(10))
+            var settings = new Settings(transportToUse.TypeName, persistenceToUse.PersistenceType, loggingSettings, forwardErrorMessages: false, errorRetentionPeriod: TimeSpan.FromDays(10))
             {
+                InstanceName = instanceName,
                 AllowMessageEditing = true,
                 ForwardErrorMessages = false,
                 TransportConnectionString = transportToUse.ConnectionString,
@@ -151,6 +152,6 @@
         readonly Action<Settings> setSettings;
         readonly Action<EndpointConfiguration> customConfiguration;
         readonly Action<IHostApplicationBuilder> hostBuilderCustomization;
-        readonly string instanceName = Settings.DEFAULT_SERVICE_NAME;
+        readonly string instanceName = Settings.DEFAULT_INSTANCE_NAME;
     }
 }

--- a/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -45,8 +45,9 @@ namespace ServiceControl.Audit.AcceptanceTests.TestSupport
 
             var loggingSettings = new LoggingSettings(Settings.SettingsRootNamespace, defaultLevel: NLog.LogLevel.Debug, logPath: logPath);
 
-            settings = new Settings(instanceName, transportToUse.TypeName, persistenceToUse.PersistenceType, loggingSettings)
+            settings = new Settings(transportToUse.TypeName, persistenceToUse.PersistenceType, loggingSettings)
             {
+                InstanceName = instanceName,
                 TransportConnectionString = transportToUse.ConnectionString,
                 MaximumConcurrencyLevel = 2,
                 ServiceControlQueueAddress = "SHOULDNOTBEUSED",
@@ -118,9 +119,9 @@ namespace ServiceControl.Audit.AcceptanceTests.TestSupport
                 {
                     var logitem = new ScenarioContext.LogItem
                     {
-                        Endpoint = settings.ServiceName,
+                        Endpoint = settings.InstanceName,
                         Level = NServiceBus.Logging.LogLevel.Fatal,
-                        LoggerName = $"{settings.ServiceName}.CriticalError",
+                        LoggerName = $"{settings.InstanceName}.CriticalError",
                         Message = $"{criticalErrorContext.Error}{Environment.NewLine}{criticalErrorContext.Exception}"
                     };
                     context.Logs.Enqueue(logitem);
@@ -152,7 +153,7 @@ namespace ServiceControl.Audit.AcceptanceTests.TestSupport
             }
         }
 
-        string instanceName = Settings.DEFAULT_SERVICE_NAME;
+        string instanceName = Settings.DEFAULT_INSTANCE_NAME;
         WebApplication host;
         Settings settings;
     }

--- a/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.Audit.UnitTests/API/APIApprovals.cs
@@ -128,10 +128,6 @@
             Approver.Verify(settings);
         }
 
-        static Settings CreateTestSettings() =>
-            new(
-                Settings.DEFAULT_SERVICE_NAME,
-                "LearningTransport",
-                "InMemory");
+        static Settings CreateTestSettings() => new("LearningTransport", "InMemory");
     }
 }

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -8,7 +8,6 @@
   },
   "MessageFilter": null,
   "ValidateConfiguration": true,
-  "SkipQueueCreation": false,
   "RootUrl": "http://localhost:8888/",
   "ApiUrl": "http://localhost:8888/api",
   "Port": 8888,

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -22,7 +22,7 @@
   "AuditLogQueue": "audit.log",
   "AuditRetentionPeriod": "30.00:00:00",
   "MaxBodySizeToStore": 102400,
-  "ServiceName": "Particular.ServiceControl.Audit",
+  "InstanceName": "Particular.ServiceControl.Audit",
   "TransportConnectionString": null,
   "MaximumConcurrencyLevel": 32,
   "ServiceControlQueueAddress": "Particular.ServiceControl",

--- a/src/ServiceControl.Audit.UnitTests/Infrastructure/When_instance_is_setup.cs
+++ b/src/ServiceControl.Audit.UnitTests/Infrastructure/When_instance_is_setup.cs
@@ -34,8 +34,9 @@
 
             var instanceInputQueueName = "SomeInstanceQueue";
 
-            var settings = new Settings(instanceInputQueueName, "FakeTransport", "InMemory")
+            var settings = new Settings("FakeTransport", "InMemory")
             {
+                InstanceName = instanceInputQueueName,
                 ForwardAuditMessages = true,
                 AssemblyLoadContextResolver = static _ => AssemblyLoadContext.Default
             };

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/CommandRunner.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/CommandRunner.cs
@@ -1,19 +1,15 @@
 ﻿namespace ServiceControl.Audit.Infrastructure.Hosting.Commands
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using ServiceControl.Audit.Infrastructure.Settings;
 
-    class CommandRunner(List<Type> commands)
+    class CommandRunner(Type commandType)
     {
         public async Task Execute(HostArguments args, Settings settings)
         {
-            foreach (var commandType in commands)
-            {
-                var command = (AbstractCommand)Activator.CreateInstance(commandType);
-                await command.Execute(args, settings);
-            }
+            var command = (AbstractCommand)Activator.CreateInstance(commandType);
+            await command.Execute(args, settings);
         }
     }
 }

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
@@ -15,7 +15,7 @@
         {
             settings.IngestAuditMessages = false;
 
-            var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
+            var endpointConfiguration = new EndpointConfiguration(settings.InstanceName);
 
             using var tokenSource = new CancellationTokenSource();
 

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/RunCommand.cs
@@ -10,7 +10,7 @@
     {
         public override async Task Execute(HostArguments args, Settings settings)
         {
-            var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
+            var endpointConfiguration = new EndpointConfiguration(settings.InstanceName);
             var assemblyScanner = endpointConfiguration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
 

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
@@ -12,11 +12,9 @@
     {
         public override async Task Execute(HostArguments args, Settings settings)
         {
-            settings.SkipQueueCreation = args.SkipQueueCreation;
-
             if (settings.IngestAuditMessages)
             {
-                if (settings.SkipQueueCreation)
+                if (args.SkipQueueCreation)
                 {
                     Logger.Info("Skipping queue creation");
                 }

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Help.txt
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Help.txt
@@ -1,17 +1,17 @@
 ﻿ServiceControl by Particular Software
 
 USAGE:
-   ServiceControl.exe --maintenance 
+   ServiceControl.exe --maintenance
 
-MAINTENANCE 
+MAINTENANCE
 
-The maintenance switch allows RavenDB Maintenance tasks to be carried out.  In this mode ServiceControl enables the RavenDB Web UI only.  
+The maintenance switch allows RavenDB Maintenance tasks to be carried out.  In this mode ServiceControl enables the RavenDB Web UI only.
 The REST API, message importers and the background document expiry are all disabled.
 
-This mode is only supported when run interactively. 
+This mode is only supported when run interactively.
 
 SERVICE INSTALL AND UNINSTALL AND CONFIGURATION OPTIONS
 
-As of Service Control 1.7 the command line  uninstall and install switches have been removed. 
+As of Service Control 1.7 the command line  uninstall and install switches have been removed.
 Please use the ServiceControl Management Utilities for adding and removing ServiceControl instances.
 

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
@@ -38,11 +38,6 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
                     s => Command = typeof(SetupCommand)
                 },
                 {
-                    "serviceName=",
-                    "Specify the service name for the installed service.",
-                    s => ServiceName = s
-                },
-                {
                     "skip-queue-creation",
                     "Skip queue creation during install/update",
                     s => SkipQueueCreation = true
@@ -93,8 +88,6 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
         public Type Command { get; private set; } = typeof(RunCommand);
 
         public bool Help { get; private set; }
-
-        public string ServiceName { get; private set; } = Settings.DEFAULT_SERVICE_NAME;
 
         public bool SkipQueueCreation { get; private set; }
 

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/HostArguments.cs
@@ -59,10 +59,6 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
                     @"Specify the service name for the installed service.", s => { ServiceName = s; }
                 },
                 {
-                    "userName=",
-                    @"Username for the account the service should run under.", s => { Username = s; }
-                },
-                {
                     "skip-queue-creation",
                     @"Skip queue creation during install/update",
                     s => { SkipQueueCreation = true; }
@@ -116,8 +112,6 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
         public bool Help { get; set; }
 
         public string ServiceName { get; set; }
-
-        public string Username { get; set; }
 
         public bool SkipQueueCreation { get; set; }
 

--- a/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
@@ -18,7 +18,7 @@ namespace ServiceControl.Audit.Infrastructure
             TransportSettings transportSettings,
             Func<ICriticalErrorContext, CancellationToken, Task> onCriticalError, EndpointConfiguration configuration)
         {
-            var endpointName = settings.ServiceName;
+            var endpointName = settings.InstanceName;
             if (configuration == null)
             {
                 configuration = new EndpointConfiguration(endpointName);

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -24,8 +24,11 @@
                 ServiceName = DEFAULT_SERVICE_NAME;
             }
 
-            // Overwrite the service name if it is specified in ENVVAR, reg, or config file
+            // Overwrite the service name if it is specified in ENVVAR, reg, or config file -- LEGACY SETTING NAME
             ServiceName = SettingsReader.Read(SettingsRootNamespace, "InternalQueueName", ServiceName);
+
+            // Overwrite the service name if it is specified in ENVVAR, reg, or config file
+            ServiceName = SettingsReader.Read(SettingsRootNamespace, "ServiceName", ServiceName);
 
             TransportType = transportType ?? SettingsReader.Read<string>(SettingsRootNamespace, "TransportType");
 

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -93,8 +93,6 @@
 
         public bool ValidateConfiguration => SettingsReader.Read(SettingsRootNamespace, "ValidateConfig", true);
 
-        public bool SkipQueueCreation { get; set; }
-
         public string RootUrl
         {
             get

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -13,22 +13,15 @@
 
     public class Settings
     {
-        public Settings(string serviceName = null, string transportType = null, string persisterType = null, LoggingSettings loggingSettings = null)
+        public Settings(string transportType = null, string persisterType = null, LoggingSettings loggingSettings = null)
         {
             LoggingSettings = loggingSettings ?? new(SettingsRootNamespace);
 
-            ServiceName = serviceName;
+            // Overwrite the instance name if it is specified in ENVVAR, reg, or config file -- LEGACY SETTING NAME
+            InstanceName = SettingsReader.Read(SettingsRootNamespace, "InternalQueueName", InstanceName);
 
-            if (string.IsNullOrEmpty(serviceName))
-            {
-                ServiceName = DEFAULT_SERVICE_NAME;
-            }
-
-            // Overwrite the service name if it is specified in ENVVAR, reg, or config file -- LEGACY SETTING NAME
-            ServiceName = SettingsReader.Read(SettingsRootNamespace, "InternalQueueName", ServiceName);
-
-            // Overwrite the service name if it is specified in ENVVAR, reg, or config file
-            ServiceName = SettingsReader.Read(SettingsRootNamespace, "ServiceName", ServiceName);
+            // Overwrite the instance name if it is specified in ENVVAR, reg, or config file
+            InstanceName = SettingsReader.Read(SettingsRootNamespace, "InstanceName", InstanceName);
 
             TransportType = transportType ?? SettingsReader.Read<string>(SettingsRootNamespace, "TransportType");
 
@@ -148,7 +141,7 @@
             set => maxBodySizeToStore = value;
         }
 
-        public string ServiceName { get; }
+        public string InstanceName { get; init; } = DEFAULT_INSTANCE_NAME;
 
         public string TransportConnectionString { get; set; }
         public int MaximumConcurrencyLevel { get; set; }
@@ -162,7 +155,7 @@
         {
             var transportSettings = new TransportSettings
             {
-                EndpointName = ServiceName,
+                EndpointName = InstanceName,
                 ConnectionString = TransportConnectionString,
                 MaxConcurrency = MaximumConcurrencyLevel,
                 TransportType = TransportType,
@@ -284,7 +277,7 @@
 
         int maxBodySizeToStore = SettingsReader.Read(SettingsRootNamespace, "MaxBodySizeToStore", MaxBodySizeToStoreDefault);
 
-        public const string DEFAULT_SERVICE_NAME = "Particular.ServiceControl.Audit";
+        public const string DEFAULT_INSTANCE_NAME = "Particular.ServiceControl.Audit";
         public static readonly SettingsRootNamespace SettingsRootNamespace = new("ServiceControl.Audit");
 
         const int MaxBodySizeToStoreDefault = 102400; //100 kb

--- a/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
@@ -47,7 +47,7 @@
             {
                 Host = new
                 {
-                    settings.ServiceName,
+                    settings.InstanceName,
                     Logging = new
                     {
                         settings.LoggingSettings.LogPath,

--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -22,6 +22,6 @@ if (arguments.Help)
 var loggingSettings = new LoggingSettings(Settings.SettingsRootNamespace);
 LoggingConfigurator.ConfigureLogging(loggingSettings);
 
-var settings = new Settings(arguments.ServiceName, loggingSettings: loggingSettings);
+var settings = new Settings(loggingSettings: loggingSettings);
 
 await new CommandRunner(arguments.Command).Execute(arguments, settings);

--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -24,4 +24,4 @@ LoggingConfigurator.ConfigureLogging(loggingSettings);
 
 var settings = new Settings(arguments.ServiceName, loggingSettings: loggingSettings);
 
-await new CommandRunner(arguments.Commands).Execute(arguments, settings);
+await new CommandRunner(arguments.Command).Execute(arguments, settings);

--- a/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/MonitoringAddAttachment.cs
@@ -58,6 +58,7 @@
             {
                 DisplayName = viewModel.InstanceName,
                 Name = viewModel.InstanceName.Replace(' ', '.'),
+                InstanceName = viewModel.InstanceName.Replace(' ', '.'),
                 ServiceDescription = viewModel.Description,
                 InstallPath = viewModel.DestinationPath,
                 LogPath = viewModel.LogPath,

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddAttachment.cs
@@ -58,6 +58,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
             {
                 serviceControlNewInstance.DisplayName = viewModel.ServiceControl.InstanceName;
                 serviceControlNewInstance.Name = viewModel.ServiceControl.InstanceName.Replace(' ', '.');
+                serviceControlNewInstance.InstanceName = viewModel.ServiceControl.InstanceName.Replace(' ', '.');
                 serviceControlNewInstance.ServiceDescription = viewModel.ServiceControl.Description;
                 serviceControlNewInstance.DBPath = viewModel.ServiceControl.DatabasePath;
                 serviceControlNewInstance.LogPath = viewModel.ServiceControl.LogPath;
@@ -82,6 +83,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
             {
                 auditNewInstance.DisplayName = viewModel.ServiceControlAudit.InstanceName;
                 auditNewInstance.Name = viewModel.ServiceControlAudit.InstanceName.Replace(' ', '.');
+                auditNewInstance.InstanceName = viewModel.ServiceControlAudit.InstanceName.Replace(' ', '.');
                 auditNewInstance.ServiceDescription = viewModel.ServiceControlAudit.Description;
                 auditNewInstance.DBPath = viewModel.ServiceControlAudit.DatabasePath;
                 auditNewInstance.LogPath = viewModel.ServiceControlAudit.LogPath;
@@ -97,7 +99,7 @@ namespace ServiceControl.Config.UI.InstanceAdd
                 auditNewInstance.AuditRetentionPeriod = viewModel.ServiceControlAudit.AuditRetentionPeriod;
                 auditNewInstance.ServiceAccount = viewModel.ServiceControlAudit.ServiceAccount;
                 auditNewInstance.ServiceAccountPwd = viewModel.ServiceControlAudit.Password;
-                auditNewInstance.ServiceControlQueueAddress = serviceControlNewInstance == null ? string.Empty : serviceControlNewInstance.Name;
+                auditNewInstance.ServiceControlQueueAddress = serviceControlNewInstance == null ? string.Empty : serviceControlNewInstance.InstanceName;
                 auditNewInstance.EnableFullTextSearchOnBodies = viewModel.ServiceControlAudit.EnableFullTextSearchOnBodies.Value;
             }
 

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsView.xaml
@@ -222,10 +222,10 @@
         </GroupBox>
         <GroupBox Grid.Row="7"
                   Grid.Column="1"
-                  Header="ENDPOINT NAME"
+                  Header="INSTANCE/QUEUE NAME"
                   Margin="0 1 0 0"
                   HeaderTemplate="{StaticResource SimpleHeaderedGroupBox}">
-            <TextBlock FontSize="14px" Text="{Binding Name}" />
+            <TextBlock FontSize="14px" Text="{Binding InstanceName}" />
         </GroupBox>
 
         <GroupBox Grid.Row="8"

--- a/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceDetails/InstanceDetailsViewModel.cs
@@ -84,6 +84,8 @@
 
         public string Name => ServiceInstance.Name;
 
+        public string InstanceName => ServiceInstance.InstanceName;
+
         public string Host
         {
             get

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/NewServiceControlAuditInstance.cs
@@ -145,6 +145,7 @@
             newAuditInstance.LogPath = LogPath;
             newAuditInstance.DBPath = DBPath;
             newAuditInstance.Name = Name;
+            newAuditInstance.InstanceName = Name;
             newAuditInstance.DisplayName = string.IsNullOrWhiteSpace(DisplayName) ? Name : DisplayName;
             newAuditInstance.ServiceDescription = Description;
             newAuditInstance.ServiceAccount = ServiceAccount;

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/PsAuditInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/AuditInstances/PsAuditInstance.cs
@@ -6,23 +6,34 @@
 
     public class PsAuditInstance
     {
-        public string Name { get; set; }
+        public string ServiceName { get; set; }
+
+        public string InstanceName { get; set; }
+
         public string Url { get; set; }
+
         public string HostName { get; set; }
+
         public int Port { get; set; }
+
         public int? DatabaseMaintenancePort { get; set; }
 
         public string InstallPath { get; set; }
+
         public string DBPath { get; set; }
+
         public string LogPath { get; set; }
 
         public string TransportPackageName { get; set; }
+
         public string ConnectionString { get; set; }
 
         public string PersistencePackageName { get; set; }
 
         public string AuditQueue { get; set; }
+
         public string AuditLogQueue { get; set; }
+
         public bool ForwardAuditMessages { get; set; }
 
         public TimeSpan AuditRetentionPeriod { get; set; }
@@ -38,7 +49,8 @@
         public static PsAuditInstance FromInstance(ServiceControlAuditInstance instance)
             => new PsAuditInstance
             {
-                Name = instance.Name,
+                ServiceName = instance.Name,
+                InstanceName = instance.InstanceName,
                 Url = instance.Url,
                 HostName = instance.HostName,
                 Port = instance.Port,

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/NewMonitoringInstance.cs
@@ -119,6 +119,7 @@ namespace ServiceControl.Management.PowerShell
                 InstallPath = InstallPath,
                 LogPath = LogPath,
                 Name = Name,
+                InstanceName = Name,
                 DisplayName = string.IsNullOrWhiteSpace(DisplayName) ? Name : DisplayName,
                 ServiceDescription = Description,
                 ServiceAccount = ServiceAccount,

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/PsMonitoringService.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/MonitoringInstances/PsMonitoringService.cs
@@ -5,25 +5,36 @@
 
     public class PsMonitoringService
     {
-        public string Name { get; set; }
+        public string ServiceName { get; set; }
+
+        public string InstanceName { get; set; }
+
         public string Url { get; set; }
+
         public string HostName { get; set; }
+
         public int Port { get; set; }
 
         public string InstallPath { get; set; }
+
         public string LogPath { get; set; }
 
         public string TransportPackageName { get; set; }
+
         public string ConnectionString { get; set; }
+
         public string ErrorQueue { get; set; }
+
         public string ServiceAccount { get; set; }
+
         public SemanticVersion Version { get; set; }
 
         public static PsMonitoringService FromInstance(MonitoringInstance instance)
         {
             var result = new PsMonitoringService
             {
-                Name = instance.Name,
+                ServiceName = instance.Name,
+                InstanceName = instance.InstanceName,
                 Url = instance.Url,
                 HostName = instance.HostName,
                 Port = instance.Port,

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
@@ -155,6 +155,7 @@ namespace ServiceControl.Management.PowerShell
             details.LogPath = LogPath;
             details.DBPath = DBPath;
             details.Name = Name;
+            details.InstanceName = Name;
             details.DisplayName = string.IsNullOrWhiteSpace(DisplayName) ? Name : DisplayName;
             details.ServiceDescription = Description;
             details.ServiceAccount = ServiceAccount;

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/PSServiceControl.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/PSServiceControl.cs
@@ -8,21 +8,32 @@
 
     public class PsServiceControl
     {
-        public string Name { get; set; }
+        public string ServiceName { get; set; }
+
+        public string InstanceName { get; set; }
+
         public string Url { get; set; }
+
         public string HostName { get; set; }
+
         public int Port { get; set; }
+
         public int? DatabaseMaintenancePort { get; set; }
 
         public string InstallPath { get; set; }
+
         public string DBPath { get; set; }
+
         public string LogPath { get; set; }
 
         public string TransportPackageName { get; set; }
+
         public string ConnectionString { get; set; }
 
         public string ErrorQueue { get; set; }
+
         public string ErrorLogQueue { get; set; }
+
         public bool ForwardErrorMessages { get; set; }
 
         public TimeSpan ErrorRetentionPeriod { get; set; }
@@ -47,7 +58,8 @@
         {
             var result = new PsServiceControl
             {
-                Name = instance.Name,
+                ServiceName = instance.Name,
+                InstanceName = instance.InstanceName,
                 Url = instance.Url,
                 HostName = instance.HostName,
                 Port = instance.Port,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -75,7 +75,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.TestSupport
             using (new DiagnosticTimer($"Creating infrastructure for {settings.EndpointName}"))
             {
                 var setupCommand = new SetupCommand();
-                await setupCommand.Execute(settings);
+                await setupCommand.Execute(new HostArguments([]), settings);
             }
 
             var configuration = new EndpointConfiguration(settings.EndpointName);

--- a/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -71,18 +71,18 @@ namespace ServiceControl.Monitoring.AcceptanceTests.TestSupport
 
             setSettings(settings);
 
-            using (new DiagnosticTimer($"Creating infrastructure for {settings.ServiceName}"))
+            using (new DiagnosticTimer($"Creating infrastructure for {settings.InstanceName}"))
             {
                 var setupCommand = new SetupCommand();
                 await setupCommand.Execute(new HostArguments([]), settings);
             }
 
-            var configuration = new EndpointConfiguration(settings.ServiceName);
+            var configuration = new EndpointConfiguration(settings.InstanceName);
             configuration.CustomizeServiceControlMonitoringEndpointTesting(context);
 
             customConfiguration(configuration);
 
-            using (new DiagnosticTimer($"Starting host for {settings.ServiceName}"))
+            using (new DiagnosticTimer($"Starting host for {settings.InstanceName}"))
             {
                 var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 Directory.CreateDirectory(logPath);
@@ -96,9 +96,9 @@ namespace ServiceControl.Monitoring.AcceptanceTests.TestSupport
                 {
                     var logitem = new ScenarioContext.LogItem
                     {
-                        Endpoint = settings.ServiceName,
+                        Endpoint = settings.InstanceName,
                         Level = LogLevel.Fatal,
-                        LoggerName = $"{settings.ServiceName}.CriticalError",
+                        LoggerName = $"{settings.InstanceName}.CriticalError",
                         Message = $"{criticalErrorContext.Error}{Environment.NewLine}{criticalErrorContext.Exception}"
                     };
                     context.Logs.Enqueue(logitem);
@@ -112,13 +112,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.TestSupport
                 host.UseServiceControlMonitoring();
                 await host.StartAsync();
 
-                HttpClient = host.Services.GetRequiredKeyedService<TestServer>(settings.ServiceName).CreateClient();
+                HttpClient = host.Services.GetRequiredKeyedService<TestServer>(settings.InstanceName).CreateClient();
             }
         }
 
         public override async Task Stop(CancellationToken cancellationToken = default)
         {
-            using (new DiagnosticTimer($"Test TearDown for {settings.ServiceName}"))
+            using (new DiagnosticTimer($"Test TearDown for {settings.InstanceName}"))
             {
                 await host.StopAsync(cancellationToken);
                 HttpClient.Dispose();

--- a/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -35,7 +35,6 @@ namespace ServiceControl.Monitoring.AcceptanceTests.TestSupport
         {
             settings = new Settings
             {
-                EndpointName = Settings.DEFAULT_ENDPOINT_NAME,
                 TransportType = transportToUse.TypeName,
                 ConnectionString = transportToUse.ConnectionString,
                 HttpHostName = "localhost",
@@ -72,18 +71,18 @@ namespace ServiceControl.Monitoring.AcceptanceTests.TestSupport
 
             setSettings(settings);
 
-            using (new DiagnosticTimer($"Creating infrastructure for {settings.EndpointName}"))
+            using (new DiagnosticTimer($"Creating infrastructure for {settings.ServiceName}"))
             {
                 var setupCommand = new SetupCommand();
                 await setupCommand.Execute(new HostArguments([]), settings);
             }
 
-            var configuration = new EndpointConfiguration(settings.EndpointName);
+            var configuration = new EndpointConfiguration(settings.ServiceName);
             configuration.CustomizeServiceControlMonitoringEndpointTesting(context);
 
             customConfiguration(configuration);
 
-            using (new DiagnosticTimer($"Starting host for {settings.EndpointName}"))
+            using (new DiagnosticTimer($"Starting host for {settings.ServiceName}"))
             {
                 var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 Directory.CreateDirectory(logPath);
@@ -113,13 +112,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.TestSupport
                 host.UseServiceControlMonitoring();
                 await host.StartAsync();
 
-                HttpClient = host.Services.GetRequiredKeyedService<TestServer>(settings.EndpointName).CreateClient();
+                HttpClient = host.Services.GetRequiredKeyedService<TestServer>(settings.ServiceName).CreateClient();
             }
         }
 
         public override async Task Stop(CancellationToken cancellationToken = default)
         {
-            using (new DiagnosticTimer($"Test TearDown for {settings.EndpointName}"))
+            using (new DiagnosticTimer($"Test TearDown for {settings.ServiceName}"))
             {
                 await host.StopAsync(cancellationToken);
                 HttpClient.Dispose();

--- a/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/WebApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/WebApplicationBuilderExtensions.cs
@@ -14,7 +14,7 @@ static class WebApplicationBuilderExtensions
 
         hostBuilder.WebHost.UseTestServer(options => options.BaseAddress = new Uri(settings.RootUrl));
         // This facilitates receiving the test server anywhere where DI is available
-        hostBuilder.Services.AddKeyedSingleton(settings.EndpointName,
+        hostBuilder.Services.AddKeyedSingleton(settings.ServiceName,
             (provider, _) => (TestServer)provider.GetRequiredService<IServer>());
 
         // // For acceptance testing purposes we are adding more controllers to the host

--- a/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/WebApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/WebApplicationBuilderExtensions.cs
@@ -14,7 +14,7 @@ static class WebApplicationBuilderExtensions
 
         hostBuilder.WebHost.UseTestServer(options => options.BaseAddress = new Uri(settings.RootUrl));
         // This facilitates receiving the test server anywhere where DI is available
-        hostBuilder.Services.AddKeyedSingleton(settings.ServiceName,
+        hostBuilder.Services.AddKeyedSingleton(settings.InstanceName,
             (provider, _) => (TestServer)provider.GetRequiredService<IServer>());
 
         // // For acceptance testing purposes we are adding more controllers to the host

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_disconnected_count.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_disconnected_count.cs
@@ -22,7 +22,7 @@
 
             await Define<TestContext>(ctx => context = ctx)
                 .WithEndpoint<MonitoredEndpoint>(b =>
-                b.CustomConfig(endpointConfig => endpointConfig.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromMilliseconds(200), "First"))
+                b.CustomConfig(endpointConfig => endpointConfig.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromMilliseconds(200), "First"))
                 .ToCreateInstance(endpointConfig => Endpoint.Create(endpointConfig), async (startableEndpoint, cancellationToken) =>
                 {
                     context.FirstInstance = await startableEndpoint.Start(cancellationToken);
@@ -30,7 +30,7 @@
                     return context.FirstInstance;
                 }))
                 .WithEndpoint<MonitoredEndpoint>(b =>
-                b.CustomConfig(endpointConfig => endpointConfig.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromMilliseconds(200), "Second"))
+                b.CustomConfig(endpointConfig => endpointConfig.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromMilliseconds(200), "Second"))
                 .ToCreateInstance(endpointConfig => Endpoint.Create(endpointConfig), async (startableEndpoint, cancellationToken) =>
                 {
                     context.SecondInstance = await startableEndpoint.Start(cancellationToken);

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_disconnected_count.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_disconnected_count.cs
@@ -22,7 +22,7 @@
 
             await Define<TestContext>(ctx => context = ctx)
                 .WithEndpoint<MonitoredEndpoint>(b =>
-                b.CustomConfig(endpointConfig => endpointConfig.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_ENDPOINT_NAME, TimeSpan.FromMilliseconds(200), "First"))
+                b.CustomConfig(endpointConfig => endpointConfig.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromMilliseconds(200), "First"))
                 .ToCreateInstance(endpointConfig => Endpoint.Create(endpointConfig), async (startableEndpoint, cancellationToken) =>
                 {
                     context.FirstInstance = await startableEndpoint.Start(cancellationToken);
@@ -30,7 +30,7 @@
                     return context.FirstInstance;
                 }))
                 .WithEndpoint<MonitoredEndpoint>(b =>
-                b.CustomConfig(endpointConfig => endpointConfig.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_ENDPOINT_NAME, TimeSpan.FromMilliseconds(200), "Second"))
+                b.CustomConfig(endpointConfig => endpointConfig.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromMilliseconds(200), "Second"))
                 .ToCreateInstance(endpointConfig => Endpoint.Create(endpointConfig), async (startableEndpoint, cancellationToken) =>
                 {
                     context.SecondInstance = await startableEndpoint.Start(cancellationToken);

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_queue_length_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_queue_length_data.cs
@@ -33,7 +33,7 @@
                          ec.UniquelyIdentifyRunningInstance()
                              .UsingCustomIdentifier(instanceId);
                          ec.EnableMetrics()
-                             .SendMetricDataToServiceControl(Settings.DEFAULT_ENDPOINT_NAME, TimeSpan.FromSeconds(1));
+                             .SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1));
                      });
                      c.DoNotFailOnErrorMessages();
                      c.When(async s =>
@@ -50,7 +50,7 @@
                      {
                          ec.MakeInstanceUniquelyAddressable("2");
                          ec.EnableMetrics()
-                             .SendMetricDataToServiceControl(Settings.DEFAULT_ENDPOINT_NAME,
+                             .SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME,
                              TimeSpan.FromSeconds(1),
                              metricsInstanceId.ToString("N"));
                      });

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_queue_length_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_queue_length_data.cs
@@ -33,7 +33,7 @@
                          ec.UniquelyIdentifyRunningInstance()
                              .UsingCustomIdentifier(instanceId);
                          ec.EnableMetrics()
-                             .SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1));
+                             .SendMetricDataToServiceControl(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromSeconds(1));
                      });
                      c.DoNotFailOnErrorMessages();
                      c.When(async s =>
@@ -50,7 +50,7 @@
                      {
                          ec.MakeInstanceUniquelyAddressable("2");
                          ec.EnableMetrics()
-                             .SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME,
+                             .SendMetricDataToServiceControl(Settings.DEFAULT_INSTANCE_NAME,
                              TimeSpan.FromSeconds(1),
                              metricsInstanceId.ToString("N"));
                      });

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_retries_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_retries_data.cs
@@ -46,7 +46,7 @@
             public EndpointWithRetries() =>
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
-                    c.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_ENDPOINT_NAME, TimeSpan.FromSeconds(1));
+                    c.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1));
                 });
 
             class Handler(TestContext testContext) : IHandleMessages<SampleMessage>

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_retries_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_retries_data.cs
@@ -46,7 +46,7 @@
             public EndpointWithRetries() =>
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
-                    c.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1));
+                    c.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromSeconds(1));
                 });
 
             class Handler(TestContext testContext) : IHandleMessages<SampleMessage>

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_timings_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_timings_data.cs
@@ -37,7 +37,7 @@
             public EndpointWithTimings() =>
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
-                    c.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_ENDPOINT_NAME, TimeSpan.FromSeconds(1));
+                    c.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1));
                 });
 
             class Handler : IHandleMessages<SampleMessage>

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_timings_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_timings_data.cs
@@ -37,7 +37,7 @@
             public EndpointWithTimings() =>
                 EndpointSetup<DefaultServerWithoutAudit>(c =>
                 {
-                    c.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_SERVICE_NAME, TimeSpan.FromSeconds(1));
+                    c.EnableMetrics().SendMetricDataToServiceControl(Settings.DEFAULT_INSTANCE_NAME, TimeSpan.FromSeconds(1));
                 });
 
             class Handler : IHandleMessages<SampleMessage>

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_sending_legacy_metric_report.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_sending_legacy_metric_report.cs
@@ -19,7 +19,7 @@
                     b.When(session =>
                     {
                         var sendOptions = new SendOptions();
-                        sendOptions.SetDestination(Settings.DEFAULT_ENDPOINT_NAME);
+                        sendOptions.SetDestination(Settings.DEFAULT_SERVICE_NAME);
                         sendOptions.SetHeader(MetricHeaders.MetricInstanceId, "MetricInstanceId");
                         return session.Send(new MetricReport { Data = "{}" }, sendOptions);
                     }))

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_sending_legacy_metric_report.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_sending_legacy_metric_report.cs
@@ -19,7 +19,7 @@
                     b.When(session =>
                     {
                         var sendOptions = new SendOptions();
-                        sendOptions.SetDestination(Settings.DEFAULT_SERVICE_NAME);
+                        sendOptions.SetDestination(Settings.DEFAULT_INSTANCE_NAME);
                         sendOptions.SetHeader(MetricHeaders.MetricInstanceId, "MetricInstanceId");
                         return session.Send(new MetricReport { Data = "{}" }, sendOptions);
                     }))

--- a/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
@@ -1,5 +1,4 @@
 {
-  "EndpointName": "Particular.Monitoring",
   "LoggingSettings": {
     "LogLevel": {
       "Name": "Info",
@@ -11,12 +10,9 @@
   "TransportType": "NServiceBus.ServiceControlLearningTransport, ServiceControl.Transports.LearningTransport",
   "ConnectionString": null,
   "ErrorQueue": "error",
-  "Username": null,
-  "EnableInstallers": false,
   "HttpHostName": "localhost",
   "HttpPort": "9999",
   "EndpointUptimeGracePeriod": "00:00:40",
-  "SkipQueueCreation": false,
   "RootUrl": "http://localhost:9999/",
   "MaximumConcurrencyLevel": 32,
   "ServiceControlThroughputDataQueue": "ServiceControl.ThroughputData"

--- a/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
@@ -6,7 +6,7 @@
     },
     "LogPath": "C:\\Logs"
   },
-  "ServiceName": "Particular.Monitoring",
+  "InstanceName": "Particular.Monitoring",
   "TransportType": "NServiceBus.ServiceControlLearningTransport, ServiceControl.Transports.LearningTransport",
   "ConnectionString": null,
   "ErrorQueue": "error",

--- a/src/ServiceControl.Monitoring/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Monitoring/HostApplicationBuilderExtensions.cs
@@ -83,12 +83,6 @@ public static class HostApplicationBuilderExtensions
             services.AddHostedService<ReportThroughputHostedService>();
         }
 
-
-        if (settings.EnableInstallers)
-        {
-            config.EnableInstallers(settings.Username);
-        }
-
         config.DefineCriticalErrorAction(onCriticalError);
 
         config.GetSettings().Set(settings);

--- a/src/ServiceControl.Monitoring/Hosting/Commands/AbstractCommand.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/AbstractCommand.cs
@@ -4,6 +4,6 @@
 
     abstract class AbstractCommand
     {
-        public abstract Task Execute(Settings settings);
+        public abstract Task Execute(HostArguments args, Settings settings);
     }
 }

--- a/src/ServiceControl.Monitoring/Hosting/Commands/CommandRunner.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/CommandRunner.cs
@@ -1,18 +1,14 @@
 namespace ServiceControl.Monitoring
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
 
-    class CommandRunner(List<Type> commands)
+    class CommandRunner(Type commandType)
     {
         public async Task Execute(HostArguments args, Settings settings)
         {
-            foreach (var commandType in commands)
-            {
-                var command = (AbstractCommand)Activator.CreateInstance(commandType);
-                await command.Execute(args, settings);
-            }
+            var command = (AbstractCommand)Activator.CreateInstance(commandType);
+            await command.Execute(args, settings);
         }
     }
 }

--- a/src/ServiceControl.Monitoring/Hosting/Commands/CommandRunner.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/CommandRunner.cs
@@ -4,22 +4,15 @@ namespace ServiceControl.Monitoring
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
-    class CommandRunner
+    class CommandRunner(List<Type> commands)
     {
-        public CommandRunner(List<Type> commands)
-        {
-            this.commands = commands;
-        }
-
-        public async Task Execute(Settings settings)
+        public async Task Execute(HostArguments args, Settings settings)
         {
             foreach (var commandType in commands)
             {
                 var command = (AbstractCommand)Activator.CreateInstance(commandType);
-                await command.Execute(settings);
+                await command.Execute(args, settings);
             }
         }
-
-        List<Type> commands;
     }
 }

--- a/src/ServiceControl.Monitoring/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/RunCommand.cs
@@ -10,7 +10,7 @@ namespace ServiceControl.Monitoring
     {
         public override async Task Execute(HostArguments args, Settings settings)
         {
-            var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
+            var endpointConfiguration = new EndpointConfiguration(settings.InstanceName);
 
             var hostBuilder = WebApplication.CreateBuilder();
             hostBuilder.AddServiceControlMonitoring((_, __) => Task.CompletedTask, settings, endpointConfiguration);

--- a/src/ServiceControl.Monitoring/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/RunCommand.cs
@@ -8,7 +8,7 @@ namespace ServiceControl.Monitoring
 
     class RunCommand : AbstractCommand
     {
-        public override async Task Execute(Settings settings)
+        public override async Task Execute(HostArguments args, Settings settings)
         {
             var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
 

--- a/src/ServiceControl.Monitoring/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Commands/SetupCommand.cs
@@ -6,9 +6,9 @@ namespace ServiceControl.Monitoring
 
     class SetupCommand : AbstractCommand
     {
-        public override Task Execute(Settings settings)
+        public override Task Execute(HostArguments args, Settings settings)
         {
-            if (settings.SkipQueueCreation)
+            if (args.SkipQueueCreation)
             {
                 Logger.Info("Skipping queue creation");
                 return Task.CompletedTask;

--- a/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
@@ -1,20 +1,17 @@
 ﻿namespace ServiceControl.Monitoring
 {
     using System;
-    using System.Collections.Generic;
 
     class HostArguments
     {
         public HostArguments(string[] args)
         {
-            var executionMode = ExecutionMode.Run;
-
             var setupOptions = new OptionSet
             {
                 {
                     "s|setup",
                     "Install queues",
-                    s => executionMode = ExecutionMode.Setup
+                    s => Command = typeof(SetupCommand)
                 },
                 {
                     "serviceName=",
@@ -29,29 +26,12 @@
             };
 
             setupOptions.Parse(args);
-
-            switch (executionMode)
-            {
-                case ExecutionMode.Setup:
-                    Commands.Add(typeof(SetupCommand));
-                    break;
-                case ExecutionMode.Run:
-                default:
-                    Commands.Add(typeof(RunCommand));
-                    break;
-            }
         }
 
-        public List<Type> Commands { get; } = [];
+        public Type Command { get; private set; } = typeof(RunCommand);
 
-        public string ServiceName { get; set; }
+        public string ServiceName { get; private set; }
 
-        public bool SkipQueueCreation { get; set; }
-
-        enum ExecutionMode
-        {
-            Run,
-            Setup
-        }
+        public bool SkipQueueCreation { get; private set; }
     }
 }

--- a/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
@@ -14,11 +14,6 @@
                     s => Command = typeof(SetupCommand)
                 },
                 {
-                    "serviceName=",
-                    "Specify the service name for the installed service.",
-                    s => ServiceName = s
-                },
-                {
                     "skip-queue-creation",
                     "Skip queue creation during install/update",
                     s => SkipQueueCreation = true
@@ -29,8 +24,6 @@
         }
 
         public Type Command { get; private set; } = typeof(RunCommand);
-
-        public string ServiceName { get; private set; } = Settings.DEFAULT_SERVICE_NAME;
 
         public bool SkipQueueCreation { get; private set; }
     }

--- a/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
@@ -19,17 +19,12 @@
                 {
                     "serviceName=",
                     "Specify the service name for the installed service.",
-                    s => overrides.Add(settings => { settings.ServiceName = s; })
-                },
-                {
-                    "userName=",
-                    "Username for the account the service should run under.",
-                    s => overrides.Add(settings => settings.Username = s)
+                    s => ServiceName = s
                 },
                 {
                     "skip-queue-creation",
                     "Skip queue creation during install/update",
-                    s => overrides.Add(settings => settings.SkipQueueCreation = true)
+                    s => SkipQueueCreation = true
                 }
             };
 
@@ -49,15 +44,9 @@
 
         public List<Type> Commands { get; } = [];
 
-        public void ApplyOverridesTo(Settings settings)
-        {
-            foreach (var @override in overrides)
-            {
-                @override.Invoke(settings);
-            }
-        }
+        public string ServiceName { get; set; }
 
-        IList<Action<Settings>> overrides = [];
+        public bool SkipQueueCreation { get; set; }
 
         enum ExecutionMode
         {

--- a/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
+++ b/src/ServiceControl.Monitoring/Hosting/HostArguments.cs
@@ -30,7 +30,7 @@
 
         public Type Command { get; private set; } = typeof(RunCommand);
 
-        public string ServiceName { get; private set; }
+        public string ServiceName { get; private set; } = Settings.DEFAULT_SERVICE_NAME;
 
         public bool SkipQueueCreation { get; private set; }
     }

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -15,6 +15,5 @@ var loggingSettings = new LoggingSettings(Settings.SettingsRootNamespace);
 LoggingConfigurator.ConfigureLogging(loggingSettings);
 
 var settings = new Settings(loggingSettings);
-arguments.ApplyOverridesTo(settings);
 
-await new CommandRunner(arguments.Commands).Execute(settings);
+await new CommandRunner(arguments.Commands).Execute(arguments, settings);

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -14,6 +14,6 @@ var arguments = new HostArguments(args);
 var loggingSettings = new LoggingSettings(Settings.SettingsRootNamespace);
 LoggingConfigurator.ConfigureLogging(loggingSettings);
 
-var settings = new Settings(loggingSettings);
+var settings = new Settings(arguments.ServiceName, loggingSettings: loggingSettings);
 
 await new CommandRunner(arguments.Command).Execute(arguments, settings);

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -14,6 +14,6 @@ var arguments = new HostArguments(args);
 var loggingSettings = new LoggingSettings(Settings.SettingsRootNamespace);
 LoggingConfigurator.ConfigureLogging(loggingSettings);
 
-var settings = new Settings(arguments.ServiceName, loggingSettings: loggingSettings);
+var settings = new Settings(loggingSettings: loggingSettings);
 
 await new CommandRunner(arguments.Command).Execute(arguments, settings);

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -16,4 +16,4 @@ LoggingConfigurator.ConfigureLogging(loggingSettings);
 
 var settings = new Settings(loggingSettings);
 
-await new CommandRunner(arguments.Commands).Execute(arguments, settings);
+await new CommandRunner(arguments.Command).Execute(arguments, settings);

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -59,17 +59,11 @@ namespace ServiceControl.Monitoring
 
         public string ErrorQueue { get; set; }
 
-        public string Username { get; set; }
-
-        public bool EnableInstallers { get; set; }
-
         public string HttpHostName { get; set; }
 
         public string HttpPort { get; set; }
 
         public TimeSpan EndpointUptimeGracePeriod { get; set; }
-
-        public bool SkipQueueCreation { get; set; }
 
         public string RootUrl => $"http://{HttpHostName}:{HttpPort}/";
 

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -16,9 +16,6 @@ namespace ServiceControl.Monitoring
         {
             LoggingSettings = loggingSettings ?? new(SettingsRootNamespace);
 
-            // Overwrite the instance name if it is specified in ENVVAR, reg, or config file -- LEGACY SETTING NAME
-            InstanceName = SettingsReader.Read(SettingsRootNamespace, "EndpointName", InstanceName);
-
             // Overwrite the instance name if it is specified in ENVVAR, reg, or config file
             InstanceName = SettingsReader.Read(SettingsRootNamespace, "InstanceName", InstanceName);
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
@@ -19,7 +19,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests
     [TestFixture]
     abstract class AcceptanceTest : NServiceBusAcceptanceTest, IAcceptanceTestInfrastructureProviderMultiInstance
     {
-        protected static string ServiceControlInstanceName { get; } = Settings.DEFAULT_SERVICE_NAME;
+        protected static string ServiceControlInstanceName { get; } = Settings.DEFAULT_INSTANCE_NAME;
         protected static string ServiceControlAuditInstanceName { get; } = Audit.Infrastructure.Settings.Settings.DEFAULT_SERVICE_NAME;
 
         public Dictionary<string, HttpClient> HttpClients => serviceControlRunnerBehavior.HttpClients;

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
@@ -20,7 +20,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests
     abstract class AcceptanceTest : NServiceBusAcceptanceTest, IAcceptanceTestInfrastructureProviderMultiInstance
     {
         protected static string ServiceControlInstanceName { get; } = Settings.DEFAULT_INSTANCE_NAME;
-        protected static string ServiceControlAuditInstanceName { get; } = Audit.Infrastructure.Settings.Settings.DEFAULT_SERVICE_NAME;
+        protected static string ServiceControlAuditInstanceName { get; } = Audit.Infrastructure.Settings.Settings.DEFAULT_INSTANCE_NAME;
 
         public Dictionary<string, HttpClient> HttpClients => serviceControlRunnerBehavior.HttpClients;
         public Dictionary<string, JsonSerializerOptions> SerializerOptions => serviceControlRunnerBehavior.SerializerOptions;

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/HttpExtensionsMultiinstance.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/HttpExtensionsMultiinstance.cs
@@ -17,37 +17,37 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.TestSupport
                 SerializerOptions = providerMultiInstance.SerializerOptions[instanceName],
             };
 
-        public static Task Put<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, T payload = null, Func<HttpStatusCode, bool> requestHasFailed = null, string instanceName = Settings.DEFAULT_SERVICE_NAME) where T : class
+        public static Task Put<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, T payload = null, Func<HttpStatusCode, bool> requestHasFailed = null, string instanceName = Settings.DEFAULT_INSTANCE_NAME) where T : class
         {
             return providerMultiInstance.ToHttpExtension(instanceName).Put(url, payload, requestHasFailed);
         }
 
-        public static Task<HttpResponseMessage> GetRaw(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, string instanceName = Settings.DEFAULT_SERVICE_NAME)
+        public static Task<HttpResponseMessage> GetRaw(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, string instanceName = Settings.DEFAULT_INSTANCE_NAME)
         {
             return providerMultiInstance.ToHttpExtension(instanceName).GetRaw(url);
         }
 
-        public static Task<ManyResult<T>> TryGetMany<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, Predicate<T> condition = null, string instanceName = Settings.DEFAULT_SERVICE_NAME) where T : class
+        public static Task<ManyResult<T>> TryGetMany<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, Predicate<T> condition = null, string instanceName = Settings.DEFAULT_INSTANCE_NAME) where T : class
         {
             return providerMultiInstance.ToHttpExtension(instanceName).TryGetMany(url, condition);
         }
 
-        public static Task<HttpStatusCode> Patch<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, T payload = null, string instanceName = Settings.DEFAULT_SERVICE_NAME) where T : class
+        public static Task<HttpStatusCode> Patch<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, T payload = null, string instanceName = Settings.DEFAULT_INSTANCE_NAME) where T : class
         {
             return providerMultiInstance.ToHttpExtension(instanceName).Patch(url, payload);
         }
 
-        public static Task<SingleResult<T>> TryGet<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, Predicate<T> condition = null, string instanceName = Settings.DEFAULT_SERVICE_NAME) where T : class
+        public static Task<SingleResult<T>> TryGet<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, Predicate<T> condition = null, string instanceName = Settings.DEFAULT_INSTANCE_NAME) where T : class
         {
             return providerMultiInstance.ToHttpExtension(instanceName).TryGet(url, condition);
         }
 
-        public static Task<SingleResult<T>> TryGetSingle<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, Predicate<T> condition = null, string instanceName = Settings.DEFAULT_SERVICE_NAME) where T : class
+        public static Task<SingleResult<T>> TryGetSingle<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, Predicate<T> condition = null, string instanceName = Settings.DEFAULT_INSTANCE_NAME) where T : class
         {
             return providerMultiInstance.ToHttpExtension(instanceName).TryGetSingle(url, condition);
         }
 
-        public static Task Post<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, T payload = null, Func<HttpStatusCode, bool> requestHasFailed = null, string instanceName = Settings.DEFAULT_SERVICE_NAME) where T : class
+        public static Task Post<T>(this IAcceptanceTestInfrastructureProviderMultiInstance providerMultiInstance, string url, T payload = null, Func<HttpStatusCode, bool> requestHasFailed = null, string instanceName = Settings.DEFAULT_INSTANCE_NAME) where T : class
         {
             return providerMultiInstance.ToHttpExtension(instanceName).Post(url, payload, requestHasFailed);
         }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -62,7 +62,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.TestSupport
                 {
                     auditSettings.ServiceControlQueueAddress = PrimaryInstanceSettings.DEFAULT_INSTANCE_NAME;
                     customServiceControlAuditSettings(auditSettings);
-                    SettingsPerInstance[AuditInstanceSettings.DEFAULT_SERVICE_NAME] = auditSettings;
+                    SettingsPerInstance[AuditInstanceSettings.DEFAULT_INSTANCE_NAME] = auditSettings;
                 }, auditEndpointConfiguration =>
                 {
                     var scanner = auditEndpointConfiguration.AssemblyScanner();
@@ -80,11 +80,11 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.TestSupport
                 },
                 _ => { },
                 auditHostBuilder => auditHostBuilderCustomization(auditHostBuilder));
-            typeof(ScenarioContext).GetProperty("CurrentEndpoint", BindingFlags.Static | BindingFlags.NonPublic)?.SetValue(run.ScenarioContext, AuditInstanceSettings.DEFAULT_SERVICE_NAME);
+            typeof(ScenarioContext).GetProperty("CurrentEndpoint", BindingFlags.Static | BindingFlags.NonPublic)?.SetValue(run.ScenarioContext, AuditInstanceSettings.DEFAULT_INSTANCE_NAME);
             await auditInstanceComponentRunner.Initialize(run);
 
-            HttpClients[AuditInstanceSettings.DEFAULT_SERVICE_NAME] = auditInstanceComponentRunner.HttpClient;
-            SerializerOptions[AuditInstanceSettings.DEFAULT_SERVICE_NAME] = auditInstanceComponentRunner.SerializerOptions;
+            HttpClients[AuditInstanceSettings.DEFAULT_INSTANCE_NAME] = auditInstanceComponentRunner.HttpClient;
+            SerializerOptions[AuditInstanceSettings.DEFAULT_INSTANCE_NAME] = auditInstanceComponentRunner.SerializerOptions;
             var auditInstance = new RemoteInstanceSetting(auditInstanceComponentRunner.InstanceTestServer.BaseAddress.ToString());
             TestServerPerRemoteInstance[auditInstance.InstanceId] = auditInstanceComponentRunner.InstanceTestServer;
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -60,7 +60,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.TestSupport
                 transportToUse,
                 new AcceptanceTestStorageConfiguration(), auditSettings =>
                 {
-                    auditSettings.ServiceControlQueueAddress = PrimaryInstanceSettings.DEFAULT_SERVICE_NAME;
+                    auditSettings.ServiceControlQueueAddress = PrimaryInstanceSettings.DEFAULT_INSTANCE_NAME;
                     customServiceControlAuditSettings(auditSettings);
                     SettingsPerInstance[AuditInstanceSettings.DEFAULT_SERVICE_NAME] = auditSettings;
                 }, auditEndpointConfiguration =>
@@ -94,7 +94,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.TestSupport
                 {
                     primarySettings.RemoteInstances = [auditInstance];
                     customServiceControlSettings(primarySettings);
-                    SettingsPerInstance[PrimaryInstanceSettings.DEFAULT_SERVICE_NAME] = primarySettings;
+                    SettingsPerInstance[PrimaryInstanceSettings.DEFAULT_INSTANCE_NAME] = primarySettings;
                 },
                 primaryEndpointConfiguration =>
                 {
@@ -118,7 +118,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.TestSupport
                     // For example one way to deal with this is to have a custom invoker that figures out the right target based on the base address
                     // in the request URI.
                     primaryHostBuilder.Services.AddKeyedSingleton("Forwarding", () => auditInstanceComponentRunner.InstanceTestServer.CreateHandler());
-                    foreach (var remoteInstance in ((PrimaryInstanceSettings)SettingsPerInstance[PrimaryInstanceSettings.DEFAULT_SERVICE_NAME]).RemoteInstances)
+                    foreach (var remoteInstance in ((PrimaryInstanceSettings)SettingsPerInstance[PrimaryInstanceSettings.DEFAULT_INSTANCE_NAME]).RemoteInstances)
                     {
                         if (TestServerPerRemoteInstance.TryGetValue(remoteInstance.InstanceId, out var testServer))
                         {
@@ -132,11 +132,11 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.TestSupport
 
                     primaryHostBuilderCustomization(primaryHostBuilder);
                 });
-            typeof(ScenarioContext).GetProperty("CurrentEndpoint", BindingFlags.Static | BindingFlags.NonPublic)?.SetValue(run.ScenarioContext, PrimaryInstanceSettings.DEFAULT_SERVICE_NAME);
+            typeof(ScenarioContext).GetProperty("CurrentEndpoint", BindingFlags.Static | BindingFlags.NonPublic)?.SetValue(run.ScenarioContext, PrimaryInstanceSettings.DEFAULT_INSTANCE_NAME);
             await primaryInstanceComponentRunner.Initialize(run);
 
-            HttpClients[PrimaryInstanceSettings.DEFAULT_SERVICE_NAME] = primaryInstanceComponentRunner.HttpClient;
-            SerializerOptions[PrimaryInstanceSettings.DEFAULT_SERVICE_NAME] = primaryInstanceComponentRunner.SerializerOptions;
+            HttpClients[PrimaryInstanceSettings.DEFAULT_INSTANCE_NAME] = primaryInstanceComponentRunner.HttpClient;
+            SerializerOptions[PrimaryInstanceSettings.DEFAULT_INSTANCE_NAME] = primaryInstanceComponentRunner.SerializerOptions;
         }
 
         public override async Task Stop(CancellationToken cancellationToken = default)

--- a/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
+++ b/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
@@ -276,7 +276,7 @@
         class TestReturnToSenderDequeuer : ReturnToSenderDequeuer
         {
             public TestReturnToSenderDequeuer(ReturnToSender returnToSender, IErrorMessageDataStore store, IDomainEvents domainEvents, string endpointName)
-                : base(returnToSender, store, domainEvents, null, null, new Settings(serviceName: endpointName))
+                : base(returnToSender, store, domainEvents, null, null, new Settings { InstanceName = endpointName })
             {
             }
 

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -13,7 +13,6 @@
   "ValidateConfiguration": true,
   "ExternalIntegrationsDispatchingBatchSize": 100,
   "DisableExternalIntegrationsPublishing": false,
-  "SkipQueueCreation": false,
   "RunCleanupBundle": false,
   "RootUrl": "http://localhost:8888/",
   "ApiUrl": "http://localhost:8888/api",

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -34,7 +34,7 @@
   "AuditRetentionPeriod": null,
   "ErrorRetentionPeriod": "10.00:00:00",
   "EventsRetentionPeriod": "14.00:00:00",
-  "ServiceName": "Particular.ServiceControl",
+  "InstanceName": "Particular.ServiceControl",
   "TransportConnectionString": null,
   "ProcessRetryBatchesFrequency": "00:00:30",
   "TimeToRestartErrorIngestionAfterFailure": "00:01:00",

--- a/src/ServiceControl/CustomChecks/InternalCustomChecks/InternalCustomChecks.cs
+++ b/src/ServiceControl/CustomChecks/InternalCustomChecks/InternalCustomChecks.cs
@@ -22,7 +22,7 @@
                 provider.GetRequiredService<HostInformation>(),
                 provider.GetRequiredService<IAsyncTimer>(),
                 provider.GetRequiredService<CustomCheckResultProcessor>(),
-                provider.GetRequiredService<Settings>().ServiceName));
+                provider.GetRequiredService<Settings>().InstanceName));
             return hostBuilder;
         }
     }

--- a/src/ServiceControl/Hosting/Commands/CommandRunner.cs
+++ b/src/ServiceControl/Hosting/Commands/CommandRunner.cs
@@ -1,20 +1,16 @@
 ﻿namespace ServiceControl.Hosting.Commands
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Particular.ServiceControl.Hosting;
     using ServiceBus.Management.Infrastructure.Settings;
 
-    class CommandRunner(List<Type> commands)
+    class CommandRunner(Type commandType)
     {
         public async Task Execute(HostArguments args, Settings settings)
         {
-            foreach (var commandType in commands)
-            {
-                var command = (AbstractCommand)Activator.CreateInstance(commandType);
-                await command.Execute(args, settings);
-            }
+            var command = (AbstractCommand)Activator.CreateInstance(commandType);
+            await command.Execute(args, settings);
         }
     }
 }

--- a/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
@@ -50,7 +50,7 @@
 
         protected virtual EndpointConfiguration CreateEndpointConfiguration(Settings settings)
         {
-            var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
+            var endpointConfiguration = new EndpointConfiguration(settings.InstanceName);
             var assemblyScanner = endpointConfiguration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
 

--- a/src/ServiceControl/Hosting/Commands/RunCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/RunCommand.cs
@@ -13,7 +13,7 @@
     {
         public override async Task Execute(HostArguments args, Settings settings)
         {
-            var endpointConfiguration = new EndpointConfiguration(settings.ServiceName);
+            var endpointConfiguration = new EndpointConfiguration(settings.InstanceName);
             var assemblyScanner = endpointConfiguration.AssemblyScanner();
             assemblyScanner.ExcludeAssemblies("ServiceControl.Plugin");
 

--- a/src/ServiceControl/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/SetupCommand.cs
@@ -14,8 +14,6 @@
     {
         public override async Task Execute(HostArguments args, Settings settings)
         {
-            settings.SkipQueueCreation = args.SkipQueueCreation;
-
             var hostBuilder = Host.CreateApplicationBuilder();
             hostBuilder.AddServiceControlInstallers(settings);
 
@@ -35,7 +33,7 @@
 
             await host.StartAsync();
 
-            if (settings.SkipQueueCreation)
+            if (args.SkipQueueCreation)
             {
                 Logger.Info("Skipping queue creation");
             }

--- a/src/ServiceControl/Hosting/Help.txt
+++ b/src/ServiceControl/Hosting/Help.txt
@@ -1,17 +1,17 @@
 ﻿ServiceControl by Particular Software
 
 USAGE:
-   ServiceControl.exe --maintenance 
+   ServiceControl.exe --maintenance
 
-MAINTENANCE 
+MAINTENANCE
 
-The maintenance switch allows RavenDB Maintenance tasks to be carried out.  In this mode ServiceControl enables the RavenDB Web UI only.  
+The maintenance switch allows RavenDB Maintenance tasks to be carried out.  In this mode ServiceControl enables the RavenDB Web UI only.
 The REST API, message importers and the background document expiry are all disabled.
 
-This mode is only supported when run interactively. 
+This mode is only supported when run interactively.
 
 SERVICE INSTALL AND UNINSTALL AND CONFIGURATION OPTIONS
 
-As of Service Control 1.7 the command line  uninstall and install switches have been removed. 
+As of Service Control 1.7 the command line  uninstall and install switches have been removed.
 Please use the ServiceControl Management Utilities for adding and removing ServiceControl instances.
 

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -38,11 +38,6 @@ namespace Particular.ServiceControl.Hosting
                     s => Command = typeof(SetupCommand)
                 },
                 {
-                    "serviceName=",
-                    "Specify the service name for the installed service.",
-                    s => ServiceName = s
-                },
-                {
                     "skip-queue-creation",
                     "Skip queue creation during install/update",
                     s => SkipQueueCreation = true
@@ -93,8 +88,6 @@ namespace Particular.ServiceControl.Hosting
         public Type Command { get; private set; } = typeof(RunCommand);
 
         public bool Help { get; private set; }
-
-        public string ServiceName { get; private set; } = Settings.DEFAULT_SERVICE_NAME;
 
         public bool SkipQueueCreation { get; private set; }
 

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -59,10 +59,6 @@ namespace Particular.ServiceControl.Hosting
                     @"Specify the service name for the installed service.", s => { ServiceName = s; }
                 },
                 {
-                    "userName=",
-                    @"Username for the account the service should run under.", s => { Username = s; }
-                },
-                {
                     "skip-queue-creation",
                     @"Skip queue creation during install/update",
                     s => { SkipQueueCreation = true; }
@@ -116,8 +112,6 @@ namespace Particular.ServiceControl.Hosting
         public bool Help { get; set; }
 
         public string ServiceName { get; set; }
-
-        public string Username { get; set; }
 
         public bool SkipQueueCreation { get; set; }
 

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -1,7 +1,6 @@
 namespace Particular.ServiceControl.Hosting
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.Reflection;
     using global::ServiceControl.Configuration;
@@ -17,30 +16,17 @@ namespace Particular.ServiceControl.Hosting
                 args = [.. args, "-m"];
             }
 
-            var executionMode = ExecutionMode.Run;
-            Commands = [typeof(RunCommand)];
-            ServiceName = Settings.DEFAULT_SERVICE_NAME;
-
             var defaultOptions = new OptionSet
             {
-                {
-                    "?|h|help", "Help about the command line options.", key => { Help = true; }
-                }
+                { "?|h|help", "Help about the command line options.", key => Help = true }
             };
 
             var maintenanceOptions = new OptionSet
             {
                 {
                     "m|maint|maintenance",
-                    @"Run RavenDB only - use for DB maintenance",
-                    s =>
-                    {
-                        Commands =
-                        [
-                            typeof(MaintenanceModeCommand)
-                        ];
-                        executionMode = ExecutionMode.Maintenance;
-                    }
+                    "Run RavenDB only - use for DB maintenance",
+                    s => Command = typeof(MaintenanceModeCommand)
                 }
             };
 
@@ -48,20 +34,18 @@ namespace Particular.ServiceControl.Hosting
             {
                 {
                     "s|setup",
-                    @"Internal use - for new installer", s =>
-                    {
-                        Commands = [typeof(SetupCommand)];
-                        executionMode = ExecutionMode.RunInstallers;
-                    }
+                    "Internal use - for new installer",
+                    s => Command = typeof(SetupCommand)
                 },
                 {
                     "serviceName=",
-                    @"Specify the service name for the installed service.", s => { ServiceName = s; }
+                    "Specify the service name for the installed service.",
+                    s => ServiceName = s
                 },
                 {
                     "skip-queue-creation",
-                    @"Skip queue creation during install/update",
-                    s => { SkipQueueCreation = true; }
+                    "Skip queue creation during install/update",
+                    s => SkipQueueCreation = true
                 }
             };
 
@@ -70,30 +54,29 @@ namespace Particular.ServiceControl.Hosting
                 {
                     "import-failed-errors",
                     "Import failed error messages",
-                    s =>
-                    {
-                        Commands = [typeof(ImportFailedErrorsCommand)];
-                        executionMode = ExecutionMode.ImportFailedErrors;
-                    }
+                    s => Command = typeof(ImportFailedErrorsCommand)
                 }
             };
 
             try
             {
                 externalInstallerOptions.Parse(args);
-                if (executionMode == ExecutionMode.RunInstallers)
+
+                if (Command == typeof(SetupCommand))
                 {
                     return;
                 }
 
                 maintenanceOptions.Parse(args);
-                if (executionMode == ExecutionMode.Maintenance)
+
+                if (Command == typeof(MaintenanceModeCommand))
                 {
                     return;
                 }
 
                 reimportFailedErrorsOptions.Parse(args);
-                if (executionMode == ExecutionMode.ImportFailedErrors)
+
+                if (Command == typeof(ImportFailedErrorsCommand))
                 {
                     return;
                 }
@@ -107,40 +90,27 @@ namespace Particular.ServiceControl.Hosting
             }
         }
 
-        public List<Type> Commands { get; private set; }
+        public Type Command { get; private set; } = typeof(RunCommand);
 
-        public bool Help { get; set; }
+        public bool Help { get; private set; }
 
-        public string ServiceName { get; set; }
+        public string ServiceName { get; private set; } = Settings.DEFAULT_SERVICE_NAME;
 
-        public bool SkipQueueCreation { get; set; }
+        public bool SkipQueueCreation { get; private set; }
 
         public void PrintUsage()
         {
             var helpText = string.Empty;
-            using (
-                var stream =
-                    Assembly.GetCallingAssembly()
-                        .GetManifestResourceStream("ServiceControl.Hosting.Help.txt"))
+
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ServiceControl.Hosting.Help.txt");
+
+            if (stream != null)
             {
-                if (stream != null)
-                {
-                    using (var streamReader = new StreamReader(stream))
-                    {
-                        helpText = streamReader.ReadToEnd();
-                    }
-                }
+                using var streamReader = new StreamReader(stream);
+                helpText = streamReader.ReadToEnd();
             }
 
             Console.Out.WriteLine(helpText);
         }
-    }
-
-    enum ExecutionMode
-    {
-        RunInstallers,
-        Run,
-        Maintenance,
-        ImportFailedErrors
     }
 }

--- a/src/ServiceControl/HostingComponent.cs
+++ b/src/ServiceControl/HostingComponent.cs
@@ -16,6 +16,6 @@ namespace Particular.ServiceControl
             services.AddSingleton<IPlatformConnectionBuilder, PlatformConnectionBuilder>();
         }
 
-        public override void Setup(Settings settings, IComponentInstallationContext context, IHostApplicationBuilder hostBuilder) => context.CreateQueue(settings.ServiceName);
+        public override void Setup(Settings settings, IComponentInstallationContext context, IHostApplicationBuilder hostBuilder) => context.CreateQueue(settings.InstanceName);
     }
 }

--- a/src/ServiceControl/Infrastructure/Api/ConfigurationApi.cs
+++ b/src/ServiceControl/Infrastructure/Api/ConfigurationApi.cs
@@ -55,7 +55,7 @@ class ConfigurationApi(ActiveLicense license,
         {
             Host = new
             {
-                settings.ServiceName,
+                settings.InstanceName,
                 Logging = new
                 {
                     settings.LoggingSettings.LogPath,

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -37,8 +37,11 @@ namespace ServiceBus.Management.Infrastructure.Settings
                 ServiceName = DEFAULT_SERVICE_NAME;
             }
 
-            // Overwrite the service name if it is specified in ENVVAR, reg, or config file
+            // Overwrite the service name if it is specified in ENVVAR, reg, or config file -- LEGACY SETTING NAME
             ServiceName = SettingsReader.Read(SettingsRootNamespace, "InternalQueueName", ServiceName);
+
+            // Overwrite the service name if it is specified in ENVVAR, reg, or config file
+            ServiceName = SettingsReader.Read(SettingsRootNamespace, "ServiceName", ServiceName);
 
             LoadErrorIngestionSettings();
 

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -94,8 +94,6 @@ namespace ServiceBus.Management.Infrastructure.Settings
 
         public bool DisableExternalIntegrationsPublishing { get; set; }
 
-        public bool SkipQueueCreation { get; set; }
-
         public bool RunCleanupBundle { get; set; }
 
         public string RootUrl

--- a/src/ServiceControl/Licensing/LicenseController.cs
+++ b/src/ServiceControl/Licensing/LicenseController.cs
@@ -26,7 +26,7 @@
                 ExpirationDate = activeLicense.Details.ExpirationDate?.ToString("O") ?? string.Empty,
                 Status = activeLicense.IsValid ? "valid" : "invalid",
                 LicenseType = activeLicense.Details.LicenseType ?? string.Empty,
-                InstanceName = settings.ServiceName ?? string.Empty,
+                InstanceName = settings.InstanceName ?? string.Empty,
                 LicenseStatus = activeLicense.Details.Status
             };
 

--- a/src/ServiceControl/Licensing/LicensingComponent.cs
+++ b/src/ServiceControl/Licensing/LicensingComponent.cs
@@ -15,7 +15,7 @@ class LicensingComponent : ServiceControlComponent
         hostBuilder.AddLicensingComponent(
             TransportManifestLibrary.Find(settings.TransportType)?.Name ?? settings.TransportType,
             settings.ErrorQueue,
-            settings.ServiceName,
+            settings.InstanceName,
             LicenseManager.FindLicense().Details.RegisteredTo,
             ServiceControlVersion.GetFileVersion());
 

--- a/src/ServiceControl/Notifications/Api/NotificationsController.cs
+++ b/src/ServiceControl/Notifications/Api/NotificationsController.cs
@@ -71,8 +71,8 @@
             {
                 await EmailSender.Send(
                         notificationsSettings.Email,
-                        $"[{settings.ServiceName}] health check notification check successful",
-                        $"[{settings.ServiceName}] health check notification check successful.");
+                        $"[{settings.InstanceName}] health check notification check successful",
+                        $"[{settings.InstanceName}] health check notification check successful.");
             }
             catch (Exception e)
             {

--- a/src/ServiceControl/Notifications/Email/CustomChecksMailNotification.cs
+++ b/src/ServiceControl/Notifications/Email/CustomChecksMailNotification.cs
@@ -33,7 +33,7 @@
             this.messageSession = messageSession;
             this.throttlingState = throttlingState;
 
-            instanceName = settings.ServiceName;
+            instanceName = settings.InstanceName;
             instanceAddress = settings.ApiUrl;
 
             if (string.IsNullOrWhiteSpace(settings.NotificationsFilter) == false)

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -22,6 +22,6 @@ if (arguments.Help)
 var loggingSettings = new LoggingSettings(Settings.SettingsRootNamespace);
 LoggingConfigurator.ConfigureLogging(loggingSettings);
 
-var settings = new Settings(arguments.ServiceName, loggingSettings: loggingSettings);
+var settings = new Settings(loggingSettings: loggingSettings);
 
 await new CommandRunner(arguments.Command).Execute(arguments, settings);

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -24,4 +24,4 @@ LoggingConfigurator.ConfigureLogging(loggingSettings);
 
 var settings = new Settings(arguments.ServiceName, loggingSettings: loggingSettings);
 
-await new CommandRunner(arguments.Commands).Execute(arguments, settings);
+await new CommandRunner(arguments.Command).Execute(arguments, settings);

--- a/src/ServiceControlInstaller.Engine.UnitTests/Services/ServiceControllerExTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Services/ServiceControllerExTests.cs
@@ -23,7 +23,7 @@
         {
             var s = new WindowsServiceDetails
             {
-                ImagePath = @"C:\Program Files (x86)\Particular Software\ServiceControl\ServiceControl.exe  --serviceName=Test.SC",
+                ImagePath = @"C:\Program Files (x86)\Particular Software\ServiceControl\ServiceControl.exe",
                 DisplayName = "Test SC",
                 Name = "Test.SC",
                 ServiceAccount = @"NT Authority\NetworkService",

--- a/src/ServiceControlInstaller.Engine.UnitTests/Validation/QueueValidationTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Validation/QueueValidationTests.cs
@@ -37,6 +37,8 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
 
             public string Name { get; set; }
 
+            public string InstanceName { get; set; }
+
             public string DisplayName { get; set; }
 
             public string ServiceAccount { get; set; }
@@ -89,6 +91,8 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
             public int? DatabaseMaintenancePort { get; set; }
 
             public string Name { get; set; }
+
+            public string InstanceName { get; set; }
 
             public string DisplayName { get; set; }
 

--- a/src/ServiceControlInstaller.Engine/Configuration/Monitoring/AppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/Monitoring/AppConfig.cs
@@ -15,11 +15,16 @@
             Config.ConnectionStrings.ConnectionStrings.Set("NServiceBus/Transport", details.ConnectionString);
             var settings = Config.AppSettings.Settings;
             var version = details.Version;
+            settings.Set(SettingsList.InstanceName, details.InstanceName, version);
             settings.Set(SettingsList.Port, details.Port.ToString());
             settings.Set(SettingsList.HostName, details.HostName);
             settings.Set(SettingsList.LogPath, details.LogPath);
             settings.Set(SettingsList.TransportType, details.TransportPackage.Name, version);
             settings.Set(SettingsList.ErrorQueue, details.ErrorQueue);
+
+            // Retired settings
+            settings.RemoveIfRetired(SettingsList.EndpointName, version);
+
             Config.Save();
         }
 

--- a/src/ServiceControlInstaller.Engine/Configuration/Monitoring/SettingsList.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/Monitoring/SettingsList.cs
@@ -1,11 +1,25 @@
 namespace ServiceControlInstaller.Engine.Configuration.Monitoring
 {
+    using NuGet.Versioning;
+
     public static class SettingsList
     {
-        public static SettingInfo Port = new SettingInfo { Name = "Monitoring/HttpPort" };
-        public static SettingInfo HostName = new SettingInfo { Name = "Monitoring/HttpHostName" };
-        public static SettingInfo LogPath = new SettingInfo { Name = "Monitoring/LogPath" };
-        public static SettingInfo TransportType = new SettingInfo { Name = "Monitoring/TransportType" };
-        public static SettingInfo ErrorQueue = new SettingInfo { Name = "Monitoring/ErrorQueue" };
+        public static readonly SettingInfo EndpointName = new()
+        {
+            Name = "Monitoring/EndpointName",
+            RemovedFrom = new(5, 5, 0)
+        };
+
+        public static SettingInfo InstanceName = new()
+        {
+            Name = "Monitoring/InstanceName",
+            SupportedFrom = new SemanticVersion(5, 5, 0)
+        };
+
+        public static SettingInfo Port = new() { Name = "Monitoring/HttpPort" };
+        public static SettingInfo HostName = new() { Name = "Monitoring/HttpHostName" };
+        public static SettingInfo LogPath = new() { Name = "Monitoring/LogPath" };
+        public static SettingInfo TransportType = new() { Name = "Monitoring/TransportType" };
+        public static SettingInfo ErrorQueue = new() { Name = "Monitoring/ErrorQueue" };
     }
 }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/AuditInstanceSettingsList.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/AuditInstanceSettingsList.cs
@@ -4,19 +4,36 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
 
     public static class AuditInstanceSettingsList
     {
-        public static readonly SettingInfo Port = new SettingInfo { Name = "ServiceControl.Audit/Port" };
-        public static readonly SettingInfo DatabaseMaintenancePort = new SettingInfo { Name = "ServiceControl.Audit/DatabaseMaintenancePort" };
-        public static readonly SettingInfo HostName = new SettingInfo { Name = "ServiceControl.Audit/HostName" };
-        public static readonly SettingInfo LogPath = new SettingInfo { Name = "ServiceControl.Audit/LogPath" };
-        public static readonly SettingInfo DBPath = new SettingInfo { Name = "ServiceControl.Audit/DBPath" };
-        public static readonly SettingInfo ForwardAuditMessages = new SettingInfo { Name = "ServiceControl.Audit/ForwardAuditMessages" };
-        public static readonly SettingInfo TransportType = new SettingInfo { Name = "ServiceControl.Audit/TransportType" };
-        public static readonly SettingInfo PersistenceType = new SettingInfo { Name = "ServiceControl.Audit/PersistenceType" };
-        public static readonly SettingInfo AuditQueue = new SettingInfo { Name = "ServiceBus/AuditQueue" };
-        public static readonly SettingInfo AuditLogQueue = new SettingInfo { Name = "ServiceBus/AuditLogQueue" };
-        public static readonly SettingInfo AuditRetentionPeriod = new SettingInfo { Name = "ServiceControl.Audit/AuditRetentionPeriod" };
-        public static readonly SettingInfo MaintenanceMode = new SettingInfo { Name = "ServiceControl.Audit/MaintenanceMode" };
-        public static readonly SettingInfo ServiceControlQueueAddress = new SettingInfo { Name = "ServiceControl.Audit/ServiceControlQueueAddress" };
-        public static readonly SettingInfo EnableFullTextSearchOnBodies = new SettingInfo { Name = "ServiceControl.Audit/EnableFullTextSearchOnBodies", SupportedFrom = new SemanticVersion(4, 17, 0) };
+        public static readonly SettingInfo InternalQueueName = new()
+        {
+            Name = "ServiceControl.Audit/InternalQueueName",
+            RemovedFrom = new(5, 5, 0)
+        };
+
+        public static readonly SettingInfo InstanceName = new()
+        {
+            Name = "ServiceControl.Audit/InstanceName",
+            SupportedFrom = new SemanticVersion(5, 5, 0)
+        };
+
+        public static readonly SettingInfo Port = new() { Name = "ServiceControl.Audit/Port" };
+        public static readonly SettingInfo DatabaseMaintenancePort = new() { Name = "ServiceControl.Audit/DatabaseMaintenancePort" };
+        public static readonly SettingInfo HostName = new() { Name = "ServiceControl.Audit/HostName" };
+        public static readonly SettingInfo LogPath = new() { Name = "ServiceControl.Audit/LogPath" };
+        public static readonly SettingInfo DBPath = new() { Name = "ServiceControl.Audit/DBPath" };
+        public static readonly SettingInfo ForwardAuditMessages = new() { Name = "ServiceControl.Audit/ForwardAuditMessages" };
+        public static readonly SettingInfo TransportType = new() { Name = "ServiceControl.Audit/TransportType" };
+        public static readonly SettingInfo PersistenceType = new() { Name = "ServiceControl.Audit/PersistenceType" };
+        public static readonly SettingInfo AuditQueue = new() { Name = "ServiceBus/AuditQueue" };
+        public static readonly SettingInfo AuditLogQueue = new() { Name = "ServiceBus/AuditLogQueue" };
+        public static readonly SettingInfo AuditRetentionPeriod = new() { Name = "ServiceControl.Audit/AuditRetentionPeriod" };
+        public static readonly SettingInfo MaintenanceMode = new() { Name = "ServiceControl.Audit/MaintenanceMode" };
+        public static readonly SettingInfo ServiceControlQueueAddress = new() { Name = "ServiceControl.Audit/ServiceControlQueueAddress" };
+
+        public static readonly SettingInfo EnableFullTextSearchOnBodies = new()
+        {
+            Name = "ServiceControl.Audit/EnableFullTextSearchOnBodies",
+            SupportedFrom = new SemanticVersion(4, 17, 0)
+        };
     }
 }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/ServiceControlAppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/ServiceControlAppConfig.cs
@@ -15,6 +15,7 @@
             Config.ConnectionStrings.ConnectionStrings.Set("NServiceBus/Transport", details.ConnectionString);
             var settings = Config.AppSettings.Settings;
             var version = details.Version;
+            settings.Set(ServiceControlSettings.InstanceName, details.InstanceName, version);
             settings.Set(ServiceControlSettings.VirtualDirectory, details.VirtualDirectory);
             settings.Set(ServiceControlSettings.Port, details.Port.ToString());
             settings.Set(ServiceControlSettings.DatabaseMaintenancePort, details.DatabaseMaintenancePort.ToString(), version);
@@ -35,6 +36,7 @@
             settings.RemoveIfRetired(ServiceControlSettings.AuditQueue, version);
             settings.RemoveIfRetired(ServiceControlSettings.AuditLogQueue, version);
             settings.RemoveIfRetired(ServiceControlSettings.ForwardAuditMessages, version);
+            settings.RemoveIfRetired(ServiceControlSettings.InternalQueueName, version);
 
             RemoveRavenDB35Settings(settings, version);
         }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/ServiceControlAuditAppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/ServiceControlAuditAppConfig.cs
@@ -17,6 +17,7 @@
             Config.ConnectionStrings.ConnectionStrings.Set("NServiceBus/Transport", instance.ConnectionString);
             var settings = Config.AppSettings.Settings;
             var version = instance.Version;
+            settings.Set(AuditInstanceSettingsList.InstanceName, instance.InstanceName, version);
             settings.Set(AuditInstanceSettingsList.Port, instance.Port.ToString());
             settings.Set(AuditInstanceSettingsList.HostName, instance.HostName);
             settings.Set(AuditInstanceSettingsList.LogPath, instance.LogPath);
@@ -64,6 +65,9 @@
                     }
                 }
             }
+
+            // Retired setting
+            settings.RemoveIfRetired(AuditInstanceSettingsList.InternalQueueName, version);
 
             RemoveRavenDB35Settings(settings, version);
         }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/SettingsList.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/SettingsList.cs
@@ -5,6 +5,18 @@ namespace ServiceControlInstaller.Engine.Configuration.ServiceControl
     // See Compatibility.cs for version switching that isn't related to Settings
     public static class ServiceControlSettings
     {
+        public static readonly SettingInfo InternalQueueName = new()
+        {
+            Name = "ServiceControl/InternalQueueName",
+            RemovedFrom = new(5, 5, 0)
+        };
+
+        public static readonly SettingInfo InstanceName = new()
+        {
+            Name = "ServiceControl/InstanceName",
+            SupportedFrom = new SemanticVersion(5, 5, 0)
+        };
+
         public static readonly SettingInfo VirtualDirectory = new() { Name = "ServiceControl/VirtualDirectory" };
         public static readonly SettingInfo Port = new() { Name = "ServiceControl/Port" };
         public static readonly SettingInfo DatabaseMaintenancePort = new SettingInfo

--- a/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/BaseService.cs
@@ -4,7 +4,6 @@
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
-    using System.Runtime;
     using System.ServiceProcess;
     using System.Threading;
     using Engine;
@@ -16,11 +15,19 @@
     public abstract class BaseService : IServiceInstance
     {
         public string Description { get; set; }
+
         public IWindowsServiceController Service { get; set; }
+
         public string InstallPath => Path.GetDirectoryName(Service.ExePath);
+
         public string DisplayName { get; set; }
+
         public string Name => Service.ServiceName;
+
+        public string InstanceName { get; set; }
+
         public string ServiceAccount { get; set; }
+
         public string ServiceAccountPwd { get; set; }
 
         public TransportInfo TransportPackage { get; set; }
@@ -231,7 +238,6 @@
                 }
             }
         }
-
 
         static void PurgeOld(string oldPath)
         {

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -27,12 +27,19 @@
         }
 
         public AppConfig AppConfig { get; set; }
+
         public ReportCard ReportCard { get; set; }
+
         public int Port { get; set; }
+
         public string HostName { get; set; }
+
         public string ErrorQueue { get; set; }
+
         public string ConnectionString { get; set; }
+
         public string LogPath { get; set; }
+
         public bool SkipQueueCreation { get; set; }
 
         public string Url => $"http://{HostName}:{Port}/";
@@ -56,6 +63,8 @@
             Service.Refresh();
 
             AppConfig = new AppConfig(this);
+
+            InstanceName = AppConfig.Read(SettingsList.InstanceName, Name);
             HostName = AppConfig.Read(SettingsList.HostName, "localhost");
             Port = AppConfig.Read(SettingsList.Port, 1234);
             LogPath = AppConfig.Read(SettingsList.LogPath, DefaultLogPath());
@@ -65,7 +74,6 @@
             Description = GetDescription();
             ServiceAccount = Service.Account;
         }
-
 
         string DefaultLogPath()
         {

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
@@ -106,7 +106,7 @@
                 ServiceAccountPwd = ServiceAccountPwd,
                 DisplayName = DisplayName,
                 Name = Name,
-                ImagePath = $"\"{Path.Combine(InstallPath, Constants.MonitoringExe)}\" --serviceName={Name}",
+                ImagePath = $"\"{Path.Combine(InstallPath, Constants.MonitoringExe)}\"",
                 ServiceDescription = ServiceDescription
             };
             var dependencies = new List<string>

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
@@ -41,23 +41,30 @@
         }
 
         public string HostName { get; set; }
+
         public int Port { get; set; }
 
         public string ErrorQueue { get; set; }
 
-
         public string InstallPath { get; set; }
+
         public string LogPath { get; set; }
 
         public TransportInfo TransportPackage { get; set; }
+
         public string ConnectionString { get; set; }
 
         public string Name { get; set; }
-        public string DisplayName { get; set; }
-        public string ServiceAccount { get; set; }
-        public string ServiceAccountPwd { get; set; }
-        public bool SkipQueueCreation { get; set; }
 
+        public string InstanceName { get; set; }
+
+        public string DisplayName { get; set; }
+
+        public string ServiceAccount { get; set; }
+
+        public string ServiceAccountPwd { get; set; }
+
+        public bool SkipQueueCreation { get; set; }
 
         public SemanticVersion Version { get; }
 

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
@@ -70,6 +70,10 @@ namespace ServiceControlInstaller.Engine.Instances
             Service.Refresh();
 
             AppConfig = CreateAppConfig();
+
+            InstanceName = AppConfig.Read(AuditInstanceSettingsList.InternalQueueName, Name);
+            InstanceName = AppConfig.Read(AuditInstanceSettingsList.InstanceName, InstanceName);
+
             HostName = AppConfig.Read(AuditInstanceSettingsList.HostName, "localhost");
             Port = AppConfig.Read(AuditInstanceSettingsList.Port, 33333);
             DatabaseMaintenancePort = AppConfig.Read<int?>(AuditInstanceSettingsList.DatabaseMaintenancePort, null);

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditNewInstance.cs
@@ -53,7 +53,7 @@
                 ServiceAccountPwd = ServiceAccountPwd,
                 DisplayName = DisplayName,
                 Name = Name,
-                ImagePath = $"\"{Path.Combine(InstallPath, Constants.ServiceControlAuditExe)}\" --serviceName={Name}",
+                ImagePath = $"\"{Path.Combine(InstallPath, Constants.ServiceControlAuditExe)}\"",
                 ServiceDescription = ServiceDescription
             };
         }

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstallableBase.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstallableBase.cs
@@ -69,23 +69,43 @@
         }
 
         public string LogPath { get; set; }
+
         public string DBPath { get; set; }
+
         public string HostName { get; set; }
+
         public string InstallPath { get; set; }
+
         public int Port { get; set; }
+
         public int? DatabaseMaintenancePort { get; set; }
+
         public string VirtualDirectory { get; set; }
+
         public string ErrorQueue { get; set; }
+
         public string ErrorLogQueue { get; set; }
+
         public string AuditQueue { get; set; }
+
         public string AuditLogQueue { get; set; }
+
         public bool ForwardAuditMessages { get; set; }
+
         public bool ForwardErrorMessages { get; set; }
+
         public TransportInfo TransportPackage { get; set; }
+
         public string ConnectionString { get; set; }
+
         public string Name { get; set; }
+
+        public string InstanceName { get; set; }
+
         public string DisplayName { get; set; }
+
         public bool SkipQueueCreation { get; set; }
+
         public bool EnableFullTextSearchOnBodies { get; set; }
 
         [XmlIgnore]

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -102,6 +102,10 @@ namespace ServiceControlInstaller.Engine.Instances
             Service.Refresh();
 
             AppConfig = CreateAppConfig();
+
+            InstanceName = AppConfig.Read(ServiceControlSettings.InternalQueueName, Name);
+            InstanceName = AppConfig.Read(ServiceControlSettings.InstanceName, InstanceName);
+
             HostName = AppConfig.Read(ServiceControlSettings.HostName, "localhost");
             Port = AppConfig.Read(ServiceControlSettings.Port, 33333);
             DatabaseMaintenancePort = AppConfig.Read<int?>(ServiceControlSettings.DatabaseMaintenancePort, null);

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlNewInstance.cs
@@ -80,7 +80,7 @@ namespace ServiceControlInstaller.Engine.Instances
                 ServiceAccountPwd = ServiceAccountPwd,
                 DisplayName = DisplayName,
                 Name = Name,
-                ImagePath = $"\"{Path.Combine(InstallPath, Constants.ServiceControlExe)}\" --serviceName={Name}",
+                ImagePath = $"\"{Path.Combine(InstallPath, Constants.ServiceControlExe)}\"",
                 ServiceDescription = ServiceDescription
             };
         }

--- a/src/ServiceControlInstaller.Engine/Interfaces.cs
+++ b/src/ServiceControlInstaller.Engine/Interfaces.cs
@@ -61,6 +61,9 @@ namespace ServiceControlInstaller.Engine
     public interface IServiceInstance : IServiceAccount, IVersionInfo
     {
         string Name { get; }
+
+        string InstanceName { get; }
+
         string DisplayName { get; }
     }
 

--- a/src/ServiceControlInstaller.Engine/Queues/QueueCreation.cs
+++ b/src/ServiceControlInstaller.Engine/Queues/QueueCreation.cs
@@ -3,51 +3,37 @@
     using System;
     using System.Diagnostics;
     using System.IO;
-    using Accounts;
     using Instances;
 
     static class QueueCreation
     {
         public static void RunQueueCreation(IServiceControlInstance instance)
         {
-            var accountName = instance.ServiceAccount;
             RunQueueCreation(instance.InstallPath,
                 Constants.ServiceControlExe,
                 instance.Name,
-                accountName,
                 instance.SkipQueueCreation);
         }
 
         public static void RunQueueCreation(IServiceControlAuditInstance instance)
         {
-            var accountName = instance.ServiceAccount;
             RunQueueCreation(instance.InstallPath,
                 Constants.ServiceControlAuditExe,
                 instance.Name,
-                accountName,
                 instance.SkipQueueCreation);
         }
 
         public static void RunQueueCreation(IMonitoringInstance instance)
         {
-            var accountName = instance.ServiceAccount;
             RunQueueCreation(instance.InstallPath,
                 Constants.MonitoringExe,
                 instance.Name,
-                accountName,
                 instance.SkipQueueCreation);
         }
 
-        static void RunQueueCreation(string installPath, string exeName, string serviceName, string serviceAccount, bool skipQueueCreation = false)
+        static void RunQueueCreation(string installPath, string exeName, string serviceName, bool skipQueueCreation = false)
         {
-            var userAccount = UserAccount.ParseAccountName(serviceAccount);
-
             var args = $"--setup --serviceName={serviceName}";
-
-            if (!userAccount.IsLocalSystem())
-            {
-                args += $" --userName=\"{userAccount.QualifiedName}\"";
-            }
 
             if (skipQueueCreation)
             {

--- a/src/ServiceControlInstaller.Engine/Queues/QueueCreation.cs
+++ b/src/ServiceControlInstaller.Engine/Queues/QueueCreation.cs
@@ -31,9 +31,9 @@
                 instance.SkipQueueCreation);
         }
 
-        static void RunQueueCreation(string installPath, string exeName, string serviceName, bool skipQueueCreation = false)
+        static void RunQueueCreation(string installPath, string exeName, string instanceName, bool skipQueueCreation = false)
         {
-            var args = $"--setup --serviceName={serviceName}";
+            var args = $"--setup";
 
             if (skipQueueCreation)
             {
@@ -49,6 +49,8 @@
                 WorkingDirectory = installPath,
                 RedirectStandardError = true
             };
+
+            processStartupInfo.EnvironmentVariables.Add("INSTANCE_NAME", instanceName);
 
             var p = Process.Start(processStartupInfo);
             if (p != null)


### PR DESCRIPTION
This PR makes the following changes:

- Aligns `HostArguments` and `CommandRunner` for all 3 instances so that they work in the same way.
- `CommandRunner` supported the idea of running multiple commands, but there was no way to use it. Also, the commands themselves were written in a way that assumed a single command would be executed per process. The ability to run multiple commands has been removed.
- `InstanceName` is now the consistent setting to use across all 3 instances to control the name of the endpoint/queue used by the instance.
  - The old setting for error and audit instances (`InternalQueueName`) will still be used if set, but the new setting will take precedence if they are both set.
  - The old setting for monitoring (`EndpointName`) did not work properly (it was never passed to `EndpointConfiguration` so instance would never consume from that queue. The broken setting has been removed and entirely replaced with `InstanceName`.
- The `serviceName` command-line parameter has been removed. Instances will now rely on the `InstanceName` configuration setting instead.
- The `userName` command-line parameter was not actually being used for anything, so it has also been removed.
- The installer engine has been updated to handle properly writing `InstanceName` to the app.config file when installing or upgrading an instance.
  - When upgrading an instance that had `InternalQueueName` set, the installer will migrate the value to `InstanceName` and remove the `InternalQueueName` setting.
