### PR TITLE
Load trialstartdate from ravenDB

### DIFF
--- a/src/ServiceControl.LicenseManagement/LicenseDetails.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseDetails.cs
@@ -42,7 +42,7 @@
             return FromLicense(new License
             {
                 LicenseType = "Trial",
-                ExpirationDate = DateTime.UtcNow.Date.AddDays(-1),
+                ExpirationDate = DateTime.UtcNow.Date.AddDays(-2), //HasLicenseDateExpired uses a grace period of 1 day
                 IsExtendedTrial = false,
                 ValidApplications = new List<string> { "All" }
             });

--- a/src/ServiceControl.LicenseManagement/LicenseDetails.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseDetails.cs
@@ -26,12 +26,23 @@
         public bool WarnUserUpgradeProtectionHasExpired { get; private init; }
         public string Status { get; private init; }
 
-        public static LicenseDetails TrialFromStartDate(DateOnly startDate)
+        public static LicenseDetails TrialFromEndDate(DateOnly endDate)
         {
             return FromLicense(new License
             {
                 LicenseType = "Trial",
-                ExpirationDate = startDate.AddDays(14).ToDateTime(TimeOnly.MinValue),
+                ExpirationDate = endDate.ToDateTime(TimeOnly.MinValue),
+                IsExtendedTrial = false,
+                ValidApplications = new List<string> { "All" }
+            });
+        }
+
+        public static LicenseDetails TrialExpired()
+        {
+            return FromLicense(new License
+            {
+                LicenseType = "Trial",
+                ExpirationDate = DateTime.UtcNow.Date.AddDays(-1),
                 IsExtendedTrial = false,
                 ValidApplications = new List<string> { "All" }
             });

--- a/src/ServiceControl.LicenseManagement/LicenseDetails.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseDetails.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.LicenseManagement
 {
     using System;
+    using System.Collections.Generic;
     using Particular.Licensing;
 
     public class LicenseDetails
@@ -24,6 +25,17 @@
         public bool WarnUserUpgradeProtectionIsExpiring { get; private init; }
         public bool WarnUserUpgradeProtectionHasExpired { get; private init; }
         public string Status { get; private init; }
+
+        public static LicenseDetails TrialFromStartDate(DateOnly startDate)
+        {
+            return FromLicense(new License
+            {
+                LicenseType = "Trial",
+                ExpirationDate = startDate.AddDays(14).ToDateTime(TimeOnly.MinValue),
+                IsExtendedTrial = false,
+                ValidApplications = new List<string> { "All" }
+            });
+        }
 
         internal static LicenseDetails FromLicense(License license)
         {

--- a/src/ServiceControl.Persistence.RavenDB/LicenseLicenseMetadataProvider.cs
+++ b/src/ServiceControl.Persistence.RavenDB/LicenseLicenseMetadataProvider.cs
@@ -5,19 +5,19 @@
 
     class LicenseLicenseMetadataProvider(IRavenSessionProvider sessionProvider) : ILicenseLicenseMetadataProvider
     {
-        public async Task<LicenseMetadata> GetLicenseMetadata(CancellationToken cancellationToken)
+        public async Task<TrialMetadata> GetLicenseMetadata(CancellationToken cancellationToken)
         {
             using (var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken))
             {
-                return await session.LoadAsync<LicenseMetadata>(LicenseMetadata.LicenseMetadataId, cancellationToken);
+                return await session.LoadAsync<TrialMetadata>(TrialMetadata.TrialMetadataId, cancellationToken);
             }
         }
 
-        public async Task InsertLicenseMetadata(LicenseMetadata licenseMetadata, CancellationToken cancellationToken)
+        public async Task InsertLicenseMetadata(TrialMetadata licenseMetadata, CancellationToken cancellationToken)
         {
             using (var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken))
             {
-                await session.StoreAsync(licenseMetadata, LicenseMetadata.LicenseMetadataId, cancellationToken);
+                await session.StoreAsync(licenseMetadata, TrialMetadata.TrialMetadataId, cancellationToken);
                 await session.SaveChangesAsync(cancellationToken);
             }
         }

--- a/src/ServiceControl.Persistence.RavenDB/LicenseLicenseMetadataProvider.cs
+++ b/src/ServiceControl.Persistence.RavenDB/LicenseLicenseMetadataProvider.cs
@@ -1,0 +1,25 @@
+﻿namespace ServiceControl.Persistence.RavenDB
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class LicenseLicenseMetadataProvider(IRavenSessionProvider sessionProvider) : ILicenseLicenseMetadataProvider
+    {
+        public async Task<LicenseMetadata> GetLicenseMetadata(CancellationToken cancellationToken)
+        {
+            using (var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken))
+            {
+                return await session.LoadAsync<LicenseMetadata>(LicenseMetadata.LicenseMetadataId, cancellationToken);
+            }
+        }
+
+        public async Task InsertLicenseMetadata(LicenseMetadata licenseMetadata, CancellationToken cancellationToken)
+        {
+            using (var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken))
+            {
+                await session.StoreAsync(licenseMetadata, LicenseMetadata.LicenseMetadataId, cancellationToken);
+                await session.SaveChangesAsync(cancellationToken);
+            }
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
@@ -65,6 +65,8 @@ class RavenPersistence(RavenPersisterSettings settings) : IPersistence
         services.AddSingleton<IRetryDocumentDataStore, RetryDocumentDataStore>();
         services.AddSingleton<IRetryHistoryDataStore, RetryHistoryDataStore>();
         services.AddSingleton<IEndpointSettingsStore, EndpointSettingsStore>();
+
+        services.AddSingleton<ILicenseLicenseMetadataProvider, LicenseLicenseMetadataProvider>();
     }
 
     public void AddInstaller(IServiceCollection services)

--- a/src/ServiceControl.Persistence.Tests.RavenDB/LicenseMetadata/LicenseMetadataTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/LicenseMetadata/LicenseMetadataTests.cs
@@ -1,0 +1,36 @@
+﻿namespace ServiceControl.Persistence.Tests.RavenDB.Operations
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
+    using ServiceControl.Persistence.RavenDB;
+
+    [TestFixture]
+    class LicenseMetadataTests : RavenPersistenceTestBase
+    {
+        public LicenseMetadataTests() =>
+            RegisterServices = services =>
+            {
+                services.AddSingleton<LicenseLicenseMetadataProvider>();
+            };
+
+        [Test]
+        public async Task LicenseMetadata_can_be_saved()
+        {
+            var licenseMetadataService = ServiceProvider.GetRequiredService<LicenseLicenseMetadataProvider>();
+
+            var metaData = new LicenseMetadata
+            {
+                TrialStartDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(14))
+            };
+
+            await licenseMetadataService.InsertLicenseMetadata(metaData, CancellationToken.None);
+
+            var result = await licenseMetadataService.GetLicenseMetadata(CancellationToken.None);
+
+            Assert.That(result.TrialStartDate, Is.EqualTo(metaData.TrialStartDate));
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.Tests.RavenDB/LicenseMetadata/LicenseMetadataTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/LicenseMetadata/LicenseMetadataTests.cs
@@ -1,4 +1,4 @@
-﻿namespace ServiceControl.Persistence.Tests.RavenDB.Operations
+﻿namespace ServiceControl.Persistence.Tests.RavenDB.LicenseMetadata
 {
     using System;
     using System.Threading;

--- a/src/ServiceControl.Persistence.Tests.RavenDB/LicenseMetadata/LicenseMetadataTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/LicenseMetadata/LicenseMetadataTests.cs
@@ -21,7 +21,7 @@
         {
             var licenseMetadataService = ServiceProvider.GetRequiredService<LicenseLicenseMetadataProvider>();
 
-            var metaData = new LicenseMetadata
+            var metaData = new TrialMetadata
             {
                 TrialStartDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(14))
             };

--- a/src/ServiceControl.Persistence/ILicenseLicenseMetadataProvider.cs
+++ b/src/ServiceControl.Persistence/ILicenseLicenseMetadataProvider.cs
@@ -5,7 +5,7 @@
 
     public interface ILicenseLicenseMetadataProvider
     {
-        Task<LicenseMetadata> GetLicenseMetadata(CancellationToken cancellationToken);
-        Task InsertLicenseMetadata(LicenseMetadata licenseMetadata, CancellationToken cancellationToken);
+        Task<TrialMetadata> GetLicenseMetadata(CancellationToken cancellationToken);
+        Task InsertLicenseMetadata(TrialMetadata licenseMetadata, CancellationToken cancellationToken);
     }
 }

--- a/src/ServiceControl.Persistence/ILicenseLicenseMetadataProvider.cs
+++ b/src/ServiceControl.Persistence/ILicenseLicenseMetadataProvider.cs
@@ -1,0 +1,11 @@
+﻿namespace ServiceControl.Persistence
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public interface ILicenseLicenseMetadataProvider
+    {
+        Task<LicenseMetadata> GetLicenseMetadata(CancellationToken cancellationToken);
+        Task InsertLicenseMetadata(LicenseMetadata licenseMetadata, CancellationToken cancellationToken);
+    }
+}

--- a/src/ServiceControl.Persistence/LicenseMetadata.cs
+++ b/src/ServiceControl.Persistence/LicenseMetadata.cs
@@ -1,0 +1,11 @@
+﻿namespace ServiceControl.Persistence
+{
+    using System;
+
+    public class LicenseMetadata
+    {
+        public DateOnly TrialStartDate { get; set; }
+
+        public static string LicenseMetadataId = "metadata/origination";
+    }
+}

--- a/src/ServiceControl.Persistence/TrialMetadata.cs
+++ b/src/ServiceControl.Persistence/TrialMetadata.cs
@@ -2,10 +2,10 @@
 {
     using System;
 
-    public class LicenseMetadata
+    public class TrialMetadata
     {
         public DateOnly TrialStartDate { get; set; }
 
-        public static string LicenseMetadataId = "metadata/origination";
+        public static string TrialMetadataId = "metadata/trialinformation";
     }
 }

--- a/src/ServiceControl.UnitTests/Licensing/ActiveLicenseTests.cs
+++ b/src/ServiceControl.UnitTests/Licensing/ActiveLicenseTests.cs
@@ -1,0 +1,113 @@
+﻿namespace ServiceControl.UnitTests.Licensing
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using LicenseManagement;
+    using NUnit.Framework;
+    using Particular.ServiceControl.Licensing;
+    using Persistence;
+
+    [TestFixture]
+    public class ActiveLicenseTests
+    {
+        [Test]
+        public async Task Corrects_trial_date_on_disk_in_the_future()
+        {
+            var today = DateTime.UtcNow.Date;
+            var trialLicense = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(66)));
+            var metadataProvider = new FakeMetadataProvider();
+            metadataProvider.Metadata = new TrialMetadata()
+            {
+                TrialStartDate = DateOnly.FromDateTime(today.AddDays(-10))
+            };
+
+            var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(trialLicense, metadataProvider, CancellationToken.None);
+
+            Assert.That(checkedDetails.ExpirationDate, Is.EqualTo(today.AddDays(-10).AddDays(14)));
+            Assert.That(checkedDetails.HasLicenseExpired(), Is.EqualTo(false));
+        }
+
+        [Test]
+        public async Task Corrects_trial_date_on_disk_in_the_past()
+        {
+            var today = DateTime.UtcNow.Date;
+            var trialLicense = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(-66)));
+            var metadataProvider = new FakeMetadataProvider();
+            metadataProvider.Metadata = new TrialMetadata()
+            {
+                TrialStartDate = DateOnly.FromDateTime(today.AddDays(-10))
+            };
+
+            var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(trialLicense, metadataProvider, CancellationToken.None);
+
+            Assert.That(checkedDetails.ExpirationDate, Is.EqualTo(today.AddDays(-10).AddDays(14)));
+            Assert.That(checkedDetails.HasLicenseExpired(), Is.EqualTo(false));
+        }
+
+        [Test]
+        public async Task Corrects_current_trial_date_on_disk_if_value_in_db_is_in_the_past()
+        {
+            var today = DateTime.UtcNow.Date;
+            var trialLicense = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(-7)));
+            var metadataProvider = new FakeMetadataProvider();
+            metadataProvider.Metadata = new TrialMetadata()
+            {
+                TrialStartDate = DateOnly.FromDateTime(today.AddDays(-20))
+            };
+
+            var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(trialLicense, metadataProvider, CancellationToken.None);
+
+            Assert.That(checkedDetails.ExpirationDate, Is.EqualTo(today.AddDays(-20).AddDays(14)));
+            Assert.That(checkedDetails.HasLicenseExpired(), Is.EqualTo(true));
+        }
+
+        [Test]
+        public async Task Detects_tempered_trial_date_in_db()
+        {
+            var today = DateTime.UtcNow.Date;
+            var trialLicense = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(14)));
+            var metadataProvider = new FakeMetadataProvider();
+            metadataProvider.Metadata = new TrialMetadata
+            {
+                TrialStartDate = DateOnly.FromDateTime(today.AddDays(20))
+            };
+
+            var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(trialLicense, metadataProvider, CancellationToken.None);
+
+            Assert.That(checkedDetails.ExpirationDate, Is.LessThan(today));
+        }
+
+        //[Test]
+        //public async Task Detects_trial_date_in_db_in_future()
+        //{
+        //    var today = DateTime.UtcNow.Date;
+        //    var temperedTrial = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(66)));
+        //    var metadataProvider = new FakeMetadataProvider();
+        //    metadataProvider.Metadata = new TrialMetadata
+        //    {
+        //        TrialStartDate = DateOnly.FromDateTime(today.AddDays(20))
+        //    };
+
+        //    var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(temperedTrial, metadataProvider, CancellationToken.None);
+
+        //    Assert.That(checkedDetails.ExpirationDate, Is.LessThan(today));
+        //}
+
+        class FakeMetadataProvider : ILicenseLicenseMetadataProvider
+        {
+            public TrialMetadata Metadata { get; set; }
+
+            public Task<TrialMetadata> GetLicenseMetadata(CancellationToken cancellationToken)
+            {
+                return Task.FromResult(Metadata);
+            }
+
+            public Task InsertLicenseMetadata(TrialMetadata licenseMetadata, CancellationToken cancellationToken)
+            {
+                Metadata = licenseMetadata;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/Licensing/ActiveLicenseTests.cs
+++ b/src/ServiceControl.UnitTests/Licensing/ActiveLicenseTests.cs
@@ -12,90 +12,96 @@
     public class ActiveLicenseTests
     {
         [Test]
-        public async Task Corrects_trial_date_on_disk_in_the_future()
+        public async Task Stores_trial_start_date_if_not_found()
+        {
+            var today = DateTime.UtcNow.Date;
+            var trialLicense = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(6)));
+            var metadataProvider = new FakeMetadataProvider();
+
+            var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(trialLicense, metadataProvider, CancellationToken.None);
+
+            Assert.That(metadataProvider.Metadata, Is.Not.Null);
+            Assert.That(metadataProvider.Metadata.TrialStartDate, Is.Not.EqualTo(DateOnly.FromDateTime(today.AddDays(6))));
+
+            Assert.That(checkedDetails.ExpirationDate, Is.EqualTo(today.AddDays(6)));
+            Assert.That(checkedDetails.HasLicenseExpired(), Is.EqualTo(false));
+        }
+
+        [Test]
+        public async Task Overrides_future_disk_trial_start_date_with_db_value_non_expired()
         {
             var today = DateTime.UtcNow.Date;
             var trialLicense = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(66)));
