### PR TITLE
Ensuring we leave at least one unhealthy instance behind

### DIFF
--- a/src/ServiceControl.Persistence/EndpointsView.cs
+++ b/src/ServiceControl.Persistence/EndpointsView.cs
@@ -1,7 +1,6 @@
 namespace ServiceControl.Persistence
 {
     using System;
-    using System.Text.Json.Serialization;
 
     public class EndpointsView
     {
@@ -12,6 +11,5 @@ namespace ServiceControl.Persistence
         public bool MonitorHeartbeat { get; set; }
         public HeartbeatInformation HeartbeatInformation { get; set; }
         public bool IsSendingHeartbeats { get; set; }
-        [JsonIgnore] public bool IsNotSendingHeartbeats { get; set; }
     }
 }

--- a/src/ServiceControl.UnitTests/Monitoring/HeartbeatEndpointSettingsSyncHostedServiceTests.cs
+++ b/src/ServiceControl.UnitTests/Monitoring/HeartbeatEndpointSettingsSyncHostedServiceTests.cs
@@ -138,12 +138,12 @@ public class HeartbeatEndpointSettingsSyncHostedServiceTests
         var mockMonitoringDataStore = new MockMonitoringDataStore(
             [new KnownEndpoint { EndpointDetails = new EndpointDetails { Name = endpointName1 } }]);
         var mockEndpointInstanceMonitoring = new MockEndpointInstanceMonitoring([
-            new EndpointsView { IsNotSendingHeartbeats = true, Name = endpointName1, Id = instanceA },
-            new EndpointsView { IsNotSendingHeartbeats = true, Name = endpointName1, Id = instanceB },
-            new EndpointsView { IsNotSendingHeartbeats = true, Name = endpointName1, Id = instanceC },
+            new EndpointsView { IsSendingHeartbeats = false, Name = endpointName1, Id = instanceA },
+            new EndpointsView { IsSendingHeartbeats = false, Name = endpointName1, Id = instanceB },
+            new EndpointsView { IsSendingHeartbeats = false, Name = endpointName1, Id = instanceC },
             new EndpointsView
             {
-                IsNotSendingHeartbeats = false,
+                IsSendingHeartbeats = true,
                 Name = endpointName1,
                 Id = DeterministicGuid.MakeId(endpointName1, "D")
             }
@@ -179,10 +179,10 @@ public class HeartbeatEndpointSettingsSyncHostedServiceTests
         var mockMonitoringDataStore = new MockMonitoringDataStore(
             [new KnownEndpoint { EndpointDetails = new EndpointDetails { Name = endpointName1 } }]);
         var mockEndpointInstanceMonitoring = new MockEndpointInstanceMonitoring([
-            new EndpointsView { IsNotSendingHeartbeats = true, Name = endpointName1, Id = instanceA },
+            new EndpointsView { IsSendingHeartbeats = false, Name = endpointName1, Id = instanceA },
             new EndpointsView
             {
-                IsNotSendingHeartbeats = false,
+                IsSendingHeartbeats = true,
                 Name = endpointName1,
                 Id = DeterministicGuid.MakeId(endpointName1, "B")
             }

--- a/src/ServiceControl.UnitTests/Monitoring/HeartbeatEndpointSettingsSyncHostedServiceTests.cs
+++ b/src/ServiceControl.UnitTests/Monitoring/HeartbeatEndpointSettingsSyncHostedServiceTests.cs
@@ -134,16 +134,18 @@ public class HeartbeatEndpointSettingsSyncHostedServiceTests
         const string endpointName1 = "Sales";
         Guid instanceA = DeterministicGuid.MakeId(endpointName1, "A");
         Guid instanceB = DeterministicGuid.MakeId(endpointName1, "B");
+        Guid instanceC = DeterministicGuid.MakeId(endpointName1, "C");
         var mockMonitoringDataStore = new MockMonitoringDataStore(
             [new KnownEndpoint { EndpointDetails = new EndpointDetails { Name = endpointName1 } }]);
         var mockEndpointInstanceMonitoring = new MockEndpointInstanceMonitoring([
             new EndpointsView { IsNotSendingHeartbeats = true, Name = endpointName1, Id = instanceA },
             new EndpointsView { IsNotSendingHeartbeats = true, Name = endpointName1, Id = instanceB },
+            new EndpointsView { IsNotSendingHeartbeats = true, Name = endpointName1, Id = instanceC },
             new EndpointsView
             {
                 IsNotSendingHeartbeats = false,
                 Name = endpointName1,
-                Id = DeterministicGuid.MakeId(endpointName1, "C")
+                Id = DeterministicGuid.MakeId(endpointName1, "D")
             }
         ]);
         var service = new HeartbeatEndpointSettingsSyncHostedService(

--- a/src/ServiceControl/Monitoring/EndpointInstanceMonitoring.cs
+++ b/src/ServiceControl/Monitoring/EndpointInstanceMonitoring.cs
@@ -120,7 +120,6 @@ namespace ServiceControl.Monitoring
             {
                 var view = endpoint.GetView();
                 view.IsSendingHeartbeats = heartbeatLookup[endpoint.Id].Any(x => x.IsSendingHeartbeats());
-                view.IsNotSendingHeartbeats = heartbeatLookup[endpoint.Id].Any(x => x.IsNotSendingHeartbeats());
                 list.Add(view);
             }
 

--- a/src/ServiceControl/Monitoring/HeartbeatEndpointSettingsSyncHostedService.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatEndpointSettingsSyncHostedService.cs
@@ -63,8 +63,9 @@ public class HeartbeatEndpointSettingsSyncHostedService(
 
     async Task PurgeMonitoringDataThatDoesNotNeedToBeTracked(CancellationToken cancellationToken)
     {
-        ILookup<string, Guid> monitorEndpointsLookup = endpointInstanceMonitoring.GetEndpoints()
-            .Where(view => view.IsNotSendingHeartbeats)
+        EndpointsView[] endpointsViews = endpointInstanceMonitoring.GetEndpoints();
+        ILookup<string, Guid> monitorEndpointsLookup = endpointsViews
+            .Where(view => !view.IsSendingHeartbeats)
             .ToLookup(view => view.Name, view => view.Id);
         await foreach (EndpointSettings endpointSetting in endpointSettingsStore.GetAllEndpointSettings()
                            .WithCancellation(cancellationToken))

--- a/src/ServiceControl/Monitoring/HeartbeatMonitor.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatMonitor.cs
@@ -47,7 +47,6 @@ namespace ServiceControl.Monitoring
         }
 
         public bool IsSendingHeartbeats() => heartbeat?.Status == HeartbeatStatus.Alive;
-        public bool IsNotSendingHeartbeats() => heartbeat?.Status == HeartbeatStatus.Dead;
         volatile RecordedHeartbeat heartbeat = new RecordedHeartbeat(HeartbeatStatus.Unknown, null);
     }
 }


### PR DESCRIPTION
### Symptoms

All unhealthy instances are deleted for untracked endpoints, causing the endpoint to not display In ServicePulse.
And no alerts about the missing endpoint.

### Who's affected

Customers with endpoints configured as `Do not track` and all endpoint instances are down.

### Root cause

We delete all instances.