### PR TITLE
Auto-expire disconnected instance in Monitoring screens

### DIFF
--- a/src/ServiceControl.Monitoring.AcceptanceTests/PerformanceTests.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/PerformanceTests.cs
@@ -27,7 +27,7 @@
             queueLengthStore = new QueueLengthStore();
 
             var settings = new Settings { EndpointUptimeGracePeriod = TimeSpan.FromMinutes(5) };
-            activityTracker = new EndpointInstanceActivityTracker(settings);
+            activityTracker = new EndpointInstanceActivityTracker(settings, TimeProvider.System);
 
             messageTypeRegistry = new MessageTypeRegistry();
 

--- a/src/ServiceControl.Monitoring.UnitTests/.editorconfig
+++ b/src/ServiceControl.Monitoring.UnitTests/.editorconfig
@@ -1,0 +1,6 @@
+﻿[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+csharp_style_var_elsewhere = true:error
+csharp_style_var_for_built_in_types = true:error

--- a/src/ServiceControl.Monitoring.UnitTests/API/APIApprovals.cs
+++ b/src/ServiceControl.Monitoring.UnitTests/API/APIApprovals.cs
@@ -19,7 +19,7 @@ public class APIApprovals
         var httpApiMethods = GetControllerRoutes()
             .Select(pair =>
             {
-                (MethodInfo method, RouteAttribute route) = pair;
+                (var method, var route) = pair;
                 var type = method.DeclaringType;
                 var httpMethods = method.GetCustomAttributes(true)
                     .OfType<IActionHttpMethodProvider>()

--- a/src/ServiceControl.Monitoring.UnitTests/API/AggregationTests.cs
+++ b/src/ServiceControl.Monitoring.UnitTests/API/AggregationTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Linq;
-    using Http.Diagrams;
     using Messaging;
     using Monitoring.Infrastructure;
     using Monitoring.Infrastructure.Api;
@@ -23,7 +22,7 @@
         public void Setup()
         {
             settings = new Settings { EndpointUptimeGracePeriod = TimeSpan.FromMinutes(5) };
-            activityTracker = new EndpointInstanceActivityTracker(settings);
+            activityTracker = new EndpointInstanceActivityTracker(settings, TimeProvider.System);
             processingTimeStore = new ProcessingTimeStore();
             endpointRegistry = new EndpointRegistry();
 
@@ -57,9 +56,9 @@
             processingTimeStore.Store([dataA], instanceAId, EndpointMessageType.Unknown(instanceAId.EndpointName));
             processingTimeStore.Store([dataB], instanceBId, EndpointMessageType.Unknown(instanceBId.EndpointName));
 
-            MonitoredEndpointDetails result = endpointMetricsApi.GetSingleEndpointMetrics(instanceAId.EndpointName);
+            var result = endpointMetricsApi.GetSingleEndpointMetrics(instanceAId.EndpointName);
 
-            MonitoredEndpointDetails model = result;
+            var model = result;
 
             Assert.That(model.Instances[0].Metrics["ProcessingTime"].Average, Is.EqualTo(5));
         }
@@ -90,7 +89,7 @@
             Array.ForEach(connected, instance => activityTracker.Record(instance, now));
             Array.ForEach(connected, instance => processingTimeStore.Store(samples, instance, EndpointMessageType.Unknown(instance.EndpointName)));
 
-            MonitoredEndpoint[] model = endpointMetricsApi.GetAllEndpointsMetrics();
+            var model = endpointMetricsApi.GetAllEndpointsMetrics();
             var item = model[0];
 
             Assert.Multiple(() =>

--- a/src/ServiceControl.Monitoring.UnitTests/ServiceControl.Monitoring.UnitTests.csproj
+++ b/src/ServiceControl.Monitoring.UnitTests/ServiceControl.Monitoring.UnitTests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit.Analyzers" />

--- a/src/ServiceControl.Monitoring/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Monitoring/HostApplicationBuilderExtensions.cs
@@ -83,6 +83,8 @@ public static class HostApplicationBuilderExtensions
             services.AddHostedService<ReportThroughputHostedService>();
         }
 
+        services.AddHostedService<RemoveExpiredEndpointInstances>();
+
         config.DefineCriticalErrorAction(onCriticalError);
 
         config.GetSettings().Set(settings);

--- a/src/ServiceControl.Monitoring/Infrastructure/HistoryPeriod.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/HistoryPeriod.cs
@@ -63,7 +63,7 @@
             new(TimeSpan.FromMinutes(10), numberOfIntervals: 60, delayedIntervals: 1),
             new(TimeSpan.FromMinutes(15), numberOfIntervals: 60, delayedIntervals: 1),
             new(TimeSpan.FromMinutes(30), numberOfIntervals: 60, delayedIntervals: 1),
-            new HistoryPeriod(TimeSpan.FromMinutes(LargestHistoryPeriod), 60, 1)
+            new(TimeSpan.FromMinutes(LargestHistoryPeriod), 60, 1)
         ];
 
         public const int LargestHistoryPeriod = 60;

--- a/src/ServiceControl.Monitoring/Infrastructure/HistoryPeriod.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/HistoryPeriod.cs
@@ -63,7 +63,9 @@
             new(TimeSpan.FromMinutes(10), numberOfIntervals: 60, delayedIntervals: 1),
             new(TimeSpan.FromMinutes(15), numberOfIntervals: 60, delayedIntervals: 1),
             new(TimeSpan.FromMinutes(30), numberOfIntervals: 60, delayedIntervals: 1),
-            new(TimeSpan.FromMinutes(60), numberOfIntervals: 60, delayedIntervals: 1)
+            new HistoryPeriod(TimeSpan.FromMinutes(LargestHistoryPeriod), 60, 1)
         ];
+
+        public const int LargestHistoryPeriod = 60;
     }
 }

