### PR TITLE
Fix watchdog re-creation of TransportInfrastructure and cancellation improvements

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_critical_storage_threshold_reached.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_critical_storage_threshold_reached.cs
@@ -34,7 +34,7 @@
                 .WithEndpoint<Sender>(b => b
                     .When(context =>
                     {
-                        return context.Logs.ToArray().Any(i => i.Message.StartsWith(ErrorIngestion.LogMessages.StoppedInfrastructure));
+                        return context.Logs.ToArray().Any(i => i.Message.StartsWith(ErrorIngestion.LogMessages.StartedInfrastructure));
                     }, (_, __) =>
                     {
                         PersisterSettings.MinimumStorageLeftRequiredForIngestion = 100;

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_critical_storage_threshold_reached.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_critical_storage_threshold_reached.cs
@@ -9,6 +9,7 @@
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
     using NUnit.Framework;
+    using Operations;
     using ServiceBus.Management.Infrastructure.Settings;
 
     [TestFixture]
@@ -33,7 +34,7 @@
                 .WithEndpoint<Sender>(b => b
                     .When(context =>
                     {
-                        return context.Logs.ToArray().Any(i => i.Message.StartsWith("Ensure started. Infrastructure started"));
+                        return context.Logs.ToArray().Any(i => i.Message.StartsWith(ErrorIngestion.LogMessages.StoppedInfrastructure));
                     }, (_, __) =>
                     {
                         PersisterSettings.MinimumStorageLeftRequiredForIngestion = 100;
@@ -43,8 +44,7 @@
                     .When(context =>
                     {
                         return context.Logs.ToArray().Any(i =>
-                            i.Message.StartsWith(
-                                "Shutting down due to failed persistence health check. Infrastructure shut down completed"));
+                            i.Message.StartsWith(ErrorIngestion.LogMessages.StoppedInfrastructure));
                     }, (bus, c) => bus.SendLocal(new MyMessage())
                     )
                     .DoNotFailOnErrorMessages())
@@ -62,8 +62,7 @@
                     .When(context =>
                     {
                         return context.Logs.ToArray().Any(i =>
-                            i.Message.StartsWith(
-                                "Ensure started. Infrastructure started"));
+                            i.Message.StartsWith(ErrorIngestion.LogMessages.StartedInfrastructure));
                     }, (session, context) =>
                     {
                         PersisterSettings.MinimumStorageLeftRequiredForIngestion = 100;
@@ -73,8 +72,7 @@
                     .When(context =>
                     {
                         ingestionShutdown = context.Logs.ToArray().Any(i =>
-                            i.Message.StartsWith(
-                                "Shutting down due to failed persistence health check. Infrastructure shut down completed"));
+                            i.Message.StartsWith(ErrorIngestion.LogMessages.StoppedInfrastructure));
 
                         return ingestionShutdown;
                     },

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/Auditing/When_critical_storage_threshold_reached.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/Auditing/When_critical_storage_threshold_reached.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting.EndpointTemplates;
+    using Audit.Auditing;
     using Microsoft.Extensions.DependencyInjection;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
@@ -35,8 +36,7 @@
                     .When(context =>
                     {
                         return context.Logs.ToArray().Any(i =>
-                            i.Message.StartsWith(
-                                "Ensure started. Infrastructure started"));
+                            i.Message.StartsWith(AuditIngestion.LogMessages.StartedInfrastructure));
                     }, (_, __) =>
                     {
                         var databaseConfiguration = ServiceProvider.GetRequiredService<DatabaseConfiguration>();
@@ -47,8 +47,7 @@
                     .When(context =>
                     {
                         return context.Logs.ToArray().Any(i =>
-                            i.Message.StartsWith(
-                                "Shutting down due to failed persistence health check. Infrastructure shut down completed"));
+                            i.Message.StartsWith(AuditIngestion.LogMessages.StoppedInfrastructure));
                     }, (bus, c) => bus.SendLocal(new MyMessage()))
                 )
                 .Done(async c => await this.TryGetSingle<MessagesView>(
@@ -72,7 +71,7 @@
                    {
                        return context.Logs.ToArray().Any(i =>
                            i.Message.StartsWith(
-                               "Ensure started. Infrastructure started"));
+                                AuditIngestion.LogMessages.StartedInfrastructure));
                    }, (session, context) =>
                    {
                        var databaseConfiguration = ServiceProvider.GetRequiredService<DatabaseConfiguration>();
@@ -83,8 +82,7 @@
                    .When(context =>
                    {
                        ingestionShutdown = context.Logs.ToArray().Any(i =>
-                           i.Message.StartsWith(
-                               "Shutting down due to failed persistence health check. Infrastructure shut down completed"));
+                           i.Message.StartsWith(AuditIngestion.LogMessages.StoppedInfrastructure));
 
                        return ingestionShutdown;
                    },

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -76,13 +76,18 @@
                 await startStopSemaphore.WaitAsync(cancellationToken);
                 logger.Debug("Ensure started. Start/stop semaphore acquired");
 
-                if (!unitOfWorkFactory.CanIngestMore())
+                var canIngest = unitOfWorkFactory.CanIngestMore();
+
+                logger.DebugFormat("Ensure started {0}", canIngest);
+
+                if (canIngest)
+                {
+                    await SetUpAndStartInfrastructure(cancellationToken);
+                }
+                else
                 {
                     await StopAndTeardownInfrastructure(cancellationToken);
-                    return;
                 }
-
-                await SetUpAndStartInfrastructure(cancellationToken);
             }
             catch (Exception e)
             {

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -130,7 +130,7 @@
                 await auditIngestor.VerifyCanReachForwardingAddress();
                 await queueIngestor.StartReceive(cancellationToken);
 
-                logger.Info("Started infrastructure");
+                logger.Info(LogMessages.StartedInfrastructure);
             }
             catch (Exception e)
             {
@@ -163,7 +163,7 @@
                 }
 
                 queueIngestor = null;
-                logger.Info("Stopped infrastructure");
+                logger.Info(LogMessages.StoppedInfrastructure);
             }
             catch (Exception e)
             {
@@ -335,5 +335,11 @@
         readonly IHostApplicationLifetime applicationLifetime;
 
         static readonly ILog logger = LogManager.GetLogger<AuditIngestion>();
+
+        internal static class LogMessages
+        {
+            internal const string StartedInfrastructure = "Started infrastructure";
+            internal const string StoppedInfrastructure = "Stopped infrastructure";
+        }
     }
 }

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -68,7 +68,7 @@
             return watchdog.OnFailure(failure);
         }
 
-        async Task EnsureStarted(CancellationToken cancellationToken = default)
+        async Task EnsureStarted(CancellationToken cancellationToken)
         {
             try
             {
@@ -177,7 +177,7 @@
             }
         }
 
-        async Task EnsureStopped(CancellationToken cancellationToken = default)
+        async Task EnsureStopped(CancellationToken cancellationToken)
         {
             try
             {

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -76,18 +76,18 @@
                 await startStopSemaphore.WaitAsync(cancellationToken);
                 logger.Debug("Ensure started. Start/stop semaphore acquired");
 
-                var canIngest = unitOfWorkFactory.CanIngestMore();
-
-                logger.DebugFormat("Ensure started {0}", canIngest);
-
-                if (canIngest)
+                if (!unitOfWorkFactory.CanIngestMore())
                 {
-                    await SetUpAndStartInfrastructure(cancellationToken);
-                }
-                else
-                {
+                    logger.Warn("Ensure started. Storage unable to ingest more. Ingestion will be paused");
+
                     await StopAndTeardownInfrastructure(cancellationToken);
+
+                    return;
                 }
+
+                logger.Debug("Ensure started. Storage able to ingest. Ingestion will be started");
+
+                await SetUpAndStartInfrastructure(cancellationToken);
             }
             catch (Exception e)
             {

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -231,7 +231,7 @@
 
         public override async Task StartAsync(CancellationToken cancellationToken)
         {
-            await watchdog.Start(() => applicationLifetime.StopApplication());
+            await watchdog.Start(() => applicationLifetime.StopApplication(), cancellationToken);
             await base.StartAsync(cancellationToken);
         }
 

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -76,18 +76,18 @@
                 await startStopSemaphore.WaitAsync(cancellationToken);
                 logger.Debug("Ensure started. Start/stop semaphore acquired");
 
-                if (!unitOfWorkFactory.CanIngestMore())
+                var canIngest = unitOfWorkFactory.CanIngestMore();
+
+                logger.DebugFormat("Ensure started {0}", canIngest);
+
+                if (canIngest)
                 {
-                    logger.Warn("Ensure started. Storage unable to ingest more. Ingestion will be paused");
-
-                    await StopAndTeardownInfrastructure(cancellationToken);
-
-                    return;
+                    await SetUpAndStartInfrastructure(cancellationToken);
                 }
-
-                logger.Debug("Ensure started. Storage able to ingest. Ingestion will be started");
-
-                await SetUpAndStartInfrastructure(cancellationToken);
+                else
+                {
+                    await StopAndTeardownInfrastructure(cancellationToken);
+                }
             }
             catch (Exception e)
             {

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -260,7 +260,7 @@
         {
             try
             {
-                await watchdog.Stop();
+                await watchdog.Stop(cancellationToken);
                 channel.Writer.Complete();
                 await base.StopAsync(cancellationToken);
             }

--- a/src/ServiceControl.Infrastructure.Tests/WatchdogTests.cs
+++ b/src/ServiceControl.Infrastructure.Tests/WatchdogTests.cs
@@ -37,8 +37,8 @@
             await stopped.Task;
         }
 
-        [Test, Ignore("When ensurestopped throws an exception, stop should also throw an exception as that is an ungraceful stop")]
-        public async Task When_stop_fails_it_reports_the_failure()
+        [Test]
+        public async Task When_stop_fails_stop_should_throw_identifying_ungraceful_stop()
         {
             string lastFailure = null;
             var started = new TaskCompletionSource<bool>();
@@ -53,9 +53,20 @@
 
             await started.Task;
 
-            await dog.Stop(TestContext.CurrentContext.CancellationToken);
+            // The following blocks the test:
+            //
+            // var ex = Assert.ThrowsAsync<Exception>(async () => await dog.Stop(TestContext.CurrentContext.CancellationToken));
+            // Assert.That(ex.Message, Is.EqualTo("Simulated"));
 
-            Assert.That(lastFailure, Is.EqualTo("Simulated"));
+            try
+            {
+                await dog.Stop(TestContext.CurrentContext.CancellationToken);
+                Assert.Fail("Should have thrown an exception");
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex.Message, Is.EqualTo("Simulated"));
+            }
         }
 
         [Test]
@@ -76,6 +87,7 @@
                 {
                     restarted.SetResult(true);
                 }
+
                 startAttempts++;
                 return Task.CompletedTask;
             }, token =>

--- a/src/ServiceControl.Infrastructure.Tests/WatchdogTests.cs
+++ b/src/ServiceControl.Infrastructure.Tests/WatchdogTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Infrastructure.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Logging;
     using NUnit.Framework;
@@ -27,7 +28,7 @@
                 return Task.CompletedTask;
             }, x => { }, () => { }, TimeSpan.FromSeconds(1), log);
 
