### PR TITLE
Update .Net dependencies to 8.0.17

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,8 +17,8 @@
     <PackageVersion Include="Fody" Version="6.9.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="HdrHistogram" Version="2.5.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.16" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.16" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.17" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />


### PR DESCRIPTION
Backport of:

- https://github.com/Particular/ServiceControl/pull/5010

to `release-6.6`


Addresses:

- #5002 