### PR TITLE
Ensuring Azure ManagementUrl setting accepts urls without the last slash

### DIFF
--- a/src/ServiceControl.Transports.ASBS.Tests/ApprovalFiles/AzureQueryTests.TestConnectionWithMissingLastSlashInManagementUrl.approved.txt
+++ b/src/ServiceControl.Transports.ASBS.Tests/ApprovalFiles/AzureQueryTests.TestConnectionWithMissingLastSlashInManagementUrl.approved.txt
@@ -1,0 +1,9 @@
+Connection test to AzureServiceBus was successful
+
+Connection settings used:
+ServiceBus name not set, defaulted to "xxxxx"
+SubscriptionId set
+TenantId set
+ClientId set
+Client secret set
+Management Url set to "https://management.azure.com"

--- a/src/ServiceControl.Transports.ASBS.Tests/AzureQueryTests.cs
+++ b/src/ServiceControl.Transports.ASBS.Tests/AzureQueryTests.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 using Particular.Approvals;
 using Transports;
 using Transports.ASBS;
-using ServiceControl.Transports.BrokerThroughput;
+using Transports.BrokerThroughput;
 
 [TestFixture]
 class AzureQueryTests : TransportTestFixture
@@ -71,6 +71,28 @@ class AzureQueryTests : TransportTestFixture
         (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
 
         Assert.IsTrue(success);
+        Approver.Verify(diagnostics, s =>
+        {
+            s = s.Replace(dictionary[AzureQuery.AzureServiceBusSettings.TenantId], "xxxxx");
+            s = s.Replace(dictionary[AzureQuery.AzureServiceBusSettings.SubscriptionId], "xxxxx");
+            s = s.Replace(dictionary[AzureQuery.AzureServiceBusSettings.ClientId], "xxxxx");
+            s = s.Replace(serviceBusName, "xxxxx");
+            return s;
+        });
+    }
+
+    [Test]
+    public async Task TestConnectionWithMissingLastSlashInManagementUrl()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        string serviceBusName = query.ExtractServiceBusName();
+        Dictionary<string, string> dictionary = GetSettings();
+        dictionary[AzureQuery.AzureServiceBusSettings.ManagementUrl] = "https://management.azure.com";
+        query.Initialize(new ReadOnlyDictionary<string, string>(dictionary));
+        (bool success, _, string diagnostics) = await query.TestConnection(cancellationTokenSource.Token);
+
+        Assert.That(success, Is.True);
         Approver.Verify(diagnostics, s =>
         {
             s = s.Replace(dictionary[AzureQuery.AzureServiceBusSettings.TenantId], "xxxxx");


### PR DESCRIPTION
It seems the logic did not cater for url without the last slash so urls like `https://management.azure.com/` and `https://management.azure.com` did not match.

This PR ensures those match.


