### PR TITLE
Update dependency NServiceBus.RabbitMQ to 10.1.5

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="NServiceBus.Metrics" Version="5.0.1" />
     <PackageVersion Include="NServiceBus.Metrics.ServiceControl" Version="5.0.0" />
     <PackageVersion Include="NServiceBus.Persistence.NonDurable" Version="2.0.1" />
-    <PackageVersion Include="NServiceBus.RabbitMQ" Version="10.1.4" />
+    <PackageVersion Include="NServiceBus.RabbitMQ" Version="10.1.5" />
     <PackageVersion Include="NServiceBus.SagaAudit" Version="5.0.2" />
     <PackageVersion Include="NServiceBus.Testing" Version="9.0.1" />
     <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="5.0.2" />


### PR DESCRIPTION
This PR updates the RabbitMQ transport on the `release-6.7` branch.