### PR TITLE
Fix audit forwarding when saga audit messages are enabled

### DIFF
--- a/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
@@ -70,8 +70,7 @@
 
         Task Forward(IReadOnlyCollection<MessageContext> messageContexts, string forwardingAddress, CancellationToken cancellationToken)
         {
-            var transportOperations = new TransportOperation[messageContexts.Count]; //We could allocate based on the actual number of ProcessedMessages but this should be OK
-            var index = 0;
+            var transportOperations = new List<TransportOperation>();
             MessageContext anyContext = null;
             foreach (var messageContext in messageContexts)
             {
@@ -90,13 +89,12 @@
                 // Forwarded messages should last as long as possible
                 outgoingMessage.Headers.Remove(Headers.TimeToBeReceived);
 
-                transportOperations[index] = new TransportOperation(outgoingMessage, new UnicastAddressTag(forwardingAddress));
-                index++;
+                transportOperations.Add(new TransportOperation(outgoingMessage, new UnicastAddressTag(forwardingAddress)));
             }
 
             return anyContext != null
                 ? messageDispatcher.Value.Dispatch(
-                    new TransportOperations(transportOperations),
+                    new TransportOperations(transportOperations.ToArray()),
                     anyContext.TransportTransaction, cancellationToken)
                 : Task.CompletedTask;
         }

--- a/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
@@ -70,7 +70,7 @@
 
         Task Forward(IReadOnlyCollection<MessageContext> messageContexts, string forwardingAddress, CancellationToken cancellationToken)
         {
-            var transportOperations = new List<TransportOperation>();
+            var transportOperations = new List<TransportOperation>(messageContexts.Count);
             MessageContext anyContext = null;
             foreach (var messageContext in messageContexts)
             {

--- a/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
@@ -94,7 +94,7 @@
 
             return anyContext != null
                 ? messageDispatcher.Value.Dispatch(
-                    new TransportOperations(transportOperations.ToArray()),
+                    new TransportOperations([.. transportOperations]),
                     anyContext.TransportTransaction, cancellationToken)
                 : Task.CompletedTask;
         }


### PR DESCRIPTION
When audit forwarding is enabled and saga audit messages (`Auditype` = `SagaSnapshot`) are being audited also, the array being used to store the transport operations would end up being too large and having `null` elements.

Changing to a `List` prevents this from being a problem.

Fixes #4893