### PR TITLE
Use 8.0-jammy-chiseled-composite image

### DIFF
--- a/src/ServiceControl.Audit/Container-README.md
+++ b/src/ServiceControl.Audit/Container-README.md
@@ -46,7 +46,7 @@ The latest release within a minor version will be tagged with `{major}.{minor}` 
 
 ## Image architecture
 
-This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
+This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
 
 ## Authors
 

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet build src/ServiceControl.Audit/ServiceControl.Audit.csproj --configur
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite
 ARG VERSION
 WORKDIR /app
 

--- a/src/ServiceControl.Monitoring/Container-README.md
+++ b/src/ServiceControl.Monitoring/Container-README.md
@@ -45,7 +45,7 @@ The latest release within a minor version will be tagged with `{major}.{minor}` 
 
 ## Image architecture
 
-This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
+This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
 
 ## Authors
 

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet build src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj 
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite
 ARG VERSION
 WORKDIR /app
 

--- a/src/ServiceControl/Container-README.md
+++ b/src/ServiceControl/Container-README.md
@@ -47,7 +47,7 @@ The latest release within a minor version will be tagged with `{major}.{minor}` 
 
 ## Image architecture
 
-This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
+This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
 
 ## Authors
 

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet build src/ServiceControl/ServiceControl.csproj --configuration Releas
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled-composite
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite
 ARG VERSION
 WORKDIR /app
 


### PR DESCRIPTION
The `noble` (Ubuntu 24.04) base image appears to have some OpenSSL compatibility problems when using the containers on Azure, so this PR switches to the `jammy` (Ubuntu 22.04) base image instead.