### PR TITLE
Validate installed binaries are not removed by external tool

### DIFF
--- a/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
+++ b/src/ServiceControlInstaller.Engine/FileSystem/FileUtils.cs
@@ -153,7 +153,7 @@ namespace ServiceControlInstaller.Engine.FileSystem
 
             // Validate 3rd-party security software didn't delete any of the files, but first, a small delay
             // so that any tool out there has a chance to remove the file before prematurely declaring victory
-            Thread.Sleep(500);
+            Thread.Sleep(1000);
             foreach (var entry in archive.Entries)
             {
                 var pathParts = entry.FullName.Split('/', '\\');


### PR DESCRIPTION
* Implementation of https://github.com/Particular/ServiceControl/issues/5191

On some systems it's possible for a 3rd-party security tool to delete one of the binaries written by ServiceControl Management during an install, creating an incomplete set of binaries that is unable to start.

This improvement checks to ensure that each binary that is expected to be present after an install is still present, and throws an exception otherwise, halting the install with an informative error message.