### PR TITLE
"Setup and run" startup option to combine setup and run into one action

### DIFF
--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -9,6 +9,9 @@ using ServiceControl.Infrastructure;
 
 AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
+// TODO Link to GitHub issue
+await IntegratedSetup.Run();
+
 ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());
 
 var arguments = new HostArguments(args);

--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -9,7 +9,7 @@ using ServiceControl.Infrastructure;
 
 AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
-// TODO Link to GitHub issue
+// Hack: See https://github.com/Particular/ServiceControl/issues/4392
 await IntegratedSetup.Run();
 
 ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());

--- a/src/ServiceControl.Audit/Properties/launchSettings.json
+++ b/src/ServiceControl.Audit/Properties/launchSettings.json
@@ -14,6 +14,13 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "commandLineArgs": "--setup"
+    },
+    "Integrated Setup": {
+      "commandName": "Project",
+      "commandLineArgs": "--integrated-setup",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/src/ServiceControl.Audit/Properties/launchSettings.json
+++ b/src/ServiceControl.Audit/Properties/launchSettings.json
@@ -9,15 +9,16 @@
     },
     "Setup ServiceControl.Audit": {
       "commandName": "Project",
+      "commandLineArgs": "--setup",
       "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "commandLineArgs": "--setup"
+      }
     },