-            var metadataProvider = new FakeMetadataProvider();
-            metadataProvider.Metadata = new TrialMetadata()
+            var metadataProvider = new FakeMetadataProvider(new TrialMetadata
             {
                 TrialStartDate = DateOnly.FromDateTime(today.AddDays(-10))
-            };
+            });
 
             var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(trialLicense, metadataProvider, CancellationToken.None);
 
             Assert.That(checkedDetails.ExpirationDate, Is.EqualTo(today.AddDays(-10).AddDays(14)));
-            Assert.That(checkedDetails.HasLicenseExpired(), Is.EqualTo(false));
+            Assert.That(checkedDetails.HasLicenseExpired(), Is.False);
         }
 
         [Test]
-        public async Task Corrects_trial_date_on_disk_in_the_past()
+        public async Task Overrides_past_disk_trial_start_date_with_db_value_non_expired()
         {
             var today = DateTime.UtcNow.Date;
             var trialLicense = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(-66)));
-            var metadataProvider = new FakeMetadataProvider();
-            metadataProvider.Metadata = new TrialMetadata()
+            var metadataProvider = new FakeMetadataProvider(new TrialMetadata
             {
                 TrialStartDate = DateOnly.FromDateTime(today.AddDays(-10))
-            };
+            });
 
             var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(trialLicense, metadataProvider, CancellationToken.None);
 
             Assert.That(checkedDetails.ExpirationDate, Is.EqualTo(today.AddDays(-10).AddDays(14)));
