### PR TITLE
Also support `ServiceControl.Audit/IngestAuditMessages`

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -63,7 +63,15 @@
                 throw new Exception("ServiceBus/AuditQueue value is required to start the instance");
             }
 
-            IngestAuditMessages = SettingsReader.Read(new SettingsRootNamespace("ServiceControl"), "IngestAuditMessages", true);
+            var serviceControlNamespace = new SettingsRootNamespace("ServiceControl");
+
+            if (!SettingsReader.TryRead(SettingsRootNamespace, "IngestAuditMessages", out bool ingestAuditMessages))
+            {
+                // Backwards compatibility
+                ingestAuditMessages = SettingsReader.Read(serviceControlNamespace, "IngestAuditMessages", true);
+            }
+
+            IngestAuditMessages = ingestAuditMessages;
 
             if (IngestAuditMessages == false)
             {

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -63,11 +63,10 @@
                 throw new Exception("ServiceBus/AuditQueue value is required to start the instance");
             }
 
-            var serviceControlNamespace = new SettingsRootNamespace("ServiceControl");
-
             if (!SettingsReader.TryRead(SettingsRootNamespace, "IngestAuditMessages", out bool ingestAuditMessages))
             {
                 // Backwards compatibility
+                var serviceControlNamespace = new SettingsRootNamespace("ServiceControl");
                 ingestAuditMessages = SettingsReader.Read(serviceControlNamespace, "IngestAuditMessages", true);
             }
 


### PR DESCRIPTION
Also support `ServiceControl.Audit/IngestAuditMessages` to avoid confusion with other "audit" settings to that have `ServiceControl.Audit` prefix.