### PR TITLE
Multiple options for configuring RavenDB client certificate

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -39,7 +39,7 @@ namespace ServiceControl.Audit.Persistence.RavenDB
                 {
                     Database = configuration.Name,
                     Urls = [configuration.ServerConfiguration.ConnectionString],
-                    Certificate = RavenClientCertificate.FindClientCertificate(),
+                    Certificate = RavenClientCertificate.FindClientCertificate(configuration.ServerConfiguration.ClientCertificateBase64),
                     Conventions = new DocumentConventions
                     {
                         SaveEnumsAsIntegers = true

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -39,7 +39,7 @@ namespace ServiceControl.Audit.Persistence.RavenDB
                 {
                     Database = configuration.Name,
                     Urls = [configuration.ServerConfiguration.ConnectionString],
-                    Certificate = RavenClientCertificate.FindClientCertificate(configuration.ServerConfiguration.ClientCertificateBase64),
+                    Certificate = RavenClientCertificate.FindClientCertificate(configuration.ServerConfiguration),
                     Conventions = new DocumentConventions
                     {
                         SaveEnumsAsIntegers = true

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -3,9 +3,6 @@
 namespace ServiceControl.Audit.Persistence.RavenDB
 {
     using System;
-    using System.IO;
-    using System.Reflection;
-    using System.Security.Cryptography.X509Certificates;
     using System.Threading;
     using System.Threading.Tasks;
     using Raven.Client.Documents;
@@ -38,21 +35,11 @@ namespace ServiceControl.Audit.Persistence.RavenDB
             {
                 await initializeSemaphore.WaitAsync(cancellationToken);
 
-                // Look for raven-client-certificate.pfx in same directory as application code
-                var applicationDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location) ?? string.Empty;
-                var certificatePath = Path.Combine(applicationDirectory, "raven-client-certificate.pfx");
-                X509Certificate2? certificate = null;
-
-                if (File.Exists(certificatePath))
-                {
-                    certificate = new X509Certificate2(certificatePath);
-                }
-
                 var store = new DocumentStore
                 {
                     Database = configuration.Name,
                     Urls = [configuration.ServerConfiguration.ConnectionString],
-                    Certificate = certificate,
+                    Certificate = RavenClientCertificate.FindClientCertificate(),
                     Conventions = new DocumentConventions
                     {
                         SaveEnumsAsIntegers = true

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -12,6 +12,7 @@
         public const string DatabaseNameKey = "RavenDB/DatabaseName";
         public const string DatabasePathKey = "DbPath";
         public const string ConnectionStringKey = "RavenDB/ConnectionString";
+        public const string ClientCertificatePathKey = "RavenDB/ClientCertificatePath";
         public const string ClientCertificateBase64Key = "RavenDB/ClientCertificateBase64";
         public const string DatabaseMaintenancePortKey = "DatabaseMaintenancePort";
         public const string ExpirationProcessTimerInSecondsKey = "ExpirationProcessTimerInSeconds";
@@ -25,6 +26,7 @@
             DatabaseNameKey,
             DatabasePathKey,
             ConnectionStringKey,
+            ClientCertificatePathKey,
             ClientCertificateBase64Key,
             DatabaseMaintenancePortKey,
             ExpirationProcessTimerInSecondsKey,
@@ -62,6 +64,10 @@
 
                 serverConfiguration = new ServerConfiguration(connectionString);
 
+                if (settings.PersisterSpecificSettings.TryGetValue(ClientCertificatePathKey, out var clientCertificatePath))
+                {
+                    serverConfiguration.ClientCertificatePath = clientCertificatePath;
+                }
                 if (settings.PersisterSpecificSettings.TryGetValue(ClientCertificateBase64Key, out var clientCertificateBase64))
                 {
                     serverConfiguration.ClientCertificateBase64 = clientCertificateBase64;

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -12,6 +12,7 @@
         public const string DatabaseNameKey = "RavenDB/DatabaseName";
         public const string DatabasePathKey = "DbPath";
         public const string ConnectionStringKey = "RavenDB/ConnectionString";
+        public const string ClientCertificateBase64Key = "RavenDB/ClientCertificateBase64";
         public const string DatabaseMaintenancePortKey = "DatabaseMaintenancePort";
         public const string ExpirationProcessTimerInSecondsKey = "ExpirationProcessTimerInSeconds";
         public const string LogPathKey = "LogPath";
@@ -24,6 +25,7 @@
             DatabaseNameKey,
             DatabasePathKey,
             ConnectionStringKey,
+            ClientCertificateBase64Key,
             DatabaseMaintenancePortKey,
             ExpirationProcessTimerInSecondsKey,
             LogPathKey,
@@ -59,6 +61,11 @@
                 }
 
                 serverConfiguration = new ServerConfiguration(connectionString);
+
+                if (settings.PersisterSpecificSettings.TryGetValue(ClientCertificateBase64Key, out var clientCertificateBase64))
+                {
+                    serverConfiguration.ClientCertificateBase64 = clientCertificateBase64;
+                }
             }
             else
             {

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -14,6 +14,7 @@
         public const string ConnectionStringKey = "RavenDB/ConnectionString";
         public const string ClientCertificatePathKey = "RavenDB/ClientCertificatePath";
         public const string ClientCertificateBase64Key = "RavenDB/ClientCertificateBase64";
+        public const string ClientCertificatePasswordKey = "RavenDB/ClientCertificatePassword";
         public const string DatabaseMaintenancePortKey = "DatabaseMaintenancePort";
         public const string ExpirationProcessTimerInSecondsKey = "ExpirationProcessTimerInSeconds";
         public const string LogPathKey = "LogPath";
@@ -28,6 +29,7 @@
             ConnectionStringKey,
             ClientCertificatePathKey,
             ClientCertificateBase64Key,
+            ClientCertificatePasswordKey,
             DatabaseMaintenancePortKey,
             ExpirationProcessTimerInSecondsKey,
             LogPathKey,
@@ -71,6 +73,10 @@
                 if (settings.PersisterSpecificSettings.TryGetValue(ClientCertificateBase64Key, out var clientCertificateBase64))
                 {
                     serverConfiguration.ClientCertificateBase64 = clientCertificateBase64;
+                }
+                if (settings.PersisterSpecificSettings.TryGetValue(ClientCertificatePasswordKey, out var clientCertificatePassword))
+                {
+                    serverConfiguration.ClientCertificatePassword = clientCertificatePassword;
                 }
             }
             else

--- a/src/ServiceControl.Audit.Persistence.RavenDB/ServerConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/ServerConfiguration.cs
@@ -20,9 +20,9 @@
         }
 
         public string ConnectionString { get; }
-        public string ClientCertificatePath { get; internal set; }
-        public string ClientCertificateBase64 { get; internal set; }
-        public string ClientCertificatePassword { get; internal set; }
+        public string ClientCertificatePath { get; set; }
+        public string ClientCertificateBase64 { get; set; }
+        public string ClientCertificatePassword { get; set; }
         public bool UseEmbeddedServer { get; }
         public string DbPath { get; internal set; } //Setter for ATT only
         public string ServerUrl { get; }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/ServerConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/ServerConfiguration.cs
@@ -18,6 +18,7 @@
         }
 
         public string ConnectionString { get; }
+        public string ClientCertificateBase64 { get; internal set; }
         public bool UseEmbeddedServer { get; }
         public string DbPath { get; internal set; } //Setter for ATT only
         public string ServerUrl { get; }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/ServerConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/ServerConfiguration.cs
@@ -22,6 +22,7 @@
         public string ConnectionString { get; }
         public string ClientCertificatePath { get; internal set; }
         public string ClientCertificateBase64 { get; internal set; }
+        public string ClientCertificatePassword { get; internal set; }
         public bool UseEmbeddedServer { get; }
         public string DbPath { get; internal set; } //Setter for ATT only
         public string ServerUrl { get; }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/ServerConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/ServerConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿namespace ServiceControl.Audit.Persistence.RavenDB
 {
-    public class ServerConfiguration
+    using ServiceControl.RavenDB;
+
+    public class ServerConfiguration : IRavenClientCertificateInfo
     {
         public ServerConfiguration(string connectionString)
         {
@@ -18,6 +20,7 @@
         }
 
         public string ConnectionString { get; }
+        public string ClientCertificatePath { get; internal set; }
         public string ClientCertificateBase64 { get; internal set; }
         public bool UseEmbeddedServer { get; }
         public string DbPath { get; internal set; } //Setter for ATT only

--- a/src/ServiceControl.Persistence.RavenDB/RavenBootstrapper.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenBootstrapper.cs
@@ -7,6 +7,7 @@
         public const string DatabaseMaintenancePortKey = "DatabaseMaintenancePort";
         public const string ExpirationProcessTimerInSecondsKey = "ExpirationProcessTimerInSeconds";
         public const string ConnectionStringKey = "RavenDB/ConnectionString";
+        public const string ClientCertificatePathKey = "RavenDB/ClientCertificatePath";
         public const string ClientCertificateBase64Key = "RavenDB/ClientCertificateBase64";
         public const string MinimumStorageLeftRequiredForIngestionKey = "MinimumStorageLeftRequiredForIngestion";
         public const string DatabaseNameKey = "RavenDB/DatabaseName";

--- a/src/ServiceControl.Persistence.RavenDB/RavenBootstrapper.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenBootstrapper.cs
@@ -9,6 +9,7 @@
         public const string ConnectionStringKey = "RavenDB/ConnectionString";
         public const string ClientCertificatePathKey = "RavenDB/ClientCertificatePath";
         public const string ClientCertificateBase64Key = "RavenDB/ClientCertificateBase64";
+        public const string ClientCertificatePasswordKey = "RavenDB/ClientCertificatePassword";
         public const string MinimumStorageLeftRequiredForIngestionKey = "MinimumStorageLeftRequiredForIngestion";
         public const string DatabaseNameKey = "RavenDB/DatabaseName";
         public const string LogsPathKey = "LogPath";

--- a/src/ServiceControl.Persistence.RavenDB/RavenBootstrapper.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenBootstrapper.cs
@@ -7,6 +7,7 @@
         public const string DatabaseMaintenancePortKey = "DatabaseMaintenancePort";
         public const string ExpirationProcessTimerInSecondsKey = "ExpirationProcessTimerInSeconds";
         public const string ConnectionStringKey = "RavenDB/ConnectionString";
+        public const string ClientCertificateBase64Key = "RavenDB/ClientCertificateBase64";
         public const string MinimumStorageLeftRequiredForIngestionKey = "MinimumStorageLeftRequiredForIngestion";
         public const string DatabaseNameKey = "RavenDB/DatabaseName";
         public const string LogsPathKey = "LogPath";

--- a/src/ServiceControl.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -39,7 +39,7 @@ namespace ServiceControl.Persistence.RavenDB
                 {
                     Database = settings.DatabaseName,
                     Urls = [settings.ConnectionString],
-                    Certificate = RavenClientCertificate.FindClientCertificate(settings.ClientCertificateBase64),
+                    Certificate = RavenClientCertificate.FindClientCertificate(settings),
                     Conventions = new DocumentConventions
                     {
                         SaveEnumsAsIntegers = true

--- a/src/ServiceControl.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -39,7 +39,7 @@ namespace ServiceControl.Persistence.RavenDB
                 {
                     Database = settings.DatabaseName,
                     Urls = [settings.ConnectionString],
-                    Certificate = RavenClientCertificate.FindClientCertificate(),
+                    Certificate = RavenClientCertificate.FindClientCertificate(settings.ClientCertificateBase64),
                     Conventions = new DocumentConventions
                     {
                         SaveEnumsAsIntegers = true

--- a/src/ServiceControl.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -3,9 +3,6 @@
 namespace ServiceControl.Persistence.RavenDB
 {
     using System;
-    using System.IO;
-    using System.Reflection;
-    using System.Security.Cryptography.X509Certificates;
     using System.Threading;
     using System.Threading.Tasks;
     using Raven.Client.Documents;
@@ -38,21 +35,11 @@ namespace ServiceControl.Persistence.RavenDB
             {
                 await initializeSemaphore.WaitAsync(cancellationToken);
 
-                // Look for raven-client-certificate.pfx in same directory as application code
-                var applicationDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location) ?? string.Empty;
-                var certificatePath = Path.Combine(applicationDirectory, "raven-client-certificate.pfx");
-                X509Certificate2? certificate = null;
-
-                if (File.Exists(certificatePath))
-                {
-                    certificate = new X509Certificate2(certificatePath);
-                }
-
                 var store = new DocumentStore
                 {
                     Database = settings.DatabaseName,
                     Urls = [settings.ConnectionString],
-                    Certificate = certificate,
+                    Certificate = RavenClientCertificate.FindClientCertificate(),
                     Conventions = new DocumentConventions
                     {
                         SaveEnumsAsIntegers = true

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -34,6 +34,7 @@
             var settings = new RavenPersisterSettings
             {
                 ConnectionString = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ConnectionStringKey),
+                ClientCertificatePath = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ClientCertificatePathKey),
                 ClientCertificateBase64 = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ClientCertificateBase64Key),
                 DatabaseName = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabaseNameKey, RavenPersisterSettings.DatabaseNameDefault),
                 DatabasePath = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabasePathKey, DefaultDatabaseLocation()),

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -36,6 +36,7 @@
                 ConnectionString = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ConnectionStringKey),
                 ClientCertificatePath = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ClientCertificatePathKey),
                 ClientCertificateBase64 = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ClientCertificateBase64Key),
+                ClientCertificatePassword = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ClientCertificatePasswordKey),
                 DatabaseName = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabaseNameKey, RavenPersisterSettings.DatabaseNameDefault),
                 DatabasePath = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabasePathKey, DefaultDatabaseLocation()),
                 DatabaseMaintenancePort = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabaseMaintenancePortKey, RavenPersisterSettings.DatabaseMaintenancePortDefault),

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -34,6 +34,7 @@
             var settings = new RavenPersisterSettings
             {
                 ConnectionString = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ConnectionStringKey),
+                ClientCertificateBase64 = SettingsReader.Read<string>(settingsRootNamespace, RavenBootstrapper.ClientCertificateBase64Key),
                 DatabaseName = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabaseNameKey, RavenPersisterSettings.DatabaseNameDefault),
                 DatabasePath = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabasePathKey, DefaultDatabaseLocation()),
                 DatabaseMaintenancePort = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.DatabaseMaintenancePortKey, RavenPersisterSettings.DatabaseMaintenancePortDefault),

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
@@ -2,8 +2,9 @@
 using Particular.LicensingComponent.Contracts;
 using ServiceControl.Persistence;
 using ServiceControl.Persistence.RavenDB.CustomChecks;
