### PR TITLE
Remove analyser for configure await

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -27,9 +27,8 @@ insert_final_newline = false
 dotnet_diagnostic.CA1068.severity = error
 dotnet_diagnostic.CA1710.severity = error
 dotnet_diagnostic.CA1711.severity = error
-dotnet_diagnostic.CA2007.severity = error
+dotnet_diagnostic.CA2007.severity = none
 dotnet_diagnostic.CA2016.severity = error
-
 
 #### .NET Coding Conventions ####
 

--- a/src/HealthCheckApp/Program.cs
+++ b/src/HealthCheckApp/Program.cs
@@ -7,7 +7,7 @@ if (string.IsNullOrEmpty(url))
     throw new Exception("Missing URL");
 }
 
-var response = await http.GetAsync(url).ConfigureAwait(false);
+var response = await http.GetAsync(url);
 response.EnsureSuccessStatusCode();
 
 if (response.Content.Headers.ContentType?.MediaType != "application/json" || response.Content.Headers.ContentLength == 0)

--- a/src/ServiceControl.Config/.editorconfig
+++ b/src/ServiceControl.Config/.editorconfig
@@ -1,8 +1,5 @@
 [*.cs]
 
-# Justification: Application synchronization contexts don't require ConfigureAwait(false)
-dotnet_diagnostic.CA2007.severity = none
-
 # may be enabled in future
 dotnet_diagnostic.PS0003.severity = none  # A parameter of type CancellationToken on a non-private delegate or method should be optional
 dotnet_diagnostic.PS0013.severity = none  # A Func used as a method parameter with a Task, ValueTask, or ValueTask<T> return type argument should have at least one CancellationToken parameter type argument unless it has a parameter type argument implementing ICancellableContext

