### PR TITLE
New endpoint to support migration of SI to SP

### DIFF
--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditDataStore.cs
@@ -42,7 +42,7 @@
             return await Task.FromResult(new QueryResult<SagaHistory>(sagaHistory, new QueryStatsInfo(string.Empty, 1)));
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
         {
             var matched = messageViews
                 .Where(w => !w.IsSystemMessage || includeSystemMessages)
@@ -51,7 +51,7 @@
             return await Task.FromResult(new QueryResult<IList<MessagesView>>(matched, new QueryStatsInfo(string.Empty, matched.Count)));
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessages(string keyword, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessages(string keyword, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
         {
             var messages = GetMessageIdsMatchingQuery(keyword);
 
@@ -61,7 +61,7 @@
             return await Task.FromResult(new QueryResult<IList<MessagesView>>(matched, new QueryStatsInfo(string.Empty, matched.Count())));
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
         {
             var messages = GetMessageIdsMatchingQuery(keyword);
 
@@ -69,7 +69,7 @@
             return await Task.FromResult(new QueryResult<IList<MessagesView>>(matched, new QueryStatsInfo(string.Empty, matched.Count)));
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
         {
             var matched = messageViews.Where(w => w.ReceivingEndpoint.Name == endpointName).ToList();
             return await Task.FromResult(new QueryResult<IList<MessagesView>>(matched, new QueryStatsInfo(string.Empty, matched.Count)));

--- a/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.InMemory/InMemoryAuditDataStore.cs
@@ -42,7 +42,7 @@
             return await Task.FromResult(new QueryResult<SagaHistory>(sagaHistory, new QueryStatsInfo(string.Empty, 1)));
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken)
         {
             var matched = messageViews
                 .Where(w => !w.IsSystemMessage || includeSystemMessages)
@@ -51,7 +51,7 @@
             return await Task.FromResult(new QueryResult<IList<MessagesView>>(matched, new QueryStatsInfo(string.Empty, matched.Count)));
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessages(string keyword, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessages(string keyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken)
         {
             var messages = GetMessageIdsMatchingQuery(keyword);
 
@@ -61,7 +61,7 @@
             return await Task.FromResult(new QueryResult<IList<MessagesView>>(matched, new QueryStatsInfo(string.Empty, matched.Count())));
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken)
         {
             var messages = GetMessageIdsMatchingQuery(keyword);
 
@@ -69,7 +69,7 @@
             return await Task.FromResult(new QueryResult<IList<MessagesView>>(matched, new QueryStatsInfo(string.Empty, matched.Count)));
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken)
         {
             var matched = messageViews.Where(w => w.ReceivingEndpoint.Name == endpointName).ToList();
             return await Task.FromResult(new QueryResult<IList<MessagesView>>(matched, new QueryStatsInfo(string.Empty, matched.Count)));

--- a/src/ServiceControl.Audit.Persistence.RavenDB/Extensions/RavenQueryExtensions.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/Extensions/RavenQueryExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Audit.Persistence.RavenDB.Extensions
 {
     using System;
+    using System.Globalization;
     using System.Linq;
     using System.Linq.Expressions;
     using Indexes;
@@ -18,6 +19,45 @@
 
             return source;
         }
+
+        public static IQueryable<MessagesViewIndex.SortAndFilterOptions> FilterBySentTimeRange(this IQueryable<MessagesViewIndex.SortAndFilterOptions> source, string range)
+        {
+            if (string.IsNullOrWhiteSpace(range))
+            {
+                return source;
+            }
+
+            var filters = range.Split(SplitChars, StringSplitOptions.None);
+            DateTime from, to;
+            try
+            {
+
+                if (filters.Length == 2)
+                {
+                    from = DateTime.Parse(filters[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                    to = DateTime.Parse(filters[1], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                    source.Where(m => m.TimeSent >= from && m.TimeSent <= to);
+
+                }
+                else
+                {
+                    from = DateTime.Parse(filters[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                    source.Where(m => m.TimeSent >= from);
+                }
+            }
+            catch (Exception)
+            {
+                throw new Exception(
+                    "Invalid sent time date range, dates need to be in ISO8601 format and it needs to be a range eg. 2016-03-11T00:27:15.474Z...2016-03-16T03:27:15.474Z");
+            }
+
+            return source;
+        }
+
+        static string[] SplitChars =
+        {
+            "..."
+        };
 
         public static IQueryable<TSource> Paging<TSource>(this IQueryable<TSource> source, PagingInfo pagingInfo)
             => source.Skip(pagingInfo.Offset).Take(pagingInfo.PageSize);

--- a/src/ServiceControl.Audit.Persistence.RavenDB/Extensions/RavenQueryExtensions.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/Extensions/RavenQueryExtensions.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.Audit.Persistence.RavenDB.Extensions
 {
     using System;
-    using System.Globalization;
     using System.Linq;
     using System.Linq.Expressions;
     using Indexes;
@@ -20,44 +19,25 @@
             return source;
         }
 
-        public static IQueryable<MessagesViewIndex.SortAndFilterOptions> FilterBySentTimeRange(this IQueryable<MessagesViewIndex.SortAndFilterOptions> source, string range)
+        public static IQueryable<MessagesViewIndex.SortAndFilterOptions> FilterBySentTimeRange(this IQueryable<MessagesViewIndex.SortAndFilterOptions> source, DateTimeRange range)
         {
-            if (string.IsNullOrWhiteSpace(range))
+            if (range == null)
             {
                 return source;
             }
 
-            var filters = range.Split(SplitChars, StringSplitOptions.None);
-            DateTime from, to;
-            try
+            if (range.From.HasValue)
             {
-
-                if (filters.Length == 2)
-                {
-                    from = DateTime.Parse(filters[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-                    to = DateTime.Parse(filters[1], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-                    source.Where(m => m.TimeSent >= from && m.TimeSent <= to);
-
-                }
-                else
-                {
-                    from = DateTime.Parse(filters[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-                    source.Where(m => m.TimeSent >= from);
-                }
+                source = source.Where(m => m.TimeSent >= range.From);
             }
-            catch (Exception)
+
+            if (range.To.HasValue)
             {
-                throw new Exception(
-                    "Invalid sent time date range, dates need to be in ISO8601 format and it needs to be a range eg. 2016-03-11T00:27:15.474Z...2016-03-16T03:27:15.474Z");
+                source = source.Where(m => m.TimeSent <= range.To);
             }
 
             return source;
         }
-
-        static string[] SplitChars =
-        {
-            "..."
-        };
 
         public static IQueryable<TSource> Paging<TSource>(this IQueryable<TSource> source, PagingInfo pagingInfo)
             => source.Skip(pagingInfo.Offset).Take(pagingInfo.PageSize);

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenAuditDataStore.cs
@@ -31,7 +31,7 @@
             return sagaHistory == null ? QueryResult<SagaHistory>.Empty() : new QueryResult<SagaHistory>(sagaHistory, new QueryStatsInfo($"{stats.ResultEtag}", stats.TotalResults));
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken)
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
@@ -46,7 +46,7 @@
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessages(string searchParam, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessages(string searchParam, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken)
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
@@ -61,7 +61,7 @@
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken)
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
@@ -77,7 +77,7 @@
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken)
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenAuditDataStore.cs
@@ -31,11 +31,12 @@
             return sagaHistory == null ? QueryResult<SagaHistory>.Empty() : new QueryResult<SagaHistory>(sagaHistory, new QueryStatsInfo($"{stats.ResultEtag}", stats.TotalResults));
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
                 .Statistics(out var stats)
+                .FilterBySentTimeRange(timeSentRange)
                 .IncludeSystemMessagesWhere(includeSystemMessages)
                 .Sort(sortInfo)
                 .Paging(pagingInfo)
@@ -45,12 +46,13 @@
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessages(string searchParam, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessages(string searchParam, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
                 .Statistics(out var stats)
                 .Search(x => x.Query, searchParam)
+                .FilterBySentTimeRange(timeSentRange)
                 .Sort(sortInfo)
                 .Paging(pagingInfo)
                 .ToMessagesView()
@@ -59,13 +61,14 @@
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
                 .Statistics(out var stats)
                 .Search(x => x.Query, keyword)
                 .Where(m => m.ReceivingEndpointName == endpoint)
+                .FilterBySentTimeRange(timeSentRange)
                 .Sort(sortInfo)
                 .Paging(pagingInfo)
                 .ToMessagesView()
@@ -74,13 +77,14 @@
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
 
-        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken)
+        public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken)
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
                 .Statistics(out var stats)
                 .IncludeSystemMessagesWhere(includeSystemMessages)
                 .Where(m => m.ReceivingEndpointName == endpointName)
+                .FilterBySentTimeRange(timeSentRange)
                 .Sort(sortInfo)
                 .Paging(pagingInfo)
                 .ToMessagesView()

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/RetentionTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/RetentionTests.cs
@@ -32,11 +32,11 @@
                 message
                 );
 
-            var queryResultBeforeExpiration = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), TestContext.CurrentContext.CancellationToken);
+            var queryResultBeforeExpiration = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), null, TestContext.CurrentContext.CancellationToken);
 
             await Task.Delay(4000);
 
-            var queryResultAfterExpiration = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), TestContext.CurrentContext.CancellationToken);
+            var queryResultAfterExpiration = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), null, TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResultBeforeExpiration.Results, Has.Count.EqualTo(1));
             Assert.Multiple(() =>

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/RetentionTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/RetentionTests.cs
@@ -28,15 +28,13 @@
         {
             var message = MakeMessage("MyMessageId");
 
-            await IngestProcessedMessagesAudits(
-                message
-                );
+            await IngestProcessedMessagesAudits(message);
 
-            var queryResultBeforeExpiration = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), null, TestContext.CurrentContext.CancellationToken);
+            var queryResultBeforeExpiration = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), cancellationToken: TestContext.CurrentContext.CancellationToken);
 
             await Task.Delay(4000);
 
-            var queryResultAfterExpiration = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), null, TestContext.CurrentContext.CancellationToken);
+            var queryResultAfterExpiration = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), cancellationToken: TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResultBeforeExpiration.Results, Has.Count.EqualTo(1));
             Assert.Multiple(() =>

--- a/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
@@ -30,7 +30,7 @@
                 message
                 );
 
-            var queryResult = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), TestContext.CurrentContext.CancellationToken);
+            var queryResult = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), null, TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.Results, Has.Count.EqualTo(1));
             Assert.That(queryResult.Results[0].MessageId, Is.EqualTo("MyMessageId"));
