### PR TITLE
Update Particular.Packaging

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -86,6 +86,6 @@
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.1.30" />
     <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.315" />
-    <GlobalPackageReference Include="Particular.Packaging" Version="4.1.0" />
+    <GlobalPackageReference Include="Particular.Packaging" Version="4.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Particular.Packaging 4.2.0 brings in MinVer 6.0.0, which adds [MSBuild caching](https://github.com/adamralph/minver/pull/1021) to speed up building.