### PR TITLE
Only require endpoint name to be available when detecting receiving endpoint details

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_ingesting_failed_message_with_missing_headers.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_ingesting_failed_message_with_missing_headers.cs
@@ -45,10 +45,6 @@ class When_ingesting_failed_message_with_missing_headers : AcceptanceTest
             {
                 c.AddMinimalRequiredHeaders();
 
-                // This is needed for ServiceControl to be able to detect both endpoint (via failed q header) and host via the processing machine header
-                // Missing endpoint or host will cause a null ref in ServicePulse
-                c.Headers[Headers.ProcessingMachine] = "MyMachine";
-
                 c.Headers[FaultsHeaderKeys.ExceptionType] = "SomeExceptionType";
                 c.Headers[FaultsHeaderKeys.Message] = "Some message";
             })
@@ -63,7 +59,6 @@ class When_ingesting_failed_message_with_missing_headers : AcceptanceTest
         // ServicePulse assumes that the receiving endpoint name is present
         Assert.That(failure.ReceivingEndpoint, Is.Not.Null);
         Assert.That(failure.ReceivingEndpoint.Name, Is.EqualTo(context.EndpointNameOfReceivingEndpoint));
-        Assert.That(failure.ReceivingEndpoint.Host, Is.EqualTo("MyMachine"));
 
         // ServicePulse needs both an exception type and description to render the UI in a resonable way
         Assert.That(failure.Exception.ExceptionType, Is.EqualTo("SomeExceptionType"));

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_ingesting_failed_message_with_missing_headers.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_ingesting_failed_message_with_missing_headers.cs
@@ -34,8 +34,8 @@ class When_ingesting_failed_message_with_missing_headers : AcceptanceTest
         //No failure time will result in utc now being used
         Assert.That(failure.TimeOfFailure, Is.GreaterThan(testStartTime));
 
-        // Both host and endpoint name is currently needed so this will be null since no host can be detected from the failed q header
-        Assert.That(failure.ReceivingEndpoint, Is.Null);
+        Assert.That(failure.ReceivingEndpoint, Is.Not.Null);
+        Assert.That(failure.ReceivingEndpoint.Name, Is.EqualTo(context.EndpointNameOfReceivingEndpoint));
     }
 
     [Test]
@@ -55,10 +55,6 @@ class When_ingesting_failed_message_with_missing_headers : AcceptanceTest
         var failure = context.Failure;
 
         Assert.That(failure, Is.Not.Null);
-
-        // ServicePulse assumes that the receiving endpoint name is present
-        Assert.That(failure.ReceivingEndpoint, Is.Not.Null);
-        Assert.That(failure.ReceivingEndpoint.Name, Is.EqualTo(context.EndpointNameOfReceivingEndpoint));
 
         // ServicePulse needs both an exception type and description to render the UI in a resonable way
         Assert.That(failure.Exception.ExceptionType, Is.EqualTo("SomeExceptionType"));

--- a/src/ServiceControl/Operations/EndpointDetailsParser.cs
+++ b/src/ServiceControl/Operations/EndpointDetailsParser.cs
@@ -80,8 +80,8 @@ namespace ServiceControl.Contracts.Operations
                     endpoint.Host = queueAndMachinename.Machine;
                 }
 
-                // If we've been now able to get the endpoint details, return the new info.
-                if (!string.IsNullOrEmpty(endpoint.Name) && !string.IsNullOrEmpty(endpoint.Host))
+                // If we've been now able to get at least the endpoint name, return the new info.
+                if (!string.IsNullOrEmpty(endpoint.Name))
                 {
                     return endpoint;
                 }


### PR DESCRIPTION
This lowers the bar further when it comes to importing failures into service control.