### PR TITLE
Improving provenance of image

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -12,10 +12,16 @@ jobs:
         include:
           - name: servicecontrol
             project: ServiceControl
+            title: ServiceControl
+            description: Gather status, performance and monitoring data for multiple endpoints from a single location.
           - name: servicecontrol-audit
             project: ServiceControl.Audit
+            title: ServiceControl Audit Instance
+            description: Provide valuable information about the message flow through a system.
           - name: servicecontrol-monitoring
             project: ServiceControl.Monitoring
+            title: ServiceControl Monitoring Instance
+            description: Track the health of a distributed system.
       fail-fast: false
     steps:
       - name: Check for secrets
@@ -52,9 +58,29 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           sbom: true
-          build-args: |
-            VERSION=${{ env.MinVerVersion }}
-            SHA=${{ github.sha }}
-            CREATED=${{ steps.date.outputs.date }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/Particular/ServiceControl/tree/${{ github.sha }}
+            org.opencontainers.image.authors="Particular Software"
+            org.opencontainers.image.vendor="Particular Software"
+            org.opencontainers.image.url=https://hub.docker.com/r/particular/${{ matrix.name }}
+            org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/
+            org.opencontainers.image.version=${{ env.MinVerVersion }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.date.outputs.date }}
+            org.opencontainers.image.title=${{ matrix.title }}
+            org.opencontainers.image.description=${{ matrix.description }}
+            org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
+          annotations: |
+            index:org.opencontainers.image.source=https://github.com/Particular/ServiceControl/tree/${{ github.sha }}
+            index:org.opencontainers.image.authors="Particular Software"
+            index:org.opencontainers.image.vendor="Particular Software"
+            index:org.opencontainers.image.url=https://hub.docker.com/r/particular/${{ matrix.name }}
+            index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/
+            index:org.opencontainers.image.version=${{ env.MinVerVersion }}
+            index:org.opencontainers.image.revision=${{ github.sha }}
+            index:org.opencontainers.image.created=${{ steps.date.outputs.date }}
+            index:org.opencontainers.image.title=${{ matrix.title }}
+            index:org.opencontainers.image.description=${{ matrix.description }}
+            index:org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
           file: src/${{ matrix.project }}/Dockerfile
           tags: ghcr.io/particular/${{ matrix.name }}:${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || env.MinVerVersion }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.9.0
       - name: Log in to GitHub container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -12,13 +12,10 @@ jobs:
         include:
           - name: servicecontrol
             project: ServiceControl
-            description: ServiceControl error instance
           - name: servicecontrol-audit
             project: ServiceControl.Audit
-            description: ServiceControl audit instance
           - name: servicecontrol-monitoring
             project: ServiceControl.Monitoring
-            description: ServiceControl monitoring instance
       fail-fast: false
     steps:
       - name: Check for secrets
