### PR TITLE
ServiceControl containers fail when using SQL Transport

### DIFF
--- a/src/ServiceControl.Audit/Container-README.md
+++ b/src/ServiceControl.Audit/Container-README.md
@@ -46,7 +46,7 @@ The latest release within a minor version will be tagged with `{major}.{minor}` 
 
 ## Image architecture
 
-This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
+This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
 
 ## Authors
 

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet build src/ServiceControl.Audit/ServiceControl.Audit.csproj --configur
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
 ARG VERSION
 WORKDIR /app
 

--- a/src/ServiceControl.Monitoring/Container-README.md
+++ b/src/ServiceControl.Monitoring/Container-README.md
@@ -45,7 +45,7 @@ The latest release within a minor version will be tagged with `{major}.{minor}` 
 
 ## Image architecture
 
-This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
+This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
 
 ## Authors
 

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet build src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj 
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
 ARG VERSION
 WORKDIR /app
 

--- a/src/ServiceControl/Container-README.md
+++ b/src/ServiceControl/Container-README.md
@@ -47,7 +47,7 @@ The latest release within a minor version will be tagged with `{major}.{minor}` 
 
 ## Image architecture
 
-This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
+This image is a multi-arch image based on the [`mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra`](https://mcr.microsoft.com/en-us/product/dotnet/aspnet/about) base image supporting `linux/arm64` and `linux/amd64`.
 
 ## Authors
 

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -9,7 +9,7 @@ RUN dotnet build src/ServiceControl/ServiceControl.csproj --configuration Releas
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
 ARG VERSION
 WORKDIR /app
 


### PR DESCRIPTION
## Symptoms

Container-hosted ServiceControl instances attempting to use SQL Transport will faill with the following exception:

> System.NotSupportedException: Globalization Invariant Mode is not supported.

## Who's affected

Users running ServiceControl on Linux containers attempting to configure the containers to use SQL Transport.

## Root cause

ServiceControl uses a "chiseled" base image to provide a smaller image size and reduced attack surface, as chiseled images do not contain things like a shell or `apt-get` not needed to run the application. However, the `jammy-chiseled-composite` base container does not contain globalization libraries which are required by the SQL Client to support things like database collation settings.