### PR TITLE
Update RavenDB to 6.2.5

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -61,7 +61,7 @@
     <PackageVersion Include="PropertyChanged.Fody" Version="4.1.0" />
     <PackageVersion Include="PropertyChanging.Fody" Version="1.30.3" />
     <PackageVersion Include="PublicApiGenerator" Version="11.4.5" />
-    <PackageVersion Include="RavenDB.Embedded" Version="6.2.4" />
+    <PackageVersion Include="RavenDB.Embedded" Version="6.2.5" />
     <PackageVersion Include="ReactiveUI.WPF" Version="20.1.63" />
     <PackageVersion Include="ServiceControl.Contracts" Version="5.0.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />


### PR DESCRIPTION
This PR updates the `release-6.6` branch to [RavenDB 6.2.5](https://github.com/ravendb/ravendb/releases/tag/6.2.5).