### PR TITLE
Fix endpoint name display and grouping for Usage (#4545)

### DIFF
--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_SanitizedNameGrouping_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_SanitizedNameGrouping_Tests.cs
@@ -27,7 +27,7 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
     {
         // Arrange
         await DataStore.CreateBuilder()
-            .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker])
+            .AddEndpoint("endpoint1", sources: [ThroughputSource.Broker])
             .ConfigureEndpoint(endpoint => endpoint.SanitizedName = "endpoint1")
                 .WithThroughput(data: [50])
             .AddEndpoint("Endpoint1", sources: [ThroughputSource.Audit])
@@ -43,6 +43,8 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
         // Assert
         Assert.That(summary, Is.Not.Null);
         Assert.That(summary, Has.Count.EqualTo(1));
+        //should see 1 endpoint with both throughputs, and return 60 as the maximum one
+        Assert.That(summary.Sum(s => s.MaxDailyThroughput), Is.EqualTo(60));
     }
 
 
@@ -51,7 +53,7 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
     {
         // Arrange
         await DataStore.CreateBuilder()
-            .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker])
+            .AddEndpoint("endpoint1", sources: [ThroughputSource.Broker])
             .ConfigureEndpoint(endpoint => endpoint.SanitizedName = "endpoint1")
                 .WithThroughput(data: [50])
             .AddEndpoint("Endpoint1", sources: [ThroughputSource.Audit])
@@ -67,6 +69,10 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
         // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.Queues.Count, Is.EqualTo(1));
+        //should see 1 endpoint with both throughputs, and return 60 as the maximum one
+        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(60));
+        Assert.That(report.ReportData.Queues.FirstOrDefault(f => f.QueueName == "Endpoint1").DailyThroughputFromAudit.Sum(s => s.MessageCount), Is.EqualTo(60));
+        Assert.That(report.ReportData.Queues.FirstOrDefault(f => f.QueueName == "Endpoint1").DailyThroughputFromBroker.Sum(s => s.MessageCount), Is.EqualTo(50));
     }
 
     [Test]
@@ -74,7 +80,7 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
     {
         // Arrange
         await DataStore.CreateBuilder()
-            .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker])
+            .AddEndpoint("endpoint1", sources: [ThroughputSource.Broker])
             .ConfigureEndpoint(endpoint => endpoint.SanitizedName = "endpoint1")
                 .WithThroughput(data: [50])
             .AddEndpoint("Endpoint1", sources: [ThroughputSource.Audit])
@@ -90,6 +96,8 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
         // Assert
         Assert.That(summary, Is.Not.Null);
         Assert.That(summary, Has.Count.EqualTo(2));
+        //two different endpoints hence total throughput is a sum of both of them
+        Assert.That(summary.Sum(s => s.MaxDailyThroughput), Is.EqualTo(110));
     }
 
 
@@ -98,7 +106,7 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
     {
         // Arrange
         await DataStore.CreateBuilder()
-            .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker])
+            .AddEndpoint("endpoint1", sources: [ThroughputSource.Broker])
             .ConfigureEndpoint(endpoint => endpoint.SanitizedName = "endpoint1")
                 .WithThroughput(data: [50])
             .AddEndpoint("Endpoint1", sources: [ThroughputSource.Audit])
@@ -114,6 +122,8 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
         // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.Queues.Count, Is.EqualTo(2));
+        //two different endpoints hence total throughput is a sum of both of them
+        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(110));
     }
 
     class BrokerThroughputQuery_WithLowerCaseSanitizedNameCleanse : IBrokerThroughputQuery

--- a/src/ServiceControl.Transports.ASBS/AzureQuery.cs
+++ b/src/ServiceControl.Transports.ASBS/AzureQuery.cs
@@ -209,7 +209,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
         DateOnly startDate,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        logger.LogInformation($"Gathering metrics for \"{brokerQueue}\" queue");
+        logger.LogInformation($"Gathering metrics for \"{brokerQueue.QueueName}\" queue");
 
         var endDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime).AddDays(-1);
         if (endDate < startDate)

--- a/src/ServiceControl.Transports/BrokerThroughput/BrokerThroughputQuery.cs
+++ b/src/ServiceControl.Transports/BrokerThroughput/BrokerThroughputQuery.cs
@@ -115,5 +115,7 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
 
     public virtual string SanitizeEndpointName(string endpointName) => endpointName;
 
+    //NOTE This was added after initial release to help with matching on sanitized name where the broker (azure) would auto lowercase all the names.
+    //If the logic was added to the SanitizeEndpointName function it would only apply to new records, and not historical data, so the report and endpoint groupings would be incorrect.
     public virtual string SanitizedEndpointNameCleanser(string endpointName) => endpointName;
 }


### PR DESCRIPTION
Cherry-pick of #4545

* update endpoint type display

* Update src/Particular.LicensingComponent/ThroughputCollector.cs



* fix logic after merge of suggestion

* Logging not displaying queue name

* Refactor same logic from summary and report into one function

* Modify existing tests to ensure we are testing for the right throughput being returned

---------