### PR TITLE
Fix `NullReferenceException` when connected to RavenDB cloud

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/CustomChecks/CheckDirtyMemory.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/CustomChecks/CheckDirtyMemory.cs
@@ -8,7 +8,6 @@ using NServiceBus.CustomChecks;
 
 class CheckDirtyMemory(MemoryInformationRetriever memoryInformationRetriever, ILogger<CheckDirtyMemory> logger) : CustomCheck("RavenDB dirty memory", "ServiceControl.Audit Health", TimeSpan.FromMinutes(5))
 {
-
     public override async Task<CheckResult> PerformCheck(CancellationToken cancellationToken = default)
     {
         var (isHighDirty, dirtyMemory) = await memoryInformationRetriever.GetMemoryInformation(cancellationToken);

--- a/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -31,6 +31,8 @@ class MemoryInformationRetriever(DatabaseConfiguration databaseConfiguration)
         var httpResponse = await client.GetAsync("/admin/debug/memory/stats?includeThreads=false&includeMappings=false", cancellationToken);
         var responseDto = JsonSerializer.Deserialize<ResponseDto>(await httpResponse.Content.ReadAsStringAsync(cancellationToken));
 
-        return (responseDto.MemoryInformation.IsHighDirty, responseDto.MemoryInformation.DirtyMemory);
+        return null == responseDto.MemoryInformation
+            ? default
+            : (responseDto.MemoryInformation.IsHighDirty, responseDto.MemoryInformation.DirtyMemory);
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -31,7 +31,7 @@ class MemoryInformationRetriever(DatabaseConfiguration databaseConfiguration)
         var httpResponse = await client.GetAsync("/admin/debug/memory/stats?includeThreads=false&includeMappings=false", cancellationToken);
         var responseDto = JsonSerializer.Deserialize<ResponseDto>(await httpResponse.Content.ReadAsStringAsync(cancellationToken));
 
-        return null == responseDto.MemoryInformation
+        return responseDto.MemoryInformation is null
             ? default
             : (responseDto.MemoryInformation.IsHighDirty, responseDto.MemoryInformation.DirtyMemory);
     }

--- a/src/ServiceControl.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -31,7 +31,7 @@ class MemoryInformationRetriever(RavenPersisterSettings persisterSettings)
         var httpResponse = await client.GetAsync("/admin/debug/memory/stats?includeThreads=false&includeMappings=false", cancellationToken);
         var responseDto = JsonSerializer.Deserialize<ResponseDto>(await httpResponse.Content.ReadAsStringAsync(cancellationToken));
 
-        return null == responseDto.MemoryInformation
+        return responseDto.MemoryInformation is null
             ? default
             : (responseDto.MemoryInformation.IsHighDirty, responseDto.MemoryInformation.DirtyMemory);
     }

--- a/src/ServiceControl.Persistence.RavenDB/MemoryInformationRetriever.cs
+++ b/src/ServiceControl.Persistence.RavenDB/MemoryInformationRetriever.cs
@@ -31,6 +31,8 @@ class MemoryInformationRetriever(RavenPersisterSettings persisterSettings)
         var httpResponse = await client.GetAsync("/admin/debug/memory/stats?includeThreads=false&includeMappings=false", cancellationToken);
         var responseDto = JsonSerializer.Deserialize<ResponseDto>(await httpResponse.Content.ReadAsStringAsync(cancellationToken));
 
-        return (responseDto.MemoryInformation.IsHighDirty, responseDto.MemoryInformation.DirtyMemory);
+        return null == responseDto.MemoryInformation
+            ? default
+            : (responseDto.MemoryInformation.IsHighDirty, responseDto.MemoryInformation.DirtyMemory);
     }
 }


### PR DESCRIPTION
Fix `NullReferenceException` when connected to RavenDB cloud which does not return memory information.