@@ -40,7 +40,7 @@
         public async Task Handles_no_results_gracefully()
         {
             var nonExistingMessage = Guid.NewGuid().ToString();
-            var queryResult = await DataStore.QueryMessages(nonExistingMessage, new PagingInfo(), new SortInfo("Id", "asc"), TestContext.CurrentContext.CancellationToken);
+            var queryResult = await DataStore.QueryMessages(nonExistingMessage, new PagingInfo(), new SortInfo("Id", "asc"), null, TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.Results, Is.Empty);
         }
@@ -73,7 +73,7 @@
             );
 
             var queryResult = await DataStore.QueryMessages("MyMessageType", new PagingInfo(),
-                new SortInfo("message_id", "asc"), TestContext.CurrentContext.CancellationToken);
+                new SortInfo("message_id", "asc"), null, TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.Results, Has.Count.EqualTo(2));
         }
@@ -158,7 +158,7 @@
 
             await configuration.CompleteDBOperation();
 
-            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), TestContext.CurrentContext.CancellationToken);
+            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), null, TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.QueryStats.TotalCount, Is.EqualTo(1));
         }
@@ -182,7 +182,7 @@
 
             await configuration.CompleteDBOperation();
 
-            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), TestContext.CurrentContext.CancellationToken);
+            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), null, TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.QueryStats.TotalCount, Is.EqualTo(1));
         }
@@ -205,7 +205,7 @@
 
             await configuration.CompleteDBOperation();
 
-            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), TestContext.CurrentContext.CancellationToken);
+            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), null, TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.QueryStats.TotalCount, Is.EqualTo(2));
         }

--- a/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
@@ -30,7 +30,7 @@
                 message
                 );
 
-            var queryResult = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), null, TestContext.CurrentContext.CancellationToken);
+            var queryResult = await DataStore.QueryMessages("MyMessageId", new PagingInfo(), new SortInfo("Id", "asc"), cancellationToken: TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.Results, Has.Count.EqualTo(1));
             Assert.That(queryResult.Results[0].MessageId, Is.EqualTo("MyMessageId"));
@@ -40,7 +40,7 @@
         public async Task Handles_no_results_gracefully()
         {
             var nonExistingMessage = Guid.NewGuid().ToString();
-            var queryResult = await DataStore.QueryMessages(nonExistingMessage, new PagingInfo(), new SortInfo("Id", "asc"), null, TestContext.CurrentContext.CancellationToken);
+            var queryResult = await DataStore.QueryMessages(nonExistingMessage, new PagingInfo(), new SortInfo("Id", "asc"), cancellationToken: TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.Results, Is.Empty);
         }
@@ -73,7 +73,7 @@
             );
 
             var queryResult = await DataStore.QueryMessages("MyMessageType", new PagingInfo(),
-                new SortInfo("message_id", "asc"), null, TestContext.CurrentContext.CancellationToken);
+                new SortInfo("message_id", "asc"), cancellationToken: TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.Results, Has.Count.EqualTo(2));
         }
@@ -158,7 +158,7 @@
 
             await configuration.CompleteDBOperation();
 
-            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), null, TestContext.CurrentContext.CancellationToken);
+            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), cancellationToken: TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.QueryStats.TotalCount, Is.EqualTo(1));
         }
@@ -182,7 +182,7 @@
 
             await configuration.CompleteDBOperation();
 
-            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), null, TestContext.CurrentContext.CancellationToken);
+            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), cancellationToken: TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.QueryStats.TotalCount, Is.EqualTo(1));
         }
