### PR TITLE
Report saga audit misconfigurations more prominently

### DIFF
--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.CustomCheckDetails.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.CustomCheckDetails.approved.txt
@@ -1,3 +1,4 @@
+Configuration: Saga Audit Configuration
 Health: ServiceControl Primary Instance
 Health: ServiceControl Remotes
 ServiceControl Health: Error Message Ingestion

--- a/src/ServiceControl/CustomChecks/InternalCustomChecks/InternalCustomChecks.cs
+++ b/src/ServiceControl/CustomChecks/InternalCustomChecks/InternalCustomChecks.cs
@@ -7,6 +7,7 @@
     using NServiceBus.CustomChecks;
     using NServiceBus.Hosting;
     using Operations;
+    using SagaAudit;
     using ServiceBus.Management.Infrastructure.Settings;
 
     static class InternalCustomChecks
@@ -16,6 +17,7 @@
             var services = hostBuilder.Services;
             services.AddCustomCheck<CriticalErrorCustomCheck>();
             services.AddCustomCheck<CheckRemotes>();
+            services.AddCustomCheck<SagaAuditMisconfigurationCustomCheck>();
 
             services.AddHostedService(provider => new InternalCustomChecksHostedService(
                 provider.GetServices<ICustomCheck>().ToList(),

--- a/src/ServiceControl/SagaAudit/SagaAuditMisconfigurationCustomCheck.cs
+++ b/src/ServiceControl/SagaAudit/SagaAuditMisconfigurationCustomCheck.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+namespace ServiceControl.SagaAudit;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.CustomChecks;
+
+class SagaAuditMisconfigurationCustomCheck() : CustomCheck("Saga Audit Configuration", "Configuration", TimeSpan.FromMinutes(5))
+{
+    static Details? lastMisconfiguredMessageDetails;
+
+    public override Task<CheckResult> PerformCheck(CancellationToken cancellationToken = default)
+    {
+        var details = lastMisconfiguredMessageDetails;
+
+        if (details is null || details.Value.OccurredAt < DateTime.UtcNow.AddMinutes(-5))
+        {
+            return Task.FromResult(CheckResult.Pass);
+        }
+
+        var endpointDescription = details.Value.Endpoint == null
+            ? "without an endpoint name header"
+            : $"from endpoint '{details.Value.Endpoint}'";
+
+        var msg = $"At least one misconfigured endpoint was detected. A saga audit message {endpointDescription} was detected within the last 5 minutes.";
+        return Task.FromResult(CheckResult.Failed(msg));
+    }
+
+    public static void LogMisconfiguredMessage(IMessageHandlerContext context)
+    {
+        lastMisconfiguredMessageDetails = new Details(context);
+    }
+
+    readonly struct Details
+    {
+        public readonly DateTime OccurredAt = DateTime.UtcNow;
+        public readonly string? Endpoint;
+
+        public Details(IMessageHandlerContext context)
+        {
+            // ReplyToAddress is the only identifying header present in saga audit messages
+            _ = context.MessageHeaders.TryGetValue(Headers.ReplyToAddress, out Endpoint);
+        }
+    }
+}

--- a/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
+++ b/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
@@ -15,6 +15,8 @@
     {
         public async Task Handle(SagaUpdatedMessage message, IMessageHandlerContext context)
         {
+            SagaAuditMisconfigurationCustomCheck.LogMisconfiguredMessage(context);
+
             if (auditQueueName is null || nextAuditQueueNameRefresh < DateTime.UtcNow)
             {
                 await RefreshAuditQueue();

--- a/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
+++ b/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
@@ -27,7 +27,8 @@
                 throw new UnrecoverableException("Could not determine audit queue name to forward saga update message. This message can be replayed after the ServiceControl Audit remote instance is running and accessible.");
             }
 
-            log.ErrorFormat("Configure the Saga Audit plugin to send messages to an audit instance. Future versions of ServiceControl may stop ingesting and forwarding Saga Audit to audit instances.");
+            var endpointName = context.MessageHeaders.TryGetValue(Headers.ReplyToAddress, out var val) ? val : "(Unknown Endpoint)";
+            log.ErrorFormat($"Received a saga audit message in the ServiceControl queue that should have been sent to the audit queue. This indicates that the enpdoint '{endpointName}' using the SagaAudit plugin is misconfigured and should be changed to audit saga changes to the system's audit queue. The message has been forwarded to the audit queue, but this may not be possible in a future version of ServiceControl.");
             await context.ForwardCurrentMessageTo(auditQueueName);
         }
 

--- a/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
+++ b/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
@@ -25,8 +25,7 @@
                 throw new UnrecoverableException("Could not determine audit queue name to forward saga update message. This message can be replayed after the ServiceControl Audit remote instance is running and accessible.");
             }
 
-            // TODO Forward saga audit messages and warn in ServiceControl 5, remove in 6
-            log.WarnFormat("Configure the Saga Audit plugin to send messages to an audit instance. ServiceControl 6 will stop ingesting and forwarding Saga Audit to audit instances.");
+            log.ErrorFormat("Configure the Saga Audit plugin to send messages to an audit instance. Future versions of ServiceControl may stop ingesting and forwarding Saga Audit to audit instances.");
             await context.ForwardCurrentMessageTo(auditQueueName);
         }
 

--- a/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
+++ b/src/ServiceControl/SagaAudit/SagaUpdatedHandler.cs
@@ -28,7 +28,7 @@
             }
 
             var endpointName = context.MessageHeaders.TryGetValue(Headers.ReplyToAddress, out var val) ? val : "(Unknown Endpoint)";
-            log.ErrorFormat($"Received a saga audit message in the ServiceControl queue that should have been sent to the audit queue. This indicates that the enpdoint '{endpointName}' using the SagaAudit plugin is misconfigured and should be changed to audit saga changes to the system's audit queue. The message has been forwarded to the audit queue, but this may not be possible in a future version of ServiceControl.");
+            log.ErrorFormat($"Received a saga audit message in the ServiceControl queue that should have been sent to the audit queue. This indicates that the endpoint '{endpointName}' using the SagaAudit plugin is misconfigured and should be changed to use the system's audit queue instead. The message has been forwarded to the audit queue, but this may not be possible in a future version of ServiceControl.");
             await context.ForwardCurrentMessageTo(auditQueueName);
         }
 


### PR DESCRIPTION
* Alternative to https://github.com/Particular/ServiceControl/issues/4177

ServiceControl 5 stopped ingesting saga audit messages in the primary/error instance, and instead began forwarding them to the audit instance as a workaround. The original intent was to remove this forwarding in the next major version.

However, removing that capability gains very little in terms of code to maintain or coupling, and instead would make saga audits sent to the wrong place result in a cryptic deserialization exception and a message in the ServiceControl error queue that is difficult to remedy.

Instead, this PR embraces the self-healing aspect of the forwarding strategy, while raising the log message from a warning to an error, and making it more prominent by surfacing the problem as a custom check that would be visible within ServicePulse.