### PR TITLE
Fix CVE ghsa-9cvc-h2w8-phrp8-phrp on 6.8

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,7 +6,6 @@
   <ItemGroup Label="Versions for direct package references">
     <PackageVersion Include="Autofac" Version="8.2.0" />
     <PackageVersion Include="AWSSDK.CloudWatch" Version="4.0.1" />
-    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.0.4" />
     <PackageVersion Include="Azure.Identity" Version="1.13.2" />
     <PackageVersion Include="Azure.Monitor.Query.Metrics" Version="1.0.0" />
     <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0" />
@@ -34,7 +33,7 @@
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.4.0" />
     <PackageVersion Include="NServiceBus" Version="9.2.7" />
     <PackageVersion Include="NServiceBus.AcceptanceTesting" Version="9.2.7" />
-    <PackageVersion Include="NServiceBus.AmazonSQS" Version="8.0.0" />
+    <PackageVersion Include="NServiceBus.AmazonSQS" Version="8.0.1" />
     <PackageVersion Include="NServiceBus.CustomChecks" Version="5.0.1" />
     <PackageVersion Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
     <PackageVersion Include="NServiceBus.Extensions.Logging" Version="3.0.1" />

--- a/src/ServiceControl.Transports.SQS/ServiceControl.Transports.SQS.csproj
+++ b/src/ServiceControl.Transports.SQS/ServiceControl.Transports.SQS.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatch" />
     <!-- Required for IAM Roles for Service Accounts even though no API is added -->
-    <PackageReference Include="AWSSDK.SecurityToken" />
     <PackageReference Include="NServiceBus.AmazonSQS" />
   </ItemGroup>
 


### PR DESCRIPTION
Result of fixing
- https://github.com/Particular/NServiceBus.AmazonSQS/issues/2977

ServiceControl 6.8.1 was indirectly affected by the CVE because it has a dependency on NServiceBus.AmazonSQS 8.0.0

This updates NServiceBus.AmazonSQS to 8.0.1 to patch the CVE.