### PR TITLE
Add tests to make sure that indexes being locked  prevents index resets on instance restarts

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
@@ -1,120 +1,126 @@
-﻿namespace ServiceControl.Audit.Persistence.RavenDB
+﻿namespace ServiceControl.Audit.Persistence.RavenDB;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Indexes;
+using SagaAudit;
+
+class DatabaseSetup(DatabaseConfiguration configuration)
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Raven.Client.Documents;
-    using Raven.Client.Documents.Indexes;
-    using Raven.Client.Documents.Operations.Expiration;
-    using Raven.Client.Documents.Operations.Indexes;
-    using Raven.Client.Exceptions;
-    using Raven.Client.ServerWide;
-    using Raven.Client.ServerWide.Operations;
-    using Raven.Client.ServerWide.Operations.Configuration;
-    using ServiceControl.Audit.Persistence.RavenDB.Indexes;
-    using ServiceControl.SagaAudit;
-
-    class DatabaseSetup(DatabaseConfiguration configuration)
+    public async Task Execute(IDocumentStore documentStore, CancellationToken cancellationToken)
     {
-        public async Task Execute(IDocumentStore documentStore, CancellationToken cancellationToken)
+        await CreateDatabase(documentStore, configuration.Name, cancellationToken);
+
+        await UpdateDatabaseSettings(documentStore, configuration.Name, cancellationToken);
+
+        await CreateIndexes(documentStore, cancellationToken);
+
+        await ConfigureExpiration(documentStore, cancellationToken);
+    }
+
+    async Task CreateDatabase(IDocumentStore documentStore, string databaseName, CancellationToken cancellationToken)
+    {
+        var dbRecord = await documentStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName), cancellationToken);
+
+        if (dbRecord is null)
         {
-            await CreateDatabase(documentStore, configuration.Name, cancellationToken);
-            await UpdateDatabaseSettings(documentStore, configuration.Name, cancellationToken);
-
-            await CreateIndexes(documentStore, cancellationToken);
-
-            await ConfigureExpiration(documentStore, cancellationToken);
-        }
-
-        async Task CreateDatabase(IDocumentStore documentStore, string databaseName, CancellationToken cancellationToken)
-        {
-            var dbRecord = await documentStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName), cancellationToken);
-
-            if (dbRecord is null)
+            try
             {
-                try
-                {
-                    var databaseRecord = new DatabaseRecord(databaseName);
-                    databaseRecord.Settings.Add("Indexing.Auto.SearchEngineType", "Corax");
-                    databaseRecord.Settings.Add("Indexing.Static.SearchEngineType", "Corax");
+                var databaseRecord = new DatabaseRecord(databaseName);
 
-                    await documentStore.Maintenance.Server.SendAsync(new CreateDatabaseOperation(databaseRecord), cancellationToken);
-                }
-                catch (ConcurrencyException)
-                {
-                    // The database was already created before calling CreateDatabaseOperation
-                }
+                SetSearchEngineType(databaseRecord, SearchEngineType.Corax);
+
+                await documentStore.Maintenance.Server.SendAsync(new CreateDatabaseOperation(databaseRecord), cancellationToken);
             }
-        }
-
-        async Task UpdateDatabaseSettings(IDocumentStore documentStore, string databaseName, CancellationToken cancellationToken)
-        {
-            var dbRecord = await documentStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName), cancellationToken);
-
-            if (dbRecord is null)
+            catch (ConcurrencyException)
             {
-                throw new InvalidOperationException($"Database '{databaseName}' does not exist.");
+                // The database was already created before calling CreateDatabaseOperation
             }