--- a/src/ServiceControl.Monitoring/Infrastructure/RemoveExpiredEndpointInstances.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/RemoveExpiredEndpointInstances.cs
@@ -1,0 +1,56 @@
+﻿namespace ServiceControl.Monitoring;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Http.Diagrams;
+using Infrastructure;
+using Infrastructure.Api;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+public class RemoveExpiredEndpointInstances(
+    ILogger<RemoveExpiredEndpointInstances> logger,
+    IEndpointMetricsApi metricsApi,
+    EndpointInstanceActivityTracker activityTracker,
+    TimeProvider timeProvider) : BackgroundService
+{
+    const int IntervalInMinutes = 5;
+
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation($"Starting {nameof(RemoveExpiredEndpointInstances)}");
+
+        try
+        {
+            using PeriodicTimer timer = new(TimeSpan.FromMinutes(IntervalInMinutes), timeProvider);
+
+            do
+            {
+                try
+                {
+                    foreach (MonitoredEndpoint monitoredEndpoint in metricsApi.GetAllEndpointsMetrics())
+                    {
+                        foreach (string endpointInstanceId in monitoredEndpoint.EndpointInstanceIds)
+                        {
+                            if (activityTracker.IsExpired(new EndpointInstanceId(monitoredEndpoint.Name,
+                                    endpointInstanceId)))
+                            {
+                                metricsApi.DeleteEndpointInstance(monitoredEndpoint.Name, endpointInstanceId);
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    logger.LogError(ex,
+                        $"Error deleting expired endpoint instances, trying again in {IntervalInMinutes} minutes.");
+                }
+            } while (await timer.WaitForNextTickAsync(cancellationToken));
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogInformation($"Stopping {nameof(RemoveExpiredEndpointInstances)} timer");
+        }
+    }
+}


### PR DESCRIPTION
Auto-prunes endpoint instances that have not reported any metrics for 1 hour

This is part of fixing https://github.com/Particular/ServicePulse/issues/1257