### PR TITLE
Add renovate config to restrict package version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,10 @@
+{
+  packageRules: [
+    {
+      description: "Keep ServiceControl.Management.PowerShell on 8.x",
+      matchFileNames: ["**/ServiceControl.Management.PowerShell.csproj"],
+      matchPackageNames: ["Microsoft.Extensions.DependencyModel"],
+      allowedVersions: "<9.0.0"
+    }
+  ]
+}


### PR DESCRIPTION
In order to prevent Renovate from trying to update the `VersionOverride`, we need to add a config file to tell it to leave the version alone.

Follow-up to #5288