### PR TITLE
Added process time to log file entry

### DIFF
--- a/src/ServiceControl.Infrastructure/LoggingConfigurator.cs
+++ b/src/ServiceControl.Infrastructure/LoggingConfigurator.cs
@@ -22,7 +22,7 @@ namespace ServiceControl.Infrastructure
             }
 
             var nlogConfig = new LoggingConfiguration();
-            var simpleLayout = new SimpleLayout("${longdate}|${threadid}|${level}|${logger}|${message}${onexception:|${exception:format=tostring}}");
+            var simpleLayout = new SimpleLayout("${longdate}|${processtime}|${threadid}|${level}|${logger}|${message}${onexception:|${exception:format=tostring}}");
 
             var fileTarget = new FileTarget
             {


### PR DESCRIPTION
Included process time - the duration the process is running - in log file entry. This can help diagnosing issues related to running time but also easily see the uptime of the process.