-
-            var updated = false;
-
-            updated |= dbRecord.Settings.TryAdd("Indexing.Auto.SearchEngineType", "Corax");
-            updated |= dbRecord.Settings.TryAdd("Indexing.Static.SearchEngineType", "Corax");
-
-            if (updated)
-            {
-                await documentStore.Maintenance.ForDatabase(databaseName).SendAsync(new PutDatabaseSettingsOperation(databaseName, dbRecord.Settings), cancellationToken);
-                await documentStore.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(databaseName, true), cancellationToken);
-                await documentStore.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(databaseName, false), cancellationToken);
-            }
-        }
-
-        public static async Task DeleteLegacySagaDetailsIndex(IDocumentStore documentStore, CancellationToken cancellationToken)
-        {
-            // If the SagaDetailsIndex exists but does not have a .Take(50000), then we remove the current SagaDetailsIndex and
-            // create a new one. If we do not remove the current one, then RavenDB will attempt to do a side-by-side migration.
-            // Doing a side-by-side migration results in the index never swapping if there is constant ingestion as RavenDB will wait.
-            // for the index to not be stale before swapping to the new index. Constant ingestion means the index will never be not-stale.
-            // This needs to stay in place until the next major version as the user could upgrade from an older version of the current
-            // Major (v5.x.x) which might still have the incorrect index.
-            var sagaDetailsIndexOperation = new GetIndexOperation("SagaDetailsIndex");
-            var sagaDetailsIndexDefinition = await documentStore.Maintenance.SendAsync(sagaDetailsIndexOperation, cancellationToken);
-            if (sagaDetailsIndexDefinition != null && !sagaDetailsIndexDefinition.Reduce.Contains("Take(50000)"))
-            {
-                await documentStore.Maintenance.SendAsync(new DeleteIndexOperation("SagaDetailsIndex"), cancellationToken);
-            }
-        }
-
-        async Task CreateIndexes(IDocumentStore documentStore, CancellationToken cancellationToken)
-        {
-            await DeleteLegacySagaDetailsIndex(documentStore, cancellationToken);
-
-            List<AbstractIndexCreationTask> indexList = [new FailedAuditImportIndex(), new SagaDetailsIndex()];
-
-            if (configuration.EnableFullTextSearch)
-            {
-                indexList.Add(new MessagesViewIndexWithFullTextSearch());
-                await documentStore.Maintenance.SendAsync(new DeleteIndexOperation("MessagesViewIndex"), cancellationToken);
-            }
-            else
-            {
-                indexList.Add(new MessagesViewIndex());
-                await documentStore.Maintenance.SendAsync(new DeleteIndexOperation("MessagesViewIndexWithFullTextSearch"), cancellationToken);
-            }
-
-            await IndexCreation.CreateIndexesAsync(indexList, documentStore, null, null, cancellationToken);
-        }
-
-        async Task ConfigureExpiration(IDocumentStore documentStore, CancellationToken cancellationToken)
-        {
-            var expirationConfig = new ExpirationConfiguration
-            {
-                Disabled = false,
-                DeleteFrequencyInSec = configuration.ExpirationProcessTimerInSeconds
-            };
-
-            await documentStore.Maintenance.SendAsync(new ConfigureExpirationOperation(expirationConfig), cancellationToken);
         }
     }