-            await dog.Start(() => { });
+            await dog.Start(() => { }, CancellationToken.None);
 
             await started.Task;
 
@@ -48,7 +49,7 @@
                 return Task.CompletedTask;
             }, token => throw new Exception("Simulated"), x => lastFailure = x, () => lastFailure = null, TimeSpan.FromSeconds(1), log);
 
-            await dog.Start(() => { });
+            await dog.Start(() => { }, CancellationToken.None);
 
             await started.Task;
 
@@ -83,7 +84,7 @@
                 return Task.CompletedTask;
             }, x => { }, () => { }, TimeSpan.FromSeconds(1), log);
 
-            await dog.Start(() => { });
+            await dog.Start(() => { }, CancellationToken.None);
 
             await started.Task;
 
@@ -125,7 +126,7 @@
                 return Task.CompletedTask;
             }, token => Task.CompletedTask, x => lastFailure = x, () => lastFailure = null, TimeSpan.FromSeconds(1), log);
 
-            await dog.Start(() => { });
+            await dog.Start(() => { }, CancellationToken.None);
 
             await recoveredFromError.Task;
 
@@ -144,7 +145,7 @@
 
             var dog = new Watchdog("test process", token => throw new Exception("Simulated"), token => Task.CompletedTask, x => lastFailure = x, () => lastFailure = null, TimeSpan.FromSeconds(1), log);
 
