### PR TITLE
Ignore https://github.com/advisories/GHSA-xhg6-9j5j-w4vf for DotNetZip in release-4

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -25,6 +25,11 @@
     <InstanceName Include="Particular.ServiceControl.Monitoring" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- DotNetZip: No replacement in net4xx, only affects unzipping unknown zips, where ServiceControl only unzips known deployment artifacts -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhg6-9j5j-w4vf" />
+  </ItemGroup>
+
   <!-- workaround for https://github.com/microsoft/MSBuildSdks/issues/477 -->
   <PropertyGroup>
     <UseArtifactsOutput>false</UseArtifactsOutput>


### PR DESCRIPTION
While DotNetZIp is vulnerable according to https://github.com/advisories/GHSA-xhg6-9j5j-w4vf, there is no drop-in replacement from .NET Framework. Additionally, this version is out of support in about a month, and the vulnerability exists only for unzipping unknown, unvetted zip files, where the ServiceControl installer is only reading known zip files from deployment artifacts.