### PR TITLE
Adjust RavenDB license test to one week out instead of two

### DIFF
--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/LicenseTest.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/LicenseTest.cs
@@ -37,7 +37,7 @@
                         Assert.That(details.Status, Is.EqualTo("Commercial"));
                         Assert.That(details.Expired, Is.False);
                         Assert.That(details.Type, Is.EqualTo("Professional"));
-                        Assert.That(DateTime.UtcNow.AddDays(14), Is.LessThan(details.Expiration), $"The RavenDB license expires {details.Expiration} which is less than 2 weeks. Contact RavenDB at <sales@ravendb.net> for the new license.");
+                        Assert.That(DateTime.UtcNow.AddDays(7), Is.LessThan(details.Expiration), $"The RavenDB license expires {details.Expiration} which is less than one week. Contact RavenDB at <sales@ravendb.net> for the new license.");
                     });
                 }
             }


### PR DESCRIPTION
The intention of the test is let us know when we need to get an updated license, but the current design means we are blocked unnecessarily when the license is still valid.

For now, I've adjusted the warning time to be one week instead of two, but what we really need to do is have a test that fails if our license is not valid for the RavenDB version we are referencing, and have some sort of out of band reminder about renewal.