### PR TITLE
[Backport to 6.9] The license status check fails when checking the license against a secured RavenDB instance

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
@@ -27,7 +27,7 @@ class DatabaseSetup(DatabaseConfiguration configuration)
 
         await CreateIndexes(documentStore, configuration.EnableFullTextSearch, cancellationToken);
 
-        await LicenseStatusCheck.WaitForLicenseOrThrow(configuration, cancellationToken);
+        await LicenseStatusCheck.WaitForLicenseOrThrow(documentStore, cancellationToken);
         await ConfigureExpiration(documentStore, cancellationToken);
     }
 

--- a/src/ServiceControl.Audit.Persistence.RavenDB/LicenseStatusCheck.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/LicenseStatusCheck.cs
@@ -1,41 +1,45 @@
 namespace ServiceControl.Audit.Persistence.RavenDB;
 
 using System;
-using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents;
 
 static class LicenseStatusCheck
 {
     record LicenseStatusFragment(string Id, string LicensedTo, string Status, bool Expired);
 
-    public static async Task WaitForLicenseOrThrow(DatabaseConfiguration configuration, CancellationToken cancellationToken)
+    public static async Task WaitForLicenseOrThrow(IDocumentStore documentStore, CancellationToken cancellationToken)
     {
-        using var client = new HttpClient
+        var ravenConfiguredHttpClient = documentStore.GetRequestExecutor().HttpClient;
+        var licenseCheckUrl = documentStore.Urls[0].TrimEnd('/') + "/license/status";
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(30_000);
+
+        try
         {
-            BaseAddress = new Uri(configuration.ServerConfiguration.ConnectionString ?? configuration.ServerConfiguration.ServerUrl)
-        };
-
-        // Not linking to the incoming cancellationToken to ensure no OperationCancelledException prevents the last InvalidOperationException to be thrown
-        using var cts = new CancellationTokenSource(30_000);
-        while (!cts.IsCancellationRequested)
-        {
-            var httpResponse = await client.GetAsync("license/status", cancellationToken);
-            var licenseStatus = await httpResponse.Content.ReadFromJsonAsync<LicenseStatusFragment>(cancellationToken);
-            if (licenseStatus.Expired)
+            while (true)
             {
-                throw new InvalidOperationException("The current RavenDB license is expired. Please, contact support");
-            }
+                var httpResponse = await ravenConfiguredHttpClient.GetAsync(licenseCheckUrl, cts.Token);
+                var licenseStatus = await httpResponse.Content.ReadFromJsonAsync<LicenseStatusFragment>(cts.Token);
+                if (licenseStatus.Expired)
+                {
+                    throw new InvalidOperationException("The current RavenDB license is expired. Please, contact support");
+                }
 
-            if (licenseStatus.LicensedTo != null && licenseStatus.Id != null)
-            {
-                return;
-            }
+                if (licenseStatus.LicensedTo != null && licenseStatus.Id != null)
+                {
+                    return;
+                }
 
-            await Task.Delay(200, cancellationToken);
+                await Task.Delay(200, cts.Token);
+            }
         }
-
-        throw new InvalidOperationException("Cannot validate the current RavenDB license. Please, contact support");
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new InvalidOperationException("Cannot validate the current RavenDB license. Please, contact support");
+        }
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/DatabaseSetup.cs
+++ b/src/ServiceControl.Persistence.RavenDB/DatabaseSetup.cs
@@ -23,7 +23,7 @@ namespace ServiceControl.Persistence.RavenDB
 
             await IndexCreation.CreateIndexesAsync(typeof(DatabaseSetup).Assembly, documentStore, null, null, cancellationToken);
 
-            await LicenseStatusCheck.WaitForLicenseOrThrow(settings, cancellationToken);
+            await LicenseStatusCheck.WaitForLicenseOrThrow(documentStore, cancellationToken);
             await ConfigureExpiration(settings, cancellationToken);
         }
 

--- a/src/ServiceControl.Persistence.RavenDB/LicenseStatusCheck.cs
+++ b/src/ServiceControl.Persistence.RavenDB/LicenseStatusCheck.cs
@@ -1,41 +1,45 @@
 namespace ServiceControl.Persistence.RavenDB;
 
 using System;
-using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents;
 
 static class LicenseStatusCheck
 {
     record LicenseStatusFragment(string Id, string LicensedTo, string Status, bool Expired);
 
-    public static async Task WaitForLicenseOrThrow(RavenPersisterSettings configuration, CancellationToken cancellationToken)
+    public static async Task WaitForLicenseOrThrow(IDocumentStore documentStore, CancellationToken cancellationToken)
     {
-        using var client = new HttpClient
+        var ravenConfiguredHttpClient = documentStore.GetRequestExecutor().HttpClient;
+        var licenseCheckUrl = documentStore.Urls[0].TrimEnd('/') + "/license/status";
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(30_000);
+
+        try
         {
-            BaseAddress = new Uri(configuration.ConnectionString ?? configuration.ServerUrl)
-        };
-
-        // Not linking to the incoming cancellationToken to ensure no OperationCancelledException prevents the last InvalidOperationException to be thrown
-        using var cts = new CancellationTokenSource(30_000);
-        while (!cts.IsCancellationRequested)
-        {
-            var httpResponse = await client.GetAsync("license/status", cancellationToken);
-            var licenseStatus = await httpResponse.Content.ReadFromJsonAsync<LicenseStatusFragment>(cancellationToken);
-            if (licenseStatus.Expired)
+            while (!cts.IsCancellationRequested)
             {
-                throw new InvalidOperationException("The current RavenDB license is expired. Please, contact support");
-            }
+                var httpResponse = await ravenConfiguredHttpClient.GetAsync(licenseCheckUrl, cancellationToken);
+                var licenseStatus = await httpResponse.Content.ReadFromJsonAsync<LicenseStatusFragment>(cancellationToken);
+                if (licenseStatus.Expired)
+                {
+                    throw new InvalidOperationException("The current RavenDB license is expired. Please, contact support");
+                }
 
-            if (licenseStatus.LicensedTo != null && licenseStatus.Id != null)
-            {
-                return;
-            }
+                if (licenseStatus.LicensedTo != null && licenseStatus.Id != null)
+                {
+                    return;
+                }
 
-            await Task.Delay(200, cancellationToken);
+                await Task.Delay(200, cts.Token);
+            }
         }
-
-        throw new InvalidOperationException("Cannot validate the current RavenDB license. Please, contact support");
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new InvalidOperationException("Cannot validate the current RavenDB license. Please, contact support");
+        }
     }
 }


### PR DESCRIPTION
Backport of:

- https://github.com/Particular/ServiceControl/pull/5274