### PR TITLE
Disable report download if using a broker but there is no broker data for last 30 days

### DIFF
--- a/src/Particular.LicensingComponent.Contracts/UserIndicator.cs
+++ b/src/Particular.LicensingComponent.Contracts/UserIndicator.cs
@@ -7,8 +7,7 @@ public enum UserIndicator
 {
     NServiceBusEndpoint,
     NotNServiceBusEndpoint,
-    NServiceBusEndpointSendOnly,
+    SendOnlyOrTransactionSessionEndpoint,
     NServiceBusEndpointNoLongerInUse,
-    TransactionSessionEndpoint,
     PlannedToDecommission
 }

--- a/src/Particular.LicensingComponent.UnitTests/Infrastructure/ThroughputCollectorTestFixture.cs
+++ b/src/Particular.LicensingComponent.UnitTests/Infrastructure/ThroughputCollectorTestFixture.cs
@@ -1,6 +1,7 @@
 ﻿namespace Particular.LicensingComponent.UnitTests.Infrastructure
 {
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
     using Contracts;
     using Microsoft.Extensions.DependencyInjection;
@@ -16,21 +17,24 @@
         [SetUp]
         public virtual Task Setup()
         {
-            configuration = new ThroughputTestsConfiguration();
+            var testMethod = GetType().GetMethod(TestContext.CurrentContext.Test.MethodName);
+            var attribute = testMethod?.GetCustomAttributes(typeof(UseNonBrokerTransportAttribute), false).FirstOrDefault();
 
-            return configuration.Configure(SetThroughputSettings, SetExtraDependencies);
+            return configuration.Configure(SetThroughputSettings, SetExtraDependencies, attribute is not UseNonBrokerTransportAttribute);
         }
 
         [TearDown]
-        public virtual Task Cleanup()
-        {
-            return configuration?.Cleanup();
-        }
+        public virtual Task Cleanup() => configuration?.Cleanup();
 
         protected ILicensingDataStore DataStore => configuration.LicensingDataStore;
 
         protected IThroughputCollector ThroughputCollector => configuration.ThroughputCollector;
 
-        protected ThroughputTestsConfiguration configuration;
+        protected ThroughputTestsConfiguration configuration = new();
+
+        [AttributeUsage(AttributeTargets.Method)]
+        public class UseNonBrokerTransportAttribute : Attribute
+        {
+        }
     }
 }

--- a/src/Particular.LicensingComponent.UnitTests/Infrastructure/ThroughputTestsConfiguration.cs
+++ b/src/Particular.LicensingComponent.UnitTests/Infrastructure/ThroughputTestsConfiguration.cs
@@ -19,8 +19,10 @@ class ThroughputTestsConfiguration
     public IAuditQuery AuditQuery { get; protected set; }
     public MonitoringService MonitoringService { get; protected set; }
 
-    public Task Configure(Action<ThroughputSettings> setThroughputSettings,
-        Action<ServiceCollection> setExtraDependencies)
+    public Task Configure(
+        Action<ThroughputSettings> setThroughputSettings,
+        Action<ServiceCollection> setExtraDependencies,
+        bool useBrokerTransport)
     {
         var throughputSettings = new ThroughputSettings("Particular.ServiceControl", "error", "Learning",
             "TestCustomer", "5.0.1");
@@ -39,7 +41,12 @@ class ThroughputTestsConfiguration
         serviceCollection.AddSingleton<IAuditCountApi, FakeAuditCountApi>();
         serviceCollection.AddSingleton<IConfigurationApi, FakeConfigurationApi>();
         serviceCollection.AddSingleton<IThroughputCollector, ThroughputCollector>();
-        serviceCollection.AddSingleton<IBrokerThroughputQuery, FakeBrokerThroughputQuery>();
+
+        if (useBrokerTransport)
+        {
+            serviceCollection.AddSingleton<IBrokerThroughputQuery, FakeBrokerThroughputQuery>();
+        }
+
         serviceCollection.AddSingleton<IAuditQuery, AuditQuery>();
         serviceCollection.AddSingleton<MonitoringService>();
 

--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_GenerationStatus_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_GenerationStatus_Tests.cs
@@ -32,6 +32,25 @@ class ThroughputCollector_GenerationStatus_Tests : ThroughputCollectorTestFixtur
     }
 
     [Test]
