### PR TITLE
Exit setup-and-run mode if setup fails

### DIFF
--- a/src/ServiceControl.Audit/Program.cs
+++ b/src/ServiceControl.Audit/Program.cs
@@ -10,7 +10,12 @@ using ServiceControl.Infrastructure;
 AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
 // Hack: See https://github.com/Particular/ServiceControl/issues/4392
-await IntegratedSetup.Run();
+var exitCode = await IntegratedSetup.Run();
+
+if (exitCode != 0)
+{
+    return exitCode;
+}
 
 ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());
 
@@ -19,7 +24,7 @@ var arguments = new HostArguments(args);
 if (arguments.Help)
 {
     arguments.PrintUsage();
-    return;
+    return 0;
 }
 
 var loggingSettings = new LoggingSettings(Settings.SettingsRootNamespace);
@@ -28,3 +33,5 @@ LoggingConfigurator.ConfigureLogging(loggingSettings);
 var settings = new Settings(loggingSettings: loggingSettings);
 
 await new CommandRunner(arguments.Command).Execute(arguments, settings);
+
+return 0;

--- a/src/ServiceControl.Infrastructure/IntegratedSetup.cs
+++ b/src/ServiceControl.Infrastructure/IntegratedSetup.cs
@@ -11,14 +11,14 @@
         const string SetupAndRunCmd = "--setup-and-run";
         const string SetupCmd = "--setup";
 
-        public static async Task Run()
+        public static async Task<int> Run()
         {
             // Using GetCommandLineArgs instead of the args passed into Main because GetCommandLineArgs provides the entry assembly path
             var args = Environment.GetCommandLineArgs().ToList();
 
             if (!args.Contains(SetupAndRunCmd))
             {
-                return;
+                return 0;
             }
 
             for (var i = 0; i < args.Count; i++)
@@ -54,10 +54,7 @@
 
             await process.WaitForExitAsync().ConfigureAwait(false);
 
-            if (process.ExitCode != 0)
-            {
-                Environment.Exit(process.ExitCode);
-            }
+            return process.ExitCode;
         }
     }
 }

--- a/src/ServiceControl.Infrastructure/IntegratedSetup.cs
+++ b/src/ServiceControl.Infrastructure/IntegratedSetup.cs
@@ -11,14 +11,14 @@
         const string SetupAndRunCmd = "--setup-and-run";
         const string SetupCmd = "--setup";
 
-        public static Task Run()
+        public static async Task Run()
         {
             // Using GetCommandLineArgs instead of the args passed into Main because GetCommandLineArgs provides the entry assembly path
             var args = Environment.GetCommandLineArgs().ToList();
 
             if (!args.Contains(SetupAndRunCmd))
             {
-                return Task.CompletedTask;
+                return;
             }
 
             for (var i = 0; i < args.Count; i++)
@@ -52,7 +52,12 @@
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            return process.WaitForExitAsync();
+            await process.WaitForExitAsync().ConfigureAwait(false);
+
+            if (process.ExitCode != 0)
+            {
+                Environment.Exit(process.ExitCode);
+            }
         }
     }
 }

--- a/src/ServiceControl.Monitoring/Program.cs
+++ b/src/ServiceControl.Monitoring/Program.cs
@@ -8,7 +8,12 @@ using ServiceControl.Monitoring;
 AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
 // Hack: See https://github.com/Particular/ServiceControl/issues/4392
-await IntegratedSetup.Run();
+var exitCode = await IntegratedSetup.Run();
+
+if (exitCode != 0)
+{
+    return exitCode;
+}
 
 ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());
 
@@ -20,3 +25,5 @@ LoggingConfigurator.ConfigureLogging(loggingSettings);
 var settings = new Settings(loggingSettings: loggingSettings);
 
 await new CommandRunner(arguments.Command).Execute(arguments, settings);
+
+return 0;

--- a/src/ServiceControl/Program.cs
+++ b/src/ServiceControl/Program.cs
@@ -10,7 +10,12 @@ using ServiceControl.Infrastructure;
 AppDomain.CurrentDomain.UnhandledException += (s, e) => LogManager.GetLogger(typeof(Program)).Error("Unhandled exception was caught.", e.ExceptionObject as Exception);
 
 // Hack: See https://github.com/Particular/ServiceControl/issues/4392
-await IntegratedSetup.Run();
+var exitCode = await IntegratedSetup.Run();
+
+if (exitCode != 0)
+{
+    return exitCode;
+}
 
 ExeConfiguration.PopulateAppSettings(Assembly.GetExecutingAssembly());
 
@@ -19,7 +24,7 @@ var arguments = new HostArguments(args);
 if (arguments.Help)
 {
     arguments.PrintUsage();
-    return;
+    return 0;
 }
 
 var loggingSettings = new LoggingSettings(Settings.SettingsRootNamespace);
@@ -28,3 +33,5 @@ LoggingConfigurator.ConfigureLogging(loggingSettings);
 var settings = new Settings(loggingSettings: loggingSettings);
 
 await new CommandRunner(arguments.Command).Execute(arguments, settings);
+
+return 0;


### PR DESCRIPTION
### Symptoms

When using the `--setup-and-run`, if something causes the setup phase to fail, ServiceControl will still proceed to the run phase, which could then result in additional errors related to missing queues or other environmental mismatches.

### Who's affected

Anyone using `--setup-and-run` option, most likely deploying ServiceControl using containers.

### Root cause

Failure to check the return code of the process executing the setup phase.