### PR TITLE
Use .NET 9 SDK

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4.3.1
         with:
+          global-json-file: global.json
           dotnet-version: 8.0.x
       - name: Download RavenDB Server
         run: ./tools/download-ravendb-server.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4.3.1
         with:
+          global-json-file: global.json
           dotnet-version: 8.0.x
       - name: Download RavenDB Server
         run: ./tools/download-ravendb-server.ps1

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/src/ServiceControl.Api/IAuditCountApi.cs
+++ b/src/ServiceControl.Api/IAuditCountApi.cs
@@ -7,6 +7,6 @@
 
     public interface IAuditCountApi
     {
-        public Task<IList<AuditCount>> GetEndpointAuditCounts(string endpoint, CancellationToken token);
+        Task<IList<AuditCount>> GetEndpointAuditCounts(string endpoint, CancellationToken token);
     }
 }

--- a/src/ServiceControl.Api/IConfigurationApi.cs
+++ b/src/ServiceControl.Api/IConfigurationApi.cs
@@ -6,8 +6,10 @@
 
     public interface IConfigurationApi
     {
-        public Task<RootUrls> GetUrls(string baseUrl, CancellationToken cancellationToken);
-        public Task<object> GetConfig(CancellationToken cancellationToken);
-        public Task<RemoteConfiguration[]> GetRemoteConfigs(CancellationToken cancellationToken);
+        Task<RootUrls> GetUrls(string baseUrl, CancellationToken cancellationToken);
+
+        Task<object> GetConfig(CancellationToken cancellationToken);
+
+        Task<RemoteConfiguration[]> GetRemoteConfigs(CancellationToken cancellationToken);
     }
 }

--- a/src/ServiceControl.Api/IEndpointsApi.cs
+++ b/src/ServiceControl.Api/IEndpointsApi.cs
@@ -7,6 +7,6 @@
 
     public interface IEndpointsApi
     {
-        public Task<List<Endpoint>> GetEndpoints(CancellationToken cancellationToken);
+        Task<List<Endpoint>> GetEndpoints(CancellationToken cancellationToken);
     }
 }

--- a/src/ServiceControl.Audit.UnitTests/Infrastructure/When_instance_is_setup.cs
+++ b/src/ServiceControl.Audit.UnitTests/Infrastructure/When_instance_is_setup.cs
@@ -75,11 +75,12 @@
 
         public Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues)
         {
-            QueuesCreated = new List<string>(additionalQueues)
-            {
+            QueuesCreated =
+            [
+                .. additionalQueues,
                 transportSettings.EndpointName,
                 transportSettings.ErrorQueue
-            };
+            ];
             return Task.CompletedTask;
         }
 

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG TARGETARCH
 WORKDIR /
 ENV CI=true

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Options.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Options.cs
@@ -167,7 +167,7 @@ namespace ServiceControl.Audit.Infrastructure.Hosting
 
         public List<string> ToList()
         {
-            return new List<string>(values);
+            return [.. values];
         }
 
         public string[] ToArray()

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -43,7 +43,7 @@
             {
                 Hostname = SettingsReader.Read(SettingsRootNamespace, "Hostname", "localhost");
                 Port = SettingsReader.Read(SettingsRootNamespace, "Port", 44444);
-            };
+            }
 
             MaximumConcurrencyLevel = SettingsReader.Read<int?>(SettingsRootNamespace, "MaximumConcurrencyLevel");
             ServiceControlQueueAddress = SettingsReader.Read<string>(SettingsRootNamespace, "ServiceControlQueueAddress");

--- a/src/ServiceControl.Config/UI/ListInstances/ListInstancesViewModel.cs
+++ b/src/ServiceControl.Config/UI/ListInstances/ListInstancesViewModel.cs
@@ -28,7 +28,7 @@
             AddAndRemoveInstances();
         }
 
-        public BindableCollection<InstanceDetailsViewModel> OrderedInstances => new BindableCollection<InstanceDetailsViewModel>(Instances.OrderBy(x => x.Name));
+        public BindableCollection<InstanceDetailsViewModel> OrderedInstances => [.. Instances.OrderBy(x => x.Name)];
 
         [AlsoNotifyFor(nameof(OrderedInstances))]
         IList<InstanceDetailsViewModel> Instances { get; }

--- a/src/ServiceControl.Config/Validation/ValidationTemplate.cs
+++ b/src/ServiceControl.Config/Validation/ValidationTemplate.cs
@@ -29,7 +29,7 @@
 
             errorsChangedSubject = new Subject<DataErrorsChangedEventArgs>();
             target.PropertyChanged += Validate;
-            properties = new HashSet<string>(target.GetType().GetProperties().Select(p => p.Name));
+            properties = [.. target.GetType().GetProperties().Select(p => p.Name)];
         }
 
         public IObservable<DataErrorsChangedEventArgs> ErrorsChangedObservable => errorsChangedSubject.AsObservable();

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG TARGETARCH
 WORKDIR /
 ENV CI=true

--- a/src/ServiceControl.Monitoring/Hosting/Options.cs
+++ b/src/ServiceControl.Monitoring/Hosting/Options.cs
@@ -167,7 +167,7 @@ namespace ServiceControl.Monitoring
 
         public List<string> ToList()
         {
-            return new List<string>(values);
+            return [.. values];
         }
 
         public string[] ToArray()

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG TARGETARCH
 WORKDIR /
 ENV CI=true

--- a/src/ServiceControl/Hosting/Options.cs
+++ b/src/ServiceControl/Hosting/Options.cs
@@ -167,7 +167,7 @@ namespace Particular.ServiceControl.Hosting
 
         public List<string> ToList()
         {
-            return new List<string>(values);
+            return [.. values];
         }
 
         public string[] ToArray()

--- a/src/ServiceControlInstaller.Engine.UnitTests/Validation/QueueValidationTests.cs
+++ b/src/ServiceControlInstaller.Engine.UnitTests/Validation/QueueValidationTests.cs
@@ -219,13 +219,13 @@ namespace ServiceControlInstaller.Engine.UnitTests.Validation
         public void CheckQueueNamesAreNotTakenByAnotherInstance_ShouldThrow()
         {
             var expectedError = "Some queue names specified are already assigned to another ServiceControl instance - Correct the values for ErrorLogQueue, ErrorQueue";
+
             var newInstance = ServiceControlNewInstance.CreateWithDefaultPersistence();
-            {
-                newInstance.TransportPackage = ServiceControlCoreTransports.Find("MSMQ");
-                newInstance.ErrorLogQueue = "errorlog";
-                newInstance.ErrorQueue = "error";
-                newInstance.ForwardErrorMessages = true;
-            };
+
+            newInstance.TransportPackage = ServiceControlCoreTransports.Find("MSMQ");
+            newInstance.ErrorLogQueue = "errorlog";
+            newInstance.ErrorQueue = "error";
+            newInstance.ForwardErrorMessages = true;
 
             var p = new QueueNameValidator(newInstance)
             {


### PR DESCRIPTION
This PR updates the repo to match our other repos and use the .NET 9 SDK for building.

> [!NOTE]
The SDK image used in the Dockerfiles has also been updated, but the runtime image is still .NET 8.