+
+    async Task UpdateDatabaseSettings(IDocumentStore documentStore, string databaseName, CancellationToken cancellationToken)
+    {
+        var databaseRecord = await documentStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName), cancellationToken) ?? throw new InvalidOperationException($"Database '{databaseName}' does not exist.");
+
+        if (!SetSearchEngineType(databaseRecord, SearchEngineType.Corax))
+        {
+            return;
+        }
+
+        await documentStore.Maintenance.ForDatabase(databaseName).SendAsync(new PutDatabaseSettingsOperation(databaseName, databaseRecord.Settings), cancellationToken);
+        await documentStore.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(databaseName, true), cancellationToken);
+        await documentStore.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(databaseName, false), cancellationToken);
+    }
+
+    public static async Task DeleteLegacySagaDetailsIndex(IDocumentStore documentStore, CancellationToken cancellationToken)
+    {
+        // If the SagaDetailsIndex exists but does not have a .Take(50000), then we remove the current SagaDetailsIndex and
+        // create a new one. If we do not remove the current one, then RavenDB will attempt to do a side-by-side migration.
+        // Doing a side-by-side migration results in the index never swapping if there is constant ingestion as RavenDB will wait.
+        // for the index to not be stale before swapping to the new index. Constant ingestion means the index will never be not-stale.
+        // This needs to stay in place until the next major version as the user could upgrade from an older version of the current
+        // Major (v5.x.x) which might still have the incorrect index.
+        var sagaDetailsIndexOperation = new GetIndexOperation(SagaDetailsIndexName);
+        var sagaDetailsIndexDefinition = await documentStore.Maintenance.SendAsync(sagaDetailsIndexOperation, cancellationToken);
+        if (sagaDetailsIndexDefinition != null && !sagaDetailsIndexDefinition.Reduce.Contains("Take(50000)"))
+        {
+            await documentStore.Maintenance.SendAsync(new DeleteIndexOperation(SagaDetailsIndexName), cancellationToken);
+        }
+    }
+
+    async Task CreateIndexes(IDocumentStore documentStore, CancellationToken cancellationToken)
+    {
+        await DeleteLegacySagaDetailsIndex(documentStore, cancellationToken);
+
+        List<AbstractIndexCreationTask> indexList = [new FailedAuditImportIndex(), new SagaDetailsIndex()];
+
+        if (configuration.EnableFullTextSearch)
+        {
+            indexList.Add(new MessagesViewIndexWithFullTextSearch());
+            await documentStore.Maintenance.SendAsync(new DeleteIndexOperation(MessagesViewIndexName), cancellationToken);
+        }
+        else
+        {
+            indexList.Add(new MessagesViewIndex());
+            await documentStore.Maintenance.SendAsync(new DeleteIndexOperation(MessagesViewIndexWithFulltextSearchName), cancellationToken);
+        }
+
+        await IndexCreation.CreateIndexesAsync(indexList, documentStore, null, null, cancellationToken);
+    }
+
+    async Task ConfigureExpiration(IDocumentStore documentStore, CancellationToken cancellationToken)
+    {
+        var expirationConfig = new ExpirationConfiguration
+        {
+            Disabled = false,
+            DeleteFrequencyInSec = configuration.ExpirationProcessTimerInSeconds
+        };
+
+        await documentStore.Maintenance.SendAsync(new ConfigureExpirationOperation(expirationConfig), cancellationToken);
+    }
+
+    bool SetSearchEngineType(DatabaseRecord database, SearchEngineType searchEngineType)
+    {
+        var updated = false;
+
+        updated |= database.Settings.TryAdd("Indexing.Auto.SearchEngineType", searchEngineType.ToString());
+        updated |= database.Settings.TryAdd("Indexing.Static.SearchEngineType", searchEngineType.ToString());
+
+        return updated;
+    }
+
+    internal const string MessagesViewIndexWithFulltextSearchName = "MessagesViewIndexWithFullTextSearch";
+    internal const string SagaDetailsIndexName = "SagaDetailsIndex";
+    internal const string MessagesViewIndexName = "MessagesViewIndex";
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
@@ -23,7 +23,7 @@ class DatabaseSetup(DatabaseConfiguration configuration)
 
         await UpdateDatabaseSettings(documentStore, configuration.Name, cancellationToken);
 
-        await CreateIndexes(documentStore, cancellationToken);
+        await CreateIndexes(documentStore, configuration.EnableFullTextSearch, cancellationToken);
 
         await ConfigureExpiration(documentStore, cancellationToken);
     }
@@ -79,13 +79,13 @@ class DatabaseSetup(DatabaseConfiguration configuration)
         }
     }
 