+using ServiceControl.RavenDB;
 
-class RavenPersisterSettings : PersistenceSettings
+class RavenPersisterSettings : PersistenceSettings, IRavenClientCertificateInfo
 {
     public int DatabaseMaintenancePort { get; set; } = DatabaseMaintenancePortDefault;
     public int ExpirationProcessTimerInSeconds { get; set; } = ExpirationProcessTimerInSecondsDefault;
@@ -23,6 +24,7 @@ class RavenPersisterSettings : PersistenceSettings
     /// User provided external RavenDB instance connection string
     /// </summary>
     public string ConnectionString { get; set; }
+    public string ClientCertificatePath { get; set; }
     public string ClientCertificateBase64 { get; set; }
     public bool UseEmbeddedServer => string.IsNullOrWhiteSpace(ConnectionString);
     public string LogPath { get; set; }

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
@@ -26,6 +26,7 @@ class RavenPersisterSettings : PersistenceSettings, IRavenClientCertificateInfo
     public string ConnectionString { get; set; }
     public string ClientCertificatePath { get; set; }
     public string ClientCertificateBase64 { get; set; }
+    public string ClientCertificatePassword { get; set; }
     public bool UseEmbeddedServer => string.IsNullOrWhiteSpace(ConnectionString);
     public string LogPath { get; set; }
     public string LogsMode { get; set; } = LogsModeDefault;

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
@@ -23,6 +23,7 @@ class RavenPersisterSettings : PersistenceSettings
     /// User provided external RavenDB instance connection string
     /// </summary>
     public string ConnectionString { get; set; }
+    public string ClientCertificateBase64 { get; set; }
     public bool UseEmbeddedServer => string.IsNullOrWhiteSpace(ConnectionString);
     public string LogPath { get; set; }
     public string LogsMode { get; set; } = LogsModeDefault;

--- a/src/ServiceControl.RavenDB/RavenClientCertificate.cs
+++ b/src/ServiceControl.RavenDB/RavenClientCertificate.cs
@@ -3,12 +3,26 @@
 namespace ServiceControl.RavenDB;
 
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
 public static class RavenClientCertificate
 {
-    public static X509Certificate2? FindClientCertificate()
+    public static X509Certificate2? FindClientCertificate(string? base64String)
     {
+        if (base64String is not null)
+        {
+            try
+            {
+                var bytes = Convert.FromBase64String(base64String);
+                return new X509Certificate2(bytes);
+            }
+            catch (Exception x) when (x is FormatException or CryptographicException)
+            {
+                throw new Exception("Could not read the RavenDB client certificate from the configured Base64 value.", x);
+            }
+        }
+
         var applicationDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location) ?? string.Empty;
         var certificatePath = Path.Combine(applicationDirectory, "raven-client-certificate.pfx");
 

--- a/src/ServiceControl.RavenDB/RavenClientCertificate.cs
+++ b/src/ServiceControl.RavenDB/RavenClientCertificate.cs
@@ -8,19 +8,24 @@ using System.Security.Cryptography.X509Certificates;
 
 public static class RavenClientCertificate
 {
-    public static X509Certificate2? FindClientCertificate(string? base64String)
+    public static X509Certificate2? FindClientCertificate(IRavenClientCertificateInfo certInfo)
     {
-        if (base64String is not null)
+        if (certInfo.ClientCertificateBase64 is not null)
         {
             try
             {
-                var bytes = Convert.FromBase64String(base64String);
+                var bytes = Convert.FromBase64String(certInfo.ClientCertificateBase64);
                 return new X509Certificate2(bytes);
             }
             catch (Exception x) when (x is FormatException or CryptographicException)
             {
                 throw new Exception("Could not read the RavenDB client certificate from the configured Base64 value.", x);
             }
+        }
+
+        if (certInfo.ClientCertificatePath is not null)
+        {
+            return new X509Certificate2(certInfo.ClientCertificatePath);
         }
 
         var applicationDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location) ?? string.Empty;
@@ -32,4 +37,10 @@ public static class RavenClientCertificate
         }
         return null;
     }
+}
+
+public interface IRavenClientCertificateInfo
+{
+    string? ClientCertificatePath { get; }
+    string? ClientCertificateBase64 { get; }
 }

