### PR TITLE
Create multi-arch database image manifest

### DIFF
--- a/.github/workflows/push-container-images.yml
+++ b/.github/workflows/push-container-images.yml
@@ -30,10 +30,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Publish to Docker Hub
         run: |
-          $containers = @('servicecontrol', 'servicecontrol-audit', 'servicecontrol-monitoring')
+          $containers = @('servicecontrol', 'servicecontrol-audit', 'servicecontrol-monitoring', 'servicecontrol-ravendb')
           $tags = "${{ steps.validate.outputs.container-tags }}" -Split ','
           $sourceTag = "${{ inputs.version }}"
-          $dbArchTags = @('x64', 'arm64v8')
 
           foreach ($tag in $tags)
           {
@@ -44,24 +43,6 @@ jobs:
               Write-Output "Command: $cmd"
               Invoke-Expression $cmd
               Write-Output "::endgroup::"
-            }
-            foreach ($dbArch in $dbArchTags)
-            {
-              Write-Output "::group::Pushing servicecontrol-ravendb:$($tag)-$($dbArch)"
-              $cmd = "docker buildx imagetools create --tag particular/servicecontrol-ravendb:$($tag)-$($dbArch) ghcr.io/particular/servicecontrol-ravendb:$($sourceTag)-$($dbArch)"
-              Write-Output "Command: $cmd"
-              Invoke-Expression $cmd
-              Write-Output "::endgroup::"
-
-              # Push RavenDB 'latest' tag using x64 image
-              if ($tag -eq 'latest' -and $dbArch -eq 'x64')
-              {
-                Write-Output "::group::Pushing servicecontrol-ravendb:latest"
-                $cmd = "docker buildx imagetools create --tag particular/servicecontrol-ravendb:latest ghcr.io/particular/servicecontrol-ravendb:$($sourceTag)-$($dbArch)"
-                Write-Output "Command: $cmd"
-                Invoke-Expression $cmd
-                Write-Output "::endgroup::"
-              }
             }
           }
       - name: Update Docker Hub Description - ServiceControl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,3 +266,16 @@ jobs:
         run: docker images
       - name: Push images to GitHub Container registry
         run: docker image push --all-tags ghcr.io/particular/servicecontrol-ravendb
+      - name: Create multi-arch manifest
+        env:
+          TAG_NAME: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || env.MinVerVersion }}
+        shell: pwsh
+        run: |
+          $manifestCreate = "docker manifest create ghcr.io/particular/servicecontrol-ravendb:${{ env.TAG_NAME }}"
+          $containers = cat src/ServiceControl.RavenDB/containers.json | ConvertFrom-Json
+          $containers | ForEach-Object -Process {
+            $manifestCreate += " --amend ghcr.io/particular/servicecontrol-ravendb:${{ env.TAG_NAME }}-$($_.tag)"
+          }
+          Invoke-Expression $manifestCreate
+          docker buildx imagetools inspect ghcr.io/particular/servicecontrol-ravendb:${{ env.TAG_NAME }}
+          docker manifest push ghcr.io/particular/servicecontrol-ravendb:${{ env.TAG_NAME }}


### PR DESCRIPTION
Creates a multi-architecture manifest for the servicecontrol-ravendb image to simplify tag usage and management for multiple architectures.