### PR TITLE
Remove permissions check from RavenDB container startup script

### DIFF
--- a/src/ServiceControl.RavenDB/sc-container-startup.sh
+++ b/src/ServiceControl.RavenDB/sc-container-startup.sh
@@ -3,14 +3,7 @@
 LEGACY_PATH="/opt/RavenDB/Server/RavenData"
 
 if [[ -d "$LEGACY_PATH" ]]; then
-  echo "ERROR: RavenDB data is being mounted to the wrong location. It should be mounted to $RAVEN_DataDir. Refer to the article 'Upgrade ServiceControl from Version 5 to Version 6' in the documentation for more details about the steps that must be taken to update ServiceControl to this version."
-  exit 1
-fi
-
-chmod -R u+rwX $RAVEN_DataDir 2> /dev/null
-
-if [[ $? -ne 0 ]]; then
-  echo "ERROR: RavenDB data permissions are not correct. The owner and group should be set to ID 999. Refer to the article 'Upgrade ServiceControl from Version 5 to Version 6' in the documentation for more details about the steps that must be taken to update ServiceControl to this version."
+  echo "ERROR: RavenDB data is being mounted to the wrong location. It should be mounted to $RAVEN_DataDir. The owner and group needs to be set to ID 999. Refer to the article 'Upgrade ServiceControl from Version 5 to Version 6' in the documentation for more details about the steps that must be taken to update ServiceControl to this version."
   exit 1
 fi
 


### PR DESCRIPTION
While the permissions check that we added is a valid check to make (RavenDB requires its data files to be owned by `999:999` and needs `rw` permissions), the check can fail when it shouldn't. 

For example, due to how Docker Desktop handles mapping Windows files that are bind mounted into the Linux container, the owner and permissions can appear incorrect while still allowing RavenDB access to the files anyway.

This PR removes the check and instead relies on RavenDB to throw exceptions to report when permissions are not correct.

We are keeping the check for the legacy data location since if that exists, it guarantees that data from the previous version is being mapped into the container, and action needs to be taken before it will work.