### PR TITLE
Fixes issue with SqlServer transport being unable to retrieve queue length

### DIFF
--- a/src/ServiceControl.Transports.SqlServer/SqlNameHelper.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlNameHelper.cs
@@ -18,10 +18,6 @@ namespace ServiceControl.Transports.SqlServer
 
         public static string Unquote(string quotedString)
         {
-            if (quotedString == null)
-            {
-                return null;
-            }
             if (!quotedString.StartsWith(prefix) || !quotedString.EndsWith(suffix))
             {
                 return quotedString;

--- a/src/ServiceControl.Transports.SqlServer/SqlNameHelper.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlNameHelper.cs
@@ -15,5 +15,19 @@ namespace ServiceControl.Transports.SqlServer
 
             return prefix + name.Replace(suffix, suffix + suffix) + suffix;
         }
+
+        public static string Unquote(string quotedString)
+        {
+            if (quotedString == null)
+            {
+                return null;
+            }
+            if (!quotedString.StartsWith(prefix) || !quotedString.EndsWith(suffix))
+            {
+                return quotedString;
+            }
+            return quotedString
+                .Substring(prefix.Length, quotedString.Length - prefix.Length - suffix.Length).Replace(suffix + suffix, suffix);
+        }
     }
 }

--- a/src/ServiceControl.Transports.SqlServer/SqlTable.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlTable.cs
@@ -7,6 +7,7 @@ namespace ServiceControl.Transports.SqlServer
         SqlTable(string name, string schema, string? catalog)
         {
             var unquotedSchema = SqlNameHelper.Unquote(schema);
+            var unquotedName = SqlNameHelper.Unquote(name);
             var quotedName = SqlNameHelper.Quote(name);
             var quotedSchema = SqlNameHelper.Quote(schema);
             //HINT: The query approximates queue length value based on max and min
@@ -20,7 +21,7 @@ namespace ServiceControl.Transports.SqlServer
                 _fullTableName = $"{quotedSchema}.{quotedName}";
 
                 LengthQuery = $"""
-                               IF (EXISTS (SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{unquotedSchema}' AND TABLE_NAME = '{name}'))
+                               IF (EXISTS (SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{unquotedSchema}' AND TABLE_NAME = '{unquotedName}'))
                                  SELECT isnull(cast(max([RowVersion]) - min([RowVersion]) + 1 AS int), 0) FROM {_fullTableName} WITH (nolock)
                                ELSE
                                  SELECT -1;
@@ -32,7 +33,7 @@ namespace ServiceControl.Transports.SqlServer
                 _fullTableName = $"{quotedCatalog}.{quotedSchema}.{quotedName}";
 
                 LengthQuery = $"""
-                               IF (EXISTS (SELECT TABLE_NAME FROM {quotedCatalog}.INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{unquotedSchema}' AND TABLE_NAME = '{name}'))
+                               IF (EXISTS (SELECT TABLE_NAME FROM {quotedCatalog}.INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{unquotedSchema}' AND TABLE_NAME = '{unquotedName}'))
                                  SELECT isnull(cast(max([RowVersion]) - min([RowVersion]) + 1 AS int), 0) FROM {_fullTableName} WITH (nolock)
                                ELSE
                                  SELECT -1;


### PR DESCRIPTION
Fixes #4462
- #4462

Using a curated UnquotedSchema was [originally being used](https://github.com/Particular/ServiceControl/commit/80d17a1c1827851136a3650225579a9cec5736a8#diff-870835946d4c0dd64ea1a804c085c265f75cedd959a350ac6655e7df1c883642L136) but removed in PR #4328. A quoted schema can potentially be received through the factory method Parse, [while splitting the parts of the queue table name ](https://github.com/SimonCropp/ServiceControl/blob/859a53300c3d7f7f5869fe04269fec842a9b6412/src/ServiceControl.Transports.SqlServer/SqlTable.cs#L55)

