### PR TITLE
Update NServiceBus.Transport.AzureServiceBus to 4.2.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -43,7 +43,7 @@
     <PackageVersion Include="NServiceBus.RabbitMQ" Version="9.1.1" />
     <PackageVersion Include="NServiceBus.SagaAudit" Version="5.0.0" />
     <PackageVersion Include="NServiceBus.Testing" Version="9.0.0" />
-    <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="4.2.0" />
+    <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="4.2.1" />
     <PackageVersion Include="NServiceBus.Transport.AzureStorageQueues" Version="13.0.0" />
     <PackageVersion Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.1" />
     <PackageVersion Include="NServiceBus.Transport.SqlServer" Version="8.1.3" />


### PR DESCRIPTION
* Backports https://github.com/Particular/ServiceControl/pull/4464 to bring fix for https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/1048 into `release-5.9` to release as ServiceControl 5.9.2

## Symptoms

It is possible that attempting to replay a message that is larger than 1024KB could fail to dispatch the message, resulting in the error message being lost.

## Who's affected

Anyone using ServiceControl 5.7.0 through 5.9.1 with the Azure Service Bus transport.

## Root cause

See https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/1048