### PR TITLE
I/O Timeouts can cause error and audit ingestion to silently stop

### DIFF
--- a/src/Particular.LicensingComponent/AuditThroughput/AuditThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/AuditThroughput/AuditThroughputCollectorHostedService.cs
@@ -40,7 +40,7 @@ public class AuditThroughputCollectorHostedService(
                 }
             } while (await timer.WaitForNextTickAsync(cancellationToken));
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             logger.LogInformation($"Stopping {nameof(AuditThroughputCollectorHostedService)}");
         }

--- a/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
@@ -53,7 +53,7 @@ public class BrokerThroughputCollectorHostedService(
                 }
             } while (await timer.WaitForNextTickAsync(stoppingToken));
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
             logger.LogInformation($"Stopping {nameof(BrokerThroughputCollectorHostedService)}");
         }

--- a/src/ServiceControl.AcceptanceTesting/ScenarioWithEndpointBehaviorExtensions.cs
+++ b/src/ServiceControl.AcceptanceTesting/ScenarioWithEndpointBehaviorExtensions.cs
@@ -139,9 +139,9 @@
                 {
                     await checkTask;
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    //Swallow
+                    // Even though we are stopping, ONLY swallow when OCE from callee to not hide any ungraceful stop errors
                 }
                 finally
                 {

--- a/src/ServiceControl.Audit/Auditing/ImportFailedAudits.cs
+++ b/src/ServiceControl.Audit/Auditing/ImportFailedAudits.cs
@@ -48,9 +48,9 @@ namespace ServiceControl.Audit.Auditing
                                 Logger.Debug($"Successfully re-imported failed audit message {transportMessage.Id}.");
                             }
                         }
-                        catch (OperationCanceledException)
+                        catch (OperationCanceledException e) when (token.IsCancellationRequested)
                         {
-                            // no-op
+                            Logger.Info("Cancelled", e);
                         }
                         catch (Exception e)
                         {

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/ImportFailedAuditsCommand.cs
@@ -7,10 +7,13 @@
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using NServiceBus;
+    using NServiceBus.Logging;
     using Settings;
 
     class ImportFailedAuditsCommand : AbstractCommand
     {
+        readonly ILog logger = LogManager.GetLogger<ImportFailedAuditsCommand>();
+
         public override async Task Execute(HostArguments args, Settings settings)
         {
             settings.IngestAuditMessages = false;
@@ -37,9 +40,9 @@
             {
                 await importer.Run(tokenSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException e) when (tokenSource.IsCancellationRequested)
             {
-                // no op
+                logger.Info("Cancelled", e);
             }
             finally
             {

--- a/src/ServiceControl.Infrastructure.Metrics/MetricsReporter.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/MetricsReporter.cs
@@ -32,7 +32,7 @@
                         await Task.Delay(interval, tokenSource.Token).ConfigureAwait(false);
                     }
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (tokenSource.IsCancellationRequested)
                 {
                     //no-op
                 }

--- a/src/ServiceControl.Infrastructure/AsyncTimer.cs
+++ b/src/ServiceControl.Infrastructure/AsyncTimer.cs
@@ -40,9 +40,9 @@
 
                             //Otherwise execute immediately
                         }
-                        catch (OperationCanceledException)
+                        catch (OperationCanceledException) when (token.IsCancellationRequested)
                         {
-                            // no-op
+                            break;
                         }
                         catch (Exception ex)
                         {
@@ -50,7 +50,7 @@
                         }
                     }
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
                 {
                     // no-op
                 }
@@ -64,7 +64,7 @@
                 return;
             }
 
-            tokenSource.Cancel();
+            await tokenSource.CancelAsync().ConfigureAwait(false);
             tokenSource.Dispose();
 
             if (task != null)
@@ -73,7 +73,7 @@
                 {
                     await task.ConfigureAwait(false);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (tokenSource.IsCancellationRequested)
                 {
                     //NOOP
                 }

--- a/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
+++ b/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
@@ -51,7 +51,7 @@ public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
 
             return Task.CompletedTask;
         }
-        catch (OperationCanceledException e)
+        catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested)
         {
             return Task.FromCanceled(e.CancellationToken);
         }
@@ -113,7 +113,7 @@ public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
 
             return Task.FromResult(result);
         }
-        catch (OperationCanceledException e)
+        catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested)
         {
             return Task.FromCanceled<int>(e.CancellationToken);
         }
@@ -136,7 +136,7 @@ public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
 
             return new ValueTask<int>(result);
         }
-        catch (OperationCanceledException e)
+        catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested)
         {
             return new ValueTask<int>(Task.FromCanceled<int>(e.CancellationToken));
         }