-    async Task CreateIndexes(IDocumentStore documentStore, CancellationToken cancellationToken)
+    internal static async Task CreateIndexes(IDocumentStore documentStore, bool enableFreeTextSearch, CancellationToken cancellationToken)
     {
         await DeleteLegacySagaDetailsIndex(documentStore, cancellationToken);
 
         List<AbstractIndexCreationTask> indexList = [new FailedAuditImportIndex(), new SagaDetailsIndex()];
 
-        if (configuration.EnableFullTextSearch)
+        if (enableFreeTextSearch)
         {
             indexList.Add(new MessagesViewIndexWithFullTextSearch());
             await documentStore.Maintenance.SendAsync(new DeleteIndexOperation(MessagesViewIndexName), cancellationToken);

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
@@ -1,9 +1,10 @@
 namespace ServiceControl.Audit.Persistence.Tests;
 
-using System;
+using System.Threading;
 using System.Threading.Tasks;
-using global::ServiceControl.Audit.Persistence.RavenDB;
 using NUnit.Framework;
+using Persistence.RavenDB;
+using Persistence.RavenDB.Indexes;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 
@@ -11,7 +12,7 @@ using Raven.Client.Documents.Operations.Indexes;
 class IndexSetupTests : PersistenceTestFixture
 {
     [Test]
-    public async Task Corax_should_the_defaul_search_engine_type()
+    public async Task Corax_should_be_the_default_search_engine_type()
     {
         var indexes = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexesOperation(0, int.MaxValue));
 
@@ -30,5 +31,28 @@ class IndexSetupTests : PersistenceTestFixture
 
         Assert.That(nonFreeTextIndex, Is.Null);
         Assert.That(freeTextIndex, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task Indexes_should_be_reset_on_setup()
+    {
+        var index = new MessagesViewIndexWithFullTextSearch { Configuration = { ["Indexing.Static.SearchEngineType"] = SearchEngineType.Lucene.ToString() } };
+
+        await IndexCreation.CreateIndexesAsync([index], configuration.DocumentStore);
+
+        //TODO: find a better way
+        await Task.Delay(1000);
+
+        var indexStatsBefore = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
+
+        Assert.That(indexStatsBefore.SearchEngineType, Is.EqualTo(SearchEngineType.Lucene));
+
+        await DatabaseSetup.CreateIndexes(configuration.DocumentStore, true, CancellationToken.None);
+
+        //TODO: find a better way
+        await Task.Delay(1000);
+
+        var indexStatsAfter = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
+        Assert.That(indexStatsAfter.SearchEngineType, Is.EqualTo(SearchEngineType.Corax));
     }
 }

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
@@ -1,0 +1,34 @@
+namespace ServiceControl.Audit.Persistence.Tests;
+
+using System;
+using System.Threading.Tasks;
+using global::ServiceControl.Audit.Persistence.RavenDB;
+using NUnit.Framework;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+
+[TestFixture]
+class IndexSetupTests : PersistenceTestFixture
+{
+    [Test]
+    public async Task Corax_should_the_defaul_search_engine_type()
+    {
+        var indexes = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexesOperation(0, int.MaxValue));
+
+        foreach (var index in indexes)
+        {
+            var indexStats = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexStatisticsOperation(DatabaseSetup.MessagesViewIndexWithFulltextSearchName));
+            Assert.That(indexStats.SearchEngineType, Is.EqualTo(SearchEngineType.Corax), $"{index.Name} is not using Corax");
+        }
+    }
+
+    [Test]
+    public async Task Free_text_search_index_should_be_used_by_default()
+    {
+        var freeTextIndex = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexOperation(DatabaseSetup.MessagesViewIndexWithFulltextSearchName));
+        var nonFreeTextIndex = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexOperation(DatabaseSetup.MessagesViewIndexName));
+
+        Assert.That(nonFreeTextIndex, Is.Null);
+        Assert.That(freeTextIndex, Is.Not.Null);
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
@@ -36,6 +36,21 @@ class IndexSetupTests : PersistenceTestFixture
     }
 
     [Test]
+    public async Task Free_text_search_index_can_be_opted_out_from()
+    {
+        await DatabaseSetup.CreateIndexes(configuration.DocumentStore, false, CancellationToken.None);
+
+        //TODO: find a better way
+        await Task.Delay(1000);
+
+        var freeTextIndex = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexOperation(DatabaseSetup.MessagesViewIndexWithFulltextSearchName));
+        var nonFreeTextIndex = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexOperation(DatabaseSetup.MessagesViewIndexName));
+
+        Assert.That(freeTextIndex, Is.Null);
+        Assert.That(nonFreeTextIndex, Is.Not.Null);
+    }
+
+    [Test]
     public async Task Indexes_should_be_reset_on_setup()
     {
         var index = new MessagesViewIndexWithFullTextSearch { Configuration = { ["Indexing.Static.SearchEngineType"] = SearchEngineType.Lucene.ToString() } };

--- a/src/ServiceControl.Audit.Persistence.Tests/PersistenceTestFixture.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/PersistenceTestFixture.cs
@@ -1,8 +1,10 @@
 ﻿namespace ServiceControl.Audit.Persistence.Tests
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Auditing.BodyStorage;
     using NUnit.Framework;
@@ -18,12 +20,15 @@
         {
             configuration = new PersistenceTestsConfiguration();
 
+            testCancellationTokenSource = Debugger.IsAttached ? new CancellationTokenSource() : new CancellationTokenSource(TestTimeout);
+
             return configuration.Configure(SetSettings);
         }
 
         [TearDown]
         public virtual Task Cleanup()
         {
+            testCancellationTokenSource?.Dispose();
             return configuration?.Cleanup();
         }
 
@@ -64,5 +69,11 @@
         protected IServiceProvider ServiceProvider => configuration.ServiceProvider;
 
         protected PersistenceTestsConfiguration configuration;
+
+        protected CancellationToken TestTimeoutCancellationToken => testCancellationTokenSource.Token;
+
+        CancellationTokenSource testCancellationTokenSource;
+
+        static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
     }
 }


### PR DESCRIPTION
This means that user can opt-into Lucene by doing the following in Raven Studio:

1. Overriding search engine type to Lucene for a specific index
2. Lock the index [with LockMode set to Ignore](https://ravendb.net/docs/article-page/7.0/csharp/client-api/operations/maintenance/indexes/set-index-lock#lock-modes)