### PR TITLE
Connection leak in NServiceBus.RabbitMQ and vulnerabilities in dependency System.Text.Json and transitive dependency System.Formats.Asn1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -71,7 +71,7 @@
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.Management" Version="7.0.2" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
     <PackageVersion Include="Validar.Fody" Version="1.9.0" />
     <PackageVersion Include="Windows7APICodePack-Shell" Version="1.1.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="NServiceBus.Metrics" Version="3.1.0" />
     <PackageVersion Include="NServiceBus.Metrics.ServiceControl" Version="3.0.6" />
     <PackageVersion Include="NServiceBus.Metrics.ServiceControl.Msmq" Version="3.0.1" />
-    <PackageVersion Include="NServiceBus.RabbitMQ" Version="7.0.5" />
+    <PackageVersion Include="NServiceBus.RabbitMQ" Version="7.0.7" />
     <PackageVersion Include="NServiceBus.SagaAudit" Version="3.0.1" />
     <PackageVersion Include="NServiceBus.Testing" Version="7.4.2" />
     <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="2.0.6" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -88,6 +88,7 @@
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+    <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />


### PR DESCRIPTION
This PR updates the following dependencies:

- NServiceBus.RabbitMQ to 7.0.7 to address a connection leak problem
- System.Text.Json to 8.0.4 to address a [vulnerability](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w)
- System.Formats.Asn1 to address a [vulnerability](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w)