### PR TITLE
Missing Content-Type results in handling the message as text/xml

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/UnitOfWork/RavenAuditIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/UnitOfWork/RavenAuditIngestionUnitOfWork.cs
@@ -35,7 +35,7 @@
             if (!body.IsEmpty)
             {
                 await using var stream = new ReadOnlyStream(body);
-                var contentType = processedMessage.Headers.GetValueOrDefault(Headers.ContentType, "text/xml");
+                var contentType = processedMessage.Headers.GetValueOrDefault(Headers.ContentType, "text/plain");
 
                 await bodyStorage.Store(processedMessage.Id, contentType, body.Length, stream);
             }

--- a/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests/AuditTests.cs
@@ -80,7 +80,7 @@
         [Test]
         public async Task Can_roundtrip_message_body()
         {
-            string expectedContentType = "text/xml";
+            string expectedContentType = "text/plain";
             var unitOfWork = await StartAuditUnitOfWork(1);
 
             var body = new byte[100];

--- a/src/ServiceControl.Audit.Persistence/BodyStorageEnricher.cs
+++ b/src/ServiceControl.Audit.Persistence/BodyStorageEnricher.cs
@@ -20,7 +20,7 @@
                 return;
             }
 
-            var contentType = GetContentType(processedMessage.Headers, "text/xml");
+            var contentType = GetContentType(processedMessage.Headers, "text/plain");
             processedMessage.MessageMetadata.Add("ContentType", contentType);
 
             var stored = await TryStoreBody(body, processedMessage, bodySize, contentType);

--- a/src/ServiceControl.Audit.UnitTests/BodyStorage/BodyStorageEnricherTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/BodyStorage/BodyStorageEnricherTests.cs
@@ -90,7 +90,7 @@ namespace ServiceControl.UnitTests.BodyStorage
                 [Headers.MessageId] = "someid",
                 ["ServiceControl.Retry.UniqueMessageId"] = "someid",
                 [Headers.ProcessingEndpoint] = "someendpoint",
-                [Headers.ContentType] = "text/xml"
+                [Headers.ContentType] = "text/plain"
             };
 
             var message = new ProcessedMessage(headers, metadata);

--- a/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
@@ -33,7 +33,7 @@
             List<FailedMessage.FailureGroup> groups)
         {
             var uniqueMessageId = context.Headers.UniqueId();
-            var contentType = GetContentType(context.Headers, "text/xml");
+            var contentType = GetContentType(context.Headers, "text/plain");
             var bodySize = context.Body.Length;
 
             processingAttempt.MessageMetadata.Add("ContentType", contentType);


### PR DESCRIPTION
Backport of:
-  Backport of https://github.com/Particular/Announcements/pull/1084

Which fixes for the `release-5.11` branch:
- https://github.com/Particular/ServiceControl/issues/5145