### PR TITLE
Report zip file creation throws System.ObjectDisposedException: Cannot access a closed Stream

### DIFF
--- a/src/Particular.LicensingComponent/WebApi/LicensingController.cs
+++ b/src/Particular.LicensingComponent/WebApi/LicensingController.cs
@@ -68,6 +68,9 @@
                 FileName = $"{fileName}.zip"
             }.ToString();
 
+            // The zip archive is written directly to the response body stream and has to remain open until the response is fully sent.
+            // This is done for performance reasons to avoid buffering the entire report in memory before sending it.
+            // The BodyWriter is used as a stream to avoid into synchronous IO operations that would be prevented by the ASP.NET Core pipeline.
             using var archive = new ZipArchive(Response.BodyWriter.AsStream(), ZipArchiveMode.Create, leaveOpen: true);
             var entry = archive.CreateEntry($"{fileName}.json");
             await using var entryStream = entry.Open();

--- a/src/Particular.LicensingComponent/WebApi/LicensingController.cs
+++ b/src/Particular.LicensingComponent/WebApi/LicensingController.cs
@@ -66,7 +66,7 @@
             }.ToString();
 
             using var archive = new ZipArchive(Response.BodyWriter.AsStream(), ZipArchiveMode.Create, leaveOpen: true);
-            var entry = archive.CreateEntry($"{Path.GetFileNameWithoutExtension(fileName)}.json");
+            var entry = archive.CreateEntry($"{fileName}.json");
             await using var entryStream = entry.Open();
             await JsonSerializer.SerializeAsync(entryStream, report, SerializationOptions.IndentedWithNoEscaping, cancellationToken);
         }

--- a/src/Particular.LicensingComponent/WebApi/LicensingController.cs
+++ b/src/Particular.LicensingComponent/WebApi/LicensingController.cs
@@ -62,7 +62,7 @@
             HttpContext.Response.ContentType = "application/zip";
             HttpContext.Response.Headers[HeaderNames.ContentDisposition] = new ContentDispositionHeaderValue("attachment")
             {
-                FileName = fileName
+                FileName = $"{fileName}.zip"
             }.ToString();
 
             using var archive = new ZipArchive(Response.BodyWriter.AsStream(), ZipArchiveMode.Create, leaveOpen: true);

--- a/src/Particular.LicensingComponent/WebApi/LicensingController.cs
+++ b/src/Particular.LicensingComponent/WebApi/LicensingController.cs
@@ -1,6 +1,7 @@
 ﻿namespace Particular.LicensingComponent.WebApi
 {
     using System.IO.Compression;
+    using System.Text;
     using System.Text.Json;
     using System.Threading;
     using Contracts;
@@ -48,7 +49,9 @@
             if (!reportStatus.ReportCanBeGenerated)
             {
                 HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-                await HttpContext.Response.WriteAsync($"Report cannot be generated – {reportStatus.Reason}", cancellationToken);
+                HttpContext.Response.ContentType = "text/plain; charset=utf-8";
+
+                await HttpContext.Response.WriteAsync($"Report cannot be generated – {reportStatus.Reason}", Encoding.UTF8, cancellationToken);
                 return;
             }
 

--- a/src/Particular.LicensingComponent/WebApi/LicensingController.cs
+++ b/src/Particular.LicensingComponent/WebApi/LicensingController.cs
@@ -65,7 +65,7 @@
                 FileName = fileName
             }.ToString();
 
-            using var archive = new ZipArchive(HttpContext.Response.Body, ZipArchiveMode.Create, leaveOpen: true);
+            using var archive = new ZipArchive(Response.BodyWriter.AsStream(), ZipArchiveMode.Create, leaveOpen: true);
             var entry = archive.CreateEntry($"{Path.GetFileNameWithoutExtension(fileName)}.json");
             await using var entryStream = entry.Open();
             await JsonSerializer.SerializeAsync(entryStream, report, SerializationOptions.IndentedWithNoEscaping, cancellationToken);


### PR DESCRIPTION
Fix and improvements for https://github.com/Particular/ServiceControl/pull/4971

The previous PR did introduce a problem because the memory stream was disposed before the response was copied which led to the following exception

```text
Category: Microsoft.AspNetCore.Server.Kestrel
EventId: 13
SpanId: 7e163d9c21343474
TraceId: 3027ff808021327a73fb7a0c655ddb6a
ParentId: 0000000000000000
ConnectionId: 0HNDQ0E7HCPSF
RequestId: 0HNDQ0E7HCPSF:00000001
RequestPath: /api/licensing/report/file

Connection id "0HNDQ0E7HCPSF", Request id "0HNDQ0E7HCPSF:00000001": An unhandled exception was thrown by the application.

Exception: 
System.ObjectDisposedException: Cannot access a closed Stream.
   at System.IO.MemoryStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.MemoryStream.ReadAsync(Memory`1 buffer, CancellationToken cancellationToken)
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Http.StreamCopyOperationInternal.CopyToAsync(Stream source, Stream destination, Nullable`1 count, Int32 bufferSize, CancellationToken cancel)
   at Microsoft.AspNetCore.Internal.FileResultHelper.WriteFileAsync(HttpContext context, Stream fileStream, RangeItemHeaderValue range, Int64 rangeLength)
   at Microsoft.AspNetCore.Mvc.Infrastructure.FileResultExecutorBase.WriteFileAsync(HttpContext context, Stream fileStream, RangeItemHeaderValue range, Int64 rangeLength)
   at Microsoft.AspNetCore.Mvc.Infrastructure.FileStreamResultExecutor.ExecuteAsync(ActionContext context, FileStreamResult result)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResultFilterAsync>g__Awaited|30_0[TFilter,TFilterAsync](ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResultExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResultNext[TFilter,TFilterAsync](State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeResultFilters()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|20_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.InvokeCore(HttpContext context)
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
```

This switches over to directly write to the output stream writer which bypasses the memory stream making things more efficient from a memory perspective but also addressing the previous problem. It would have been possible to remove the dispose on the memory stream and ship that as a patch too but given I already had this improvement lined up I figured I also test this one which made me discover the original problem

<img width="963" alt="image" src="https://github.com/user-attachments/assets/50d43c6b-e726-4aa9-b804-6de64dff76e7" />

<img width="963" alt="image" src="https://github.com/user-attachments/assets/a755afde-b0ce-464c-9bfa-e81ef6ce3c09" />

Yes I'm using Andreas license ;)