@@ -38,26 +35,26 @@ jobs:
         with:
           version: ${{ env.MinVerVersion }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.9.0
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub container registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build & inspect image
-        env:
-          TAG_NAME: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || env.MinVerVersion }}
-        run: |
-          docker buildx build --push --tag ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }} \
-              --file src/${{ matrix.project }}/Dockerfile \
-              --build-arg VERSION=${{ env.MinVerVersion }} \
-              --annotation "index:org.opencontainers.image.title=${{ matrix.name }}" \
-              --annotation "index:org.opencontainers.image.description=${{ matrix.description }}" \
-              --annotation "index:org.opencontainers.image.created=$(date '+%FT%TZ')" \
-              --annotation "index:org.opencontainers.image.revision=${{ github.sha }}" \
-              --annotation "index:org.opencontainers.image.authors=Particular Software" \
-              --annotation "index:org.opencontainers.image.vendor=Particular Software" \
-              --annotation "index:org.opencontainers.image.version=${{ env.MinVerVersion }}" \
-              --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}/tree/${{ github.sha }}" \
-              --annotation "index:org.opencontainers.image.url=https://hub.docker.com/r/particular/${{ matrix.name }}" \
-              --annotation "index:org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/" \
-              --annotation "index:org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra" \
-              --platform linux/arm64,linux/amd64 .
-          docker buildx imagetools inspect ghcr.io/particular/${{ matrix.name }}:${{ env.TAG_NAME }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get current date
+        id: date
+        run: echo "date=$(date '+%FT%TZ')" >> $GITHUB_OUTPUT
+      - name: Build and push image to GitHub container registry
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          sbom: true
+          build-args: |
+            VERSION=${{ env.MinVerVersion }}
+            SHA=${{ github.sha }}
+            CREATED=${{ steps.date.outputs.date }}
+          file: src/${{ matrix.project }}/Dockerfile
+          tags: ghcr.io/particular/${{ matrix.name }}:${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || env.MinVerVersion }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -46,7 +46,7 @@ jobs:
         id: date
         run: echo "date=$(date '+%FT%TZ')" >> $GITHUB_OUTPUT
       - name: Build and push image to GitHub container registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.14.0
         with:
           context: .
           push: true

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           version: ${{ env.MinVerVersion }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.9.0
       - name: Log in to GitHub container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-db-container.yml
+++ b/.github/workflows/build-db-container.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           version: ${{ env.MinVerVersion }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.9.0
       - name: Log in to GitHub container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-db-container.yml
+++ b/.github/workflows/build-db-container.yml
@@ -24,8 +24,14 @@ jobs:
         uses: ./.github/actions/validate-version
         with:
           version: ${{ env.MinVerVersion }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub container registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Docker arm64 emulation
         run: docker run --privileged --rm tonistiigi/binfmt --install arm64
       - name: Build images

--- a/.github/workflows/build-db-container.yml
+++ b/.github/workflows/build-db-container.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.9.0
       - name: Log in to GitHub container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/container-integration-test.yml
+++ b/.github/workflows/container-integration-test.yml
@@ -56,9 +56,13 @@ jobs:
       - name: Run MinVer
         uses: Particular/run-minver-action@v1.0.0
       - name: Log in to GitHub container registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/container-integration-test.yml
+++ b/.github/workflows/container-integration-test.yml
@@ -62,7 +62,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/push-container-images.yml
+++ b/.github/workflows/push-container-images.yml
@@ -28,7 +28,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/push-container-images.yml
+++ b/.github/workflows/push-container-images.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           version: ${{ inputs.version }}
       - name: Log in to GitHub container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/push-container-images.yml
+++ b/.github/workflows/push-container-images.yml
@@ -22,28 +22,32 @@ jobs:
         with:
           version: ${{ inputs.version }}
       - name: Log in to GitHub container registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Publish to Docker Hub
         run: |
           $containers = @('servicecontrol', 'servicecontrol-audit', 'servicecontrol-monitoring', 'servicecontrol-ravendb')
           $tags = "${{ steps.validate.outputs.container-tags }}" -Split ','
           $sourceTag = "${{ inputs.version }}"
 
-          foreach ($tag in $tags)
+          foreach($name in $containers)
           {
-            foreach($name in $containers)
-            {
-              Write-Output "::group::Pushing $($name):$($tag)"
-              $cmd = "docker buildx imagetools create --tag particular/$($name):$($tag) ghcr.io/particular/$($name):$($sourceTag)"
-              Write-Output "Command: $cmd"
-              Invoke-Expression $cmd
-              Write-Output "::endgroup::"
-            }
+            Write-Output "::group::Pushing $name with $tags tags"
+            $tagsCLI = $tags -replace "^", "--tag particular/${name}:"
+            $cmd = "docker buildx imagetools create $tagsCLI ghcr.io/particular/${name}:$sourceTag"
+            Write-Output "Command: $cmd"
+            Invoke-Expression $cmd
+            Write-Output "::endgroup::"
           }
       - name: Update Docker Hub Description - ServiceControl
         if: ${{ steps.validate.outputs.latest == 'true' }}

--- a/.github/workflows/push-container-images.yml
+++ b/.github/workflows/push-container-images.yml
@@ -33,7 +33,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.9.0
       - name: Publish to Docker Hub
         run: |
           $containers = @('servicecontrol', 'servicecontrol-audit', 'servicecontrol-monitoring', 'servicecontrol-ravendb')

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -11,15 +11,21 @@ RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH -
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
 ARG VERSION
+ARG SHA=unknown
+ARG CREATED=2000-01-01T00:00:00Z
 WORKDIR /app
 
-LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
-      org.opencontainers.image.authors="Particular Software" \
-      org.opencontainers.image.url=https://docs.particular.net/servicecontrol/ \
-      org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/ \
-      org.opencontainers.image.version=$VERSION \
-      org.opencontainers.image.title=ServiceControl.Audit \
-      org.opencontainers.image.description="ServiceControl audit instance"
+LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl/tree/$SHA
+LABEL org.opencontainers.image.authors="Particular Software"
+LABEL org.opencontainers.image.vendor="Particular Software"
+LABEL org.opencontainers.image.url=https://hub.docker.com/r/particular/servicecontrol-audit
+LABEL org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.revision=$SHA
+LABEL org.opencontainers.image.created=$CREATED
+LABEL org.opencontainers.image.title="ServiceControl Audit Instance"
+LABEL org.opencontainers.image.description="Provide valuable information about the message flow through a system."
+LABEL org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
 
 EXPOSE 44444
 

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -10,22 +10,7 @@ RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH -
 
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
-ARG VERSION
-ARG SHA=unknown
-ARG CREATED=2000-01-01T00:00:00Z
 WORKDIR /app
-
-LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl/tree/$SHA
-LABEL org.opencontainers.image.authors="Particular Software"
-LABEL org.opencontainers.image.vendor="Particular Software"
-LABEL org.opencontainers.image.url=https://hub.docker.com/r/particular/servicecontrol-audit
-LABEL org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/
-LABEL org.opencontainers.image.version=$VERSION
-LABEL org.opencontainers.image.revision=$SHA
-LABEL org.opencontainers.image.created=$CREATED
-LABEL org.opencontainers.image.title="ServiceControl Audit Instance"
-LABEL org.opencontainers.image.description="Provide valuable information about the message flow through a system."
-LABEL org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
 
 EXPOSE 44444
 

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -11,15 +11,21 @@ RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH -
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
 ARG VERSION
+ARG SHA=unknown
+ARG CREATED=2000-01-01T00:00:00Z
 WORKDIR /app
 
-LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
-      org.opencontainers.image.authors="Particular Software" \
-      org.opencontainers.image.url=https://docs.particular.net/servicecontrol/ \
-      org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/ \
-      org.opencontainers.image.version=$VERSION \
-      org.opencontainers.image.title=ServiceControl.Monitoring \
-      org.opencontainers.image.description="ServiceControl monitoring instance"
+LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl/tree/$SHA
+LABEL org.opencontainers.image.authors="Particular Software"
+LABEL org.opencontainers.image.vendor="Particular Software"
+LABEL org.opencontainers.image.url=https://hub.docker.com/r/particular/servicecontrol-monitoring
+LABEL org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.revision=$SHA
+LABEL org.opencontainers.image.created=$CREATED
+LABEL org.opencontainers.image.title="ServiceControl Monitoring Instance"
+LABEL org.opencontainers.image.description="Track the health of a distributed system."
+LABEL org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
 
 EXPOSE 33633
 

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -10,22 +10,7 @@ RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH -
 
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
-ARG VERSION
-ARG SHA=unknown
-ARG CREATED=2000-01-01T00:00:00Z
 WORKDIR /app
-
-LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl/tree/$SHA
-LABEL org.opencontainers.image.authors="Particular Software"
-LABEL org.opencontainers.image.vendor="Particular Software"
-LABEL org.opencontainers.image.url=https://hub.docker.com/r/particular/servicecontrol-monitoring
-LABEL org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/
-LABEL org.opencontainers.image.version=$VERSION
-LABEL org.opencontainers.image.revision=$SHA
-LABEL org.opencontainers.image.created=$CREATED
-LABEL org.opencontainers.image.title="ServiceControl Monitoring Instance"
-LABEL org.opencontainers.image.description="Track the health of a distributed system."
-LABEL org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
 
 EXPOSE 33633
 

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -11,15 +11,22 @@ RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH -
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
 ARG VERSION
+ARG SHA=unknown
+ARG CREATED=2000-01-01T00:00:00Z
 WORKDIR /app
 
-LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
-      org.opencontainers.image.authors="Particular Software" \
-      org.opencontainers.image.url=https://docs.particular.net/servicecontrol/ \
-      org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/ \
-      org.opencontainers.image.version=$VERSION \
-      org.opencontainers.image.title=ServiceControl \
-      org.opencontainers.image.description="ServiceControl primary instance"
+LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl/tree/$SHA
+LABEL org.opencontainers.image.authors="Particular Software"
+LABEL org.opencontainers.image.vendor="Particular Software"
+LABEL org.opencontainers.image.url=https://hub.docker.com/r/particular/servicecontrol
+LABEL org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.revision=$SHA
+LABEL org.opencontainers.image.created=$CREATED
+LABEL org.opencontainers.image.title="ServiceControl"
+LABEL org.opencontainers.image.description="Gather status, performance and monitoring data for multiple endpoints from a single location."
+LABEL org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
+
 
 EXPOSE 33333
 

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -10,23 +10,7 @@ RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH -
 
 # Runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
-ARG VERSION
-ARG SHA=unknown
-ARG CREATED=2000-01-01T00:00:00Z
 WORKDIR /app
-
-LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl/tree/$SHA
-LABEL org.opencontainers.image.authors="Particular Software"
-LABEL org.opencontainers.image.vendor="Particular Software"
-LABEL org.opencontainers.image.url=https://hub.docker.com/r/particular/servicecontrol
-LABEL org.opencontainers.image.documentation=https://docs.particular.net/servicecontrol/
-LABEL org.opencontainers.image.version=$VERSION
-LABEL org.opencontainers.image.revision=$SHA
-LABEL org.opencontainers.image.created=$CREATED
-LABEL org.opencontainers.image.title="ServiceControl"
-LABEL org.opencontainers.image.description="Gather status, performance and monitoring data for multiple endpoints from a single location."
-LABEL org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite-extra
-
 
 EXPOSE 33333
 


### PR DESCRIPTION
Using native action to login to ghcr.io.
Replaced multiple tagging commands with a single one Using build-push-action instead of script.
This adds the provenance by default, see https://docs.docker.com/build/ci/github-actions/attestations/#default-provenance.

This gives the image a better score in DockerHub scout health score.

This is the same changes as https://github.com/Particular/ServiceControl.Connector.MassTransit/pull/182