### PR TITLE
SQL Server and PostgreSQL can indicate report 0 as the queue length value

### DIFF
--- a/src/ServiceControl.Transports.PostgreSql/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.PostgreSql/QueueLengthProvider.cs
@@ -132,7 +132,7 @@ class QueueLengthProvider : AbstractQueueLengthProvider
 
     static readonly ILog Logger = LogManager.GetLogger<QueueLengthProvider>();
 
-    static readonly TimeSpan QueryDelayInterval = TimeSpan.FromSeconds(1);
+    static readonly TimeSpan QueryDelayInterval = TimeSpan.FromMilliseconds(200);
 
     const int QueryChunkSize = 10;
 }

--- a/src/ServiceControl.Transports.SqlServer/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.SqlServer/QueueLengthProvider.cs
@@ -130,7 +130,7 @@
 
         static readonly ILog Logger = LogManager.GetLogger<QueueLengthProvider>();
 
-        static readonly TimeSpan QueryDelayInterval = TimeSpan.FromSeconds(1);
+        static readonly TimeSpan QueryDelayInterval = TimeSpan.FromMilliseconds(200);
 
         const int QueryChunkSize = 10;
     }


### PR DESCRIPTION
Backport of #4557 which fixes #4556 for the `release-6.0` branch