### PR TITLE
Support minimum PowerShell 7.4 as PowerShell 7.2 is now out of support

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/setup-dotnet@v4.1.0
         with:
           dotnet-version: 8.0.x
+      - name: dotnet info
+        run: dotnet --info
       - name: Download RavenDB Server
         shell: pwsh
         run: ./tools/download-ravendb-server.ps1

--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+  "sdk": {
+    "version": "8.0.400",
+    "rollForward": "latestFeature"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "3.7.56"
+  }
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -65,7 +65,7 @@
     <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="8.0.1" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Management" Version="8.0.0" />
-    <PackageVersion Include="System.Management.Automation" Version="7.2.21" />
+    <PackageVersion Include="System.Management.Automation" Version="7.4.6" />
     <PackageVersion Include="System.Reactive.Linq" Version="6.0.1" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.1" />
     <PackageVersion Include="System.ServiceProcess.ServiceController" Version="8.0.1" />

--- a/src/ServiceControl.LicenseManagement/LicenseDetails.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseDetails.cs
@@ -33,7 +33,7 @@
                 LicenseType = "Trial",
                 ExpirationDate = endDate.ToDateTime(TimeOnly.MinValue),
                 IsExtendedTrial = false,
-                ValidApplications = new List<string> { "All" }
+                ValidApplications = ["All"]
             });
         }
 
@@ -44,7 +44,7 @@
                 LicenseType = "Trial",
                 ExpirationDate = DateTime.UtcNow.Date.AddDays(-2), //HasLicenseDateExpired uses a grace period of 1 day
                 IsExtendedTrial = false,
-                ValidApplications = new List<string> { "All" }
+                ValidApplications = ["All"]
             });
         }
 

--- a/src/ServiceControl.LicenseManagement/ServiceControl.LicenseManagement.csproj
+++ b/src/ServiceControl.LicenseManagement/ServiceControl.LicenseManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Management.PowerShell/Particular.ServiceControl.Management.psd1
+++ b/src/ServiceControl.Management.PowerShell/Particular.ServiceControl.Management.psd1
@@ -25,7 +25,7 @@ Copyright = '© 2010-{{Date}} NServiceBus Ltd. All rights reserved'
 Description = 'ServiceControl Management'
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '7.2'
+PowerShellVersion = '7.4'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''

--- a/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
+++ b/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
@@ -17,7 +17,6 @@
 
     <!--Ensures that all project references are explicitly defined in this file -->
     <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
-    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
+++ b/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
@@ -12,8 +12,8 @@
   -->
 
   <PropertyGroup>
-    <!-- Must stay net6.0 to support PowerShell 7.2 LTS -->
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <!-- Must stay net8.0 to support PowerShell 7.4 LTS -->
+    <TargetFramework>net8.0-windows</TargetFramework>
 
     <!--Ensures that all project references are explicitly defined in this file -->
     <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>

--- a/src/ServiceControlInstaller.Engine/Accounts/Lsa.cs
+++ b/src/ServiceControlInstaller.Engine/Accounts/Lsa.cs
@@ -25,7 +25,7 @@
                 // the user has no privileges
                 if (win32ErrorCode == StatusObjectNameNotFound)
                 {
-                    return new string[0];
+                    return [];
                 }
 
                 HandleLsaResult(result);

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/UpgradeInfo.cs
@@ -6,13 +6,13 @@
     public class UpgradeInfo
     {
         static readonly SemanticVersion[] LastVersionForEachMajor =
-        {
+        [
             new(1, 48, 0),
             new(2, 1, 5),
             new(3, 8, 4),
             new(4, 33, 0), // Added IngestErrorMessages setting to enable message replay during 4to5 upgrade guide scenario 
-            new(5, 11, 0),
-        };
+            new(5, 11, 0)
+        ];
 
         public SemanticVersion[] UpgradePath { get; private init; }
         public bool HasIncompatibleVersion { get; private init; }

--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -147,8 +147,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
 
         internal static void UnzipToSubdirectory(Stream zipStream, string targetPath)
         {
-            using var zip = new ZipArchive(zipStream, ZipArchiveMode.Read, leaveOpen: false);
-            zip.ExtractToDirectory(targetPath, overwriteFiles: true);
+            ZipFile.ExtractToDirectory(zipStream, targetPath, overwriteFiles: true);
         }
 
         static void RunWithRetries(Action action)
@@ -165,7 +164,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
                 {
                     Debug.WriteLine($"ServiceControlInstaller.Engine.FileSystem.FileUtils::RunWithRetries Action failed, {attempts} attempts remaining. Reason: {ex.Message} ({ex.GetType().FullName})");
                     // Yes, Task.Delay would be better but would require all calls to be async
-                    // and in 99.9% this sleep will not hit 
+                    // and in 99.9% this sleep will not hit
                     Thread.Sleep(100);
                 }
             }

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
@@ -32,11 +32,11 @@
             get
             {
                 const string flagFileName = ".notconfigured";
-                return new[]
-                {
+                return
+                [
                     Path.Combine(InstallPath, flagFileName),
                     Path.Combine(LogPath, flagFileName)
-                };
+                ];
             }
         }
 