--- a/src/ServiceControl.RavenDB/RavenClientCertificate.cs
+++ b/src/ServiceControl.RavenDB/RavenClientCertificate.cs
@@ -15,7 +15,7 @@ public static class RavenClientCertificate
             try
             {
                 var bytes = Convert.FromBase64String(certInfo.ClientCertificateBase64);
-                return new X509Certificate2(bytes);
+                return new X509Certificate2(bytes, certInfo.ClientCertificatePassword);
             }
             catch (Exception x) when (x is FormatException or CryptographicException)
             {
@@ -25,7 +25,7 @@ public static class RavenClientCertificate
 
         if (certInfo.ClientCertificatePath is not null)
         {
-            return new X509Certificate2(certInfo.ClientCertificatePath);
+            return new X509Certificate2(certInfo.ClientCertificatePath, certInfo.ClientCertificatePassword);
         }
 
         var applicationDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location) ?? string.Empty;
@@ -33,7 +33,7 @@ public static class RavenClientCertificate
 
         if (File.Exists(certificatePath))
         {
-            return new X509Certificate2(certificatePath);
+            return new X509Certificate2(certificatePath, certInfo.ClientCertificatePassword);
         }
         return null;
     }
@@ -43,4 +43,5 @@ public interface IRavenClientCertificateInfo
 {
     string? ClientCertificatePath { get; }
     string? ClientCertificateBase64 { get; }
+    string? ClientCertificatePassword { get; }
 }

