### PR TITLE
Add the message body back to the MessageFailed event when non-binary & under LOH limit

### DIFF
--- a/src/ServiceControl/Recoverability/ExternalIntegration/MessageFailedConverter.cs
+++ b/src/ServiceControl/Recoverability/ExternalIntegration/MessageFailedConverter.cs
@@ -75,6 +75,10 @@ namespace ServiceControl.Recoverability.ExternalIntegration
             {
                 return (string)body;
             }
+            else if (last.MessageMetadata.TryGetValue("MsgFullText", out body))
+            {
+                return (string)body;
+            }
 
             return last.Body;
         }


### PR DESCRIPTION
Fix for https://github.com/Particular/ServiceControl/issues/4474

Body storage and full-text indexing were changed a lot in the switch from RavenDB 3.5 to RavenDB 5. As a result, the message body was not found when publishing MessageFailed events because it was looking in the wrong place.

As [documented here](https://docs.particular.net/servicecontrol/contracts#alerting-on-failedmessages-events), the body is only available if it is small enough to not be stored on the Large Object Heap (smaller than 85KB) and [full-text indexing of message bodies](https://docs.particular.net/servicecontrol/servicecontrol-instances/configuration#performance-tuning-servicecontrolenablefulltextsearchonbodies) is enabled.