@@ -205,7 +205,7 @@
 
             await configuration.CompleteDBOperation();
 
-            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), null, TestContext.CurrentContext.CancellationToken);
+            var queryResult = await DataStore.GetMessages(false, new PagingInfo(), new SortInfo("message_id", "asc"), cancellationToken: TestContext.CurrentContext.CancellationToken);
 
             Assert.That(queryResult.QueryStats.TotalCount, Is.EqualTo(2));
         }

--- a/src/ServiceControl.Audit.Persistence/IAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence/IAuditDataStore.cs
@@ -14,10 +14,10 @@
     {
         Task<QueryResult<IList<KnownEndpointsView>>> QueryKnownEndpoints(CancellationToken cancellationToken);
         Task<QueryResult<SagaHistory>> QuerySagaHistoryById(Guid input, CancellationToken cancellationToken);
-        Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken);
-        Task<QueryResult<IList<MessagesView>>> QueryMessages(string searchParam, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken);
-        Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken);
-        Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken);
+        Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken);
+        Task<QueryResult<IList<MessagesView>>> QueryMessages(string searchParam, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken);
+        Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken);
+        Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken);
         Task<QueryResult<IList<MessagesView>>> QueryMessagesByConversationId(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken);
         Task<MessageBodyView> GetMessageBody(string messageId, CancellationToken cancellationToken);
         Task<QueryResult<IList<AuditCount>>> QueryAuditCounts(string endpointName, CancellationToken cancellationToken);

--- a/src/ServiceControl.Audit.Persistence/IAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence/IAuditDataStore.cs
@@ -14,10 +14,10 @@
     {
         Task<QueryResult<IList<KnownEndpointsView>>> QueryKnownEndpoints(CancellationToken cancellationToken);
         Task<QueryResult<SagaHistory>> QuerySagaHistoryById(Guid input, CancellationToken cancellationToken);
-        Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken);
-        Task<QueryResult<IList<MessagesView>>> QueryMessages(string searchParam, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken);
-        Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken);
-        Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange, CancellationToken cancellationToken);
+        Task<QueryResult<IList<MessagesView>>> GetMessages(bool includeSystemMessages, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> QueryMessages(string searchParam, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
         Task<QueryResult<IList<MessagesView>>> QueryMessagesByConversationId(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken);
         Task<MessageBodyView> GetMessageBody(string messageId, CancellationToken cancellationToken);
         Task<QueryResult<IList<AuditCount>>> QueryAuditCounts(string endpointName, CancellationToken cancellationToken);

--- a/src/ServiceControl.Audit.Persistence/Infrastructure/DateTimeRange.cs
+++ b/src/ServiceControl.Audit.Persistence/Infrastructure/DateTimeRange.cs
@@ -1,0 +1,28 @@
+namespace ServiceControl.Audit.Infrastructure;
+
+using System;
+using System.Globalization;
+
+public class DateTimeRange
+{
+    public DateTime? From { get; }
+    public DateTime? To { get; }
+
+    public DateTimeRange(string from = null, string to = null)
+    {
+        if (from != null)
+        {
+            From = DateTime.Parse(from, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        }
+        if (to != null)
+        {
+            To = DateTime.Parse(to, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        }
+    }
+
+    public DateTimeRange(DateTime? from = null, DateTime? to = null)
+    {
+        From = from;
+        To = to;
+    }
+}

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.HttpApiRoutes.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.HttpApiRoutes.approved.txt
@@ -12,4 +12,5 @@ GET /messages => ServiceControl.Audit.Auditing.MessagesView.GetMessagesControlle
 GET /messages/{id}/body => ServiceControl.Audit.Auditing.MessagesView.GetMessagesController:Get(String id, CancellationToken cancellationToken)
 GET /messages/search => ServiceControl.Audit.Auditing.MessagesView.GetMessagesController:Search(PagingInfo pagingInfo, SortInfo sortInfo, String q, CancellationToken cancellationToken)
 GET /messages/search/{keyword} => ServiceControl.Audit.Auditing.MessagesView.GetMessagesController:SearchByKeyWord(PagingInfo pagingInfo, SortInfo sortInfo, String keyword, CancellationToken cancellationToken)
+GET /messages2 => ServiceControl.Audit.Auditing.MessagesView.GetMessages2Controller:GetAllMessages(SortInfo sortInfo, Int32 pageSize, String endpointName, String from, String to, String q, CancellationToken cancellationToken)
 GET /sagas/{id} => ServiceControl.Audit.SagaAudit.SagasController:Sagas(PagingInfo pagingInfo, Guid id, CancellationToken cancellationToken)

--- a/src/ServiceControl.Audit/Auditing/MessagesView/GetMessages2Controller.cs
+++ b/src/ServiceControl.Audit/Auditing/MessagesView/GetMessages2Controller.cs
@@ -18,7 +18,8 @@ public class GetMessages2Controller(IAuditDataStore dataStore) : ControllerBase
         [FromQuery] SortInfo sortInfo,
         [FromQuery(Name = "page_size")] int pageSize,
         [FromQuery(Name = "endpoint_name")] string endpointName,
-        [FromQuery(Name = "range")] string range,
+        [FromQuery(Name = "from")] string from,
+        [FromQuery(Name = "to")] string to,
         string q,
         CancellationToken cancellationToken)
     {
@@ -28,11 +29,11 @@ public class GetMessages2Controller(IAuditDataStore dataStore) : ControllerBase
         {
             if (string.IsNullOrWhiteSpace(q))
             {
-                result = await dataStore.GetMessages(false, pagingInfo, sortInfo, range, cancellationToken);
+                result = await dataStore.GetMessages(false, pagingInfo, sortInfo, new DateTimeRange(from, to), cancellationToken);
             }
             else
             {
-                result = await dataStore.QueryMessages(q, pagingInfo, sortInfo, range, cancellationToken);
+                result = await dataStore.QueryMessages(q, pagingInfo, sortInfo, new DateTimeRange(from, to), cancellationToken);
             }
         }
         else
@@ -40,12 +41,12 @@ public class GetMessages2Controller(IAuditDataStore dataStore) : ControllerBase
             if (string.IsNullOrWhiteSpace(q))
             {
                 result = await dataStore.QueryMessagesByReceivingEndpoint(false, endpointName, pagingInfo, sortInfo,
-                    range, cancellationToken);
+                    new DateTimeRange(from, to), cancellationToken);
             }
             else
             {
                 result = await dataStore.QueryMessagesByReceivingEndpointAndKeyword(endpointName, q, pagingInfo,
-                    sortInfo, range, cancellationToken);
+                    sortInfo, new DateTimeRange(from, to), cancellationToken);
             }
         }
 

--- a/src/ServiceControl.Audit/Auditing/MessagesView/GetMessages2Controller.cs
+++ b/src/ServiceControl.Audit/Auditing/MessagesView/GetMessages2Controller.cs
@@ -1,0 +1,56 @@
+namespace ServiceControl.Audit.Auditing.MessagesView;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Infrastructure;
+using Infrastructure.WebApi;
+using Microsoft.AspNetCore.Mvc;
+using Persistence;
+
+[ApiController]
+[Route("api")]
+public class GetMessages2Controller(IAuditDataStore dataStore) : ControllerBase
+{
+    [Route("messages2")]
+    [HttpGet]
+    public async Task<IList<MessagesView>> GetAllMessages(
+        [FromQuery] SortInfo sortInfo,
+        [FromQuery(Name = "page_size")] int pageSize,
+        [FromQuery(Name = "endpoint_name")] string endpointName,
+        [FromQuery(Name = "range")] string range,
+        string q,
+        CancellationToken cancellationToken)
+    {
+        QueryResult<IList<MessagesView>> result;
+        var pagingInfo = new PagingInfo(pageSize: pageSize);
+        if (string.IsNullOrWhiteSpace(endpointName))
+        {
+            if (string.IsNullOrWhiteSpace(q))
+            {
+                result = await dataStore.GetMessages(false, pagingInfo, sortInfo, range, cancellationToken);
+            }
+            else
+            {
+                result = await dataStore.QueryMessages(q, pagingInfo, sortInfo, range, cancellationToken);
+            }
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(q))
+            {
+                result = await dataStore.QueryMessagesByReceivingEndpoint(false, endpointName, pagingInfo, sortInfo,
+                    range, cancellationToken);
+            }
+            else
+            {
+                result = await dataStore.QueryMessagesByReceivingEndpointAndKeyword(endpointName, q, pagingInfo,
+                    sortInfo, range, cancellationToken);
+            }
+        }
+
+        Response.WithTotalCount(result.QueryStats.TotalCount);
+
+        return result.Results;
+    }
+}