--- a/src/ServiceControl.DomainEvents/DomainEvents.cs
+++ b/src/ServiceControl.DomainEvents/DomainEvents.cs
@@ -20,8 +20,7 @@
             {
                 try
                 {
-                    await handler.Handle(domainEvent, cancellationToken)
-                        ;
+                    await handler.Handle(domainEvent, cancellationToken);
                 }
                 catch (Exception e)
                 {
@@ -35,8 +34,7 @@
             {
                 try
                 {
-                    await handler.Handle(domainEvent, cancellationToken)
-                    ;
+                    await handler.Handle(domainEvent, cancellationToken);
                 }
                 catch (Exception e)
                 {

--- a/src/ServiceControl.DomainEvents/DomainEvents.cs
+++ b/src/ServiceControl.DomainEvents/DomainEvents.cs
@@ -21,7 +21,7 @@
                 try
                 {
                     await handler.Handle(domainEvent, cancellationToken)
-                        .ConfigureAwait(false);
+                        ;
                 }
                 catch (Exception e)
                 {
@@ -36,7 +36,7 @@
                 try
                 {
                     await handler.Handle(domainEvent, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
                 }
                 catch (Exception e)
                 {

--- a/src/ServiceControl.Infrastructure.Metrics/MetricsReporter.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/MetricsReporter.cs
@@ -29,7 +29,7 @@
                     while (!tokenSource.IsCancellationRequested)
                     {
                         Print();
-                        await Task.Delay(interval, tokenSource.Token).ConfigureAwait(false);
+                        await Task.Delay(interval, tokenSource.Token);
                     }
                 }
                 catch (OperationCanceledException) when (tokenSource.IsCancellationRequested)

--- a/src/ServiceControl.Infrastructure/AsyncTimer.cs
+++ b/src/ServiceControl.Infrastructure/AsyncTimer.cs
@@ -22,20 +22,20 @@
             {
                 try
                 {
-                    await Task.Delay(due, token).ConfigureAwait(false);
+                    await Task.Delay(due, token);
 
                     while (!token.IsCancellationRequested)
                     {
                         try
                         {
-                            var result = await callback(token).ConfigureAwait(false);
+                            var result = await callback(token);
                             if (result == TimerJobExecutionResult.DoNotContinueExecuting)
                             {
                                 tokenSource.Cancel();
                             }
                             else if (result == TimerJobExecutionResult.ScheduleNextExecution)
                             {
-                                await Task.Delay(interval, token).ConfigureAwait(false);
+                                await Task.Delay(interval, token);
                             }
 
                             //Otherwise execute immediately
@@ -64,14 +64,14 @@
                 return;
             }
 
-            await tokenSource.CancelAsync().ConfigureAwait(false);
+            await tokenSource.CancelAsync();
             tokenSource.Dispose();
 
             if (task != null)
             {
                 try
                 {
-                    await task.ConfigureAwait(false);
+                    await task;
                 }
                 catch (OperationCanceledException) when (tokenSource.IsCancellationRequested)
                 {

--- a/src/ServiceControl.Infrastructure/IntegratedSetup.cs
+++ b/src/ServiceControl.Infrastructure/IntegratedSetup.cs
@@ -52,7 +52,7 @@
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            await process.WaitForExitAsync().ConfigureAwait(false);
+            await process.WaitForExitAsync();
 
             return process.ExitCode;
         }

--- a/src/ServiceControl.Infrastructure/WaitHandleExtensions.cs
+++ b/src/ServiceControl.Infrastructure/WaitHandleExtensions.cs
@@ -22,12 +22,12 @@ namespace ServiceControl.Infrastructure
                 tokenRegistration = cancellationToken.Register(
                     state => ((TaskCompletionSource<bool>)state).TrySetCanceled(),
                     tcs);
-                return await tcs.Task.ConfigureAwait(false);
+                return await tcs.Task;
             }
             finally
             {
                 registeredHandle?.Unregister(null);
-                await tokenRegistration.DisposeAsync().ConfigureAwait(false);
+                await tokenRegistration.DisposeAsync();
             }
         }
 

--- a/src/ServiceControl.Infrastructure/Watchdog.cs
+++ b/src/ServiceControl.Infrastructure/Watchdog.cs
@@ -61,7 +61,7 @@
                         cancellationTokenSource.CancelAfter(MaxStartDurationMs);
 
                         log.Debug($"Ensuring {taskName} is running");
-                        await ensureStarted(cancellationTokenSource.Token).ConfigureAwait(false);
+                        await ensureStarted(cancellationTokenSource.Token);
                         clearFailure();
                         startup = false;
                     }
@@ -85,7 +85,7 @@
                     }
                     try
                     {
-                        await Task.Delay(timeToWaitBetweenStartupAttempts, shutdownTokenSource.Token).ConfigureAwait(false);
+                        await Task.Delay(timeToWaitBetweenStartupAttempts, shutdownTokenSource.Token);
                     }
                     catch (OperationCanceledException) when (shutdownTokenSource.IsCancellationRequested)
                     {
@@ -102,8 +102,8 @@
             try
             {
                 log.Debug($"Stopping watching process {taskName}");
-                await shutdownTokenSource.CancelAsync().ConfigureAwait(false);
-                await watchdog.ConfigureAwait(false);
+                await shutdownTokenSource.CancelAsync();
+                await watchdog;
             }
             catch (Exception e)
             {
@@ -112,7 +112,7 @@
             }
             finally
             {
-                await ensureStopped(cancellationToken).ConfigureAwait(false);
+                await ensureStopped(cancellationToken);
             }
         }
     }

--- a/src/ServiceControl.Monitoring/.editorconfig
+++ b/src/ServiceControl.Monitoring/.editorconfig
@@ -1,4 +1,0 @@
-[*.cs]
-
-# Justification: Application synchronization contexts don't require ConfigureAwait(false)
-dotnet_diagnostic.CA2007.severity = none

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -42,4 +42,8 @@
     <InternalsVisibleTo Include="ServiceControl.Monitoring.UnitTests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EditorConfigFiles Remove=".editorconfig" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -41,9 +41,5 @@
     <InternalsVisibleTo Include="ServiceControl.Monitoring.AcceptanceTests" />
     <InternalsVisibleTo Include="ServiceControl.Monitoring.UnitTests" />
   </ItemGroup>
-
-  <ItemGroup>
-    <EditorConfigFiles Remove=".editorconfig" />
-  </ItemGroup>
-
+  
 </Project>

--- a/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
+++ b/src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj
@@ -41,5 +41,5 @@
     <InternalsVisibleTo Include="ServiceControl.Monitoring.AcceptanceTests" />
     <InternalsVisibleTo Include="ServiceControl.Monitoring.UnitTests" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/ServiceControl.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -51,7 +51,7 @@ namespace ServiceControl.Persistence.RavenDB
                 await StartupChecks.EnsureServerVersion(store, cancellationToken);
 
                 var databaseSetup = new DatabaseSetup(settings, store);
-                await databaseSetup.Execute(cancellationToken).ConfigureAwait(false);
+                await databaseSetup.Execute(cancellationToken);
             }
             finally
             {

--- a/src/ServiceControlInstaller.Engine.UnitTests/RunEngineTasksExplicitly.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/RunEngineTasksExplicitly.cs
@@ -72,7 +72,7 @@
             // constructer of ServiceControlInstanceMetadata extracts version from zip
             details.Version = Constants.CurrentVersion;
 
-            await details.Validate(s => Task.FromResult(false)).ConfigureAwait(false);
+            await details.Validate(s => Task.FromResult(false));
             if (details.ReportCard.HasErrors)
             {
                 throw new Exception($"Validation errors:  {string.Join("\r\n", details.ReportCard.Errors)}");
@@ -95,27 +95,27 @@
             RemoveAltMSMQQueues();
 
             logger.Info("Recreating the MSMQ instance");
-            await CreateInstanceMSMQ().ConfigureAwait(false);
+            await CreateInstanceMSMQ();
 
             logger.Info("Changing the URLACL");
             var msmqTestInstance = InstanceFinder.ServiceControlInstances().First(p => p.Name.Equals("Test.ServiceControl.MSMQ", StringComparison.OrdinalIgnoreCase));
             msmqTestInstance.HostName = Environment.MachineName;
             msmqTestInstance.Port = 33338;
             msmqTestInstance.DatabaseMaintenancePort = 33339;
-            await installer.Update(msmqTestInstance, true).ConfigureAwait(false);
+            await installer.Update(msmqTestInstance, true);
             Assert.That(msmqTestInstance.Service.Status, Is.EqualTo(ServiceControllerStatus.Running), "Update URL change failed");
 
             logger.Info("Changing LogPath");
             msmqTestInstance = InstanceFinder.ServiceControlInstances().First(p => p.Name.Equals("Test.ServiceControl.MSMQ", StringComparison.OrdinalIgnoreCase));
             msmqTestInstance.LogPath = Path.Combine(Path.GetTempPath(), "testloggingchange");
-            await installer.Update(msmqTestInstance, true).ConfigureAwait(false);
+            await installer.Update(msmqTestInstance, true);
             Assert.That(msmqTestInstance.Service.Status, Is.EqualTo(ServiceControllerStatus.Running), "Update Logging changed failed");
 
             logger.Info("Updating Queue paths");
             msmqTestInstance = InstanceFinder.ServiceControlInstances().First(p => p.Name.Equals("Test.ServiceControl.MSMQ", StringComparison.OrdinalIgnoreCase));
             msmqTestInstance.AuditQueue = "alternateAudit";
             msmqTestInstance.ErrorQueue = "alternateError";
-            await installer.Update(msmqTestInstance, true).ConfigureAwait(false);
+            await installer.Update(msmqTestInstance, true);
             Assert.That(msmqTestInstance.Service.Status, Is.EqualTo(ServiceControllerStatus.Running), "Update Queues changed failed");
         }
 

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringInstance.cs
@@ -116,7 +116,7 @@
         {
             try
             {
-                await new PathsValidator(this).RunValidation(false).ConfigureAwait(false);
+                await new PathsValidator(this).RunValidation(false);
             }
             catch (EngineValidationException ex)
             {

--- a/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/MonitoringNewInstance.cs
@@ -181,7 +181,7 @@
 
             try
             {
-                ReportCard.CancelRequested = await new PathsValidator(this).RunValidation(true, promptToProceed).ConfigureAwait(false);
+                ReportCard.CancelRequested = await new PathsValidator(this).RunValidation(true, promptToProceed);
             }
             catch (EngineValidationException ex)
             {

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlBaseService.cs
@@ -398,7 +398,7 @@ namespace ServiceControlInstaller.Engine.Instances
 
         public async Task ValidateChanges()
         {
-            await ValidatePaths().ConfigureAwait(false);
+            await ValidatePaths();
 
             ValidateQueueNames();
 

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstallableBase.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstallableBase.cs
@@ -245,7 +245,7 @@
 
             try
             {
-                ReportCard.CancelRequested = await ValidatePaths(promptToProceed).ConfigureAwait(false);
+                ReportCard.CancelRequested = await ValidatePaths(promptToProceed);
             }
             catch (EngineValidationException ex)
             {

--- a/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
+++ b/src/ServiceControlInstaller.Engine/Instances/ServiceControlInstance.cs
@@ -77,7 +77,7 @@ namespace ServiceControlInstaller.Engine.Instances
         {
             try
             {
-                await new PathsValidator(this).RunValidation(false).ConfigureAwait(false);
+                await new PathsValidator(this).RunValidation(false);
             }
             catch (EngineValidationException ex)
             {

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendAuditInstaller.cs
@@ -27,7 +27,7 @@
             instanceInstaller.Version = Constants.CurrentVersion;
 
             //Validation
-            await instanceInstaller.Validate(promptToProceed).ConfigureAwait(false);
+            await instanceInstaller.Validate(promptToProceed);
             if (instanceInstaller.ReportCard.HasErrors)
             {
                 foreach (var error in instanceInstaller.ReportCard.Errors)

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendMonitoringInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendMonitoringInstaller.cs
@@ -26,7 +26,7 @@
             instanceInstaller.ReportCard = new ReportCard();
 
             //Validation
-            await instanceInstaller.Validate(promptToProceed).ConfigureAwait(false);
+            await instanceInstaller.Validate(promptToProceed);
             if (instanceInstaller.ReportCard.HasErrors)
             {
                 foreach (var error in instanceInstaller.ReportCard.Errors)
@@ -143,7 +143,7 @@
         internal async Task<bool> Update(MonitoringInstance instance, bool startService)
         {
             instance.ReportCard = new ReportCard();
-            await instance.ValidateChanges().ConfigureAwait(false);
+            await instance.ValidateChanges();
             if (instance.ReportCard.HasErrors)
             {
                 foreach (var error in instance.ReportCard.Errors)

--- a/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
+++ b/src/ServiceControlInstaller.Engine/Unattended/UnattendServiceControlInstaller.cs
@@ -32,7 +32,7 @@
                 instanceInstaller.Version = Constants.CurrentVersion;
 
                 //Validation
-                await instanceInstaller.Validate(promptToProceed).ConfigureAwait(false);
+                await instanceInstaller.Validate(promptToProceed);
 
                 if (instanceInstaller.ReportCard.HasErrors)
                 {
@@ -147,7 +147,7 @@
         internal async Task<bool> Update(ServiceControlInstance instance, bool startService)
         {
             instance.ReportCard = new ReportCard();
-            await instance.ValidateChanges().ConfigureAwait(false);
+            await instance.ValidateChanges();
             if (instance.ReportCard.HasErrors)
             {
                 return false;

--- a/src/ServiceControlInstaller.Engine/Validation/AbstractCommandChecks.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/AbstractCommandChecks.cs
@@ -26,12 +26,12 @@
         public async Task<bool> CanAddInstance()
         {
             // Check for license
-            if (!await IsLicenseOk().ConfigureAwait(false))
+            if (!await IsLicenseOk())
             {
                 return false;
             }
 
-            if (await OldVersionOfServiceControlInstalled().ConfigureAwait(false))
+            if (await OldVersionOfServiceControlInstalled())
             {
                 return false;
             }
@@ -47,7 +47,7 @@
                 .Select(i => i.TransportPackage)
                 .First(t => t is not null);
 
-            var continueInstall = await RabbitMqCheckIsOK(transport, Constants.CurrentVersion, false).ConfigureAwait(false);
+            var continueInstall = await RabbitMqCheckIsOK(transport, Constants.CurrentVersion, false);
 
             return continueInstall;
         }
@@ -68,14 +68,14 @@
             {
                 var verb = isDelete ? "remove" : "edit";
                 var message = $"This instance version {instanceVersion} is newer than the installer version {Constants.CurrentVersion}. This installer can only {verb} instances with versions between {Constants.CurrentVersion.Major}.0.0 and {Constants.CurrentVersion}.";
-                await NotifyError(title, message).ConfigureAwait(false);
+                await NotifyError(title, message);
                 return false;
             }
 
             if (installerOfDifferentMajor && !isDelete)
             {
                 var message = $"This installer cannot edit instances created by a different major version. A {instanceVersion.Major}.* installer version greater or equal to {instanceVersion.Major}.{instanceVersion.Minor}.{instanceVersion.Patch} must be used instead.";
-                await NotifyError(title, message).ConfigureAwait(false);
+                await NotifyError(title, message);
                 return false;
             }
 
@@ -99,18 +99,18 @@
                 return true;
             }
 
-            return await PromptForRabbitMqCheck(isUpgrade).ConfigureAwait(false);
+            return await PromptForRabbitMqCheck(isUpgrade);
         }
 
         public async Task<bool> CanUpgradeInstance(BaseService instance, bool forceUpgradeDb = false)
         {
             // Check for license
-            if (!await IsLicenseOk().ConfigureAwait(false))
+            if (!await IsLicenseOk())
             {
                 return false;
             }
 
-            if (await OldVersionOfServiceControlInstalled().ConfigureAwait(false))
+            if (await OldVersionOfServiceControlInstalled())
             {
                 return false;
             }
@@ -119,7 +119,7 @@
             var cantUpdateTransport = instance.TransportPackage.Removed && instance.TransportPackage.AutoMigrateTo is null;
             if (cantUpdateTransport)
             {
-                await NotifyForDeprecatedMessageTransport(instance.TransportPackage).ConfigureAwait(false);
+                await NotifyForDeprecatedMessageTransport(instance.TransportPackage);
                 return false;
             }
 
@@ -134,11 +134,11 @@
 
                     if (!forceUpgradeAllowed)
                     {
-                        await NotifyError("Cannot run the command", "Only ServiceControl 4.x primary instances that use RavenDB 3.5 persistence can be force-upgraded.").ConfigureAwait(false);
+                        await NotifyError("Cannot run the command", "Only ServiceControl 4.x primary instances that use RavenDB 3.5 persistence can be force-upgraded.");
                         return false;
                     }
 
-                    if (!await PromptToContinueWithForcedUpgrade().ConfigureAwait(false))
+                    if (!await PromptToContinueWithForcedUpgrade())
                     {
                         return false;
                     }
@@ -149,7 +149,7 @@
 
                     if (!compatibleStorageEngine)
                     {
-                        await NotifyForIncompatibleStorageEngine(baseInstance).ConfigureAwait(false);
+                        await NotifyForIncompatibleStorageEngine(baseInstance);
                         return false;
                     }
                 }
@@ -159,12 +159,12 @@
                 var upgradeInfo = UpgradeInfo.GetUpgradePathFor(instance.Version);
                 if (upgradeInfo.HasIncompatibleVersion)
                 {
-                    await NotifyForIncompatibleUpgradeVersion(upgradeInfo).ConfigureAwait(false);
+                    await NotifyForIncompatibleUpgradeVersion(upgradeInfo);
                     return false;
                 }
             }
 
-            if (!await RabbitMqCheckIsOK(instance.TransportPackage, instance.Version, isUpgrade: true).ConfigureAwait(false))
+            if (!await RabbitMqCheckIsOK(instance.TransportPackage, instance.Version, isUpgrade: true))
             {
                 return false;
             }
@@ -177,7 +177,7 @@
             if (OldScmuCheck.OldVersionOfServiceControlInstalled(out var installedVersion))
             {
                 var message = $"An old version {installedVersion} of ServiceControl Management is installed, which will not work after installing new instances. Before installing ServiceControl 5 instances, you must either uninstall the {installedVersion} instance or update it to a 4.x version at least {OldScmuCheck.MinimumScmuVersion}.";
-                await NotifyError("Outdated Version Installed", message).ConfigureAwait(false);
+                await NotifyError("Outdated Version Installed", message);
                 return true;
             }
 
@@ -189,7 +189,7 @@
             var licenseCheckResult = CheckLicenseIsValid();
             if (!licenseCheckResult.Valid)
             {
-                await NotifyError("License Error", $"Upgrade could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact contact@particular.net").ConfigureAwait(false);
+                await NotifyError("License Error", $"Upgrade could not continue due to an issue with the current license. {licenseCheckResult.Message}.  Contact contact@particular.net");
                 return false;
             }
 
@@ -203,7 +203,7 @@
                 return false;
             }
 
-            var proceed = await PromptToStopRunningInstance(instance).ConfigureAwait(false);
+            var proceed = await PromptToStopRunningInstance(instance);
 
             return !proceed;
         }

--- a/src/ServiceControlInstaller.Engine/Validation/PathsValidator.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/PathsValidator.cs
@@ -69,7 +69,7 @@ namespace ServiceControlInstaller.Engine.Validation
                 //Do Checks that only make sense on add instance
                 if (includeNewInstanceChecks)
                 {
-                    cancelRequested = await CheckPathsAreEmpty(promptToProceed).ConfigureAwait(false);
+                    cancelRequested = await CheckPathsAreEmpty(promptToProceed);
                 }
 
                 return cancelRequested;
@@ -104,7 +104,7 @@ namespace ServiceControlInstaller.Engine.Validation
 
                     if (directory.EnumerateFileSystemInfos().Any())
                     {
-                        var shouldProceed = await promptToProceed(pathInfo).ConfigureAwait(false);
+                        var shouldProceed = await promptToProceed(pathInfo);
                         if (!shouldProceed)
                         {
                             return true;


### PR DESCRIPTION
Since I don't see a use case where SC would need to set it

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007#when-to-suppress-warnings

