### PR TITLE
Upgrade path for version 5 to version 6

### DIFF
--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
@@ -5,13 +5,12 @@
 
     public class UpgradeInfo
     {
-        static readonly SemanticVersion[] LatestMajors =
+        static readonly SemanticVersion[] LastVersionForEachMajor =
         {
             new(1, 48, 0),
             new(2, 1, 5),
             new(3, 8, 4),
-            new(4, 26, 0), // Introduced RavenDB5 audit persistence
-            new(4, 33, 0),
+            new(4, 33, 0), // Specifically needed so installed V4 SCMU can understand V5 instance details
             new(5, 11, 0),
         };
 
@@ -20,7 +19,7 @@
 
         public static UpgradeInfo GetUpgradePathFor(SemanticVersion current) //5.0.0 // 4.24.0
         {
-            var upgradePath = LatestMajors
+            var upgradePath = LastVersionForEachMajor
                 .Where(x => current.CompareTo(x, VersionComparison.Version) < 0)
                 .ToArray();
 

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
@@ -11,6 +11,8 @@
             new(2, 1, 5),
             new(3, 8, 4),
             new(4, 26, 0), // Introduced RavenDB5 audit persistence
+            new(4, 33, 0),
+            new(5, 11, 0),
         };
 
         public SemanticVersion[] UpgradePath { get; private init; }

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
@@ -10,8 +10,7 @@
             new(1, 48, 0),
             new(2, 1, 5),
             new(3, 8, 4),
-            // Added IngestErrorMessages setting to enable message replay during 4to5 upgrade guide scenario 
-            new(4, 33, 0),
+            new(4, 33, 0), // Added IngestErrorMessages setting to enable message replay during 4to5 upgrade guide scenario 
             new(5, 11, 0),
         };
 

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
@@ -10,7 +10,8 @@
             new(1, 48, 0),
             new(2, 1, 5),
             new(3, 8, 4),
-            new(4, 33, 0), // Specifically needed so installed V4 SCMU can understand V5 instance details
+            // Added IngestErrorMessages setting to enable message replay during 4to5 upgrade guide scenario 
+            new(4, 33, 0),
             new(5, 11, 0),
         };
 

--- a/src/ServiceControlInstaller.Engine/Validation/OldScmuCheck.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/OldScmuCheck.cs
@@ -4,6 +4,12 @@
     using System.Linq;
     using Microsoft.Win32;
 
+    /// <summary>
+    /// Even though <see cref="ServiceControlInstaller.Engine.Configuration.ServiceControl.UpgradeInfo"/> contains
+    /// the upgrade path, and that path contains 4.33.0 as a step, this check still needs to exist to validate that
+    /// either 1) An AdvancedInstaller-based-SCMU is not installed on the system, or 2) The AdvancedInstaller-SCMU
+    /// is version 4.33.x and can understand ServiceControl 5+ transport/persistence type names.
+    /// </summary>
     public static class OldScmuCheck
     {
         public static readonly Version MinimumScmuVersion = new Version(4, 33, 0);


### PR DESCRIPTION
Defines the upgrade path to get to version 6.

4.33 wasn't already in there because we had a separate check in https://github.com/Particular/ServiceControl/blob/master/src/ServiceControlInstaller.Engine/Validation/OldScmuCheck.cs that was more concerned with the version of SCMU than ServiceControl itself, which we called from SCMU startup and also from the PowerShell AbstractCommandChecks.

The reason for that was V5 started using codenames for transport and persistence type rather than full type names, so an SCMU instance prior to 4.33 would not be able to even tell you what the transport type of an installed V5 instance was and could easily corrupt things.