--- a/src/ServiceControl.Audit/Auditing/MessagesView/GetMessagesController.cs
+++ b/src/ServiceControl.Audit/Auditing/MessagesView/GetMessagesController.cs
@@ -17,7 +17,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> GetAllMessages([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, [FromQuery(Name = "include_system_messages")] bool includeSystemMessages, CancellationToken cancellationToken)
         {
-            var result = await dataStore.GetMessages(includeSystemMessages, pagingInfo, sortInfo, cancellationToken);
+            var result = await dataStore.GetMessages(includeSystemMessages, pagingInfo, sortInfo, null, cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }
@@ -26,7 +26,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> GetEndpointMessages([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, [FromQuery(Name = "include_system_messages")] bool includeSystemMessages, string endpoint, CancellationToken cancellationToken)
         {
-            var result = await dataStore.QueryMessagesByReceivingEndpoint(includeSystemMessages, endpoint, pagingInfo, sortInfo, cancellationToken);
+            var result = await dataStore.QueryMessagesByReceivingEndpoint(includeSystemMessages, endpoint, pagingInfo, sortInfo, null, cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }
@@ -70,7 +70,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> Search([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, string q, CancellationToken cancellationToken)
         {
-            var result = await dataStore.QueryMessages(q, pagingInfo, sortInfo, cancellationToken);
+            var result = await dataStore.QueryMessages(q, pagingInfo, sortInfo, null, cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }
@@ -79,7 +79,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> SearchByKeyWord([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, string keyword, CancellationToken cancellationToken)
         {
-            var result = await dataStore.QueryMessages(keyword, pagingInfo, sortInfo, cancellationToken);
+            var result = await dataStore.QueryMessages(keyword, pagingInfo, sortInfo, null, cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }
@@ -88,7 +88,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> Search([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, string endpoint, string q, CancellationToken cancellationToken)
         {
-            var result = await dataStore.QueryMessagesByReceivingEndpointAndKeyword(endpoint, q, pagingInfo, sortInfo, cancellationToken);
+            var result = await dataStore.QueryMessagesByReceivingEndpointAndKeyword(endpoint, q, pagingInfo, sortInfo, null, cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }
@@ -97,7 +97,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> SearchByKeyword([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, string endpoint, string keyword, CancellationToken cancellationToken)
         {
-            var result = await dataStore.QueryMessagesByReceivingEndpointAndKeyword(endpoint, keyword, pagingInfo, sortInfo, cancellationToken);
+            var result = await dataStore.QueryMessagesByReceivingEndpointAndKeyword(endpoint, keyword, pagingInfo, sortInfo, null, cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }

--- a/src/ServiceControl.Audit/Auditing/MessagesView/GetMessagesController.cs
+++ b/src/ServiceControl.Audit/Auditing/MessagesView/GetMessagesController.cs
@@ -17,7 +17,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> GetAllMessages([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, [FromQuery(Name = "include_system_messages")] bool includeSystemMessages, CancellationToken cancellationToken)
         {
-            var result = await dataStore.GetMessages(includeSystemMessages, pagingInfo, sortInfo, null, cancellationToken);
+            var result = await dataStore.GetMessages(includeSystemMessages, pagingInfo, sortInfo, cancellationToken: cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }
@@ -26,7 +26,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> GetEndpointMessages([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, [FromQuery(Name = "include_system_messages")] bool includeSystemMessages, string endpoint, CancellationToken cancellationToken)
         {
-            var result = await dataStore.QueryMessagesByReceivingEndpoint(includeSystemMessages, endpoint, pagingInfo, sortInfo, null, cancellationToken);
+            var result = await dataStore.QueryMessagesByReceivingEndpoint(includeSystemMessages, endpoint, pagingInfo, sortInfo, cancellationToken: cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }
@@ -70,7 +70,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> Search([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, string q, CancellationToken cancellationToken)
         {
-            var result = await dataStore.QueryMessages(q, pagingInfo, sortInfo, null, cancellationToken);
+            var result = await dataStore.QueryMessages(q, pagingInfo, sortInfo, cancellationToken: cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }
@@ -79,7 +79,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> SearchByKeyWord([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, string keyword, CancellationToken cancellationToken)
         {
-            var result = await dataStore.QueryMessages(keyword, pagingInfo, sortInfo, null, cancellationToken);
+            var result = await dataStore.QueryMessages(keyword, pagingInfo, sortInfo, cancellationToken: cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }
@@ -88,7 +88,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> Search([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, string endpoint, string q, CancellationToken cancellationToken)
         {
-            var result = await dataStore.QueryMessagesByReceivingEndpointAndKeyword(endpoint, q, pagingInfo, sortInfo, null, cancellationToken);
+            var result = await dataStore.QueryMessagesByReceivingEndpointAndKeyword(endpoint, q, pagingInfo, sortInfo, cancellationToken: cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }
@@ -97,7 +97,7 @@ namespace ServiceControl.Audit.Auditing.MessagesView
         [HttpGet]
         public async Task<IList<MessagesView>> SearchByKeyword([FromQuery] PagingInfo pagingInfo, [FromQuery] SortInfo sortInfo, string endpoint, string keyword, CancellationToken cancellationToken)
         {
-            var result = await dataStore.QueryMessagesByReceivingEndpointAndKeyword(endpoint, keyword, pagingInfo, sortInfo, null, cancellationToken);
+            var result = await dataStore.QueryMessagesByReceivingEndpointAndKeyword(endpoint, keyword, pagingInfo, sortInfo, cancellationToken: cancellationToken);
             Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
             return result.Results;
         }

--- a/src/ServiceControl.Persistence.RavenDB/ErrorMessagesDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ErrorMessagesDataStore.cs
@@ -35,7 +35,7 @@
             PagingInfo pagingInfo,
             SortInfo sortInfo,
             bool includeSystemMessages,
-            string timeSentRange
+            DateTimeRange timeSentRange
             )
         {
             using var session = await sessionProvider.OpenSession();
@@ -58,7 +58,7 @@
             PagingInfo pagingInfo,
             SortInfo sortInfo,
             bool includeSystemMessages,
-            string timeSentRange
+            DateTimeRange timeSentRange
             )
         {
             using var session = await sessionProvider.OpenSession();
@@ -83,7 +83,7 @@
             string searchKeyword,
             PagingInfo pagingInfo,
             SortInfo sortInfo,
-            string timeSentRange
+            DateTimeRange timeSentRange
             )
         {
             using var session = await sessionProvider.OpenSession();
@@ -127,7 +127,7 @@
             string searchTerms,
             PagingInfo pagingInfo,
             SortInfo sortInfo,
-            string timeSentRange
+            DateTimeRange timeSentRange
             )
         {
             using var session = await sessionProvider.OpenSession();

--- a/src/ServiceControl.Persistence.RavenDB/ErrorMessagesDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ErrorMessagesDataStore.cs
@@ -34,12 +34,14 @@
         public async Task<QueryResult<IList<MessagesView>>> GetAllMessages(
             PagingInfo pagingInfo,
             SortInfo sortInfo,
-            bool includeSystemMessages
+            bool includeSystemMessages,
+            string timeSentRange
             )
         {
             using var session = await sessionProvider.OpenSession();
             var query = session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
                 .IncludeSystemMessagesWhere(includeSystemMessages)
+                .FilterBySentTimeRange(timeSentRange)
                 .Statistics(out var stats)
                 .Sort(sortInfo)
                 .Paging(pagingInfo)
@@ -55,12 +57,14 @@
             string endpointName,
             PagingInfo pagingInfo,
             SortInfo sortInfo,
-            bool includeSystemMessages
+            bool includeSystemMessages,
+            string timeSentRange
             )
         {
             using var session = await sessionProvider.OpenSession();
             var query = session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
                 .IncludeSystemMessagesWhere(includeSystemMessages)
+                .FilterBySentTimeRange(timeSentRange)
                 .Where(m => m.ReceivingEndpointName == endpointName)
                 .Statistics(out var stats)
                 .Sort(sortInfo)
@@ -78,7 +82,8 @@
             string endpointName,
             string searchKeyword,
             PagingInfo pagingInfo,
-            SortInfo sortInfo
+            SortInfo sortInfo,
+            string timeSentRange
             )
         {
             using var session = await sessionProvider.OpenSession();
@@ -86,6 +91,7 @@
                 .Statistics(out var stats)
                 .Search(x => x.Query, searchKeyword)
                 .Where(m => m.ReceivingEndpointName == endpointName)
+                .FilterBySentTimeRange(timeSentRange)
                 .Sort(sortInfo)
                 .Paging(pagingInfo)
                 .OfType<FailedMessage>()
@@ -120,13 +126,15 @@
         public async Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(
             string searchTerms,
             PagingInfo pagingInfo,
-            SortInfo sortInfo
+            SortInfo sortInfo,
+            string timeSentRange
             )
         {
             using var session = await sessionProvider.OpenSession();
             var query = session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
                 .Statistics(out var stats)
                 .Search(x => x.Query, searchTerms)
+                .FilterBySentTimeRange(timeSentRange)
                 .Sort(sortInfo)
                 .Paging(pagingInfo)
                 .OfType<FailedMessage>()

--- a/src/ServiceControl.Persistence.RavenDB/RavenQueryExtensions.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenQueryExtensions.cs
@@ -174,6 +174,40 @@ namespace ServiceControl.Persistence
             return source;
         }
 
+        public static IRavenQueryable<MessagesViewIndex.SortAndFilterOptions> FilterBySentTimeRange(this IRavenQueryable<MessagesViewIndex.SortAndFilterOptions> source, string range)
+        {
+            if (string.IsNullOrWhiteSpace(range))
+            {
+                return source;
+            }
+
+            var filters = range.Split(SplitChars, StringSplitOptions.None);
+            DateTime from, to;
+            try
+            {
+
+                if (filters.Length == 2)
+                {
+                    from = DateTime.Parse(filters[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                    to = DateTime.Parse(filters[1], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                    source.Where(m => m.TimeSent >= from && m.TimeSent <= to);
+
+                }
+                else
+                {
+                    from = DateTime.Parse(filters[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                    source.Where(m => m.TimeSent >= from);
+                }
+            }
+            catch (Exception)
+            {
+                throw new Exception(
+                    "Invalid sent time date range, dates need to be in ISO8601 format and it needs to be a range eg. 2016-03-11T00:27:15.474Z...2016-03-16T03:27:15.474Z");
+            }
+
+            return source;
+        }
+
         public static IAsyncDocumentQuery<T> FilterByQueueAddress<T>(this IAsyncDocumentQuery<T> source, string queueAddress)
         {
             if (string.IsNullOrWhiteSpace(queueAddress))

--- a/src/ServiceControl.Persistence.RavenDB/RavenQueryExtensions.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenQueryExtensions.cs
@@ -174,35 +174,21 @@ namespace ServiceControl.Persistence
             return source;
         }
 
-        public static IRavenQueryable<MessagesViewIndex.SortAndFilterOptions> FilterBySentTimeRange(this IRavenQueryable<MessagesViewIndex.SortAndFilterOptions> source, string range)
+        public static IRavenQueryable<MessagesViewIndex.SortAndFilterOptions> FilterBySentTimeRange(this IRavenQueryable<MessagesViewIndex.SortAndFilterOptions> source, DateTimeRange range)
         {
-            if (string.IsNullOrWhiteSpace(range))
+            if (range == null)
             {
                 return source;
             }
 
-            var filters = range.Split(SplitChars, StringSplitOptions.None);
-            DateTime from, to;
-            try
+            if (range.From.HasValue)
             {
-
-                if (filters.Length == 2)
-                {
-                    from = DateTime.Parse(filters[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-                    to = DateTime.Parse(filters[1], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-                    source.Where(m => m.TimeSent >= from && m.TimeSent <= to);
-
-                }
-                else
-                {
-                    from = DateTime.Parse(filters[0], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-                    source.Where(m => m.TimeSent >= from);
-                }
+                source = source.Where(m => m.TimeSent >= range.From);
             }
-            catch (Exception)
+
+            if (range.To.HasValue)
             {
-                throw new Exception(
-                    "Invalid sent time date range, dates need to be in ISO8601 format and it needs to be a range eg. 2016-03-11T00:27:15.474Z...2016-03-16T03:27:15.474Z");
+                source = source.Where(m => m.TimeSent <= range.To);
             }
 
             return source;

--- a/src/ServiceControl.Persistence.Tests/Recoverability/ReturnToSenderDequeuerTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/ReturnToSenderDequeuerTests.cs
@@ -168,22 +168,24 @@
 
         class FakeErrorMessageDataStore : IErrorMessageDataStore
         {
-            public Task<byte[]> FetchFromFailedMessage(string bodyId) => Task.FromResult(Encoding.UTF8.GetBytes(bodyId));
-
-            public Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, string timeSentRange) => throw new NotImplementedException();
+            public Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages,
+                DateTimeRange timeSentRange = null) =>
+                throw new NotImplementedException();
 
             public Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo,
-                bool includeSystemMessages, string timeSentRange) =>
+                bool includeSystemMessages, DateTimeRange timeSentRange = null) =>
                 throw new NotImplementedException();
 
             public Task<QueryResult<IList<MessagesView>>> GetAllMessagesByConversation(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo,
                 bool includeSystemMessages) =>
                 throw new NotImplementedException();
 
-            public Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange) => throw new NotImplementedException();
+            public Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo,
+                DateTimeRange timeSentRange = null) =>
+                throw new NotImplementedException();
 
             public Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo,
-                string timeSentRange) =>
+                DateTimeRange timeSentRange = null) =>
                 throw new NotImplementedException();
 
             public Task FailedMessageMarkAsArchived(string failedMessageId) => throw new NotImplementedException();
@@ -238,6 +240,7 @@
 
             public Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress) => throw new NotImplementedException();
 
+            public Task<byte[]> FetchFromFailedMessage(string bodyId) => Task.FromResult(Encoding.UTF8.GetBytes(bodyId));
             public Task StoreEventLogItem(EventLogItem logItem) => throw new NotImplementedException();
 
             public Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages) => throw new NotImplementedException();

--- a/src/ServiceControl.Persistence.Tests/Recoverability/ReturnToSenderDequeuerTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/ReturnToSenderDequeuerTests.cs
@@ -170,17 +170,21 @@
         {
             public Task<byte[]> FetchFromFailedMessage(string bodyId) => Task.FromResult(Encoding.UTF8.GetBytes(bodyId));
 
-            public Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages) => throw new NotImplementedException();
+            public Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, string timeSentRange) => throw new NotImplementedException();
 
             public Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo,
-                bool includeSystemMessages) =>
+                bool includeSystemMessages, string timeSentRange) =>
                 throw new NotImplementedException();
 
             public Task<QueryResult<IList<MessagesView>>> GetAllMessagesByConversation(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo,
                 bool includeSystemMessages) =>
                 throw new NotImplementedException();
 
-            public Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo) => throw new NotImplementedException();
+            public Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange) => throw new NotImplementedException();
+
+            public Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo,
+                string timeSentRange) =>
+                throw new NotImplementedException();
 
             public Task FailedMessageMarkAsArchived(string failedMessageId) => throw new NotImplementedException();
 
@@ -235,8 +239,6 @@
             public Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress) => throw new NotImplementedException();
 
             public Task StoreEventLogItem(EventLogItem logItem) => throw new NotImplementedException();
-
-            public Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo) => throw new NotImplementedException();
 
             public Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages) => throw new NotImplementedException();
         }

--- a/src/ServiceControl.Persistence/IErrorMessageDatastore.cs
+++ b/src/ServiceControl.Persistence/IErrorMessageDatastore.cs
@@ -13,10 +13,11 @@
 
     public interface IErrorMessageDataStore
     {
-        Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages);
-        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, string timeSentRange = null);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, string timeSentRange = null);
         Task<QueryResult<IList<MessagesView>>> GetAllMessagesByConversation(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages);
-        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange = null);
+        Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange = null);
         Task FailedMessageMarkAsArchived(string failedMessageId);
         Task<FailedMessage[]> FailedMessagesFetch(Guid[] ids);
         Task StoreFailedErrorImport(FailedErrorImport failure);
@@ -70,8 +71,6 @@
 
         // AuditEventLogWriter
         Task StoreEventLogItem(EventLogItem logItem);
-
-        Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo);
 
         Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages);
     }

--- a/src/ServiceControl.Persistence/IErrorMessageDatastore.cs
+++ b/src/ServiceControl.Persistence/IErrorMessageDatastore.cs
@@ -13,11 +13,11 @@
 
     public interface IErrorMessageDataStore
     {
-        Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, string timeSentRange = null);
-        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, string timeSentRange = null);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange timeSentRange = null);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange timeSentRange = null);
         Task<QueryResult<IList<MessagesView>>> GetAllMessagesByConversation(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages);
-        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange = null);
-        Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo, string timeSentRange = null);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null);
+        Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null);
         Task FailedMessageMarkAsArchived(string failedMessageId);
         Task<FailedMessage[]> FailedMessagesFetch(Guid[] ids);
         Task StoreFailedErrorImport(FailedErrorImport failure);

