### PR TITLE
Escape slashes on id of message

### DIFF
--- a/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs
+++ b/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs
@@ -7,12 +7,12 @@
     using System.Runtime.Versioning;
     using System.Threading;
     using System.Threading.Tasks;
+    using Configuration;
+    using Infrastructure;
     using NServiceBus.Logging;
     using NServiceBus.Transport;
+    using Persistence;
     using ServiceBus.Management.Infrastructure.Installers;
-    using ServiceControl.Configuration;
-    using ServiceControl.Infrastructure;
-    using ServiceControl.Persistence;
 
     class ErrorIngestionFaultPolicy
     {
@@ -79,12 +79,12 @@
             if (!AppEnvironment.RunningInContainer)
             {
                 // Write to Log Path
-                var filePath = Path.Combine(logPath, $"{failure.Id}.txt");
+                string filePath = Path.Combine(logPath, $"{failure.Id.Replace("/", "_")}.txt");
                 await File.WriteAllTextAsync(filePath, failure.ExceptionInfo, cancellationToken);
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    WriteToEventLog("A message import has failed. A log file has been written to " + filePath);
+                    WriteToEventLog($"A message import has failed. A log file has been written to {filePath}");
                 }
             }
         }


### PR DESCRIPTION
The slash of the id needs to be escaped so it does not get confused with a folder separator character and hence preventing the file from being written.

As you can see in https://github.com/Particular/ServiceControl/blob/71f04aa211b605f5eaaf653336e381907f5b5fe6/src/ServiceControl.Persistence/FailedErrorImport.cs#L11 the id has a `/` and this causes a `DirectoryNotFoundException` in https://github.com/Particular/ServiceControl/blob/1051df8a187eb10ed96d65868f13a6fc4381679a/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs#L83


Fixes https://github.com/Particular/ServiceControl/issues/4654