### PR TITLE
Azure Service Bus transport may hang when stopping the receiver during retry batch processing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
           registry-password: ${{ secrets.DOCKERHUB_TOKEN }}  
       - name: Setup RabbitMQ
-        uses: Particular/setup-rabbitmq-action@v1.7.0
+        uses: Particular/setup-rabbitmq-action@v1.7.1
         if: matrix.test-category == 'RabbitMQ'
         with:
           connection-string-name: ServiceControl_TransportTests_RabbitMQ_ConnectionString

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           connection-string-env-var: ServiceControl_TransportTests_SQL_ConnectionString
           catalog: nservicebus
       - name: Setup PostgreSQL
-        uses: Particular/setup-postgres-action@v1.0.1
+        uses: Particular/setup-postgres-action@v1.0.2
         if: matrix.test-category == 'PostgreSQL'
         with:          
           connection-string-name: ServiceControl_TransportTests_PostgreSQL_ConnectionString

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="NServiceBus.RabbitMQ" Version="9.1.1" />
     <PackageVersion Include="NServiceBus.SagaAudit" Version="5.0.1" />
     <PackageVersion Include="NServiceBus.Testing" Version="9.0.0" />
-    <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="4.2.3" />
+    <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="4.2.4" />
     <PackageVersion Include="NServiceBus.Transport.AzureStorageQueues" Version="13.0.1" />
     <PackageVersion Include="NServiceBus.Transport.Msmq.Sources" Version="3.0.1" />
     <PackageVersion Include="NServiceBus.Transport.SqlServer" Version="8.1.6" />


### PR DESCRIPTION
### Symptoms

Retrying failed messages appears to hang and is never completed

### Who's affected

Only users of ServiceControl using Azure Service Bus may be affected.

### Root cause

The `messageProcessingCancellationTokenSource` may be null when the `ReturnToSenderDequeuer` stops the transport receiver causing the Azure Service Bus `StopReceive` method to hang.