--- a/src/ServiceControl.Persistence/Infrastructure/DateTimeRange.cs
+++ b/src/ServiceControl.Persistence/Infrastructure/DateTimeRange.cs
@@ -1,0 +1,28 @@
+namespace ServiceControl.Persistence.Infrastructure;
+
+using System;
+using System.Globalization;
+
+public class DateTimeRange
+{
+    public DateTime? From { get; }
+    public DateTime? To { get; }
+
+    public DateTimeRange(string from = null, string to = null)
+    {
+        if (from != null)
+        {
+            From = DateTime.Parse(from, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        }
+        if (to != null)
+        {
+            To = DateTime.Parse(to, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+        }
+    }
+
+    public DateTimeRange(DateTime? from = null, DateTime? to = null)
+    {
+        From = from;
+        To = to;
+    }
+}

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.HttpApiRoutes.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.HttpApiRoutes.approved.txt
@@ -45,6 +45,7 @@ GET /messages => ServiceControl.CompositeViews.Messages.GetMessagesController:Me
 GET /messages/{id}/body => ServiceControl.CompositeViews.Messages.GetMessagesController:Get(String id, String instanceId)
 GET /messages/search => ServiceControl.CompositeViews.Messages.GetMessagesController:Search(PagingInfo pagingInfo, SortInfo sortInfo, String q)
 GET /messages/search/{keyword} => ServiceControl.CompositeViews.Messages.GetMessagesController:SearchByKeyWord(PagingInfo pagingInfo, SortInfo sortInfo, String keyword)
+GET /messages2 => ServiceControl.CompositeViews.Messages.GetMessages2Controller:Messages(SortInfo sortInfo, Int32 pageSize, String endpointName, String from, String to, String q)
 GET /notifications/email => ServiceControl.Notifications.Api.NotificationsController:GetEmailNotificationsSettings()
 POST /notifications/email => ServiceControl.Notifications.Api.NotificationsController:UpdateSettings(UpdateEmailNotificationsSettingsRequest request)
 POST /notifications/email/test => ServiceControl.Notifications.Api.NotificationsController:SendTestEmail()

--- a/src/ServiceControl.UnitTests/ScatterGather/MessageView_ScatterGatherTest.cs
+++ b/src/ServiceControl.UnitTests/ScatterGather/MessageView_ScatterGatherTest.cs
@@ -17,7 +17,7 @@
         {
             var api = new TestApi(null, null, null);
 
-            Results = api.AggregateResults(new ScatterGatherApiMessageViewContext(null, new SortInfo()), GetData());
+            Results = api.AggregateResults(new ScatterGatherApiMessageViewContext(new PagingInfo(), new SortInfo()), GetData());
         }
 
         protected abstract QueryResult<IList<MessagesView>>[] GetData();

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
@@ -16,7 +16,7 @@ namespace ServiceControl.CompositeViews.Messages
 
         protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(ScatterGatherApiMessageViewWithSystemMessagesContext input)
         {
-            return DataStore.GetAllMessages(input.PagingInfo, input.SortInfo, input.IncludeSystemMessages);
+            return DataStore.GetAllMessages(input.PagingInfo, input.SortInfo, input.IncludeSystemMessages, input.TimeSentRange);
         }
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
@@ -12,7 +12,7 @@ namespace ServiceControl.CompositeViews.Messages
         SortInfo SortInfo,
         bool IncludeSystemMessages,
         string EndpointName,
-        string TimeSentRange = null)
+        DateTimeRange TimeSentRange = null)
         : ScatterGatherApiMessageViewWithSystemMessagesContext(PagingInfo, SortInfo, IncludeSystemMessages, TimeSentRange);
 
     public class GetAllMessagesForEndpointApi : ScatterGatherApiMessageView<IErrorMessageDataStore, AllMessagesForEndpointContext>

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
@@ -11,8 +11,9 @@ namespace ServiceControl.CompositeViews.Messages
         PagingInfo PagingInfo,
         SortInfo SortInfo,
         bool IncludeSystemMessages,
