### PR TITLE
cache sqltable query

### DIFF
--- a/src/ServiceControl.Transports.SqlServer/SqlNameHelper.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlNameHelper.cs
@@ -1,4 +1,5 @@
-﻿namespace ServiceControl.Transports.SqlServer
+﻿#nullable enable
+namespace ServiceControl.Transports.SqlServer
 {
     class SqlNameHelper
     {
@@ -7,33 +8,12 @@
 
         public static string Quote(string name)
         {
-            if (name == null)
-            {
-                return null;
-            }
-
             if (name.StartsWith(prefix) && name.EndsWith(suffix))
             {
                 return name;
             }
 
             return prefix + name.Replace(suffix, suffix + suffix) + suffix;
-        }
-
-        public static string Unquote(string quotedString)
-        {
-            if (quotedString == null)
-            {
-                return null;
-            }
-
-            if (!quotedString.StartsWith(prefix) || !quotedString.EndsWith(suffix))
-            {
-                return quotedString;
-            }
-
-            return quotedString
-                .Substring(prefix.Length, quotedString.Length - prefix.Length - suffix.Length).Replace(suffix + suffix, suffix);
         }
     }
 }

--- a/src/ServiceControl.Transports.SqlServer/SqlNameHelper.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlNameHelper.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 namespace ServiceControl.Transports.SqlServer
 {
-    class SqlNameHelper
+    static class SqlNameHelper
     {
         const string prefix = "[";
         const string suffix = "]";


### PR DESCRIPTION
 * cache sql QueueLengthQuery on table to avoid calculating it every time in the fast path
 * use _fullTableName in calculation of query and re-use it in quals, hashcode, and tostring
 * remove SqlNameHelper.Unquote since not used
 * enabled nullable checks for SqlNameHelper and SqlTable