### PR TITLE
Exclude Particular.Monitoring from usage reports by default

### DIFF
--- a/src/Particular.LicensingComponent/Shared/PlatformEndpointHelper.cs
+++ b/src/Particular.LicensingComponent/Shared/PlatformEndpointHelper.cs
@@ -13,6 +13,7 @@
                 || endpointName.EndsWith(".TimeoutsDispatcher", StringComparison.OrdinalIgnoreCase)
                 || endpointName.StartsWith($"{throughputSettings.ServiceControlQueue}.", StringComparison.OrdinalIgnoreCase)
                 || endpointName.Equals(ServiceControlSettings.ServiceControlThroughputDataQueue, StringComparison.OrdinalIgnoreCase)
+                || endpointName.StartsWith("Particular.Monitoring", StringComparison.OrdinalIgnoreCase)
                 || AuditThroughputCollectorHostedService.AuditQueues.Any(a => endpointName.Equals(a, StringComparison.OrdinalIgnoreCase));
         }
     }


### PR DESCRIPTION
ServiceControl doesn't have a setting for the monitoring queue. Always exclude hardcoded Particular.Monitoring.

- [x] smoke test