### PR TITLE
Remove ServiceInsight references, replace with servicepulse 

### DIFF
--- a/docs/testing-scenarios.md
+++ b/docs/testing-scenarios.md
@@ -40,7 +40,7 @@ A long (though not exhaustive) list, although not every change will merit runnin
    - [ ] Generate message messages with non-trivial content using `send-fulltext 1 10`. Open ServicePulse and check if a message can be found in the search box using one of the strings from the `LongString` property
    - [ ] Generate messages using `fanout` and check in the [Sequence Diagram] view in ServicePulse that the graph is properly visualized
 - [ ] Saga Auditing
-   - [ ] Generate messages using `saga-audits 1` and check in the [Saga] view in ServiePulse that the graph is properly visualized
+   - [ ] Generate messages using `saga-audits 1` and check in the [Saga] view in ServicePulse that the graph is properly visualized
 - [ ] Integration Events
    - [ ] Download [integration events sample](https://docs.particular.net/samples/servicecontrol/events-subscription/). Switch the sample to the appropriate transport. 
    - [ ] Generate a failing message in the `NServiceBusEndptoin` and validate that an integration event `MessageFailed` is received by the `EndpointsMonitor` 


### PR DESCRIPTION
<!-- Review the pull request guidelines:  https://github.com/Particular/StaffSuccess/blob/master/github/raising-pull-requests.md -->

<!--
This is the default pull request template.

If you're raising a PR that will be RFCed, please use the RFC template by adding &template=rfc.md to the URL or copy the template: https://github.com/Particular/StaffSuccess/blob/master/.github/PULL_REQUEST_TEMPLATE/rfc.md  
-->
- https://github.com/Particular/GeneralPlatformExperience/issues/3559
- RFC : https://github.com/Particular/GeneralPlatformExperience/pull/3698

As part of the above issue, this PR removes references to SI 
## Change type

- [ ] Tiny mistakes or improvements that don't change the content or meaning
- [ ] A small decision according to the [decision-making guidelines](https://github.com/Particular/StaffSuccess/blob/master/guidelines/decision-making.md#process-for-small-decisions)
  - [ ] (Not required for decisions made by task forces) Decision type has been verified by someone not directly involved in the change being made in order to avoid bias.
  - [ ] (Not required for decisions made by task forces) The person verifying the decision type must **LEAVE A COMMENT** on this PR stating they approve the decision type. This does not imply agreement with the change, but only that the change type is correct. Sample comment: "Decision type has been verified as a small decision"
  - [ ] The PR has been approved by a reviewer who is not also the small decision verifier
  - [ ] Consider, is there some automation or other process that will make the necessary people aware of this at the appropriate time? If so, no announcement is needed. Otherwise, after the PR is merged, announce it in the relevant channel (e.g. in #staff-success or, if absolutely all staff should see it, in #announcements) and ping all the impacted parties.
- [ ] A [decision requiring an RFC but not a task force](https://github.com/Particular/StaffSuccess/blob/master/guidelines/decision-making.md#decisions-requiring-an-rfc-but-not-necessarily-a-task-force).
- [ ] An [RFC](https://github.com/Particular/StaffSuccess/blob/master/guidelines/RFC-process.md) created by a task force
- [x] Documentation update
- [ ] Other: