### PR TITLE
handle messagetype being null

### DIFF
--- a/src/ServiceControl.Monitoring/Infrastructure/Api/EndpointMetricsApi.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/Api/EndpointMetricsApi.cs
@@ -221,7 +221,9 @@
 
         static MonitoredEndpointMessageType[] GetMonitoredMessageTypes(IEnumerable<EndpointMessageType> messageTypes)
         {
-            return messageTypes.Select(mt => MonitoredEndpointMessageTypeParser.Parse(mt.MessageType))
+            return messageTypes
+                .Where(mt => !string.IsNullOrEmpty(mt.MessageType))
+                .Select(mt => MonitoredEndpointMessageTypeParser.Parse(mt.MessageType))
                 .ToArray();
         }
 

--- a/src/ServiceControl.Monitoring/Infrastructure/EndpointMessageType.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/EndpointMessageType.cs
@@ -4,7 +4,7 @@
     {
         public EndpointMessageType(string endpointName, string enclosedMessageTypes)
         {
-            var index = enclosedMessageTypes.IndexOf(';');
+            var index = (enclosedMessageTypes ?? "").IndexOf(';');
 
             var firstType = index != -1
                 ? enclosedMessageTypes.Substring(0, index)


### PR DESCRIPTION
fixes the symptoms of #3980 

handle messageType being null when processing an endpoint. Note that any null endpoints get filtered out of the displayed results set, in [messageTypes.ts](https://github.com/Particular/ServicePulse/blob/5af9e3a68b66b9a7ba750cd937c0af42353b97e4/src/Frontend/src/components/monitoring/messageTypes.ts#L54):

```js
      // filter out system message types
      .filter((mt) => mt.id && mt.typeName)
```

There is another discussion to be held as to whether unknown and uninferrable messagetypes should be passed through as null, since this prevents metrics being shown for these messages, but this is an imperfect first step to prevent an exception when handling this case
