### PR TITLE
Use chiseled base image

### DIFF
--- a/.github/workflows/push-container-images.yml
+++ b/.github/workflows/push-container-images.yml
@@ -33,7 +33,7 @@ jobs:
           $containers = @('servicecontrol', 'servicecontrol-audit', 'servicecontrol-monitoring')
           $tags = "${{ steps.validate.outputs.container-tags }}" -Split ','
           $sourceTag = "${{ inputs.version }}"
-          $dbArchTags = @('x64', 'arm64v8', 'arm32v7')
+          $dbArchTags = @('x64', 'arm64v8')
 
           foreach ($tag in $tags)
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
               --annotation "index:org.opencontainers.image.url=https://hub.docker.com/r/particular/${{ matrix.name }}" \
               --annotation "index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" \
               --annotation "index:org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0" \
-              --platform linux/arm64,linux/arm,linux/amd64 .
+              --platform linux/arm64,linux/amd64 .
           docker buildx imagetools inspect ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }}
   db-containers:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/Container-README.md
+++ b/Container-README.md
@@ -51,9 +51,9 @@ The latest release within a minor version will be tagged with `{major}.{minor}` 
 
 ## Image architecture
 
-The `servicecontrol`, `servicecontrol-audit`, and `servicecontrol-monitoring` images are multi-arch images based on the `mcr.microsoft.com/dotnet/aspnet:8.0` base image supporting `linux/arm64`, `linux/arm`, and `linux/amd64`.
+The `servicecontrol`, `servicecontrol-audit`, and `servicecontrol-monitoring` images are multi-arch images based on the `mcr.microsoft.com/dotnet/aspnet:8.0` base image supporting `linux/arm64` and `linux/amd64`.
 
