### PR TITLE
Changing fallback for content type to text/plain

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/UnitOfWork/RavenAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/UnitOfWork/RavenAuditIngestionUnitOfWork.cs
@@ -35,7 +35,7 @@
             if (!body.IsEmpty)
             {
                 await using var stream = new ReadOnlyStream(body);
-                var contentType = processedMessage.Headers.GetValueOrDefault(Headers.ContentType, "text/xml");
+                var contentType = processedMessage.Headers.GetValueOrDefault(Headers.ContentType, "text/plain");
 
                 await bodyStorage.Store(processedMessage.Id, contentType, body.Length, stream, cancellationToken);
             }

--- a/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
@@ -80,7 +80,7 @@
         [Test]
         public async Task Can_roundtrip_message_body()
         {
-            string expectedContentType = "text/xml";
+            string expectedContentType = "text/plain";
             var unitOfWork = await StartAuditUnitOfWork(1);
 
             var body = new byte[100];

--- a/src/ServiceControl.Audit.Persistence/BodyStorageEnricher.cs
+++ b/src/ServiceControl.Audit.Persistence/BodyStorageEnricher.cs
@@ -21,7 +21,7 @@
                 return;
             }
 
-            var contentType = GetContentType(processedMessage.Headers, "text/xml");
+            var contentType = GetContentType(processedMessage.Headers, "text/plain");
             processedMessage.MessageMetadata.Add("ContentType", contentType);
 
             var stored = await TryStoreBody(body, processedMessage, bodySize, contentType, cancellationToken);

--- a/src/ServiceControl.Audit.UnitTests/BodyStorage/BodyStorageEnricherTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/BodyStorage/BodyStorageEnricherTests.cs
@@ -92,7 +92,7 @@ namespace ServiceControl.UnitTests.BodyStorage
                 [Headers.MessageId] = "someid",
                 ["ServiceControl.Retry.UniqueMessageId"] = "someid",
                 [Headers.ProcessingEndpoint] = "someendpoint",
-                [Headers.ContentType] = "text/xml"
+                [Headers.ContentType] = "text/plain"
             };
 
             var message = new ProcessedMessage(headers, metadata);

--- a/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
@@ -33,7 +33,7 @@
             List<FailedMessage.FailureGroup> groups)
         {
             var uniqueMessageId = context.Headers.UniqueId();
-            var contentType = GetContentType(context.Headers, "text/xml");
+            var contentType = GetContentType(context.Headers, "text/plain");
             var bodySize = context.Body.Length;
 
             processingAttempt.MessageMetadata.Add("ContentType", contentType);


### PR DESCRIPTION
Two reasons:
1. To match what happens in ServicePulse: https://github.com/Particular/ServicePulse/blob/6b6e5d429e5239f6c4300ae4b191f9317ad3ce77/src/Frontend/src/stores/MessageStore.ts#L214
2. ServicePulse tries to pretty-print XML and this will break most of the times for unrecognized content type: https://github.com/Particular/ServicePulse/blob/6b6e5d429e5239f6c4300ae4b191f9317ad3ce77/src/Frontend/src/stores/MessageStore.ts#L221