### PR TITLE
Dirty memory check may fail connecting to RavenDB when using external mode

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -13,7 +13,7 @@ class MemoryInformationRetriever(DatabaseConfiguration databaseConfiguration)
     // string when running in external mode. However, the tricky part is that when tests are run they
     // behave like if it was external mode. If the connection string contain always only the server
     // URL, this code is safe, otherwise it need to be adjusted to extract the server URL.
-    readonly HttpClient client = new() { BaseAddress = new Uri(databaseConfiguration.ServerConfiguration.ServerUrl ?? databaseConfiguration.ServerConfiguration.ConnectionString) };
+    readonly HttpClient client = new() { BaseAddress = new Uri(databaseConfiguration.ServerConfiguration.ConnectionString ?? databaseConfiguration.ServerConfiguration.ServerUrl) };
 
     record ResponseDto
     {

--- a/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -11,8 +11,8 @@ class MemoryInformationRetriever(DatabaseConfiguration databaseConfiguration)
     // Connection string is composed of the server URL. The ?? operator is needed because ServerUrl
     // is populated when running embedded and connection string when running in external mode.
     // However, the tricky part is that when tests are run they behave like if it was external mode.
-    // ServerUrl is always populated by the persister settings, hence the code first checks for the
-    // presence of a connection string, and if null, falls back to ServerUrl
+    // Only one of ConnectionString and ServerUrl will be non-null, so we'll check ConnectionString first
+    // to be consistent with the error instance implementation, where ServerUrl always has a value.
     readonly HttpClient client = new() { BaseAddress = new Uri(databaseConfiguration.ServerConfiguration.ConnectionString ?? databaseConfiguration.ServerConfiguration.ServerUrl) };
 
     record ResponseDto

--- a/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -8,11 +8,11 @@ using System.Threading.Tasks;
 
 class MemoryInformationRetriever(DatabaseConfiguration databaseConfiguration)
 {
-    // What does a connection string look like? Is it only a URI or could it contain other stuff?
-    // The ?? operator is needed because ServerUrl is populated when running embedded and connection
-    // string when running in external mode. However, the tricky part is that when tests are run they
-    // behave like if it was external mode. If the connection string contain always only the server
-    // URL, this code is safe, otherwise it need to be adjusted to extract the server URL.
+    // Connection string is composed of the server URL. The ?? operator is needed because ServerUrl
+    // is populated when running embedded and connection string when running in external mode.
+    // However, the tricky part is that when tests are run they behave like if it was external mode.
+    // ServerUrl is always populated by the persister settings, hence the code first checks for the
+    // presence of a connection string, and if null, falls back to ServerUrl
     readonly HttpClient client = new() { BaseAddress = new Uri(databaseConfiguration.ServerConfiguration.ConnectionString ?? databaseConfiguration.ServerConfiguration.ServerUrl) };
 
     record ResponseDto

--- a/src/ServiceControl.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -8,11 +8,11 @@ using System.Threading.Tasks;
 
 class MemoryInformationRetriever(RavenPersisterSettings persisterSettings)
 {
-    // What does a connection string look like? Is it only a URI or could it contain other stuff?
-    // The ?? operator is needed because ServerUrl is populated when running embedded and connection
-    // string when running in external mode. However, the tricky part is that when tests are run they
-    // behave like if it was external mode. If the connection string contain always only the server
-    // URL, this code is safe, otherwise it need to be adjusted to extract the server URL.
+    // Connection string is composed of the server URL. The ?? operator is needed because ServerUrl
+    // is populated when running embedded and connection string when running in external mode.
+    // However, the tricky part is that when tests are run they behave like if it was external mode.
+    // ServerUrl is always populated by the persister settings, hence the code first checks for the
+    // presence of a connection string, and if null, falls back to ServerUrl
     readonly HttpClient client = new() { BaseAddress = new Uri(persisterSettings.ConnectionString ?? persisterSettings.ServerUrl) };
 
     record ResponseDto

--- a/src/ServiceControl.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -9,10 +9,11 @@ using System.Threading.Tasks;
 class MemoryInformationRetriever(RavenPersisterSettings persisterSettings)
 {
     // What does a connection string look like? Is it only a URI or could it contain other stuff?
-    // The primary instance has only the concept of a connection string (vs the Audit instance having
-    // both a ServiceUrl and a ConnectionString). If the connection string contain always only the
-    // server URL, this code is safe, otherwise it need to be adjusted to extract the server URL.
-    readonly HttpClient client = new() { BaseAddress = new Uri(persisterSettings.ServerUrl ?? persisterSettings.ConnectionString) };
+    // The ?? operator is needed because ServerUrl is populated when running embedded and connection
+    // string when running in external mode. However, the tricky part is that when tests are run they
+    // behave like if it was external mode. If the connection string contain always only the server
+    // URL, this code is safe, otherwise it need to be adjusted to extract the server URL.
+    readonly HttpClient client = new() { BaseAddress = new Uri(persisterSettings.ConnectionString ?? persisterSettings.ServerUrl) };
 
     record ResponseDto
     {


### PR DESCRIPTION
The RavenDB persister (both for the primary and the audit instances) always sets the ServerUrl value to `localhost` using the configured maintenance port. When running in external mode and RavenDB is on the same machine or the RavenDB container is in the same network, `localhost` may work, and the persisted connection string and server URL values match. However, it's better to favor using the connection string over the server URL when connecting to RavenDB to retrieve dirty memory details, and fallback to the server URL if the connection string is not set.