-The `servicecontrol-ravendb` image is based on versions of the [`ravendb/ravendb`](https://hub.docker.com/r/ravendb/ravendb) image, and have separate tags for `-x64`, `-arm64v8`, and `-arm32v7`.
+The `servicecontrol-ravendb` image is based on versions of the [`ravendb/ravendb`](https://hub.docker.com/r/ravendb/ravendb) image, and have separate tags for `-x64`, `-arm64v8`.
 
 ## Authors
 

--- a/Container-README.md
+++ b/Container-README.md
@@ -51,7 +51,7 @@ The latest release within a minor version will be tagged with `{major}.{minor}` 
 
 ## Image architecture
 
-The `servicecontrol`, `servicecontrol-audit`, and `servicecontrol-monitoring` images are multi-arch images based on the `mcr.microsoft.com/dotnet/aspnet:8.0` base image supporting `linux/arm64` and `linux/amd64`.
+The `servicecontrol`, `servicecontrol-audit`, and `servicecontrol-monitoring` images are multi-arch images based on the `mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite` base image supporting `linux/arm64` and `linux/amd64`.
 
 The `servicecontrol-ravendb` image is based on versions of the [`ravendb/ravendb`](https://hub.docker.com/r/ravendb/ravendb) image, and have separate tags for `-x64`, `-arm64v8`.
 

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -32,7 +32,6 @@
   <PropertyGroup>
     <RuntimeIdentifier Condition="'$(WindowsSelfContained)' == 'true'">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetArch)' == 'amd64'">linux-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetArch)' == 'arm'">linux-arm</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetArch)' == 'arm64'">linux-arm64</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/HealthCheckApp/HealthCheckApp.csproj
+++ b/src/HealthCheckApp/HealthCheckApp.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>healthcheck</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.dll.config;nsb*.txt" DirExclude=".db;.logs" DestinationFolder="$(ArtifactsPath)healthcheck" />
+  </ItemGroup>
+
+</Project>

--- a/src/HealthCheckApp/HealthCheckApp.csproj
+++ b/src/HealthCheckApp/HealthCheckApp.csproj
@@ -1,16 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyName>healthcheck</AssemblyName>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <InvariantGlobalization>true</InvariantGlobalization>
+    <AssemblyName>healthcheck</AssemblyName>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Artifact Include="$(OutputPath)" FileExclude="ServiceControl.dll.config;nsb*.txt" DirExclude=".db;.logs" DestinationFolder="$(ArtifactsPath)healthcheck" />
-  </ItemGroup>
 
 </Project>

--- a/src/HealthCheckApp/Program.cs
+++ b/src/HealthCheckApp/Program.cs
@@ -1,0 +1,19 @@
+﻿using var http = new HttpClient();
+
+var url = args.FirstOrDefault();
+
+if (string.IsNullOrEmpty(url))
+{
+    throw new Exception("Missing URL");
+}
+
+var response = await http.GetAsync(url).ConfigureAwait(false);
+response.EnsureSuccessStatusCode();
+
+if (response.Content.Headers.ContentType?.MediaType != "application/json" || response.Content.Headers.ContentLength == 0)
+{
+    throw new Exception("Invalid ContentType or Length");
+}
+
+Console.WriteLine("OK");
+return 0;

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -8,7 +8,6 @@ COPY . .
 RUN dotnet build src/ServiceControl.Audit/ServiceControl.Audit.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
-
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
 ARG VERSION
@@ -23,6 +22,7 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
       org.opencontainers.image.description="ServiceControl audit instance"
 
 EXPOSE 44444
+
 COPY --from=build /deploy/Particular.ServiceControl.Audit ./app
 COPY --from=build /healthcheck /healthcheck
 

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -6,7 +6,7 @@ ENV CI=true
 
 COPY . .
 RUN dotnet build src/ServiceControl.Audit/ServiceControl.Audit.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
-RUN dotnet build src/HealthCheckApp/HealthCheckApp.csproj --configuration Release --property:TargetArch=$TARGETARCH
+RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 
 # Runtime image
@@ -24,7 +24,7 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
 
 EXPOSE 44444
 COPY --from=build /deploy/Particular.ServiceControl.Audit ./app
-COPY --from=build /deploy/healthcheck ./healthcheck
+COPY --from=build /healthcheck /healthcheck
 
 ENV PersistenceType=RavenDB \
     AuditRetentionPeriod=7

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -23,7 +23,7 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
 
 EXPOSE 44444
 
-COPY --from=build /deploy/Particular.ServiceControl.Audit ./app
+COPY --from=build /deploy/Particular.ServiceControl.Audit /app
 COPY --from=build /healthcheck /healthcheck
 
 ENV PersistenceType=RavenDB \
@@ -31,5 +31,6 @@ ENV PersistenceType=RavenDB \
 
 HEALTHCHECK --start-period=10s CMD ["/healthcheck/healthcheck", "http://localhost:44444/api/configuration"]
 
+WORKDIR /app
 USER $APP_UID
-ENTRYPOINT ["./app/ServiceControl.Audit"]
+ENTRYPOINT ["/app/ServiceControl.Audit"]

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=build /deploy/healthcheck ./healthcheck
 ENV PersistenceType=RavenDB \
     AuditRetentionPeriod=7
 
-HEALTHCHECK --start-period=10s CMD /healthcheck/healthcheck http://localhost:44444/api/configuration || exit 1
+HEALTHCHECK --start-period=10s CMD ["/healthcheck/healthcheck", "http://localhost:44444/api/configuration"]
 
 USER $APP_UID
 ENTRYPOINT ["./app/ServiceControl.Audit"]

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -11,7 +11,7 @@ RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH -
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
 ARG VERSION
-WORKDIR /
+WORKDIR /app
 
 LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
       org.opencontainers.image.authors="Particular Software" \
@@ -31,6 +31,5 @@ ENV PersistenceType=RavenDB \
 
 HEALTHCHECK --start-period=10s CMD ["/healthcheck/healthcheck", "http://localhost:44444/api/configuration"]
 
-WORKDIR /app
 USER $APP_UID
 ENTRYPOINT ["/app/ServiceControl.Audit"]

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -6,14 +6,13 @@ ENV CI=true
 
 COPY . .
 RUN dotnet build src/ServiceControl.Audit/ServiceControl.Audit.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
+RUN dotnet build src/HealthCheckApp/HealthCheckApp.csproj --configuration Release --property:TargetArch=$TARGETARCH
 
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
 ARG VERSION
 WORKDIR /
-
-RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 
 LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
       org.opencontainers.image.authors="Particular Software" \
@@ -25,12 +24,12 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
 
 EXPOSE 44444
 COPY --from=build /deploy/Particular.ServiceControl.Audit ./app
+COPY --from=build /deploy/healthcheck ./healthcheck
 
 ENV PersistenceType=RavenDB \
     AuditRetentionPeriod=7
 
-HEALTHCHECK --start-period=60s CMD wget --tries=1 --no-verbose -O/dev/null http://localhost:44444/api/configuration || exit 1
-
+HEALTHCHECK --start-period=10s CMD /healthcheck/healthcheck http://localhost:44444/api/configuration || exit 1
 
 USER $APP_UID
 ENTRYPOINT ["./app/ServiceControl.Audit"]

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -27,7 +27,7 @@ EXPOSE 33633
 COPY --from=build /deploy/Particular.ServiceControl.Monitoring ./app
 COPY --from=build /deploy/healthcheck ./healthcheck
 
-HEALTHCHECK --start-period=10s CMD /healthcheck/healthcheck http://localhost:33633/connection || exit 1
+HEALTHCHECK --start-period=10s CMD ["/healthcheck/healthcheck", "http://localhost:33633/connection"]
 
 USER $APP_UID
 ENTRYPOINT ["./app/ServiceControl.Monitoring"]

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -6,7 +6,7 @@ ENV CI=true
 
 COPY . .
 RUN dotnet build src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
-RUN dotnet build src/HealthCheckApp/HealthCheckApp.csproj --configuration Release --property:TargetArch=$TARGETARCH
+RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 
 # Runtime image
@@ -25,7 +25,7 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
 EXPOSE 33633
 
 COPY --from=build /deploy/Particular.ServiceControl.Monitoring ./app
-COPY --from=build /deploy/healthcheck ./healthcheck
+COPY --from=build /healthcheck /healthcheck
 
 HEALTHCHECK --start-period=10s CMD ["/healthcheck/healthcheck", "http://localhost:33633/connection"]
 

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -11,7 +11,7 @@ RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH -
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
 ARG VERSION
-WORKDIR /
+WORKDIR /app
 
 LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
       org.opencontainers.image.authors="Particular Software" \
@@ -28,6 +28,5 @@ COPY --from=build /healthcheck /healthcheck
 
 HEALTHCHECK --start-period=10s CMD ["/healthcheck/healthcheck", "http://localhost:33633/connection"]
 
-WORKDIR /app
 USER $APP_UID
 ENTRYPOINT ["/app/ServiceControl.Monitoring"]

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -8,7 +8,6 @@ COPY . .
 RUN dotnet build src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
-
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
 ARG VERSION

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -23,10 +23,11 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
 
 EXPOSE 33633
 
-COPY --from=build /deploy/Particular.ServiceControl.Monitoring ./app
+COPY --from=build /deploy/Particular.ServiceControl.Monitoring /app
 COPY --from=build /healthcheck /healthcheck
 
 HEALTHCHECK --start-period=10s CMD ["/healthcheck/healthcheck", "http://localhost:33633/connection"]
 
+WORKDIR /app
 USER $APP_UID
-ENTRYPOINT ["./app/ServiceControl.Monitoring"]
+ENTRYPOINT ["/app/ServiceControl.Monitoring"]

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -6,14 +6,13 @@ ENV CI=true
 
 COPY . .
 RUN dotnet build src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
+RUN dotnet build src/HealthCheckApp/HealthCheckApp.csproj --configuration Release --property:TargetArch=$TARGETARCH
 
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
 ARG VERSION
 WORKDIR /
-
-RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 
 LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
       org.opencontainers.image.authors="Particular Software" \
@@ -26,9 +25,9 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
 EXPOSE 33633
 
 COPY --from=build /deploy/Particular.ServiceControl.Monitoring ./app
+COPY --from=build /deploy/healthcheck ./healthcheck
 
-HEALTHCHECK --start-period=60s CMD wget --tries=1 --no-verbose -O/dev/null http://localhost:33633/connection || exit 1
-
+HEALTHCHECK --start-period=10s CMD /healthcheck/healthcheck http://localhost:33633/connection || exit 1
 
 USER $APP_UID
 ENTRYPOINT ["./app/ServiceControl.Monitoring"]

--- a/src/ServiceControl.RavenDB/containers.json
+++ b/src/ServiceControl.RavenDB/containers.json
@@ -6,9 +6,5 @@
     {
         "arch": "arm64/v8",
         "tag": "arm64v8"
-    },
-    {
-        "arch": "arm/v7",
-        "tag": "arm32v7"
     }
 ]

--- a/src/ServiceControl.sln
+++ b/src/ServiceControl.sln
@@ -177,6 +177,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Particular.LicensingCompone
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Particular.LicensingComponent.UnitTests", "Particular.LicensingComponent.UnitTests\Particular.LicensingComponent.UnitTests.csproj", "{51F5504E-E915-40EC-B96E-CA700A57982C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HealthCheckApp", "HealthCheckApp\HealthCheckApp.csproj", "{D523E575-6975-4974-A173-B47996A73914}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -955,6 +957,18 @@ Global
 		{51F5504E-E915-40EC-B96E-CA700A57982C}.Release|x64.Build.0 = Release|Any CPU
 		{51F5504E-E915-40EC-B96E-CA700A57982C}.Release|x86.ActiveCfg = Release|Any CPU
 		{51F5504E-E915-40EC-B96E-CA700A57982C}.Release|x86.Build.0 = Release|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Debug|x64.Build.0 = Debug|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Debug|x86.Build.0 = Debug|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Release|x64.ActiveCfg = Release|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Release|x64.Build.0 = Release|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Release|x86.ActiveCfg = Release|Any CPU
+		{D523E575-6975-4974-A173-B47996A73914}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -23,7 +23,7 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
 
 EXPOSE 33333
 
-COPY --from=build /deploy/Particular.ServiceControl ./app
+COPY --from=build /deploy/Particular.ServiceControl /app
 COPY --from=build /healthcheck /healthcheck
 
 ENV PersistenceType=RavenDB \
@@ -32,5 +32,6 @@ ENV PersistenceType=RavenDB \
 
 HEALTHCHECK --start-period=10s CMD ["/healthcheck/healthcheck", "http://localhost:33333/api/configuration"]
 
+WORKDIR /app
 USER $APP_UID
-ENTRYPOINT ["./app/ServiceControl"]
+ENTRYPOINT ["/app/ServiceControl"]

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -30,7 +30,7 @@ ENV PersistenceType=RavenDB \
     ForwardErrorMessages=false \
     ErrorRetentionPeriod=15
 
-HEALTHCHECK --start-period=10s CMD /healthcheck/healthcheck http://localhost:33333/api/configuration || exit 1
+HEALTHCHECK --start-period=10s CMD ["/healthcheck/healthcheck", "http://localhost:33333/api/configuration"]
 
 USER $APP_UID
 ENTRYPOINT ["./app/ServiceControl"]

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -6,8 +6,7 @@ ENV CI=true
 
 COPY . .
 RUN dotnet build src/ServiceControl/ServiceControl.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
-RUN dotnet build src/HealthCheckApp/HealthCheckApp.csproj --configuration Release --property:TargetArch=$TARGETARCH
-
+RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
@@ -24,7 +23,7 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
 
 EXPOSE 33333
 COPY --from=build /deploy/Particular.ServiceControl ./app
-COPY --from=build /deploy/healthcheck ./healthcheck
+COPY --from=build /healthcheck /healthcheck
 
 ENV PersistenceType=RavenDB \
     ForwardErrorMessages=false \

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -11,7 +11,7 @@ RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH -
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
 ARG VERSION
-WORKDIR /
+WORKDIR /app
 
 LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
       org.opencontainers.image.authors="Particular Software" \
@@ -32,6 +32,5 @@ ENV PersistenceType=RavenDB \
 
 HEALTHCHECK --start-period=10s CMD ["/healthcheck/healthcheck", "http://localhost:33333/api/configuration"]
 
-WORKDIR /app
 USER $APP_UID
 ENTRYPOINT ["/app/ServiceControl"]

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -22,6 +22,7 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
       org.opencontainers.image.description="ServiceControl primary instance"
 
 EXPOSE 33333
+
 COPY --from=build /deploy/Particular.ServiceControl ./app
 COPY --from=build /healthcheck /healthcheck
 

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -6,14 +6,13 @@ ENV CI=true
 
 COPY . .
 RUN dotnet build src/ServiceControl/ServiceControl.csproj --configuration Release -graph --property:TargetArch=$TARGETARCH
+RUN dotnet build src/HealthCheckApp/HealthCheckApp.csproj --configuration Release --property:TargetArch=$TARGETARCH
 
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
 ARG VERSION
 WORKDIR /
-
-RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 
 LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
       org.opencontainers.image.authors="Particular Software" \
@@ -25,12 +24,13 @@ LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceContr
 
 EXPOSE 33333
 COPY --from=build /deploy/Particular.ServiceControl ./app
+COPY --from=build /deploy/healthcheck ./healthcheck
 
 ENV PersistenceType=RavenDB \
     ForwardErrorMessages=false \
     ErrorRetentionPeriod=15
 
-HEALTHCHECK --start-period=60s CMD wget --tries=1 --no-verbose -O/dev/null http://localhost:33333/api/configuration || exit 1
+HEALTHCHECK --start-period=10s CMD /healthcheck/healthcheck http://localhost:33333/api/configuration || exit 1
 
 USER $APP_UID
 ENTRYPOINT ["./app/ServiceControl"]


### PR DESCRIPTION
Changing the base image for the three application images from `mcr.microsoft.com/dotnet/aspnet:8.0` to `mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite` decreases the overall image size (as reported by `docker images`) drastically. Sizes are from the `linux/amd64` architecture image.

| Image | Previous Image Size | Updated Size |
|-|:-:|:-:|
| particular/servicecontrol | 391.57 MB | 213.54 MB |
| particular/servicecontrol-audit | 385.85 MB | 207.81 MB |
| particular/servicecontrol-monitoring | 375.04 MB | 197.01 MB |

The difference of 178.03 MB in each case is the difference between in size between base images.