### PR TITLE
Handle trailing slash in /api request

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/RootController.cs
@@ -18,17 +18,19 @@
         [HttpGet]
         public OkObjectResult Urls()
         {
-            var baseUrl = Request.GetDisplayUrl() + "/";
+            var baseUrl = Request.GetDisplayUrl();
+
+            if (!baseUrl.EndsWith('/'))
+            {
+                baseUrl += "/";
+            }
+
             var model = new RootUrls
             {
                 KnownEndpointsUrl = "/endpoints/known", // relative URI to allow proxying
-                MessageSearchUrl =
-                    baseUrl + "messages/search/{keyword}/{?page,per_page,direction,sort}",
-                EndpointsMessageSearchUrl =
-                    baseUrl +
-                    "endpoints/{name}/messages/search/{keyword}/{?page,per_page,direction,sort}",
-                EndpointsMessagesUrl =
-                    baseUrl + "endpoints/{name}/messages/{?page,per_page,direction,sort}",
+                MessageSearchUrl = baseUrl + "messages/search/{keyword}/{?page,per_page,direction,sort}",
+                EndpointsMessageSearchUrl = baseUrl + "endpoints/{name}/messages/search/{keyword}/{?page,per_page,direction,sort}",
+                EndpointsMessagesUrl = baseUrl + "endpoints/{name}/messages/{?page,per_page,direction,sort}",
                 AuditCountUrl = baseUrl + "endpoints/{name}/audit-count",
                 Name = SettingsReader.Read(Settings.SettingsRootNamespace, "Name", "ServiceControl.Audit"),
                 Description = SettingsReader.Read(Settings.SettingsRootNamespace, "Description", "The audit backend for the Particular Service Platform"),

--- a/src/ServiceControl/Infrastructure/Api/ConfigurationApi.cs
+++ b/src/ServiceControl/Infrastructure/Api/ConfigurationApi.cs
@@ -14,12 +14,15 @@ using ServiceBus.Management.Infrastructure.Settings;
 using ServiceControl.Api;
 using ServiceControl.Api.Contracts;
 
-class ConfigurationApi(ActiveLicense license,
-    Settings settings,
-    IHttpClientFactory httpClientFactory, MassTransitConnectorHeartbeatStatus connectorHeartbeatStatus) : IConfigurationApi
+class ConfigurationApi(ActiveLicense license, Settings settings, IHttpClientFactory httpClientFactory, MassTransitConnectorHeartbeatStatus connectorHeartbeatStatus) : IConfigurationApi
 {
     public Task<RootUrls> GetUrls(string baseUrl, CancellationToken cancellationToken)
     {
+        if (!baseUrl.EndsWith('/'))
+        {
+            baseUrl += "/";
+        }
+
         var model = new RootUrls
         {
             EndpointsUrl = baseUrl + "endpoints",
@@ -27,13 +30,9 @@ class ConfigurationApi(ActiveLicense license,
             SagasUrl = baseUrl + "sagas",
             ErrorsUrl = baseUrl + "errors/{?page,per_page,direction,sort}",
             EndpointsErrorUrl = baseUrl + "endpoints/{name}/errors/{?page,per_page,direction,sort}",
-            MessageSearchUrl =
-                baseUrl + "messages/search/{keyword}/{?page,per_page,direction,sort}",
-            EndpointsMessageSearchUrl =
-                baseUrl +
-                "endpoints/{name}/messages/search/{keyword}/{?page,per_page,direction,sort}",
-            EndpointsMessagesUrl =
-                baseUrl + "endpoints/{name}/messages/{?page,per_page,direction,sort}",
+            MessageSearchUrl = baseUrl + "messages/search/{keyword}/{?page,per_page,direction,sort}",
+            EndpointsMessageSearchUrl = baseUrl + "endpoints/{name}/messages/search/{keyword}/{?page,per_page,direction,sort}",
+            EndpointsMessagesUrl = baseUrl + "endpoints/{name}/messages/{?page,per_page,direction,sort}",
             AuditCountUrl = baseUrl + "endpoints/{name}/audit-count",
             Name = SettingsReader.Read(Settings.SettingsRootNamespace, "Name", "ServiceControl"),
             Description = SettingsReader.Read(Settings.SettingsRootNamespace, "Description", "The management backend for the Particular Service Platform"),

--- a/src/ServiceControl/Infrastructure/WebApi/RootController.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/RootController.cs
@@ -13,7 +13,7 @@
     {
         [Route("")]
         [HttpGet]
-        public Task<RootUrls> Urls() => configurationApi.GetUrls(Request.GetDisplayUrl() + "/", default);
+        public Task<RootUrls> Urls() => configurationApi.GetUrls(Request.GetDisplayUrl(), default);
 
         [Route("instance-info")]
         [Route("configuration")]


### PR DESCRIPTION
This PR ensures that the response contest of an `/api` request is consistent regardless if a trailing slash was included in the request or not.

The PR also includes some minor formatting/whitespace tweaks.