+    public async Task Should_return_ReportCanBeGenerated_true_when_not_using_broker_and_no_broker_throughput_for_last_30_days()
+    {
+        // Arrange
+        await DataStore.CreateBuilder()
+            .AddEndpoint().WithThroughput(source: Contracts.ThroughputSource.Audit, startDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-2), days: 2)
+            .Build();
+
+        var throughputCollector = new ThroughputCollector(DataStore, configuration.ThroughputSettings, null, null, null);
+
+        // Act
+        var reportGenerationState = await throughputCollector.GetReportGenerationState(default);
+
+        // Assert
+        Assert.That(reportGenerationState.ReportCanBeGenerated, Is.True);
+        Assert.That(reportGenerationState.Reason, Is.EqualTo(""));
+    }
+
+
+    [Test]
     public async Task Should_return_ReportCanBeGenerated_true_when_using_broker_and_there_is_broker_throughput_for_last_30_days()
     {
         // Arrange

--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_Report_Indicator_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_Report_Indicator_Tests.cs
@@ -47,7 +47,7 @@ class ThroughputCollector_Report_Indicator_Tests : ThroughputCollectorTestFixtur
         await DataStore.CreateBuilder()
             .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker, ThroughputSource.Monitoring])
             .ConfigureEndpoint(ThroughputSource.Broker,
-                endpoint => endpoint.UserIndicator = UserIndicator.TransactionSessionEndpoint.ToString())
+                endpoint => endpoint.UserIndicator = UserIndicator.SendOnlyOrTransactionSessionEndpoint.ToString())
             .WithThroughput(ThroughputSource.Broker, days: 2)
             .WithThroughput(ThroughputSource.Monitoring, days: 2)
             .Build();
@@ -60,6 +60,6 @@ class ThroughputCollector_Report_Indicator_Tests : ThroughputCollectorTestFixtur
         Assert.That(report.ReportData.Queues.Length, Is.EqualTo(1));
 
         Assert.That(report.ReportData.Queues[0].UserIndicator,
-            Is.EqualTo(UserIndicator.TransactionSessionEndpoint.ToString()));
+            Is.EqualTo(UserIndicator.SendOnlyOrTransactionSessionEndpoint.ToString()));
     }
 }

--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
@@ -60,7 +60,7 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
             .WithThroughput(days: 2)
             .AddEndpoint("Endpoint3", sources: [ThroughputSource.Broker])
             .ConfigureEndpoint(
-                endpoint => endpoint.UserIndicator = UserIndicator.NServiceBusEndpointSendOnly.ToString())
+                endpoint => endpoint.UserIndicator = UserIndicator.SendOnlyOrTransactionSessionEndpoint.ToString())
             .WithThroughput(days: 2)
             .AddEndpoint("Endpoint4", sources: [ThroughputSource.Broker])
             .ConfigureEndpoint(endpoint => endpoint.UserIndicator = UserIndicator.PlannedToDecommission.ToString())

