### PR TITLE
Fix RavenDB Management Studio link binding issue

### DIFF
--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs
@@ -81,7 +81,7 @@ namespace ServiceControl.Config.UI.AdvancedOptions
 
         public bool InMaintenanceMode => ServiceControlInstance.InMaintenanceMode;
 
-        public string RavenStudioUrl => ServiceControlInstance.RavenDbStudioUrl;
+        public string RavenDbStudioUrl => ServiceControlInstance.RavenDbStudioUrl;
 
         public bool IsRunning
         {


### PR DESCRIPTION
# Fix RavenDB Management Studio link binding issue

## Summary
This PR fixes a property name mismatch introduced in PR #5237 that caused the RavenDB Management Studio hyperlink to be grayed out and non-functional in the ServiceControl Management UI.

## Problem
After merging PR #5237 "Point RavenDB Management Studio link to localhost", the RavenDB Management Studio link in the Advanced Options maintenance mode section became unresponsive. The link appeared grayed out and clicking it had no effect.

## Root Cause
PR #5237 renamed the property from `StorageUrl` to `RavenDbStudioUrl` in `ServiceControlBaseService.cs`, but the corresponding ViewModel property in `ServiceControlAdvancedViewModel.cs` was incorrectly named `RavenStudioUrl` (missing "Db"). This property name mismatch caused the WPF data binding to fail.

## Solution
- Fixed property name in `ServiceControlAdvancedViewModel.cs` from `RavenStudioUrl` to `RavenDbStudioUrl`
- This ensures proper binding between the ViewModel and the underlying ServiceControlInstance property

## Files Changed
- `src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedViewModel.cs`

## Testing
- RavenDB Management Studio hyperlink now appears as an active blue link
- Clicking the link properly opens the RavenDB Studio at `http://localhost:{port}/studio/index.html#databases`
- Right-click context menu "Copy to Clipboard" functionality works correctly

Fixes issue introduced in #5237