### PR TITLE
Set custom checks TTL to 1 minute to prevent clock skew issues

### DIFF
--- a/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
+++ b/src/ServiceControl.Audit/Infrastructure/NServiceBusFactory.cs
@@ -43,7 +43,10 @@ namespace ServiceControl.Audit.Infrastructure
                 routing.RouteToEndpoint(typeof(RegisterNewEndpoint), serviceControlLogicalQueue);
                 routing.RouteToEndpoint(typeof(MarkMessageFailureResolvedByRetry), serviceControlLogicalQueue);
 
-                configuration.ReportCustomChecksTo(transportCustomization.ToTransportQualifiedQueueName(settings.ServiceControlQueueAddress), TimeSpan.FromMinutes(1));
+                configuration.ReportCustomChecksTo(
+                    transportCustomization.ToTransportQualifiedQueueName(settings.ServiceControlQueueAddress),
+                    TimeSpan.FromMinutes(1) // Prevent clock skew issues, overrides calculated TTL due to some custom check using short reporting intervals (i.e. 5s results in 20s TTL)
+                );
             }
 
             configuration.GetSettings().Set(settings.LoggingSettings);


### PR DESCRIPTION
Set custom checks TTL to 1 minute, as the default TTL is 4*the reporting interval. This can cause issues with clock skew between instances.

For example, the report interval for [AuditIngestionCustomCheck](https://github.com/Particular/ServiceControl/blob/master/src/ServiceControl.Audit/Auditing/AuditIngestionCustomCheck.cs) is 5 seconds, this means the TTL for that is 20 seconds. A clock skew of 20 seconds between hosts is not uncommon.