### PR TITLE
Remove support email from error messages

### DIFF
--- a/src/ServiceControl.Transports.ASBS/DeadLetterQueueCheck.cs
+++ b/src/ServiceControl.Transports.ASBS/DeadLetterQueueCheck.cs
@@ -33,7 +33,7 @@
 
             if (deadLetterMessageCount > 0)
             {
-                var result = $"{deadLetterMessageCount} messages in the Dead Letter Queue '{stagingQueue}'. This could indicate a problem with ServiceControl's retries. Please submit a support ticket to Particular using support@particular.net if you would like help from our engineers to ensure no message loss while resolving these dead letter messages.";
+                var result = $"{deadLetterMessageCount} messages in the Dead Letter Queue '{stagingQueue}'. This could indicate a problem with ServiceControl's retries. Please submit a support ticket to Particular if you would like help from our engineers to ensure no message loss while resolving these dead letter messages.";
 
                 Logger.Warn(result);
                 return CheckResult.Failed(result);

--- a/src/ServiceControl.Transports.Msmq/DeadLetterQueueCheck.cs
+++ b/src/ServiceControl.Transports.Msmq/DeadLetterQueueCheck.cs
@@ -75,7 +75,7 @@
 
         static string MessagesInDeadLetterQueue(float currentValue)
         {
-            return $"{currentValue} messages in the Dead Letter Queue on {Environment.MachineName}. This could indicate a problem with ServiceControl's retries. Please submit a support ticket to Particular using support@particular.net if you would like help from our engineers to ensure no message loss while resolving these dead letter messages.";
+            return $"{currentValue} messages in the Dead Letter Queue on {Environment.MachineName}. This could indicate a problem with ServiceControl's retries. Please submit a support ticket to Particular if you would like help from our engineers to ensure no message loss while resolving these dead letter messages.";
         }
 
         static string CounterMightBeLocalized(string categoryName, string counterName, string counterInstanceName)


### PR DESCRIPTION
The support@particular.net email is no longer supported for creating new cases.