### PR TITLE
Fix batch message deduplication logic to not update batch on already batched message - 5.11

### DIFF
--- a/src/ServiceControl.Persistence.RavenDB/RetryDocumentDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RetryDocumentDataStore.cs
@@ -113,7 +113,7 @@
                 }
             };
 
-            return new PatchCommandData(FailedMessageRetry.MakeDocumentId(messageId), null, patch: patchRequest, patchIfMissing: patchRequest);
+            return new PatchCommandData(FailedMessageRetry.MakeDocumentId(messageId), null, patch: new PatchRequest { Script = "" }, patchIfMissing: patchRequest);
         }
 
         public async Task GetBatchesForAll(DateTime cutoff, Func<string, DateTime, Task> callback)


### PR DESCRIPTION
Backport of #4789 which fixes https://github.com/Particular/ServiceControl/issues/4797 for the 5.11 release