### PR TITLE
Only display instructions for MSMQ

### DIFF
--- a/src/Particular.LicensingComponent/Shared/ServiceControlSettings.cs
+++ b/src/Particular.LicensingComponent/Shared/ServiceControlSettings.cs
@@ -10,15 +10,12 @@
         public static string ServiceControlThroughputDataQueueSetting = "ServiceControlThroughputDataQueue";
         public static string ServiceControlThroughputDataQueue = SettingsReader.Read(ThroughputSettings.SettingsNamespace, ServiceControlThroughputDataQueueSetting, "ServiceControl.ThroughputData");
 
-        static string SCQueue = $"{ThroughputSettings.SettingsNamespace.Root}/{ServiceControlThroughputDataQueueSetting}";
-        static string SCQueueDescription = $"Service Control throughput processing queue. This setting must match the equivalent `Monitoring/{ServiceControlThroughputDataQueueSetting}` setting for the Monitoring instance.";
-
         static string MonitoringQueue = $"Monitoring/{ServiceControlThroughputDataQueueSetting}";
-        static string MonitoringQueueDescription = $"Queue to send monitoring throughput data to for processing by ServiceControl. This setting must match the equivalent `{ThroughputSettings.SettingsNamespace.Root}/{ServiceControlThroughputDataQueueSetting}` setting for the ServiceControl instance.";
+        static string MonitoringQueueDescription = $"Queue to send monitoring throughput data to for processing by ServiceControl. This setting only needs to be specified if the Monitoring instance is not hosted in the same machine as the Error instance is running on.";
 
         public static List<ThroughputConnectionSetting> GetServiceControlConnectionSettings()
         {
-            return [new ThroughputConnectionSetting(SCQueue, SCQueueDescription)];
+            return [];
         }
 
         public static List<ThroughputConnectionSetting> GetMonitoringConnectionSettings()

--- a/src/Particular.LicensingComponent/ThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/ThroughputCollector.cs
@@ -20,7 +20,7 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
         var throughputConnectionSettings = new ThroughputConnectionSettings
         {
             ServiceControlSettings = ServiceControlSettings.GetServiceControlConnectionSettings(),
-            MonitoringSettings = ServiceControlSettings.GetMonitoringConnectionSettings(),
+            MonitoringSettings = throughputSettings.TransportType == "MSMQ" ? ServiceControlSettings.GetMonitoringConnectionSettings() : [],
             BrokerSettings = throughputQuery?.Settings.Select(pair => new ThroughputConnectionSetting($"{ThroughputSettings.SettingsNamespace.Root}/{pair.Key}", pair.Description)).ToList() ?? []
         };
         return await Task.FromResult(throughputConnectionSettings);


### PR DESCRIPTION
This PR removes the incorrect instructions for ASQ.
<img width="2010" height="672" alt="image" src="https://github.com/user-attachments/assets/d31b3f6f-3ae6-4d39-b9c8-bb585cb5350d" />

And updates the instruction for MSMQ so that they explicitly mention that the settings are only to be used if needed.
