### PR TITLE
Handle the RegexMatchTimeoutException

### DIFF
--- a/src/ServiceControl/Recoverability/Grouping/Groupers/ExceptionTypeAndStackTraceFailureClassifier.cs
+++ b/src/ServiceControl/Recoverability/Grouping/Groupers/ExceptionTypeAndStackTraceFailureClassifier.cs
@@ -47,7 +47,7 @@ namespace ServiceControl.Recoverability
             }
             catch (RegexMatchTimeoutException)
             {
-                return GetNonStandardClassification(exception.ExceptionType);
+                // Intentionally empty - if the parsing fails, treat it as if exception.Message is null or empty, not throw an exception
             }
 
 


### PR DESCRIPTION
This PR handles the RegexMatchTimeoutException by returning the GetNonStandardClassification