-            Assert.That(checkedDetails.HasLicenseExpired(), Is.EqualTo(false));
+            Assert.That(checkedDetails.HasLicenseExpired(), Is.False);
         }
 
         [Test]
-        public async Task Corrects_current_trial_date_on_disk_if_value_in_db_is_in_the_past()
+        public async Task Overrides_disk_trial_start_date_with_db_value_expired()
         {
             var today = DateTime.UtcNow.Date;
             var trialLicense = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(-7)));
-            var metadataProvider = new FakeMetadataProvider();
-            metadataProvider.Metadata = new TrialMetadata()
+            var metadataProvider = new FakeMetadataProvider(new TrialMetadata
             {
                 TrialStartDate = DateOnly.FromDateTime(today.AddDays(-20))
-            };
+            });
 
             var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(trialLicense, metadataProvider, CancellationToken.None);
 
             Assert.That(checkedDetails.ExpirationDate, Is.EqualTo(today.AddDays(-20).AddDays(14)));
-            Assert.That(checkedDetails.HasLicenseExpired(), Is.EqualTo(true));
+            Assert.That(checkedDetails.HasLicenseExpired(), Is.True);
         }
 
         [Test]
-        public async Task Detects_tempered_trial_date_in_db()
+        public async Task Detects_tempered_trial_date_in_db_and_voids_license()
         {
             var today = DateTime.UtcNow.Date;
             var trialLicense = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(14)));