--- a/src/ServiceControl.RavenDB/RavenClientCertificate.cs
+++ b/src/ServiceControl.RavenDB/RavenClientCertificate.cs
@@ -1,0 +1,21 @@
+#nullable enable
+
+namespace ServiceControl.RavenDB;
+
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+
+public static class RavenClientCertificate
+{
+    public static X509Certificate2? FindClientCertificate()
+    {
+        var applicationDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location) ?? string.Empty;
+        var certificatePath = Path.Combine(applicationDirectory, "raven-client-certificate.pfx");
+
+        if (File.Exists(certificatePath))
+        {
+            return new X509Certificate2(certificatePath);
+        }
+        return null;
+    }
+}

--- a/src/ServiceControl.RavenDB/RavenClientCertificate.cs
+++ b/src/ServiceControl.RavenDB/RavenClientCertificate.cs
@@ -25,6 +25,10 @@ public static class RavenClientCertificate
 
         if (certInfo.ClientCertificatePath is not null)
         {
+            if (!File.Exists(certInfo.ClientCertificatePath))
+            {
+                throw new Exception("Could not read the RavenDB client certificate from the supplied path because no file was found.");
+            }
             return new X509Certificate2(certInfo.ClientCertificatePath, certInfo.ClientCertificatePassword);
         }
 


### PR DESCRIPTION
Adds the following configuration options as environment variables for connecting to external RavenDB instances, generally for use when deployed as a container:

* `RAVENDB_CLIENTCERTIFICATEPATH`: Provide a path to the client certificate, for example, to a path loaded in a mounted secrets volume.
* `RAVENDB_CLIENTCERTIFICATEBASE64`: Provide the client certificate as a Base64-encoded string.
* `RAVENDB_CLIENTCERTIFICATEPASSWORD`: If using a password-protected *.pfx certificate, supply the password to read it. If using a non-protected certificate, do not include this option.

If the certificate path or Base64 options are not used, the app will still look for a certificate in a static path in the application root. When deployed as a container, this path is `/app/raven-client-certificate.pfx`.

* Fixes https://github.com/Particular/ServiceControl/issues/4759