### PR TITLE
Update NServiceBus.RabbitMQ to 10.1.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="NServiceBus.Metrics" Version="5.0.1" />
     <PackageVersion Include="NServiceBus.Metrics.ServiceControl" Version="5.0.0" />
     <PackageVersion Include="NServiceBus.Persistence.NonDurable" Version="2.0.1" />
-    <PackageVersion Include="NServiceBus.RabbitMQ" Version="10.1.0" />
+    <PackageVersion Include="NServiceBus.RabbitMQ" Version="10.1.1" />
     <PackageVersion Include="NServiceBus.SagaAudit" Version="5.0.2" />
     <PackageVersion Include="NServiceBus.Testing" Version="9.0.1" />
     <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="5.0.0" />


### PR DESCRIPTION
This PR updates the `release-6.6` branch to [NServiceBus.RabbitMQ 10.1.1](https://github.com/Particular/NServiceBus.RabbitMQ/releases/tag/10.1.1).