### PR TITLE
Ensuring Azure ManagementUrl setting accepts urls without the last slash

### DIFF
--- a/src/ServiceControl.Transports.ASBS.Tests/ApprovalFiles/AzureQueryTests.TestConnectionWithMissingLastSlashInManagementUrl.approved.txt
+++ b/src/ServiceControl.Transports.ASBS.Tests/ApprovalFiles/AzureQueryTests.TestConnectionWithMissingLastSlashInManagementUrl.approved.txt
@@ -1,0 +1,9 @@
+Connection test to AzureServiceBus was successful
+
+Connection settings used:
+ServiceBus name not set, defaulted to "xxxxx"
+SubscriptionId set
+TenantId set
+ClientId set
+Client secret set
+Management Url set to "https://management.azure.com"


### PR DESCRIPTION
It seems the logic did not cater for url without the last slash so urls like `https://management.azure.com/` and `https://management.azure.com` did not match.

This PR ensures those match