--- a/src/ServiceControlInstaller.Engine/Instances/PersistenceManifest.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/PersistenceManifest.cs
@@ -15,11 +15,11 @@
 
         public bool IsSupported { get; set; } = true;
 
-        public Setting[] Settings { get; set; } = Array.Empty<Setting>();
+        public Setting[] Settings { get; set; } = [];
 
-        public string[] SettingsWithPathsToCleanup { get; set; } = Array.Empty<string>();
+        public string[] SettingsWithPathsToCleanup { get; set; } = [];
 
-        public string[] Aliases { get; set; } = Array.Empty<string>();
+        public string[] Aliases { get; set; } = [];
 
         internal bool IsMatch(string persistenceType) =>
             string.Equals(TypeName, persistenceType, StringComparison.Ordinal) // Type names are case-sensitive

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
@@ -330,7 +330,7 @@ namespace ServiceControlInstaller.Engine.Instances
 
         protected virtual IEnumerable<string> GetPersistencePathsToCleanUp()
         {
-            return Enumerable.Empty<string>();
+            return [];
         }
 
         protected virtual void ValidateConnectionString()

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstallableBase.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstallableBase.cs
@@ -59,12 +59,12 @@
             get
             {
                 const string flagFileName = ".notconfigured";
-                return new[]
-                {
+                return
+                [
                     Path.Combine(InstallPath, flagFileName),
                     Path.Combine(DBPath, flagFileName),
                     Path.Combine(LogPath, flagFileName)
-                };
+                ];
             }
         }
 

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -26,7 +26,7 @@ namespace ServiceControlInstaller.Engine.Instances
 
         public TimeSpan? AuditRetentionPeriod { get; set; }
 
-        public List<RemoteInstanceSetting> RemoteInstances { get; set; } = new List<RemoteInstanceSetting>();
+        public List<RemoteInstanceSetting> RemoteInstances { get; set; } = [];
 
         public PersistenceManifest PersistenceManifest { get; set; }
 
@@ -207,12 +207,12 @@ namespace ServiceControlInstaller.Engine.Instances
         protected override IEnumerable<string> GetPersistencePathsToCleanUp()
         {
             string[] keys =
-            {
+            [
                 "Raven/IndexStoragePath",
                 "Raven/CompiledIndexCacheDirectory",
                 "Raven/Esent/LogsPath",
                 ServiceControlSettings.DBPath.Name
-            };
+            ];
 
             var settings = AppConfig.Config.AppSettings.Settings;
             foreach (var key in keys)

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlNewInstance.cs
@@ -42,7 +42,7 @@ namespace ServiceControlInstaller.Engine.Instances
 
         public override string DirectoryName => "ServiceControl";
 
-        public List<RemoteInstanceSetting> RemoteInstances { get; set; } = new List<RemoteInstanceSetting>();
+        public List<RemoteInstanceSetting> RemoteInstances { get; set; } = [];
 
         public void AddRemoteInstance(string apiUri)
         {

--- a/src/ServiceControlInstaller.Engine/Instances/TransportInfo.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/TransportInfo.cs
@@ -21,7 +21,7 @@
 
         public string AutoMigrateTo { get; set; }
 
-        public string[] Aliases { get; set; } = Array.Empty<string>();
+        public string[] Aliases { get; set; } = [];
 
         public string ZipName
         {
@@ -65,6 +65,6 @@
 
     public class TransportManifest
     {
-        public TransportInfo[] Definitions { get; set; } = Array.Empty<TransportInfo>();
+        public TransportInfo[] Definitions { get; set; } = [];
     }
 }

--- a/src/ServiceControlInstaller.Engine/Queues/QueueCreationException.cs
+++ b/src/ServiceControlInstaller.Engine/Queues/QueueCreationException.cs
@@ -1,7 +1,6 @@
 namespace ServiceControlInstaller.Engine.Queues
 {
     using System;
-    using System.Runtime.Serialization;
 
     public class QueueCreationFailedException : Exception
     {
@@ -10,12 +9,6 @@ namespace ServiceControlInstaller.Engine.Queues
         }
 
         public QueueCreationFailedException(string message, Exception inner) : base(message, inner)
-        {
-        }
-
-        protected QueueCreationFailedException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/ServiceControlInstaller.Engine/Queues/QueueCreationTimeoutException.cs
+++ b/src/ServiceControlInstaller.Engine/Queues/QueueCreationTimeoutException.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControlInstaller.Engine.Queues
 {
     using System;
-    using System.Runtime.Serialization;
 
     public class QueueCreationTimeoutException : Exception
     {
@@ -10,12 +9,6 @@
         }
 
         public QueueCreationTimeoutException(string message, Exception inner) : base(message, inner)
-        {
-        }
-
-        protected QueueCreationTimeoutException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/ServiceControlInstaller.Engine/Queues/ServiceControlQueueCreationTimeoutException.cs
+++ b/src/ServiceControlInstaller.Engine/Queues/ServiceControlQueueCreationTimeoutException.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControlInstaller.Engine.Queues
 {
     using System;
-    using System.Runtime.Serialization;
 
     public class ServiceControlQueueCreationTimeoutException : Exception
     {
@@ -10,12 +9,6 @@
         }
 
         public ServiceControlQueueCreationTimeoutException(string message, Exception inner) : base(message, inner)
-        {
-        }
-
-        protected ServiceControlQueueCreationTimeoutException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/ServiceControlInstaller.Engine/ReportCard/TruncatedStringList.cs
+++ b/src/ServiceControlInstaller.Engine/ReportCard/TruncatedStringList.cs
@@ -96,7 +96,7 @@
             }
         }
 
-        List<string> itemList = new List<string>();
+        List<string> itemList = [];
 
         int maxLength;
     }

--- a/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
+++ b/src/ServiceControlInstaller.Engine/ServiceControlInstaller.Engine.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Must stay net6.0 to support PowerShell 7.2 LTS -->
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <!-- Must stay net8.0 to support PowerShell 7.4 LTS -->
+    <TargetFramework>net8.0-windows</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/ServiceControlInstaller.Engine/Services/WindowsServiceController.cs
+++ b/src/ServiceControlInstaller.Engine/Services/WindowsServiceController.cs
@@ -287,7 +287,7 @@
 
 
         static readonly string[] Win32ChangeErrorMessages =
-        {
+        [
             "The request was accepted",
             "The request is not supported",
             "Access Denied",
@@ -313,10 +313,10 @@
             "The account under which this service runs is either invalid or lacks the permissions to run the service",
             "The service exists in the database of services available from the system",
             "The service is currently paused in the system"
-        };
+        ];
 
         static readonly string[] Win32ServiceErrorMessages =
-        {
+        [
             "The request was accepted.",
             "The request is not supported.",
             "The user did not have the necessary access.",
@@ -342,6 +342,6 @@
             "The account under which this service runs is either invalid or lacks the permissions to run the service.",
             "The service exists in the database of services available from the system.",
             "The service is currently paused in the system."
-        };
+        ];
     }
 }

