### PR TITLE
Some queue types RabbitMQ supports are not handled properly, causing ServiceControl usage collection to fail

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="NServiceBus.Metrics" Version="5.0.1" />
     <PackageVersion Include="NServiceBus.Metrics.ServiceControl" Version="5.0.0" />
     <PackageVersion Include="NServiceBus.Persistence.NonDurable" Version="2.0.1" />
-    <PackageVersion Include="NServiceBus.RabbitMQ" Version="10.1.5" />
+    <PackageVersion Include="NServiceBus.RabbitMQ" Version="10.1.6" />
     <PackageVersion Include="NServiceBus.SagaAudit" Version="5.0.2" />
     <PackageVersion Include="NServiceBus.Testing" Version="9.0.1" />
     <PackageVersion Include="NServiceBus.Transport.AzureServiceBus" Version="5.0.2" />


### PR DESCRIPTION
Backport of #5205 which fixes #5207 for the `release-6.7` branch