### PR TITLE
Limit throughput data returned to 14 months

### DIFF
--- a/src/Particular.LicensingComponent.Contracts/EndpointThroughputSummary.cs
+++ b/src/Particular.LicensingComponent.Contracts/EndpointThroughputSummary.cs
@@ -7,6 +7,7 @@ public class EndpointThroughputSummary
     public bool IsKnownEndpoint { get; set; }
     public string UserIndicator { get; set; }
     public long MaxDailyThroughput { get; set; }
+    public long MaxMonthlyThroughput { get; set; }
 }
 
 public class UpdateUserIndicator

--- a/src/Particular.LicensingComponent.Contracts/ThroughputSettings.cs
+++ b/src/Particular.LicensingComponent.Contracts/ThroughputSettings.cs
@@ -2,7 +2,12 @@
 
 using ServiceControl.Configuration;
 
-public class ThroughputSettings(string serviceControlQueue, string errorQueue, string transportType, string customerName, string serviceControlVersion)
+public class ThroughputSettings(
+    string serviceControlQueue,
+    string errorQueue,
+    string transportType,
+    string customerName,
+    string serviceControlVersion)
 {
     public static readonly SettingsRootNamespace SettingsNamespace = new("LicensingComponent");
 

--- a/src/Particular.LicensingComponent.UnitTests/Infrastructure/DataStoreBuilder.cs
+++ b/src/Particular.LicensingComponent.UnitTests/Infrastructure/DataStoreBuilder.cs
@@ -91,6 +91,33 @@ class DataStoreBuilder(ILicensingDataStore store)
         return this;
     }
 
+    public DataStoreBuilder WithThroughput(ThroughputData throughput)
+    {
+        Endpoint endpoint = endpoints.LastOrDefault() ??
+                            throw new InvalidOperationException(
+                                $"Need to add an endpoint before calling {nameof(WithThroughput)}");
+
+        var source = endpoint.Id.ThroughputSource;
+        if (endpoints.SingleOrDefault(e => e.Id.Name == endpoint.Id.Name && e.Id.ThroughputSource == source) == null)
+        {
+            throw new InvalidOperationException(
+                $"Need to add endpoint {endpoint.Id.Name}:{source} before calling {nameof(WithThroughput)}");
+        }
+
+        var idForThroughput = new EndpointIdentifier(endpoint.Id.Name, source);
+
+        if (endpointThroughput.TryGetValue(idForThroughput, out List<ThroughputData> throughputList))
+        {
+            throughputList.Add(throughput);
+        }
+        else
+        {
+            endpointThroughput.Add(idForThroughput, [throughput]);
+        }
+
+        return this;
+    }
+
     public async Task Build()
     {
         foreach (Endpoint endpoint in endpoints)

--- a/src/Particular.LicensingComponent/ThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/ThroughputCollector.cs
@@ -71,7 +71,8 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
                 Name = endpointData.Name,
                 UserIndicator = endpointData.UserIndicator ?? (endpointData.IsKnownEndpoint ? Contracts.UserIndicator.NServiceBusEndpoint.ToString() : string.Empty),
                 IsKnownEndpoint = endpointData.IsKnownEndpoint,
-                MaxDailyThroughput = endpointData.ThroughputData.Max()
+                MaxDailyThroughput = endpointData.ThroughputData.MaxDailyThroughput(),
+                MaxMonthlyThroughput = endpointData.ThroughputData.MaxMonthlyThroughput()
             };
 
             endpointSummaries.Add(endpointSummary);
@@ -130,7 +131,7 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
                 EndpointIndicators = endpointData.EndpointIndicators ?? [],
                 NoDataOrSendOnly = endpointData.ThroughputData.Sum() == 0,
                 Scope = endpointData.Scope ?? "",
-                Throughput = endpointData.ThroughputData.Max(),
+                Throughput = endpointData.ThroughputData.MaxDailyThroughput(),
                 DailyThroughputFromAudit = endpointData.ThroughputData.FromSource(ThroughputSource.Audit).Select(s => new DailyThroughput { DateUTC = s.DateUTC, MessageCount = s.MessageCount }).ToArray(),
                 DailyThroughputFromMonitoring = endpointData.ThroughputData.FromSource(ThroughputSource.Monitoring).Select(s => new DailyThroughput { DateUTC = s.DateUTC, MessageCount = s.MessageCount }).ToArray(),
                 DailyThroughputFromBroker = notAnNsbEndpoint ? [] : endpointData.ThroughputData.FromSource(ThroughputSource.Broker).Select(s => new DailyThroughput { DateUTC = s.DateUTC, MessageCount = s.MessageCount }).ToArray()