-        string EndpointName)
-        : ScatterGatherApiMessageViewWithSystemMessagesContext(PagingInfo, SortInfo, IncludeSystemMessages);
+        string EndpointName,
+        string TimeSentRange = null)
+        : ScatterGatherApiMessageViewWithSystemMessagesContext(PagingInfo, SortInfo, IncludeSystemMessages, TimeSentRange);
 
     public class GetAllMessagesForEndpointApi : ScatterGatherApiMessageView<IErrorMessageDataStore, AllMessagesForEndpointContext>
     {
@@ -21,6 +22,6 @@ namespace ServiceControl.CompositeViews.Messages
         {
         }
 
-        protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(AllMessagesForEndpointContext input) => DataStore.GetAllMessagesForEndpoint(input.EndpointName, input.PagingInfo, input.SortInfo, input.IncludeSystemMessages);
+        protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(AllMessagesForEndpointContext input) => DataStore.GetAllMessagesForEndpoint(input.EndpointName, input.PagingInfo, input.SortInfo, input.IncludeSystemMessages, input.TimeSentRange);
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/GetMessages2Controller.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetMessages2Controller.cs
@@ -22,7 +22,8 @@ public class GetMessages2Controller(
         [FromQuery] SortInfo sortInfo,
         [FromQuery(Name = "page_size")] int pageSize,
         [FromQuery(Name = "endpoint_name")] string endpointName,
-        [FromQuery(Name = "range")] string range,
+        [FromQuery(Name = "from")] string from,
+        [FromQuery(Name = "to")] string to,
         string q)
     {
         QueryResult<IList<MessagesView>> result;
@@ -33,13 +34,13 @@ public class GetMessages2Controller(
             {
                 result = await allMessagesApi.Execute(
                     new ScatterGatherApiMessageViewWithSystemMessagesContext(pagingInfo,
-                        sortInfo, false, range),
+                        sortInfo, false, new DateTimeRange(from, to)),
                     Request.GetEncodedPathAndQuery());
             }
             else
             {
                 result = await searchApi.Execute(
-                    new SearchApiContext(pagingInfo, sortInfo, q, range),
+                    new SearchApiContext(pagingInfo, sortInfo, q, new DateTimeRange(from, to)),
                     Request.GetEncodedPathAndQuery());
             }
         }
@@ -49,12 +50,12 @@ public class GetMessages2Controller(
             {
                 result = await allMessagesEndpointApi.Execute(
                     new AllMessagesForEndpointContext(pagingInfo, sortInfo, false,
-                        endpointName, range),
+                        endpointName, new DateTimeRange(from, to)),
                     Request.GetEncodedPathAndQuery());
             }
             else
             {
-                result = await searchEndpointApi.Execute(new SearchEndpointContext(pagingInfo, sortInfo, q, endpointName, range),
+                result = await searchEndpointApi.Execute(new SearchEndpointContext(pagingInfo, sortInfo, q, endpointName, new DateTimeRange(from, to)),
                     Request.GetEncodedPathAndQuery());
             }
         }

--- a/src/ServiceControl/CompositeViews/Messages/GetMessages2Controller.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetMessages2Controller.cs
@@ -1,0 +1,66 @@
+namespace ServiceControl.CompositeViews.Messages;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Infrastructure.WebApi;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Persistence.Infrastructure;
+
+[ApiController]
+[Route("api")]
+public class GetMessages2Controller(
+    GetAllMessagesApi allMessagesApi,
+    GetAllMessagesForEndpointApi allMessagesEndpointApi,
+    SearchApi searchApi,
+    SearchEndpointApi searchEndpointApi)
+    : ControllerBase
+{
+    [Route("messages2")]
+    [HttpGet]
+    public async Task<IList<MessagesView>> Messages(
+        [FromQuery] SortInfo sortInfo,
+        [FromQuery(Name = "page_size")] int pageSize,
+        [FromQuery(Name = "endpoint_name")] string endpointName,
+        [FromQuery(Name = "range")] string range,
+        string q)
+    {
+        QueryResult<IList<MessagesView>> result;
+        var pagingInfo = new PagingInfo(pageSize: pageSize);
+        if (string.IsNullOrWhiteSpace(endpointName))
+        {
+            if (string.IsNullOrWhiteSpace(q))
+            {
+                result = await allMessagesApi.Execute(
+                    new ScatterGatherApiMessageViewWithSystemMessagesContext(pagingInfo,
+                        sortInfo, false, range),
+                    Request.GetEncodedPathAndQuery());
+            }
+            else
+            {
+                result = await searchApi.Execute(
+                    new SearchApiContext(pagingInfo, sortInfo, q, range),
+                    Request.GetEncodedPathAndQuery());
+            }
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(q))
+            {
+                result = await allMessagesEndpointApi.Execute(
+                    new AllMessagesForEndpointContext(pagingInfo, sortInfo, false,
+                        endpointName, range),
+                    Request.GetEncodedPathAndQuery());
+            }
+            else
+            {
+                result = await searchEndpointApi.Execute(new SearchEndpointContext(pagingInfo, sortInfo, q, endpointName, range),
+                    Request.GetEncodedPathAndQuery());
+            }
+        }
+
+        Response.WithTotalCount(result.QueryStats.TotalCount);
+
+        return result.Results;
+    }
+}

