### PR TITLE
Do not try to parse the RavenDB dirty memory value

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/CustomChecks/CheckDirtyMemory.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/CustomChecks/CheckDirtyMemory.cs
@@ -12,6 +12,8 @@ class CheckDirtyMemory(MemoryInformationRetriever memoryInformationRetriever) : 
     {
         var (isHighDirty, dirtyMemory) = await memoryInformationRetriever.GetMemoryInformation(cancellationToken);
 
+        Log.Debug($"RavenDB dirty memory value: {dirtyMemory}.");
+
         if (isHighDirty)
         {
             var message = $"There is a high level of RavenDB dirty memory ({dirtyMemory}). See https://docs.particular.net/servicecontrol/troubleshooting#ravendb-dirty-memory for guidance on how to mitigate the issue.";

--- a/src/ServiceControl.Audit.Persistence.RavenDB/CustomChecks/CheckDirtyMemory.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/CustomChecks/CheckDirtyMemory.cs
@@ -10,11 +10,11 @@ class CheckDirtyMemory(MemoryInformationRetriever memoryInformationRetriever) : 
 {
     public override async Task<CheckResult> PerformCheck(CancellationToken cancellationToken = default)
     {
-        var (isHighDirty, dirtyMemoryKb) = await memoryInformationRetriever.GetMemoryInformation(cancellationToken);
+        var (isHighDirty, dirtyMemory) = await memoryInformationRetriever.GetMemoryInformation(cancellationToken);
 
         if (isHighDirty)
         {
-            var message = $"There is a high level of RavenDB dirty memory ({dirtyMemoryKb}kb). See https://docs.particular.net/servicecontrol/troubleshooting#ravendb-dirty-memory for guidance on how to mitigate the issue.";
+            var message = $"There is a high level of RavenDB dirty memory ({dirtyMemory}). See https://docs.particular.net/servicecontrol/troubleshooting#ravendb-dirty-memory for guidance on how to mitigate the issue.";
             Log.Warn(message);
             return CheckResult.Failed(message);
         }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -26,16 +26,11 @@ class MemoryInformationRetriever(DatabaseConfiguration databaseConfiguration)
         public string DirtyMemory { get; set; }
     }
 
-    public async Task<(bool IsHighDirty, int DirtyMemoryKb)> GetMemoryInformation(CancellationToken cancellationToken = default)
+    public async Task<(bool IsHighDirty, string DirtyMemory)> GetMemoryInformation(CancellationToken cancellationToken = default)
     {
         var httpResponse = await client.GetAsync("/admin/debug/memory/stats?includeThreads=false&includeMappings=false", cancellationToken);
         var responseDto = JsonSerializer.Deserialize<ResponseDto>(await httpResponse.Content.ReadAsStringAsync(cancellationToken));
 
-        var values = responseDto.MemoryInformation.DirtyMemory.Split(' ');
-        if (!string.Equals(values[1], "KBytes", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new InvalidOperationException($"Unexpected response. Was expecting memory details in KBytes, instead received: {responseDto.MemoryInformation.DirtyMemory}");
-        }
-        return (responseDto.MemoryInformation.IsHighDirty, int.Parse(values[0]));
+        return (responseDto.MemoryInformation.IsHighDirty, responseDto.MemoryInformation.DirtyMemory);
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckDirtyMemory.cs
+++ b/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckDirtyMemory.cs
@@ -12,6 +12,8 @@ class CheckDirtyMemory(MemoryInformationRetriever memoryInformationRetriever) : 
     {
         var (isHighDirty, dirtyMemory) = await memoryInformationRetriever.GetMemoryInformation(cancellationToken);
 
+        Log.Debug($"RavenDB dirty memory value: {dirtyMemory}.");
+
         if (isHighDirty)
         {
             var message = $"There is a high level of RavenDB dirty memory ({dirtyMemory}). See https://docs.particular.net/servicecontrol/troubleshooting#ravendb-dirty-memory for guidance on how to mitigate the issue.";

--- a/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckDirtyMemory.cs
+++ b/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckDirtyMemory.cs
@@ -10,11 +10,11 @@ class CheckDirtyMemory(MemoryInformationRetriever memoryInformationRetriever) : 
 {
     public override async Task<CheckResult> PerformCheck(CancellationToken cancellationToken = default)
     {
-        var (isHighDirty, dirtyMemoryKb) = await memoryInformationRetriever.GetMemoryInformation(cancellationToken);
+        var (isHighDirty, dirtyMemory) = await memoryInformationRetriever.GetMemoryInformation(cancellationToken);
 
         if (isHighDirty)
         {
-            var message = $"There is a high level of RavenDB dirty memory ({dirtyMemoryKb}kb). See https://docs.particular.net/servicecontrol/troubleshooting#ravendb-dirty-memory for guidance on how to mitigate the issue.";
+            var message = $"There is a high level of RavenDB dirty memory ({dirtyMemory}). See https://docs.particular.net/servicecontrol/troubleshooting#ravendb-dirty-memory for guidance on how to mitigate the issue.";
             Log.Warn(message);
             return CheckResult.Failed(message);
         }

--- a/src/ServiceControl.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -25,16 +25,11 @@ class MemoryInformationRetriever(RavenPersisterSettings persisterSettings)
         public string DirtyMemory { get; set; }
     }
 
-    public async Task<(bool IsHighDirty, int DirtyMemoryKb)> GetMemoryInformation(CancellationToken cancellationToken = default)
+    public async Task<(bool IsHighDirty, string DirtyMemory)> GetMemoryInformation(CancellationToken cancellationToken = default)
     {
         var httpResponse = await client.GetAsync("/admin/debug/memory/stats?includeThreads=false&includeMappings=false", cancellationToken);
         var responseDto = JsonSerializer.Deserialize<ResponseDto>(await httpResponse.Content.ReadAsStringAsync(cancellationToken));
 
-        var values = responseDto.MemoryInformation.DirtyMemory.Split(' ');
-        if (!string.Equals(values[1], "KBytes", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new InvalidOperationException($"Unexpected response. Was expecting memory details in KBytes, instead received: {responseDto.MemoryInformation.DirtyMemory}");
-        }
-        return (responseDto.MemoryInformation.IsHighDirty, int.Parse(values[0]));
+        return (responseDto.MemoryInformation.IsHighDirty, responseDto.MemoryInformation.DirtyMemory);
     }
 }


### PR DESCRIPTION
The unit might change unexpectedly. Instead, treat it as a string.