-    "Integrated Setup": {
+    "Setup and Run ServiceControl.Audit": {
       "commandName": "Project",
       "commandLineArgs": "--setup-and-run",
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ServiceControl.Audit/Properties/launchSettings.json
+++ b/src/ServiceControl.Audit/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "Integrated Setup": {
       "commandName": "Project",
-      "commandLineArgs": "--integrated-setup",
+      "commandLineArgs": "--setup-and-run",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ServiceControl.Infrastructure/IntegratedSetup.cs
+++ b/src/ServiceControl.Infrastructure/IntegratedSetup.cs
@@ -1,0 +1,56 @@
+﻿namespace ServiceControl.Infrastructure
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public static class IntegratedSetup
+    {
+        const string ArgName = "--integrated-setup";
+
+        public static Task Run()
+        {
+            // Contains DLL if executed as `dotnet PATH`, which args passed to Main() do not
+            var args = Environment.GetCommandLineArgs().ToList();
+            if (!args.Contains(ArgName))
+            {
+                return Task.CompletedTask;
+            }
+
+            for (var i = 0; i < args.Count; i++)
+            {
+                if (args[i] == ArgName)
+                {
+                    args[i] = "--setup";
+                }
+            }
+
+            var processPath = Environment.ProcessPath;
+            var commandLine = Environment.CommandLine.Replace(ArgName, "--setup");
+            if (!Path.GetFileNameWithoutExtension(processPath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+            {
+                args.RemoveAt(0);
+            }
+
+            var startInfo = new ProcessStartInfo(processPath, args)
+            {
+                UseShellExecute = false,
+                WorkingDirectory = Environment.CurrentDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            var process = Process.Start(startInfo);
+
+            process.OutputDataReceived += (s, e) => Console.WriteLine(e.Data);
+            process.ErrorDataReceived += (s, e) => Console.Error.WriteLine(e.Data);
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            return process.WaitForExitAsync();
+        }
+    }
+}

--- a/src/ServiceControl.Infrastructure/IntegratedSetup.cs
+++ b/src/ServiceControl.Infrastructure/IntegratedSetup.cs
@@ -8,27 +8,28 @@
 
     public static class IntegratedSetup
     {
-        const string ArgName = "--integrated-setup";
+        const string SetupAndRunCmd = "--setup-and-run";
+        const string SetupCmd = "--setup";
 
         public static Task Run()
         {
             // Contains DLL if executed as `dotnet PATH`, which args passed to Main() do not
             var args = Environment.GetCommandLineArgs().ToList();
-            if (!args.Contains(ArgName))
+            if (!args.Contains(SetupAndRunCmd))
             {
                 return Task.CompletedTask;
             }
 
             for (var i = 0; i < args.Count; i++)
             {
-                if (args[i] == ArgName)
+                if (args[i] == SetupAndRunCmd)
                 {
-                    args[i] = "--setup";
+                    args[i] = SetupCmd;
                 }
             }
 
             var processPath = Environment.ProcessPath;
-            var commandLine = Environment.CommandLine.Replace(ArgName, "--setup");
+            var commandLine = Environment.CommandLine.Replace(SetupAndRunCmd, SetupCmd);
             if (!Path.GetFileNameWithoutExtension(processPath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
             {
                 args.RemoveAt(0);

--- a/src/ServiceControl.Infrastructure/IntegratedSetup.cs
+++ b/src/ServiceControl.Infrastructure/IntegratedSetup.cs
@@ -13,8 +13,9 @@
 
         public static Task Run()
         {
-            // Contains DLL if executed as `dotnet PATH`, which args passed to Main() do not
+            // Using GetCommandLineArgs instead of the args passed into Main because GetCommandLineArgs provides the entry assembly path
             var args = Environment.GetCommandLineArgs().ToList();
+
             if (!args.Contains(SetupAndRunCmd))
             {
                 return Task.CompletedTask;
@@ -29,7 +30,7 @@
             }
 
             var processPath = Environment.ProcessPath;
-            var commandLine = Environment.CommandLine.Replace(SetupAndRunCmd, SetupCmd);
+
             if (!Path.GetFileNameWithoutExtension(processPath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
             {
                 args.RemoveAt(0);

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -7,6 +7,9 @@ using ServiceControl.Monitoring;
 
 AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
+// TODO Link to GitHub issue
+await IntegratedSetup.Run();
+
 ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());
 
 var arguments = new HostArguments(args);

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -7,7 +7,7 @@ using ServiceControl.Monitoring;
 
 AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
-// TODO Link to GitHub issue
+// Hack: See https://github.com/Particular/ServiceControl/issues/4392
 await IntegratedSetup.Run();
 
 ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());

--- a/src/ServiceControl.Monitoring/Properties/launchSettings.json
+++ b/src/ServiceControl.Monitoring/Properties/launchSettings.json
@@ -9,15 +9,16 @@
     },
     "Setup ServiceControl.Monitoring": {
       "commandName": "Project",
+      "commandLineArgs": "--setup",
       "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "commandLineArgs": "--setup"
+      }
     },
-    "Integrated Setup": {
+    "Setup and Run ServiceControl.Monitoring": {
       "commandName": "Project",
       "commandLineArgs": "--setup-and-run",
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ServiceControl.Monitoring/Properties/launchSettings.json
+++ b/src/ServiceControl.Monitoring/Properties/launchSettings.json
@@ -14,6 +14,13 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "commandLineArgs": "--setup"
+    },
+    "Integrated Setup": {
+      "commandName": "Project",
+      "commandLineArgs": "--integrated-setup",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/src/ServiceControl.Monitoring/Properties/launchSettings.json
+++ b/src/ServiceControl.Monitoring/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "Integrated Setup": {
       "commandName": "Project",
-      "commandLineArgs": "--integrated-setup",
+      "commandLineArgs": "--setup-and-run",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -9,6 +9,9 @@ using ServiceControl.Infrastructure;
 
 AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
+// TODO Link to GitHub issue
+await IntegratedSetup.Run();
+
 ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());
 
 var arguments = new HostArguments(args);

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -9,7 +9,7 @@ using ServiceControl.Infrastructure;
 
 AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
-// TODO Link to GitHub issue
+// Hack: See https://github.com/Particular/ServiceControl/issues/4392
 await IntegratedSetup.Run();
 
 ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());

--- a/src/ServiceControl/Properties/launchSettings.json
+++ b/src/ServiceControl/Properties/launchSettings.json
@@ -9,15 +9,16 @@
     },
     "Setup ServiceControl": {
       "commandName": "Project",
+      "commandLineArgs": "--setup",
       "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "commandLineArgs": "--setup"
+      }
     },
-    "Integrated Setup": {
+    "Setup and Run ServiceControl": {
       "commandName": "Project",
       "commandLineArgs": "--setup-and-run",
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ServiceControl/Properties/launchSettings.json
+++ b/src/ServiceControl/Properties/launchSettings.json
@@ -14,6 +14,13 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "commandLineArgs": "--setup"
+    },
+    "Integrated Setup": {
+      "commandName": "Project",
+      "commandLineArgs": "--integrated-setup",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/src/ServiceControl/Properties/launchSettings.json
+++ b/src/ServiceControl/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "Integrated Setup": {
       "commandName": "Project",
-      "commandLineArgs": "--integrated-setup",
+      "commandLineArgs": "--setup-and-run",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
This PR introdces a new `--setup-and-run` command that combines the `--setup` step into a normal run, creating queues and initializing the database on every app startup.

The current implementation executes a secondary child process of each ServiceControl executable on startup that runs setup, and once that exits, the instance continues to run in normal mode. This is less than ideal but was a quicker implementation than redesigning the entire startup methodology. That context is captured in https://github.com/Particular/ServiceControl/issues/4392.

This is particularly useful for container-based deployment, where having setup and run implemented as separate commands creates unnecessary deployment complexity in the form of requiring init containers.

