### PR TITLE
Setting proper queue name on edit & retry

### DIFF
--- a/src/ServiceControl.Persistence.Tests/Recoverability/EditMessageTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/EditMessageTests.cs
@@ -218,7 +218,7 @@
         }
 
         [Test]
-        public async Task Should_assign_edited_message_correct_akcnowledgment_queue_address()
+        public async Task Should_assign_correct_akcnowledgment_queue_address_when_editing_and_retyring()
         {
             var messageFailure = await CreateAndStoreFailedMessage();
             var message = CreateEditMessage(messageFailure.UniqueMessageId);

--- a/src/ServiceControl.Persistence.Tests/Recoverability/EditMessageTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/EditMessageTests.cs
@@ -22,7 +22,7 @@
         readonly TestableUnicastDispatcher dispatcher = new();
         readonly ErrorQueueNameCache errorQueueNameCache = new()
         {
-            ResolvedErrorAddress = "TestAddress"
+            ResolvedErrorAddress = "errorQueueName"
         };
 
         public EditMessageTests() =>

--- a/src/ServiceControl/Recoverability/RecoverabilityComponent.cs
+++ b/src/ServiceControl/Recoverability/RecoverabilityComponent.cs
@@ -47,6 +47,7 @@
 
             //Return to sender - registered both as singleton and hosted service because it is a dependency of the RetryProcessor
             services.AddSingleton<ReturnToSender>();
+            services.AddSingleton<ErrorQueueNameCache>();
             services.AddSingleton<ReturnToSenderDequeuer>();
             services.AddHostedService(provider => provider.GetRequiredService<ReturnToSenderDequeuer>());
 

--- a/src/ServiceControl/Recoverability/Retrying/Infrastructure/ErrorQueueNameCache.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Infrastructure/ErrorQueueNameCache.cs
@@ -1,23 +1,22 @@
-﻿namespace ServiceControl.Recoverability
+﻿namespace ServiceControl.Recoverability;
+
+using System;
+
+class ErrorQueueNameCache
 {
-    using System;
+    string resolvedErrorAddress;
 
-    class ErrorQueueNameCache
+    public string ResolvedErrorAddress
     {
-        string resolvedErrorAddress;
-
-        public string ResolvedErrorAddress
+        get
         {
-            get
+            if (string.IsNullOrEmpty(resolvedErrorAddress))
             {
-                if (string.IsNullOrEmpty(resolvedErrorAddress))
-                {
-                    throw new InvalidOperationException($"{nameof(ResolvedErrorAddress)} is not set. Please set it before accessing.");
-                }
-
-                return resolvedErrorAddress;
+                throw new InvalidOperationException($"{nameof(ResolvedErrorAddress)} is not set. Please set it before accessing.");
             }
-            set => resolvedErrorAddress = value;
+
+            return resolvedErrorAddress;
         }
+        set => resolvedErrorAddress = value;
     }
 }

--- a/src/ServiceControl/Recoverability/Retrying/Infrastructure/ErrorQueueNameCache.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Infrastructure/ErrorQueueNameCache.cs
@@ -1,0 +1,23 @@
+﻿namespace ServiceControl.Recoverability
+{
+    using System;
+
+    class ErrorQueueNameCache
+    {
+        string resolvedErrorAddress;
+
+        public string ResolvedErrorAddress
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(resolvedErrorAddress))
+                {
+                    throw new InvalidOperationException($"{nameof(ResolvedErrorAddress)} is not set. Please set it before accessing.");
+                }
+
+                return resolvedErrorAddress;
+            }
+            set => resolvedErrorAddress = value;
+        }
+    }
+}


### PR DESCRIPTION
This sets the proper queue name when using "Edit & Retry" functionality. This fixes the following issues:

- https://github.com/Particular/ServiceControl/issues/4837
- https://github.com/Particular/ServiceControl.Connector.MassTransit/issues/243


https://github.com/user-attachments/assets/7101e471-a5d5-4ba9-9510-7b613ff80df3