--- a/src/Particular.LicensingComponent/ThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/ThroughputCollector.cs
@@ -97,7 +97,7 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
     async Task<ReportGenerationState> GetReportGenerationStateForBroker(CancellationToken cancellationToken)
     {
         var reportCanBeGenerated = await dataStore.IsThereThroughputForLastXDaysForSource(30, ThroughputSource.Broker, false, cancellationToken);
-        var reason = reportCanBeGenerated ? string.Empty : $"Need at least one day of usage data in the last 30 days from {transport} broker.";
+        var reason = reportCanBeGenerated ? string.Empty : "Need at least one day of usage data in the last 30 days from the configured broker.";
 
         return new ReportGenerationState(transport)
         {

--- a/src/Particular.LicensingComponent/ThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/ThroughputCollector.cs
@@ -96,6 +96,15 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
             ReportCanBeGenerated = await dataStore.IsThereThroughputForLastXDays(30, cancellationToken)
         };
 
+        //ensure that if there is a broker that we only allow generation if there is broker data in the last 30 days
+        if (reportGenerationState.ReportCanBeGenerated && throughputQuery != null)
+        {
+            if (!await dataStore.IsThereThroughputForLastXDaysForSource(30, ThroughputSource.Broker, false, cancellationToken))
+            {
+                reportGenerationState.ReportCanBeGenerated = false;
+            }
+        }
+
         if (!reportGenerationState.ReportCanBeGenerated)
         {
             reportGenerationState.Reason = "24 hours worth of data needs to exist in the last 30 days.";

--- a/src/Particular.LicensingComponent/ThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/ThroughputCollector.cs
@@ -97,7 +97,7 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
     async Task<ReportGenerationState> GetReportGenerationStateForBroker(CancellationToken cancellationToken)
     {
         var reportCanBeGenerated = await dataStore.IsThereThroughputForLastXDaysForSource(30, ThroughputSource.Broker, false, cancellationToken);
-        var reason = reportCanBeGenerated ? string.Empty : $"Need at least one day of usage data in the last 30 days from ${transport} broker.";
+        var reason = reportCanBeGenerated ? string.Empty : $"Need at least one day of usage data in the last 30 days from {transport} broker.";
 
         return new ReportGenerationState(transport)
         {

--- a/src/Particular.LicensingComponent/ThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/ThroughputCollector.cs
@@ -89,28 +89,33 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
         return endpointSummaries;
     }
 
-    public async Task<ReportGenerationState> GetReportGenerationState(CancellationToken cancellationToken)
+    public async Task<ReportGenerationState> GetReportGenerationState(CancellationToken cancellationToken) =>
+        throughputQuery == null ?
+            await GetReportGenerationStateForNonBroker(cancellationToken) :
+            await GetReportGenerationStateForBroker(cancellationToken);
+
+    async Task<ReportGenerationState> GetReportGenerationStateForBroker(CancellationToken cancellationToken)
     {
-        var reportGenerationState = new ReportGenerationState(transport)
+        var reportCanBeGenerated = await dataStore.IsThereThroughputForLastXDaysForSource(30, ThroughputSource.Broker, false, cancellationToken);
+        var reason = reportCanBeGenerated ? string.Empty : $"Need at least one day of usage data in the last 30 days from ${transport} broker.";
+
+        return new ReportGenerationState(transport)
         {
-            ReportCanBeGenerated = await dataStore.IsThereThroughputForLastXDays(30, cancellationToken)
+            ReportCanBeGenerated = reportCanBeGenerated,
+            Reason = reason
         };
+    }
 
-        //ensure that if there is a broker that we only allow generation if there is broker data in the last 30 days
-        if (reportGenerationState.ReportCanBeGenerated && throughputQuery != null)
+    async Task<ReportGenerationState> GetReportGenerationStateForNonBroker(CancellationToken cancellationToken)
+    {
+        var reportCanBeGenerated = await dataStore.IsThereThroughputForLastXDays(30, cancellationToken);
+        var reason = reportCanBeGenerated ? string.Empty : $"Need at least one day of usage data in the last 30 days.";
+
+        return new ReportGenerationState(transport)
         {
-            if (!await dataStore.IsThereThroughputForLastXDaysForSource(30, ThroughputSource.Broker, false, cancellationToken))
-            {
-                reportGenerationState.ReportCanBeGenerated = false;
-            }
-        }
-
-        if (!reportGenerationState.ReportCanBeGenerated)
-        {
-            reportGenerationState.Reason = "24 hours worth of data needs to exist in the last 30 days.";
-        }
-
-        return reportGenerationState;
+            ReportCanBeGenerated = reportCanBeGenerated,
+            Reason = reason
+        };
     }
 
     public async Task<SignedReport> GenerateThroughputReport(string spVersion, DateTime? reportEndDate, CancellationToken cancellationToken)


### PR DESCRIPTION
Currently the report download button on the Usage page is enabled as long as there is 1 day of data in the last 30 days.
This could produce incomplete reports if a broker transport is used but not configured correctly, and the data is only coming from a subset of endpoints that have Audit and/or Monitoring configured.

This change ensures that the report download button is not enabled if a broker transport is being used, but there's no data from the broker.