--- a/src/ServiceControl.Infrastructure/Watchdog.cs
+++ b/src/ServiceControl.Infrastructure/Watchdog.cs
@@ -54,9 +54,10 @@
 
                         failedOnStartup ??= false;
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException e) when (!shutdownTokenSource.IsCancellationRequested)
                     {
-                        //Do not Delay
+                        // Continue, as OCE is not from caller
+                        log.Info("Start cancelled, retrying...", e);
                         continue;
                     }
                     catch (Exception e)
@@ -81,9 +82,9 @@
                     {
                         await Task.Delay(timeToWaitBetweenStartupAttempts, shutdownTokenSource.Token).ConfigureAwait(false);
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (shutdownTokenSource.IsCancellationRequested)
                     {
-                        //Ignore
+                        //Ignore, no need to log cancellation of delay
                     }
                 }
                 try

--- a/src/ServiceControl.Monitoring/Infrastructure/RemoveExpiredEndpointInstances.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/RemoveExpiredEndpointInstances.cs
@@ -48,7 +48,7 @@ public class RemoveExpiredEndpointInstances(
                 }
             } while (await timer.WaitForNextTickAsync(cancellationToken));
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             logger.LogInformation($"Stopping {nameof(RemoveExpiredEndpointInstances)} timer");
         }

--- a/src/ServiceControl.Monitoring/Infrastructure/ReportThroughputHostedService.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/ReportThroughputHostedService.cs
@@ -42,7 +42,7 @@
                     }
                 } while (await timer.WaitForNextTickAsync(cancellationToken));
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 logger.LogInformation($"Stopping {nameof(ReportThroughputHostedService)} timer");
             }

--- a/src/ServiceControl.Persistence.RavenDB/ExternalIntegrationRequestsDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ExternalIntegrationRequestsDataStore.cs
@@ -82,7 +82,7 @@
                         await signal.WaitHandle.WaitOneAsync(cancellationToken);
                         signal.Reset();
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
                         break;
                     }
@@ -91,7 +91,7 @@
                 }
                 while (!cancellationToken.IsCancellationRequested);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // ignore
             }

--- a/src/ServiceControl.Persistence.RavenDB/FailedErrorImportDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/FailedErrorImportDataStore.cs
@@ -35,9 +35,9 @@
                             Logger.Debug($"Successfully re-imported failed error message {transportMessage.Id}.");
                         }
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested)
                     {
-                        //  no-op
+                        Logger.Info("Cancelled", e);
                     }
                     catch (Exception e)
                     {

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -110,7 +110,7 @@ namespace ServiceControl.RavenDB
 
                         Logger.Info("RavenDB server process restarted successfully.");
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (shutdownCancellationToken.IsCancellationRequested)
                     {
                         //no-op
                     }

--- a/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
@@ -43,7 +43,7 @@ namespace ServiceControl.Transports.ASBS
 
                     UpdateAllQueueLengths(queueRuntimeInfos);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
                     // no-op
                 }

--- a/src/ServiceControl.Transports.ASQ/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.ASQ/QueueLengthProvider.cs
@@ -42,7 +42,7 @@
 
                     await Task.Delay(QueryDelayInterval, stoppingToken);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
                     // no-op
                 }
@@ -67,7 +67,7 @@
 
                 problematicQueuesNames.TryRemove(queueLength.QueueName, out _);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // no-op
             }

--- a/src/ServiceControl.Transports.Learning/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.Learning/QueueLengthProvider.cs
@@ -30,7 +30,7 @@
 
                     await Task.Delay(QueryDelayInterval, stoppingToken);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
                     // It's OK. We're shutting down
                 }

--- a/src/ServiceControl.Transports.PostgreSql/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.PostgreSql/QueueLengthProvider.cs
@@ -49,7 +49,7 @@ class QueueLengthProvider : AbstractQueueLengthProvider
 
                 UpdateQueueLengthStore();
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 // no-op
             }

--- a/src/ServiceControl.Transports.RabbitMQ/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/QueueLengthProvider.cs
@@ -39,7 +39,7 @@
 
                     await Task.Delay(QueryDelayInterval, stoppingToken);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
                     // no-op
                 }
@@ -141,7 +141,7 @@
 
                     action(model);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     // no-op
                 }

--- a/src/ServiceControl.Transports.SQS/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.SQS/QueueLengthProvider.cs
@@ -65,7 +65,7 @@
 
                     await Task.Delay(QueryDelayInterval, stoppingToken);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
                     // no-op
                 }