-            await dog.Start(() => { onStartupFailureCalled.SetResult(true); });
+            await dog.Start(() => { onStartupFailureCalled.SetResult(true); }, CancellationToken.None);
 
             await onStartupFailureCalled.Task;
 

--- a/src/ServiceControl.Infrastructure.Tests/WatchdogTests.cs
+++ b/src/ServiceControl.Infrastructure.Tests/WatchdogTests.cs
@@ -31,7 +31,7 @@
 
             await started.Task;
 
-            await dog.Stop();
+            await dog.Stop(TestContext.CurrentContext.CancellationToken);
 
             await stopped.Task;
         }
@@ -52,7 +52,7 @@
 
             await started.Task;
 
-            await dog.Stop();
+            await dog.Stop(TestContext.CurrentContext.CancellationToken);
 
             Assert.That(lastFailure, Is.EqualTo("Simulated"));
         }
@@ -91,7 +91,7 @@
 
             await restarted.Task;
 
-            await dog.Stop();
+            await dog.Stop(TestContext.CurrentContext.CancellationToken);
         }
 
         [Test]
@@ -129,7 +129,7 @@
 
             await recoveredFromError.Task;
 
-            await dog.Stop();
+            await dog.Stop(TestContext.CurrentContext.CancellationToken);
 
             //Make sure failure is cleared
             Assert.That(lastFailure, Is.Null);

