### PR TITLE
Remove DotNetZip

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,6 @@
     <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.0.1" />
     <PackageVersion Include="ByteSize" Version="2.1.2" />
     <PackageVersion Include="Caliburn.Micro" Version="4.0.212" />
-    <PackageVersion Include="DotNetZip" Version="1.16.0" />
     <PackageVersion Include="FluentValidation" Version="11.10.0" />
     <PackageVersion Include="Fody" Version="6.8.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />

--- a/src/ServiceControlInstaller.Engine.UnitTests/Zip/UnpackTest.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Zip/UnpackTest.cs
@@ -2,9 +2,9 @@
 {
     using System;
     using System.IO;
+    using System.IO.Compression;
     using System.Linq;
     using FileSystem;
-    using Ionic.Zip;
     using NUnit.Framework;
 
     [TestFixture]
@@ -38,11 +38,7 @@
                 }
             }
 
-            using (var zip = new ZipFile())
-            {
-                zip.AddDirectory(workingFolder.FullName, null);
-                zip.Save(zipFilePath);
-            }
+            ZipFile.CreateFromDirectory(workingFolder.FullName, zipFilePath);
 
             Console.WriteLine(zipFilePath);
         }

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -3,11 +3,11 @@ namespace ServiceControlInstaller.Engine.FileSystem
     using System;
     using System.Diagnostics;
     using System.IO;
+    using System.IO.Compression;
     using System.Linq;
     using System.Reflection;
     using System.Security.AccessControl;
     using System.Threading;
-    using Ionic.Zip;
 
     static class FileUtils
     {
@@ -147,8 +147,8 @@ namespace ServiceControlInstaller.Engine.FileSystem
 
         internal static void UnzipToSubdirectory(Stream zipStream, string targetPath)
         {
-            using var zip = ZipFile.Read(zipStream);
-            zip.ExtractAll(targetPath, ExtractExistingFileAction.OverwriteSilently);
+            using var zip = new ZipArchive(zipStream, ZipArchiveMode.Read, leaveOpen: false);
+            zip.ExtractToDirectory(targetPath, overwriteFiles: true);
         }
 
         static void RunWithRetries(Action action)

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" />
     <PackageReference Include="System.Management" />


### PR DESCRIPTION
Replace the single use of vulnerable/deprecated DotNetZip with System.IO.Compression.ZipFile