--- a/src/ServiceControl/CompositeViews/Messages/GetMessagesController.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetMessagesController.cs
@@ -106,7 +106,7 @@ namespace ServiceControl.CompositeViews.Messages
             var forwarderError = await forwarder.SendAsync(HttpContext, remote.BaseAddress, httpMessageInvoker);
             if (forwarderError != ForwarderError.None && HttpContext.GetForwarderErrorFeature()?.Exception is { } exception)
             {
-                logger.Warn($"Failed to forward the request ot remote instance at {remote.BaseAddress + HttpContext.Request.GetEncodedPathAndQuery()}.", exception);
+                logger.Warn($"Failed to forward the request to remote instance at {remote.BaseAddress}{HttpContext.Request.GetEncodedPathAndQuery()}.", exception);
             }
 
             return Empty;

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApiMessageView.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApiMessageView.cs
@@ -9,9 +9,10 @@ namespace ServiceControl.CompositeViews.Messages
     public record ScatterGatherApiMessageViewWithSystemMessagesContext(
         PagingInfo PagingInfo,
         SortInfo SortInfo,
-        bool IncludeSystemMessages) : ScatterGatherApiMessageViewContext(PagingInfo, SortInfo);
+        bool IncludeSystemMessages,
+        string TimeSentRange = null) : ScatterGatherApiMessageViewContext(PagingInfo, SortInfo, TimeSentRange);
 