--- a/src/ServiceControl.Infrastructure.Tests/WatchdogTests.cs
+++ b/src/ServiceControl.Infrastructure.Tests/WatchdogTests.cs
@@ -36,7 +36,7 @@
             await stopped.Task;
         }
 
-        [Test]
+        [Test, Ignore("When ensurestopped throws an exception, stop should also throw an exception as that is an ungraceful stop")]
         public async Task When_stop_fails_it_reports_the_failure()
         {
             string lastFailure = null;

--- a/src/ServiceControl.Infrastructure/Watchdog.cs
+++ b/src/ServiceControl.Infrastructure/Watchdog.cs
@@ -53,8 +53,12 @@
                 {
                     try
                     {
+                        // Host builder start is launching the loop. The watch dog loop task runs in isolation
+                        // We want the start not to run to infinity. An NServiceBus endpoint should easily
+                        // start within 15 seconds.
+                        const int MaxStartDurationMs = 15000;
                         using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(shutdownTokenSource.Token);
-                        cancellationTokenSource.CancelAfter(15000);
+                        cancellationTokenSource.CancelAfter(MaxStartDurationMs);
 
                         log.Debug($"Ensuring {taskName} is running");
                         await ensureStarted(cancellationTokenSource.Token).ConfigureAwait(false);

--- a/src/ServiceControl.Infrastructure/Watchdog.cs
+++ b/src/ServiceControl.Infrastructure/Watchdog.cs
@@ -41,7 +41,7 @@
             return ensureStopped(shutdownTokenSource.Token);
         }
 
-        public Task Start(Action onFailedOnStartup)
+        public Task Start(Action onFailedOnStartup, CancellationToken cancellationToken)
         {
             watchdog = Task.Run(async () =>
             {
@@ -88,7 +88,8 @@
                         //Ignore, no need to log cancellation of delay
                     }
                 }
-            });
+            }, cancellationToken);
+
             return Task.CompletedTask;
         }
 

--- a/src/ServiceControl/Operations/ErrorIngestion.cs
+++ b/src/ServiceControl/Operations/ErrorIngestion.cs
@@ -132,7 +132,7 @@
         {
             try
             {
-                await watchdog.Stop();
+                await watchdog.Stop(cancellationToken);
                 channel.Writer.Complete();
                 await base.StopAsync(cancellationToken);
             }

--- a/src/ServiceControl/Operations/ErrorIngestion.cs
+++ b/src/ServiceControl/Operations/ErrorIngestion.cs
@@ -72,7 +72,7 @@
 
         public override async Task StartAsync(CancellationToken cancellationToken)
         {
-            await watchdog.Start(() => applicationLifetime.StopApplication());
+            await watchdog.Start(() => applicationLifetime.StopApplication(), cancellationToken);
             await base.StartAsync(cancellationToken);
         }
 


### PR DESCRIPTION
- Watchdog didn't invoke TransportInfrastructure.Shutdown
- Added maximum start timeout
- Watchdog stop now supports cancellation
- Watchdog stop no longer hiding failing stop and throws