### PR TITLE
Use global.json to specify MSBuild project SDK versions

### DIFF
--- a/src/LegacyArtifacts/LegacyArtifacts.csproj
+++ b/src/LegacyArtifacts/LegacyArtifacts.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+﻿<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
+++ b/src/ServiceControlInstaller.Packaging/ServiceControlInstaller.Packaging.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+﻿<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,5 @@
+{
+    "msbuild-sdks": {
+        "Microsoft.Build.NoTargets": "3.7.0"
+    }
+}


### PR DESCRIPTION
This PR moves the version information for the Microsoft.Build.NoTargets SDK to a `global.json` file because Dependabot does not currently support updating the version when it is specified directly in the project file.

This does also ensure that the same version is used for every project in the solution that references it.