--- a/src/Particular.LicensingComponent/ThroughputDataExtensions.cs
+++ b/src/Particular.LicensingComponent/ThroughputDataExtensions.cs
@@ -10,13 +10,29 @@ static class ThroughputDataExtensions
 
     public static long Sum(this List<ThroughputData> throughputs) => throughputs.SelectMany(t => t).Sum(kvp => kvp.Value);
 
-    public static long Max(this List<ThroughputData> throughputs)
+    public static long MaxDailyThroughput(this List<ThroughputData> throughputs)
     {
         var items = throughputs.SelectMany(t => t).ToArray();
 
         if (items.Any())
         {
             return items.Max(kvp => kvp.Value);
+        }
+
+        return 0;
+    }
+
+    public static long MaxMonthlyThroughput(this List<ThroughputData> throughputs)
+    {
+        var monthlySums = throughputs
+            .SelectMany(data => data)
+            .GroupBy(kvp => $"{kvp.Key.Year}-{kvp.Key.Month}")
+            .Select(group => group.Sum(kvp => kvp.Value))
+            .ToArray();
+
+        if (monthlySums.Any())
+        {
+            return monthlySums.Max();
         }
 
         return 0;

--- a/src/ServiceControl.LicenseManagement/LicenseDetails.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseDetails.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.LicenseManagement
 {
     using System;
-    using System.Collections.Generic;
     using Particular.Licensing;
 
     public class LicenseDetails

--- a/src/ServiceControl.Persistence.RavenDB/Throughput/LicensingDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Throughput/LicensingDataStore.cs
@@ -122,14 +122,14 @@ class LicensingDataStore(
 
     public async Task<IDictionary<string, IEnumerable<ThroughputData>>> GetEndpointThroughputByQueueName(IList<string> queueNames, CancellationToken cancellationToken)
     {
-        var results = queueNames.ToDictionary(queueName => queueName, queueNames => new List<ThroughputData>() as IEnumerable<ThroughputData>);
+        var results = queueNames.ToDictionary(queueName => queueName, _ => new List<ThroughputData>() as IEnumerable<ThroughputData>);
 
         var store = await storeProvider.GetDocumentStore(cancellationToken);
         using IAsyncDocumentSession session = store.OpenAsyncSession(databaseConfiguration.Name);
 
         var query = session.Query<EndpointDocument>()
             .Where(document => document.SanitizedName.In(queueNames))
-            .Include(builder => builder.IncludeTimeSeries(ThroughputTimeSeriesName));
+            .Include(builder => builder.IncludeTimeSeries(ThroughputTimeSeriesName, DateTime.UtcNow.AddMonths(-14)));
 
         var documents = await query.ToListAsync(cancellationToken);
 

--- a/src/ServiceControl/Licensing/LicensingComponent.cs
+++ b/src/ServiceControl/Licensing/LicensingComponent.cs
@@ -11,13 +11,16 @@ using ServiceBus.Management.Infrastructure.Settings;
 class LicensingComponent : ServiceControlComponent
 {
     public override void Configure(Settings settings, ITransportCustomization transportCustomization,
-        IHostApplicationBuilder hostBuilder) =>
+        IHostApplicationBuilder hostBuilder)
+    {
+        var licenseDetails = LicenseManager.FindLicense().Details;
         hostBuilder.AddLicensingComponent(
             TransportManifestLibrary.Find(settings.TransportType)?.Name ?? settings.TransportType,
             settings.ErrorQueue,
             settings.InstanceName,
-            LicenseManager.FindLicense().Details.RegisteredTo,
+            licenseDetails.RegisteredTo,
             ServiceControlVersion.GetFileVersion());
+    }
 
     public override void Setup(Settings settings, IComponentInstallationContext context,
         IHostApplicationBuilder hostBuilder) =>


### PR DESCRIPTION
The throughput calculation is supposed to only look at the last 12 months of data.
This PR adds a filter to the data, so it only considers the last 14 months.
We use 14 months to ensure we have whole months and not partial months.