-    public record ScatterGatherApiMessageViewContext(PagingInfo PagingInfo, SortInfo SortInfo) : ScatterGatherContext(PagingInfo);
+    public record ScatterGatherApiMessageViewContext(PagingInfo PagingInfo, SortInfo SortInfo, string TimeSentRange = null) : ScatterGatherContext(PagingInfo);
 
     public abstract class ScatterGatherApiMessageView<TDataStore, TInput> : ScatterGatherApi<TDataStore, TInput, IList<MessagesView>>
         where TInput : ScatterGatherApiMessageViewContext
@@ -51,7 +52,7 @@ namespace ServiceControl.CompositeViews.Messages
                 combined.Sort(comparer);
             }
 
-            return combined;
+            return combined.Take(input.PagingInfo.PageSize).ToList();
         }
 
         IComparer<MessagesView> FinalOrder(SortInfo sortInfo) => MessageViewComparer.FromSortInfo(sortInfo);

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApiMessageView.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApiMessageView.cs
@@ -10,9 +10,9 @@ namespace ServiceControl.CompositeViews.Messages
         PagingInfo PagingInfo,
         SortInfo SortInfo,
         bool IncludeSystemMessages,
-        string TimeSentRange = null) : ScatterGatherApiMessageViewContext(PagingInfo, SortInfo, TimeSentRange);
+        DateTimeRange TimeSentRange = null) : ScatterGatherApiMessageViewContext(PagingInfo, SortInfo, TimeSentRange);
 
-    public record ScatterGatherApiMessageViewContext(PagingInfo PagingInfo, SortInfo SortInfo, string TimeSentRange = null) : ScatterGatherContext(PagingInfo);
+    public record ScatterGatherApiMessageViewContext(PagingInfo PagingInfo, SortInfo SortInfo, DateTimeRange TimeSentRange = null) : ScatterGatherContext(PagingInfo);
 
     public abstract class ScatterGatherApiMessageView<TDataStore, TInput> : ScatterGatherApi<TDataStore, TInput, IList<MessagesView>>
         where TInput : ScatterGatherApiMessageViewContext

--- a/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
@@ -10,8 +10,9 @@ namespace ServiceControl.CompositeViews.Messages
     public record SearchApiContext(
         PagingInfo PagingInfo,
         SortInfo SortInfo,
-        string SearchQuery)
-        : ScatterGatherApiMessageViewContext(PagingInfo, SortInfo);
+        string SearchQuery,
+        string TimeSentRange = null)
+        : ScatterGatherApiMessageViewContext(PagingInfo, SortInfo, TimeSentRange);
 
     public class SearchApi : ScatterGatherApiMessageView<IErrorMessageDataStore, SearchApiContext>
     {
@@ -21,6 +22,6 @@ namespace ServiceControl.CompositeViews.Messages
         }
 
         protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(SearchApiContext input) =>
-            DataStore.GetAllMessagesForSearch(input.SearchQuery, input.PagingInfo, input.SortInfo);
+            DataStore.GetAllMessagesForSearch(input.SearchQuery, input.PagingInfo, input.SortInfo, input.TimeSentRange);
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
@@ -11,7 +11,7 @@ namespace ServiceControl.CompositeViews.Messages
         PagingInfo PagingInfo,
         SortInfo SortInfo,
         string SearchQuery,
-        string TimeSentRange = null)
+        DateTimeRange TimeSentRange = null)
         : ScatterGatherApiMessageViewContext(PagingInfo, SortInfo, TimeSentRange);
 
     public class SearchApi : ScatterGatherApiMessageView<IErrorMessageDataStore, SearchApiContext>

--- a/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
@@ -12,7 +12,7 @@ namespace ServiceControl.CompositeViews.Messages
         SortInfo SortInfo,
         string Keyword,
         string Endpoint,
-        string TimeSentRange = null)
+        DateTimeRange TimeSentRange = null)
         : ScatterGatherApiMessageViewContext(PagingInfo, SortInfo, TimeSentRange);
 
     public class SearchEndpointApi : ScatterGatherApiMessageView<IErrorMessageDataStore, SearchEndpointContext>

--- a/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
@@ -11,8 +11,9 @@ namespace ServiceControl.CompositeViews.Messages
         PagingInfo PagingInfo,
         SortInfo SortInfo,
         string Keyword,
-        string Endpoint)
-        : ScatterGatherApiMessageViewContext(PagingInfo, SortInfo);
+        string Endpoint,
+        string TimeSentRange = null)
+        : ScatterGatherApiMessageViewContext(PagingInfo, SortInfo, TimeSentRange);
 
     public class SearchEndpointApi : ScatterGatherApiMessageView<IErrorMessageDataStore, SearchEndpointContext>
     {
@@ -22,6 +23,6 @@ namespace ServiceControl.CompositeViews.Messages
         }
 
         protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(SearchEndpointContext input) =>
-            DataStore.SearchEndpointMessages(input.Endpoint, input.Keyword, input.PagingInfo, input.SortInfo);
+            DataStore.SearchEndpointMessages(input.Endpoint, input.Keyword, input.PagingInfo, input.SortInfo, input.TimeSentRange);
     }
 }


### PR DESCRIPTION
As part of the ongoing work to migrate SI to SP, we identified that paging in SI does not return the correct results once the user reaches page 2 or higher. The only correct page is page 1.

The TF working on this has evaluated whether paging is needed at all for the screens in SP and decided that, to provide accurate results, we are not migrating paging, given the issues.

This PR introduces a new endpoint that:
- returns only the top x messages
- supports filtering the messages by time sent range
- fixed a bug where the results could return more than the page size limit