### PR TITLE
Added missed overload for preventing creation of delayed delivery infrastructure on RabbitMQ for quorum queues

### DIFF
--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQConventionalRoutingTransportCustomization.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQConventionalRoutingTransportCustomization.cs
@@ -22,7 +22,7 @@
                 throw new InvalidOperationException("Connection string not configured");
             }
 
-            var transport = new RabbitMQTransport(RoutingTopology.Conventional(queueType), transportSettings.ConnectionString);
+            var transport = new RabbitMQTransport(RoutingTopology.Conventional(queueType), transportSettings.ConnectionString, enableDelayedDelivery: false);
             transport.TransportTransactionMode = transport.GetSupportedTransactionModes().Contains(preferredTransactionMode) ? preferredTransactionMode : TransportTransactionMode.ReceiveOnly;
 
             return transport;

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/RabbitMQQueryTests.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/RabbitMQQueryTests.cs
@@ -41,7 +41,6 @@ class RabbitMQQueryTests : TransportTestFixture
             Assert.AreEqual("/", queueName.Scope);
             if (queueName.QueueName == transportSettings.EndpointName)
             {
-                CollectionAssert.Contains(queueName.EndpointIndicators, "DelayBinding");
                 CollectionAssert.Contains(queueName.EndpointIndicators, "ConventionalTopologyBinding");
             }
         }


### PR DESCRIPTION
Missed disabling delayed delivery for RabbitMQ transport quorum conventional queues.

- Related to: https://github.com/Particular/ServiceControl/pull/4351