### PR TITLE
Add exponential backoff when the async timer fails

### DIFF
--- a/src/ServiceControl.Infrastructure/AsyncTimer.cs
+++ b/src/ServiceControl.Infrastructure/AsyncTimer.cs
@@ -57,7 +57,7 @@ public class TimerJob
         }, CancellationToken.None);
     }
 
-    public async Task Stop()
+    public async Task Stop(CancellationToken cancellationToken)
     {
         if (tokenSource == null)
         {
@@ -67,16 +67,18 @@ public class TimerJob
         await tokenSource.CancelAsync().ConfigureAwait(false);
         tokenSource.Dispose();
 
-        if (task != null)
+        if (task == null)
         {
-            try
-            {
-                await task.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (tokenSource.IsCancellationRequested)
-            {
-                //NOOP
-            }
+            return;
+        }
+
+        try
+        {
+            Task.WaitAll([task], cancellationToken);
+        }
+        catch (OperationCanceledException) when (tokenSource.IsCancellationRequested)
+        {
+            //NOOP
         }
     }
 

--- a/src/ServiceControl.Monitoring/Licensing/LicenseCheckHostedService.cs
+++ b/src/ServiceControl.Monitoring/Licensing/LicenseCheckHostedService.cs
@@ -20,7 +20,7 @@
             return Task.CompletedTask;
         }
 
-        public Task StopAsync(CancellationToken cancellationToken) => timer.Stop();
+        public Task StopAsync(CancellationToken cancellationToken) => timer.Stop(cancellationToken);
 
         TimerJob timer;
 

--- a/src/ServiceControl/CustomChecks/InternalCustomChecks/InternalCustomCheckManager.cs
+++ b/src/ServiceControl/CustomChecks/InternalCustomChecks/InternalCustomCheckManager.cs
@@ -67,7 +67,7 @@
                 : TimerJobExecutionResult.DoNotContinueExecuting;
         }
 
-        public Task Stop() => timer?.Stop() ?? Task.CompletedTask;
+        public Task Stop() => timer?.Stop(CancellationToken.None) ?? Task.CompletedTask;
 
         TimerJob timer;
         readonly ICustomCheck check;

--- a/src/ServiceControl/Licensing/LicenseCheckHostedService.cs
+++ b/src/ServiceControl/Licensing/LicenseCheckHostedService.cs
@@ -21,7 +21,7 @@
             return Task.CompletedTask;
         }
 
-        public Task StopAsync(CancellationToken cancellationToken) => timer.Stop();
+        public Task StopAsync(CancellationToken cancellationToken) => timer.Stop(cancellationToken);
 
         TimerJob timer;
 

--- a/src/ServiceControl/Monitoring/HeartbeatMonitoringHostedService.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatMonitoringHostedService.cs
@@ -24,17 +24,7 @@
             timer = scheduler.Schedule(_ => CheckEndpoints(), TimeSpan.Zero, TimeSpan.FromSeconds(5), e => { log.Error("Exception occurred when monitoring endpoint instances", e); });
         }
 
-        public async Task StopAsync(CancellationToken cancellationToken)
-        {
-            try
-            {
-                await timer.Stop();
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                //NOOP, invoked Stop does not
-            }
-        }
+        public Task StopAsync(CancellationToken cancellationToken) => timer.Stop(cancellationToken);
 
         async Task<TimerJobExecutionResult> CheckEndpoints()
         {

--- a/src/ServiceControl/Recoverability/RecoverabilityComponent.cs
+++ b/src/ServiceControl/Recoverability/RecoverabilityComponent.cs
@@ -174,10 +174,7 @@
                 return Task.CompletedTask;
             }
 
-            public Task StopAsync(CancellationToken cancellationToken)
-            {
-                return timer?.Stop() ?? Task.CompletedTask;
-            }
+            public Task StopAsync(CancellationToken cancellationToken) => timer?.Stop(cancellationToken) ?? Task.CompletedTask;
 
             async Task<TimerJobExecutionResult> ProcessRequestedBulkRetryOperations()
             {
@@ -237,10 +234,7 @@
                 return Task.CompletedTask;
             }
 
-            public Task StopAsync(CancellationToken cancellationToken)
-            {
-                return timer.Stop();
-            }
+            public Task StopAsync(CancellationToken cancellationToken) => timer.Stop(cancellationToken);
 
             TimerJob timer;
             readonly IAsyncTimer scheduler;
@@ -266,10 +260,7 @@
                 return Task.CompletedTask;
             }
 
-            public async Task StopAsync(CancellationToken cancellationToken)
-            {
-                await timer.Stop();
-            }
+            public Task StopAsync(CancellationToken cancellationToken) => timer.Stop(cancellationToken);
 
             async Task<TimerJobExecutionResult> Process(CancellationToken cancellationToken)
             {


### PR DESCRIPTION
We've seen logs being flooded by the coding using the async timer during failure scenarios.

To prevent this an exponential backoff strategy capped at 60s will be used for consecutive failures executing the async timer.