@@ -104,7 +104,7 @@
                 var response = await client.GetQueueAttributesAsync(attReq, cancellationToken);
                 sizes[queue] = response.ApproximateNumberOfMessages;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // no-op
             }

--- a/src/ServiceControl.Transports.SqlServer/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.SqlServer/QueueLengthProvider.cs
@@ -47,7 +47,7 @@
 
                     UpdateQueueLengthStore();
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
                     // no-op
                 }

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
@@ -125,7 +125,7 @@ namespace ServiceControl.CompositeViews.Messages
                     httpRequestException);
                 return QueryResult<TOut>.Empty();
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) // Intentional, used to gracefully handle timeout
             {
                 logger.Warn($"Failed to query remote instance at {remoteInstanceSetting.BaseAddress} due to a timeout");
                 return QueryResult<TOut>.Empty();

--- a/src/ServiceControl/CustomChecks/InternalCustomChecks/InternalCustomCheckManager.cs
+++ b/src/ServiceControl/CustomChecks/InternalCustomChecks/InternalCustomCheckManager.cs
@@ -40,9 +40,9 @@
             {
                 result = await check.PerformCheck(cancellationToken);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested)
             {
-                //Do nothing as we are shutting down
+                Logger.Info("Cancelled", e);
             }
             catch (Exception ex)
             {

--- a/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/ImportFailedErrorsCommand.cs
@@ -7,6 +7,7 @@
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using NServiceBus;
+    using NServiceBus.Logging;
     using Operations;
     using Particular.ServiceControl;
     using Particular.ServiceControl.Hosting;
@@ -14,6 +15,8 @@
 
     class ImportFailedErrorsCommand : AbstractCommand
     {
+        readonly ILog Log = LogManager.GetLogger<ImportFailedErrorsCommand>();
+
         public override async Task Execute(HostArguments args, Settings settings)
         {
             settings.IngestErrorMessages = false;
@@ -38,9 +41,9 @@
             {
                 await importFailedErrors.Run(tokenSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException e) when (tokenSource.IsCancellationRequested)
             {
-                // no-op
+                Log.Info("Cancelled", e);
             }
             finally
             {

--- a/src/ServiceControl/Infrastructure/Metrics/MetricsReporterHostedService.cs
+++ b/src/ServiceControl/Infrastructure/Metrics/MetricsReporterHostedService.cs
@@ -30,7 +30,7 @@
             {
                 await reporter.Stop();
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 //NOOP
             }

--- a/src/ServiceControl/Monitoring/HeartbeatEndpointSettingsSyncHostedService.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatEndpointSettingsSyncHostedService.cs
@@ -45,7 +45,7 @@ public class HeartbeatEndpointSettingsSyncHostedService(
                 }
             } while (await timer.WaitForNextTickAsync(cancellationToken));
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             logger.LogInformation($"Stopping {nameof(HeartbeatEndpointSettingsSyncHostedService)}");
         }

--- a/src/ServiceControl/Monitoring/HeartbeatMonitoringHostedService.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatMonitoringHostedService.cs
@@ -30,9 +30,9 @@
             {
                 await timer.Stop();
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                //NOOP
+                //NOOP, invoked Stop does not
             }
         }
 

--- a/src/ServiceControl/Operations/CheckRemotes.cs
+++ b/src/ServiceControl/Operations/CheckRemotes.cs
@@ -73,7 +73,11 @@
                 remoteSettings.TemporarilyUnavailable = true;
                 throw new TimeoutException($"The remote instance at '{remoteSettings.BaseAddress}' doesn't seem to be available. It will be temporarily disabled. Reason: {e.Message}", e);
             }
-            catch (OperationCanceledException e)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Cancelled, noop
+            }
+            catch (OperationCanceledException e) // Intentional, OCE gracefully handled by other catch
             {
                 remoteSettings.TemporarilyUnavailable = true;
                 throw new TimeoutException($"The remote at '{remoteSettings.BaseAddress}' did not respond within the allotted time of '{queryTimeout}'. It will be temporarily disabled.", e);


### PR DESCRIPTION
### Description

I/O Timeouts can cause error and audit ingestion to silently stop. 

### Symptoms

No error or audit messages are ingested.

### Who's affected

Versions 4, 5 and 6 are affected by this issue.

NOTE: Versions prior to 4.32.0 are not affected.

### Root cause

OperationCancelledException can cause hanging ingestion, unnoticed failing tasks, and no logging of timeouts 

### Backported to

- [6.3.1](https://github.com/Particular/ServiceControl/milestone/292) https://github.com/Particular/ServiceControl/pull/4791
- [5.11.4](https://github.com/Particular/ServiceControl/milestone/293) https://github.com/Particular/ServiceControl/pull/4792