### PR TITLE
Use .NET 8 version of Microsoft.Extensions.DependencyModel for PowerShell

### DIFF
--- a/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
+++ b/src/ServiceControl.Management.PowerShell/ServiceControl.Management.PowerShell.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" GeneratePathProperty="true" VersionOverride="8.0.2" />
     <PackageReference Include="System.Management.Automation" />
   </ItemGroup>
 
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <Artifact Include="$(OutputPath)" DestinationFolder="$(PowerShellModuleArtifactsPath)" />
-    <Artifact Include="$(PkgMicrosoft_Extensions_DependencyModel)\lib\netstandard2.0\Microsoft.Extensions.DependencyModel.dll" DestinationFolder="$(PowerShellModuleArtifactsPath)" />
+    <Artifact Include="$(PkgMicrosoft_Extensions_DependencyModel)\lib\net8.0\Microsoft.Extensions.DependencyModel.dll" DestinationFolder="$(PowerShellModuleArtifactsPath)" />
     <Artifact Include="$(PowerShellModuleName).psd1" DestinationFolder="$(PowerShellModuleArtifactsPath)" />
     <Artifact Include="$(PowerShellModuleName).psm1" DestinationFolder="$(PowerShellModuleArtifactsPath)" />
     <Artifact Include="$(PowerShellModuleName).format.ps1xml" DestinationFolder="$(PowerShellModuleArtifactsPath)" />


### PR DESCRIPTION
Since PowerShell 7.4 is based on .NET 8, we need to use the .NET 8 version of `Microsoft.Extensions.DependencyModel` in the PowerShell module.

However, just downgrading the version referenced in `Directory.Packages.props` isn't an option because there are other projects where downgrading breaks some transitive references.

To solve both of these constraints, I've introduced a `VersionOverride` in the PowerShell module project to allow it to use its own separate version of the package.


Fixes #5292 