### PR TITLE
Replace hardcoded config file names with constants in unit tests to fix teardown issue

### DIFF
--- a/src/ServiceControl.Audit.UnitTests/PopulateAppSettingsTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/PopulateAppSettingsTests.cs
@@ -10,6 +10,8 @@ using NUnit.Framework;
 [TestFixture]
 public class PopulateAppSettingsTests
 {
+    const string ConfigFileName = "ServiceControl.Audit.exe.config";
+
     [Test]
     public async Task Should_populate_appSettings_from_exe_config_file()
     {
@@ -24,7 +26,7 @@ public class PopulateAppSettingsTests
                       </configuration>
                       """;
 
-        await File.WriteAllTextAsync("ServiceControl.Audit.exe.config", config);
+        await File.WriteAllTextAsync(ConfigFileName, config);
 
         var fileName = "ServiceControl.Audit";
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -70,5 +72,5 @@ public class PopulateAppSettingsTests
     }
 
     [TearDown]
-    public void TearDown() => File.Delete("ServiceControl.exe.config");
+    public void TearDown() => File.Delete(ConfigFileName);
 }

--- a/src/ServiceControl.Monitoring.UnitTests/PopulateAppSettingsTests.cs
+++ b/src/ServiceControl.Monitoring.UnitTests/PopulateAppSettingsTests.cs
@@ -10,6 +10,8 @@ using NUnit.Framework;
 [TestFixture]
 public class PopulateAppSettingsTests
 {
+    const string ConfigFileName = "ServiceControl.Monitoring.exe.config";
+
     [Test]
     public async Task Should_populate_appSettings_from_exe_config_file()
     {
@@ -24,7 +26,7 @@ public class PopulateAppSettingsTests
                       </configuration>
                       """;
 
-        await File.WriteAllTextAsync("ServiceControl.Monitoring.exe.config", config);
+        await File.WriteAllTextAsync(ConfigFileName, config);
 
         var fileName = "ServiceControl.Monitoring";
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -74,5 +76,5 @@ public class PopulateAppSettingsTests
     }
 
     [TearDown]
-    public void TearDown() => File.Delete("ServiceControl.exe.config");
+    public void TearDown() => File.Delete(ConfigFileName);
 }

--- a/src/ServiceControl.UnitTests/PopulateAppSettingsTests.cs
+++ b/src/ServiceControl.UnitTests/PopulateAppSettingsTests.cs
@@ -10,6 +10,8 @@ using NUnit.Framework;
 [TestFixture]
 public class PopulateAppSettingsTests
 {
+    const string ConfigFileName = "ServiceControl.exe.config";
+
     [Test]
     public async Task Should_populate_appSettings_from_exe_config_file()
     {
@@ -24,7 +26,7 @@ public class PopulateAppSettingsTests
                       </configuration>
                       """;
 
-        await File.WriteAllTextAsync("ServiceControl.exe.config", config);
+        await File.WriteAllTextAsync(ConfigFileName, config);
 
         var fileName = "ServiceControl";
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -72,5 +74,5 @@ public class PopulateAppSettingsTests
     }
 
     [TearDown]
-    public void TearDown() => File.Delete("ServiceControl.exe.config");
+    public void TearDown() => File.Delete(ConfigFileName);
 }


### PR DESCRIPTION
Test introduced in the following PR has incorrect teardown implementation:

- https://github.com/Particular/ServiceControl/pull/5248