### PR TITLE
Allow JIT killing of Raven.Embedded.EmbeddedServer by tearing it down as part of stop sequence

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/IRavenPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/IRavenPersistenceLifecycle.cs
@@ -6,6 +6,6 @@
     interface IRavenPersistenceLifecycle
     {
         Task Initialize(CancellationToken cancellationToken = default);
-        Task Stop(CancellationToken cancellationToken);
+        Task Stop(CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/IRavenPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/IRavenPersistenceLifecycle.cs
@@ -6,5 +6,6 @@
     interface IRavenPersistenceLifecycle
     {
         Task Initialize(CancellationToken cancellationToken = default);
+        Task Stop(CancellationToken cancellationToken);
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
@@ -72,6 +72,8 @@ namespace ServiceControl.Audit.Persistence.RavenDB
             }
         }
 
+        public Task Stop(CancellationToken cancellationToken) => database!.Stop(cancellationToken);
+
         public void Dispose()
         {
             documentStore?.Dispose();

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
@@ -72,7 +72,7 @@ namespace ServiceControl.Audit.Persistence.RavenDB
             }
         }
 
-        public Task Stop(CancellationToken cancellationToken) => database!.Stop(cancellationToken);
+        public Task Stop(CancellationToken cancellationToken = default) => database!.Stop(cancellationToken);
 
         public void Dispose()
         {

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -64,6 +64,8 @@ namespace ServiceControl.Audit.Persistence.RavenDB
             }
         }
 
+        public Task Stop(CancellationToken cancellationToken) => Task.CompletedTask; // We are not stopping an external instance
+
         public void Dispose() => documentStore?.Dispose();
 
         IDocumentStore? documentStore;

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -64,7 +64,7 @@ namespace ServiceControl.Audit.Persistence.RavenDB
             }
         }
 
-        public Task Stop(CancellationToken cancellationToken) => Task.CompletedTask; // We are not stopping an external instance
+        public Task Stop(CancellationToken cancellationToken = default) => Task.CompletedTask; // We are not stopping an external instance
 
         public void Dispose() => documentStore?.Dispose();
 

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceLifecycleHostedService.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistenceLifecycleHostedService.cs
@@ -8,6 +8,6 @@ namespace ServiceControl.Audit.Persistence.RavenDB
     {
         public Task StartAsync(CancellationToken cancellationToken) => lifecycle.Initialize(cancellationToken);
 
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => lifecycle.Stop(cancellationToken);
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/IRavenPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/IRavenPersistenceLifecycle.cs
@@ -8,6 +8,6 @@ namespace ServiceControl.Persistence.RavenDB
     interface IRavenPersistenceLifecycle
     {
         Task Initialize(CancellationToken cancellationToken = default);
-        Task Stop(CancellationToken cancellationToken);
+        Task Stop(CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/IRavenPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/IRavenPersistenceLifecycle.cs
@@ -8,5 +8,6 @@ namespace ServiceControl.Persistence.RavenDB
     interface IRavenPersistenceLifecycle
     {
         Task Initialize(CancellationToken cancellationToken = default);
+        Task Stop(CancellationToken cancellationToken);
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
@@ -69,6 +69,14 @@ namespace ServiceControl.Persistence.RavenDB
             }
         }
 
+        public async Task Stop(CancellationToken cancellationToken)
+        {
+            if (database != null)
+            {
+                await database.Stop(cancellationToken);
+            }
+        }
+
         public void Dispose()
         {
             documentStore?.Dispose();

--- a/src/ServiceControl.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -59,6 +59,8 @@ namespace ServiceControl.Persistence.RavenDB
             }
         }
 
+        public Task Stop(CancellationToken cancellationToken) => Task.CompletedTask;
+
         public void Dispose() => documentStore?.Dispose();
 
         IDocumentStore? documentStore;

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceLifecycleHostedService.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceLifecycleHostedService.cs
@@ -10,6 +10,6 @@ namespace ServiceControl.Persistence.RavenDB
     {
         public Task StartAsync(CancellationToken cancellationToken) => persistenceLifecycle.Initialize(cancellationToken);
 
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => persistenceLifecycle.Stop(cancellationToken);
     }
 }

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -213,7 +213,7 @@ namespace ServiceControl.RavenDB
                 }
             }
 
-            EmbeddedServer.Instance = null!;
+            serverOptions = null!;
             Logger.Debug("Stopped RavenDB server");
         }
 
@@ -224,14 +224,14 @@ namespace ServiceControl.RavenDB
                 return;
             }
 
-            if (EmbeddedServer.Instance != null)
+            if (serverOptions != null)
             {
                 EmbeddedServer.Instance.ServerProcessExited -= OnServerProcessExited;
             }
 
             shutdownTokenSource.Cancel();
 
