### PR TITLE
remove container spin up test from manual testing scenarios

### DIFF
--- a/docs/testing-scenarios.md
+++ b/docs/testing-scenarios.md
@@ -4,7 +4,6 @@ A long (though not exhaustive) list, although not every change will merit runnin
 
 ## Instance management installation
 
-- [ ] Create a new instance of ServiceControl using the docker images
 - [ ] Upgrade an existing instance of ServiceControl to the version being released
 - [ ] Create a new instance of ServiceControl
 - [ ] Check with both localhost and a custom hostname


### PR DESCRIPTION
every build of ServiceControl creates instances from the docker images, so this step isn't required as part of manual smoke-testing