### PR TITLE
Update NServiceBus.RabbitMQ to version that addresses connection leak

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="NServiceBus.Metrics" Version="5.0.0" />
     <PackageVersion Include="NServiceBus.Metrics.ServiceControl" Version="5.0.0" />
     <PackageVersion Include="NServiceBus.Persistence.NonDurable" Version="2.0.0" />
-    <PackageVersion Include="NServiceBus.RabbitMQ" Version="9.1.0" />
+    <PackageVersion Include="NServiceBus.RabbitMQ" Version="9.1.1" />
     <PackageVersion Include="NServiceBus.SagaAudit" Version="5.0.0" />
     <PackageVersion Include="NServiceBus.Testing" Version="9.0.0" />
     <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="4.2.0" />


### PR DESCRIPTION
Backport of https://github.com/Particular/ServiceControl/pull/4390 to `release-5.6`