-            var metadataProvider = new FakeMetadataProvider();
-            metadataProvider.Metadata = new TrialMetadata
+            var metadataProvider = new FakeMetadataProvider(new TrialMetadata
             {
                 TrialStartDate = DateOnly.FromDateTime(today.AddDays(20))
-            };
+            });
 
             var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(trialLicense, metadataProvider, CancellationToken.None);
 
             Assert.That(checkedDetails.ExpirationDate, Is.LessThan(today));
+            Assert.That(checkedDetails.HasLicenseExpired(), Is.True);
         }
-
-        //[Test]
-        //public async Task Detects_trial_date_in_db_in_future()
-        //{
-        //    var today = DateTime.UtcNow.Date;
-        //    var temperedTrial = LicenseDetails.TrialFromEndDate(DateOnly.FromDateTime(today.AddDays(66)));
-        //    var metadataProvider = new FakeMetadataProvider();
-        //    metadataProvider.Metadata = new TrialMetadata
-        //    {
-        //        TrialStartDate = DateOnly.FromDateTime(today.AddDays(20))
-        //    };
-
-        //    var checkedDetails = await ActiveLicense.EnsureTrialLicenseIsValid(temperedTrial, metadataProvider, CancellationToken.None);
-
-        //    Assert.That(checkedDetails.ExpirationDate, Is.LessThan(today));
-        //}
 
         class FakeMetadataProvider : ILicenseLicenseMetadataProvider
         {
+            public FakeMetadataProvider()
+            {
+            }
+
+            public FakeMetadataProvider(TrialMetadata metadata)
+            {
+                Metadata = metadata;
+            }
+
             public TrialMetadata Metadata { get; set; }
 
             public Task<TrialMetadata> GetLicenseMetadata(CancellationToken cancellationToken)

--- a/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
+++ b/src/ServiceControl.UnitTests/ServiceControl.UnitTests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing"/>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NServiceBus.Testing" />
     <PackageReference Include="NUnit" />
@@ -20,7 +20,7 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Particular.Approvals" />
     <PackageReference Include="PublicApiGenerator" />
-    <PackageReference Include="System.Linq.Async"/>
+    <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl/Licensing/ActiveLicense.cs
+++ b/src/ServiceControl/Licensing/ActiveLicense.cs
@@ -1,6 +1,10 @@
 ﻿namespace Particular.ServiceControl.Licensing
 {
+    using System.Threading.Tasks;
+    using System.Threading;
+    using System;
     using global::ServiceControl.LicenseManagement;
+    using global::ServiceControl.Persistence;
     using NServiceBus.Logging;
 
     public class ActiveLicense
@@ -9,7 +13,7 @@
 
         public bool IsValid { get; set; }
 
-        internal LicenseDetails Details { get; set; }
+        public LicenseDetails Details { get; set; }
 
         public void Refresh()
         {
@@ -20,6 +24,43 @@
             IsValid = !detectedLicense.Details.HasLicenseExpired();
 
             Details = detectedLicense.Details;
+        }
+
+        public async Task EnsureTrialLicenseIsValid(ILicenseLicenseMetadataProvider licenseLicenseMetadataProvider, CancellationToken cancellationToken)
+        {
+            Details = await EnsureTrialLicenseIsValid(Details, licenseLicenseMetadataProvider, cancellationToken);
+        }
+
+        public static async Task<LicenseDetails> EnsureTrialLicenseIsValid(LicenseDetails licenseDetails, ILicenseLicenseMetadataProvider licenseLicenseMetadataProvider, CancellationToken cancellationToken)
+        {
+            if (licenseDetails.LicenseType.Equals("trial", StringComparison.OrdinalIgnoreCase))
+            {
+                var metadata = await licenseLicenseMetadataProvider.GetLicenseMetadata(cancellationToken);
+                if (metadata == null)
+                {
+                    //No start date stored in the database, store one.
+                    metadata = new TrialMetadata
+                    {
+                        //The trial period is 14 days
+                        TrialStartDate = DateOnly.FromDateTime(licenseDetails.ExpirationDate.Value.AddDays(14))
+                    };
+
+                    await licenseLicenseMetadataProvider.InsertLicenseMetadata(metadata, cancellationToken);
+                    return licenseDetails;
+                }
+                if (metadata.TrialStartDate >= DateOnly.FromDateTime(DateTime.Now))
+                {
+                    // Someone has tampered with the date stored in RavenDB, set the license to expired
+                    return LicenseDetails.TrialExpired();
+                }
+                if (DateOnly.FromDateTime(licenseDetails.ExpirationDate ?? DateTime.MinValue) != metadata.TrialStartDate.AddDays(14))
+                {
+                    //The trial end date stored by the license component has been tempered with or reset, use the RavenDB value
+                    return LicenseDetails.TrialFromEndDate(metadata.TrialStartDate.AddDays(14));
+                }
+                //Otherwise use the trial date stored by the licensing component
+            }
+            return licenseDetails;
         }
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(ActiveLicense));

--- a/src/ServiceControl/Licensing/ActiveLicense.cs
+++ b/src/ServiceControl/Licensing/ActiveLicense.cs
@@ -31,7 +31,7 @@
             Details = await EnsureTrialLicenseIsValid(Details, licenseLicenseMetadataProvider, cancellationToken);
         }
 
