### PR TITLE
Update NServiceBus.RabbitMQ to 10.1.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="NServiceBus.Metrics" Version="5.0.1" />
     <PackageVersion Include="NServiceBus.Metrics.ServiceControl" Version="5.0.0" />
     <PackageVersion Include="NServiceBus.Persistence.NonDurable" Version="2.0.1" />
-    <PackageVersion Include="NServiceBus.RabbitMQ" Version="10.0.1" />
+    <PackageVersion Include="NServiceBus.RabbitMQ" Version="10.1.0" />
     <PackageVersion Include="NServiceBus.SagaAudit" Version="5.0.2" />
     <PackageVersion Include="NServiceBus.Testing" Version="9.0.1" />
     <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="5.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.5" />
     <PackageVersion Include="Mindscape.Raygun4Net.NetCore" Version="11.2.1" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.4.0" />
-    <PackageVersion Include="NServiceBus" Version="9.2.6" />
+    <PackageVersion Include="NServiceBus" Version="9.2.7" />
     <PackageVersion Include="NServiceBus.AcceptanceTesting" Version="9.2.6" />
     <PackageVersion Include="NServiceBus.AmazonSQS" Version="7.3.0" />
     <PackageVersion Include="NServiceBus.CustomChecks" Version="5.0.1" />


### PR DESCRIPTION
Dependabot is broken again, so here's a manual PR to do what it should have done.