### PR TITLE
Check that server version is greater than or equal to the client

### DIFF
--- a/src/ServiceControl.RavenDB/ServiceControl.RavenDB.csproj
+++ b/src/ServiceControl.RavenDB/ServiceControl.RavenDB.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="ByteSize" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="NServiceBus" />
-    <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="RavenDB.Embedded" />
   </ItemGroup>
 

--- a/src/ServiceControl.RavenDB/ServiceControl.RavenDB.csproj
+++ b/src/ServiceControl.RavenDB/ServiceControl.RavenDB.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="ByteSize" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="NServiceBus" />
+    <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="RavenDB.Embedded" />
   </ItemGroup>
 

--- a/src/ServiceControl.RavenDB/StartupChecks.cs
+++ b/src/ServiceControl.RavenDB/StartupChecks.cs
@@ -9,6 +9,16 @@
     {
         public static async Task EnsureServerVersion(IDocumentStore store, CancellationToken cancellationToken = default)
         {
+            // RavenDB compatibility policy is that the major/minor version of the server must be
+            // equal or higher than the client and ignores the patch version.
+            //
+            // https://docs.ravendb.net/6.2/client-api/faq/backward-compatibility/#compatibility---ravendb-42-and-higher
+            //
+            // > Starting with version 4.2, RavenDB clients are compatible with any server of their own version and higher.
+            // > E.g. -
+            // >
+            // > Client 4.2 is compatible with Server 4.2, Server 4.5, Server 5.2, and any other server of a higher version.
+
             var build = await store.Maintenance.Server.SendAsync(new GetBuildNumberOperation(), cancellationToken);
             var serverProductVersion = new Version(build.ProductVersion);
 


### PR DESCRIPTION
The following prior PR does a fixed minor/major comparison between client and server:

- https://github.com/Particular/ServiceControl/pull/4484 

However, the PR description hints that it follows the RavenDB guidance:

> It now verifies that the server product version is >= client product version. This aligns with the RavenDB Client/Server Compatibility statement.

This PR fixes this. It parses the version numbers and then compares by only using the `Major.Minor`.