-        public static async Task<LicenseDetails> EnsureTrialLicenseIsValid(LicenseDetails licenseDetails, ILicenseLicenseMetadataProvider licenseLicenseMetadataProvider, CancellationToken cancellationToken)
+        internal static async Task<LicenseDetails> EnsureTrialLicenseIsValid(LicenseDetails licenseDetails, ILicenseLicenseMetadataProvider licenseLicenseMetadataProvider, CancellationToken cancellationToken)
         {
             if (licenseDetails.LicenseType.Equals("trial", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/ServiceControl/Licensing/LicenseCheckHostedService.cs
+++ b/src/ServiceControl/Licensing/LicenseCheckHostedService.cs
@@ -4,19 +4,32 @@
     using System.Threading;
     using System.Threading.Tasks;
     using global::ServiceControl.Infrastructure.BackgroundTasks;
+    using global::ServiceControl.LicenseManagement;
+    using global::ServiceControl.Persistence;
     using Microsoft.Extensions.Hosting;
     using NServiceBus.Logging;
 
-    class LicenseCheckHostedService(ActiveLicense activeLicense, IAsyncTimer scheduler) : IHostedService
+    class LicenseCheckHostedService(ActiveLicense activeLicense, ILicenseLicenseMetadataProvider licenseLicenseMetadataProvide, IAsyncTimer scheduler) : IHostedService
     {
         public Task StartAsync(CancellationToken cancellationToken)
         {
             var due = TimeSpan.FromHours(8);
-            timer = scheduler.Schedule(_ =>
+            timer = scheduler.Schedule(async _ =>
             {
                 activeLicense.Refresh();
-                return ScheduleNextExecutionTask;
-            }, due, due, ex => Logger.Error("Unhandled error while refreshing the license.", ex));
+
+                if (activeLicense.Details.IsTrialLicense)
+                {
+                    var metadata = await licenseLicenseMetadataProvide.GetLicenseMetadata(cancellationToken);
+                    if (DateOnly.FromDateTime(activeLicense.Details.ExpirationDate ?? DateTime.MinValue) != metadata.TrialStartDate.AddDays(14))
+                    {
+                        activeLicense.IsValid = false;
+                        activeLicense.Details = LicenseDetails.TrialFromStartDate(metadata.TrialStartDate);
+                    }
+                }
+
+                return TimerJobExecutionResult.ScheduleNextExecution;
+            }, TimeSpan.FromTicks(0), due, ex => Logger.Error("Unhandled error while refreshing the license.", ex));
             return Task.CompletedTask;
         }
 
@@ -25,6 +38,5 @@
         TimerJob timer;
 
         static readonly ILog Logger = LogManager.GetLogger<LicenseCheckHostedService>();
-        static readonly Task<TimerJobExecutionResult> ScheduleNextExecutionTask = Task.FromResult(TimerJobExecutionResult.ScheduleNextExecution);
     }
 }

--- a/src/ServiceControl/Licensing/LicenseCheckHostedService.cs
+++ b/src/ServiceControl/Licensing/LicenseCheckHostedService.cs
@@ -4,12 +4,11 @@
     using System.Threading;
     using System.Threading.Tasks;
     using global::ServiceControl.Infrastructure.BackgroundTasks;
-    using global::ServiceControl.LicenseManagement;
     using global::ServiceControl.Persistence;
     using Microsoft.Extensions.Hosting;
     using NServiceBus.Logging;
 
-    class LicenseCheckHostedService(ActiveLicense activeLicense, ILicenseLicenseMetadataProvider licenseLicenseMetadataProvide, IAsyncTimer scheduler) : IHostedService
+    class LicenseCheckHostedService(ActiveLicense activeLicense, ILicenseLicenseMetadataProvider licenseLicenseMetadataProvider, IAsyncTimer scheduler) : IHostedService
     {
         public Task StartAsync(CancellationToken cancellationToken)
         {
@@ -17,29 +16,7 @@
             timer = scheduler.Schedule(async _ =>
             {
                 activeLicense.Refresh();
-
-                if (activeLicense.Details.LicenseType.Equals("trial", StringComparison.OrdinalIgnoreCase))
-                {
-                    var metadata = await licenseLicenseMetadataProvide.GetLicenseMetadata(cancellationToken);
-                    if (metadata == null)
-                    {
-                        metadata = new TrialMetadata
-                        {
-                            TrialStartDate = DateOnly.FromDateTime(activeLicense.Details.ExpirationDate.Value.AddDays(-14))
-                        };
-
-                        await licenseLicenseMetadataProvide.InsertLicenseMetadata(metadata, cancellationToken);
-                    }
-                    else if (DateOnly.FromDateTime(activeLicense.Details.ExpirationDate ?? DateTime.MinValue) != metadata.TrialStartDate.AddDays(14))
-                    {
-                        activeLicense.Details = LicenseDetails.TrialFromStartDate(metadata.TrialStartDate);
-                    }
-                    else if (metadata.TrialStartDate >= DateOnly.FromDateTime(DateTime.Now))
-                    {
-                        // Someone has tampered with the date, set the license to expired
-                        activeLicense.Details = LicenseDetails.TrialFromStartDate(DateOnly.FromDateTime(DateTime.Now.AddDays(-15)));
-                    }
-                }
+                await activeLicense.EnsureTrialLicenseIsValid(licenseLicenseMetadataProvider, cancellationToken);
 
                 return TimerJobExecutionResult.ScheduleNextExecution;
             }, TimeSpan.FromTicks(0), due, ex => Logger.Error("Unhandled error while refreshing the license.", ex));


### PR DESCRIPTION
A spike to workshop an idea of how to validate the trial start date from RavenDB.

Overrides the active license if the license is a trial license, and if the start dates don't match.

We could also add hashing and date range checking to make this more thorough.