-            if (EmbeddedServer.Instance != null)
+            if (serverOptions != null)
             {
                 // Set GracefulShutdownTimeout to Zero and exist ASAP, under normal operation instance would already
                 // have been allowed to gracefully stop during "Stop" method.

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -221,6 +221,8 @@ namespace ServiceControl.RavenDB
 
             if (EmbeddedServer.Instance != null)
             {
+                // Set GracefulShutdownTimeout to Zero and exist ASAP, under normal operation instance would already
+                // have been allowed to gracefully stop during "Stop" method.
                 serverOptions!.GracefulShutdownTimeout = TimeSpan.Zero;
                 Logger.Debug("Disposing RavenDB server");
                 EmbeddedServer.Instance.Dispose();

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -198,13 +198,13 @@ namespace ServiceControl.RavenDB
             // until its GracefulShutdownTimeout is reached and then does a Process.Kill. Due to this behavior this can
             // be shorter or longer than the allowed stop duration.
             //
-            // With the Task.WhenAny 2 things can happen:
+            // When Task.WhenAny is called, 2 things can happen:
             //
             // a. The Task.Delay gets cancelled first
             // b. The EmbeddedServer.Dispose completes first
             //
             // If the Task.Delay gets cancelled first this means Dispose is still running and
-            // then we try and kill the process
+            // then we try and kill the process, if not disposed completed and we're done.
 
             serverOptions!.GracefulShutdownTimeout = TimeSpan.FromHours(1); // During Stop/Dispose we manually control this
 

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -53,15 +53,19 @@ namespace ServiceControl.RavenDB
 
             var nugetPackagesPath = Path.Combine(databaseConfiguration.DbPath, "Packages", "NuGet");
 
-            LoggingSource.Instance.SetupLogMode(
-                (LogMode)255,
-                Path.Combine(databaseConfiguration.LogPath, "Raven.Embedded"),
-                retentionTime: TimeSpan.FromDays(14),
-                retentionSize: 1024 * 1024 * 10,
-                compress: false
-            );
+            var logMode = Enum.Parse<LogMode>(databaseConfiguration.LogsMode);
 
-            LoggingSource.Instance.EnableConsoleLogging();
+            if (logMode == LogMode.Information) // Most verbose
+            {
+                LoggingSource.Instance.EnableConsoleLogging();
+                LoggingSource.Instance.SetupLogMode(
+                    logMode,
+                    Path.Combine(databaseConfiguration.LogPath, "Raven.Embedded"),
+                    retentionTime: TimeSpan.FromDays(14),
+                    retentionSize: 1024 * 1024 * 10,
+                    compress: false
+                );
+            }
 
             Logger.InfoFormat("Loading RavenDB license from {0}", licenseFileNameAndServerDirectory.LicenseFileName);
             var serverOptions = new ServerOptions

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -251,7 +251,7 @@ namespace ServiceControl.RavenDB
 
             if (serverOptions != null)
             {
-                // Set GracefulShutdownTimeout to Zero and exist ASAP, under normal operation instance would already
+                // Set GracefulShutdownTimeout to Zero and exit ASAP, under normal operation instance would already
                 // have been allowed to gracefully stop during "Stop" method.
                 serverOptions!.GracefulShutdownTimeout = TimeSpan.Zero;
                 Logger.Debug("Disposing RavenDB server");

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -66,6 +66,7 @@ namespace ServiceControl.RavenDB
             Logger.InfoFormat("Loading RavenDB license from {0}", licenseFileNameAndServerDirectory.LicenseFileName);
             var serverOptions = new ServerOptions
             {
+                GracefulShutdownTimeout = TimeSpan.FromHours(1), // During Stop/Dispose we manually control this
                 CommandLineArgs =
                 [
                     $"--Logs.Mode={databaseConfiguration.LogsMode}",

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -53,7 +53,7 @@ namespace ServiceControl.RavenDB
             var nugetPackagesPath = Path.Combine(databaseConfiguration.DbPath, "Packages", "NuGet");
 
             Logger.InfoFormat("Loading RavenDB license from {0}", licenseFileNameAndServerDirectory.LicenseFileName);
-            serverOptions = new ServerOptions
+            var serverOptions = new ServerOptions
             {
                 CommandLineArgs =
                 [
@@ -85,6 +85,7 @@ namespace ServiceControl.RavenDB
 
         void Start(ServerOptions serverOptions)
         {
+            this.serverOptions = serverOptions;
             EmbeddedServer.Instance.ServerProcessExited += OnServerProcessExited;
             EmbeddedServer.Instance.StartServer(serverOptions);
 
@@ -220,7 +221,7 @@ namespace ServiceControl.RavenDB
 
             if (EmbeddedServer.Instance != null)
             {
-                serverOptions.GracefulShutdownTimeout = TimeSpan.Zero;
+                serverOptions!.GracefulShutdownTimeout = TimeSpan.Zero;
                 Logger.Debug("Disposing RavenDB server");
                 EmbeddedServer.Instance.Dispose();
                 Logger.Debug("Disposed RavenDB server");
@@ -309,7 +310,7 @@ RavenDB Logging Level:              {configuration.LogsMode}
         readonly EmbeddedDatabaseConfiguration configuration;
         readonly CancellationToken shutdownCancellationToken;
         readonly CancellationTokenRegistration applicationStoppingRegistration;
-        static ServerOptions serverOptions;
+        ServerOptions? serverOptions;
 
         static TimeSpan delayBetweenRestarts = TimeSpan.FromSeconds(60);
         static readonly ILog Logger = LogManager.GetLogger<EmbeddedDatabase>();

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -206,6 +206,9 @@ namespace ServiceControl.RavenDB
                     Logger.WarnFormat("Killing RavenDB server PID {0} child process because host cancelled", processId);
                     var ravenChildProcess = Process.GetProcessById(processId);
                     ravenChildProcess.Kill(entireProcessTree: true);
+                    // Kill only signals
+                    Logger.WarnFormat("Waiting for RavenDB server PID {0} to exit... ", processId);
+                    await ravenChildProcess.WaitForExitAsync(CancellationToken.None);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Teardown Raven.Embedded.EmbeddedServer as part of stop sequence so that we kill the instance if needed as adhering to cancellation is not possible in host builder root container dispose.

When the Embedded RavenDB client supports a Stop with cancellation this code can be simplified.