### PR TITLE
remove redundant code

### DIFF
--- a/src/ServiceControl/Monitoring/EndpointInstanceMonitor.cs
+++ b/src/ServiceControl/Monitoring/EndpointInstanceMonitor.cs
@@ -120,7 +120,7 @@ namespace ServiceControl.Monitoring
                 HeartbeatInformation = lastSeen.HasValue ? new HeartbeatInformation
                 {
                     ReportedStatus = status == HeartbeatStatus.Alive ? HeartbeatMonitoringStatus.Beating : HeartbeatMonitoringStatus.Dead,
-                    LastReportAt = lastSeen ?? DateTime.MinValue
+                    LastReportAt = lastSeen
                 } : null
             };
         }

--- a/src/ServiceControl/Monitoring/EndpointInstanceMonitor.cs
+++ b/src/ServiceControl/Monitoring/EndpointInstanceMonitor.cs
@@ -120,7 +120,7 @@ namespace ServiceControl.Monitoring
                 HeartbeatInformation = lastSeen.HasValue ? new HeartbeatInformation
                 {
                     ReportedStatus = status == HeartbeatStatus.Alive ? HeartbeatMonitoringStatus.Beating : HeartbeatMonitoringStatus.Dead,
-                    LastReportAt = lastSeen
+                    LastReportAt = lastSeen.Value
                 } : null
             };
         }


### PR DESCRIPTION
related to https://github.com/Particular/ServiceControl/pull/4435

@johnsimons @PhilBastian unless I'm mistaken, the null coalescing is redundant, since we're already in the branch that requires `lastSeen.HasValue == true`