--- a/src/ServiceControlInstaller.Engine/UrlAcl/UrlReservation.cs
+++ b/src/ServiceControlInstaller.Engine/UrlAcl/UrlReservation.cs
@@ -311,7 +311,7 @@
             return bytes;
         }
 
-        List<SecurityIdentifier> securityIdentifiers = new List<SecurityIdentifier>();
+        List<SecurityIdentifier> securityIdentifiers = [];
 
         const int GENERIC_EXECUTE = 536870912;
         static Regex urlPattern = new Regex(@"^(?<protocol>https?)://(?<hostname>([^/]*?))(:(?<port>\d{0,5}))?(/(?<virtual>[^:]*))?/$", RegexOptions.Compiled | RegexOptions.IgnoreCase);

--- a/src/ServiceControlInstaller.Engine/Validation/QueueNameValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/QueueNameValidator.cs
@@ -9,8 +9,8 @@ namespace ServiceControlInstaller.Engine.Validation
     {
         QueueNameValidator()
         {
-            SCInstances = new List<IServiceControlInstance>();
-            AuditInstances = new List<IServiceControlAuditInstance>();
+            SCInstances = [];
+            AuditInstances = [];
         }
 
         internal QueueNameValidator(IServiceControlInstance instance) : this()
@@ -47,8 +47,8 @@ namespace ServiceControlInstaller.Engine.Validation
 
         void DetermineAuditQueueNames(IServiceControlAuditInstance instance)
         {
-            queues = new List<QueueInfo>
-            {
+            queues =
+            [
                 new QueueInfo
                 {
                     PropertyName = "AuditQueue",
@@ -56,7 +56,7 @@ namespace ServiceControlInstaller.Engine.Validation
                     QueueName = instance.AuditQueue,
                     QueueType = QueueType.Audit
                 }
-            };
+            ];
 
             if (instance.ForwardAuditMessages)
             {
@@ -72,8 +72,8 @@ namespace ServiceControlInstaller.Engine.Validation
 
         void DetermineServiceControlQueueNames(IServiceControlInstance instance)
         {
-            queues = new List<QueueInfo>
-            {
+            queues =
+            [
                 new QueueInfo
                 {
                     PropertyName = "ErrorQueue",
@@ -81,7 +81,7 @@ namespace ServiceControlInstaller.Engine.Validation
                     QueueName = instance.ErrorQueue,
                     QueueType = QueueType.Error
                 }
-            };
+            ];
 
             if (instance.ForwardErrorMessages)
             {

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-    "Microsoft.Build.NoTargets": "3.7.56"
-  }
-}


### PR DESCRIPTION
This update makes PowerShell 7.4 LTS (which uses .NET 8 LTS internally) the lowest-supported PowerShell version.

The previous supported version, PowerShell 7.2, is [now unsupported by Microsoft](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.4#powershell-end-of-support-dates) along with .NET 6.