### PR TITLE
Remove opening a connection to the database when validating SQL connection strings.

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,8 +1,10 @@
 <Project>
+
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
+
   <ItemGroup Label="Versions for direct package references">
     <PackageVersion Include="Autofac" Version="8.1.1" />
     <PackageVersion Include="AWSSDK.CloudWatch" Version="3.7.401.31" />
@@ -19,7 +21,6 @@
     <PackageVersion Include="HdrHistogram" Version="2.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
@@ -48,7 +49,6 @@
     <PackageVersion Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.1" />
     <PackageVersion Include="NServiceBus.Transport.SqlServer" Version="8.1.4" />
     <PackageVersion Include="NServiceBus.Transport.PostgreSql" Version="8.1.4" />
-    <PackageVersion Include="Npgsql" Version="8.0.4" />
     <PackageVersion Include="NuGet.Versioning" Version="6.11.1" />
     <PackageVersion Include="NUnit" Version="4.2.2" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.3.0" />
@@ -75,6 +75,7 @@
     <PackageVersion Include="Validar.Fody" Version="1.9.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />
   </ItemGroup>
+
   <ItemGroup Label="Versions to pin transitive references">
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="8.0.1" />
@@ -88,9 +89,11 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
+
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.1.43" />
     <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.322" />
     <GlobalPackageReference Include="Particular.Packaging" Version="4.2.0" />
   </ItemGroup>
+
 </Project>

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlAuditInstance.cs
@@ -9,6 +9,7 @@ namespace ServiceControlInstaller.Engine.Instances
     using Configuration.ServiceControl;
     using FileSystem;
     using Queues;
+    using ServiceControlInstaller.Engine.Validation;
     using Services;
 
     public class ServiceControlAuditInstance : ServiceControlBaseService, IServiceControlAuditInstance
@@ -128,6 +129,18 @@ namespace ServiceControlInstaller.Engine.Instances
                 yield return folderPath.StartsWith("~") //Raven uses ~ to indicate path is relative to bin folder e.g. ~/Data/Logs
                     ? Path.Combine(InstallPath, folderPath.Remove(0, 1))
                     : folderPath;
+            }
+        }
+
+        protected override void ValidateConnectionString()
+        {
+            try
+            {
+                ConnectionStringValidator.Validate(this);
+            }
+            catch (EngineValidationException ex)
+            {
+                ReportCard.Errors.Add(ex.Message);
             }
         }
     }

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -16,8 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetZip" />
-    <PackageReference Include="Microsoft.Data.SqlClient" />
-    <PackageReference Include="Npgsql" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" />
     <PackageReference Include="System.Management" />

--- a/src/ServiceControlInstaller.Engine/Validation/ConnectionStringValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/ConnectionStringValidator.cs
@@ -4,8 +4,6 @@
     using System.Data.Common;
     using System.Linq;
     using Accounts;
-    using Microsoft.Data.SqlClient;
-    using Npgsql;
 
     class ConnectionStringValidator
     {
@@ -56,22 +54,10 @@
 
         void CheckMsSqlConnectionString()
         {
-            string[] customKeys = { "Queue Schema", "Subscriptions Table" };
-
             try
             {
                 //Check  validity of connection string. This will throw if invalid
                 var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
-
-                //The NSB SQL Transport can have custom key/value pairs in the connection string
-                // that won't make sense to SQL. Remove these from the string we want to validate.
-                foreach (var customKey in customKeys)
-                {
-                    if (builder.ContainsKey(customKey))
-                    {
-                        builder.Remove(customKey);
-                    }
-                }
 
                 //Check that localsystem is not used when integrated security is enabled
                 if (builder.ContainsKey("Integrated Security"))
@@ -92,55 +78,23 @@
                         }
                     }
                 }
-
-                //Attempt to connect to DB
-                using (var s = new SqlConnection(builder.ConnectionString))
-                {
-                    s.Open();
-                }
             }
             catch (ArgumentException argumentException)
             {
                 throw new EngineValidationException($"Connection String is invalid - {argumentException.Message}");
-            }
-            catch (SqlException sqlEx)
-            {
-                throw new EngineValidationException($"SQL connection failed - {sqlEx.Message}");
             }
         }
 
         void CheckPostgreSqlConnectString()
         {
-            string[] customKeys = { "Queue Schema", "Subscriptions Table" };
-
             try
             {
                 //Check  validity of connection string. This will throw if invalid
                 var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
-
-                //The NSB PostgreSQL Transport can have custom key/value pairs in the connection string
-                // that won't make sense to PostgreSQL. Remove these from the string we want to validate.
-                foreach (var customKey in customKeys)
-                {
-                    if (builder.ContainsKey(customKey))
-                    {
-                        builder.Remove(customKey);
-                    }
-                }
-
-                //Attempt to connect to DB
-                using (var s = new NpgsqlConnection(builder.ConnectionString))
-                {
-                    s.Open();
-                }
             }
             catch (ArgumentException argumentException)
             {
                 throw new EngineValidationException($"Connection String is invalid - {argumentException.Message}");
-            }
-            catch (SqlException sqlEx)
-            {
-                throw new EngineValidationException($"PostgreSQL connection failed - {sqlEx.Message}");
             }
         }
 


### PR DESCRIPTION
Resolves #1845

This PR removes connecting to the database when the installer engine performs connection string validation for SQL/PostgreSQL transports. Some validation is required to check to make sure our custom properties work, however the routines remove those properties and opens a connection to the database to validation the vanilla connection string. Validation of the vanilla connection string by connecting to the database is outside of the responsibility of the Particular Platform. No similar checks are made to confirm any other transports connection strings are correct by performing a connection in any other part of the platform.