### PR TITLE
[DO NOT MERGE] Allow disabling RabbitMQ broker requirement checks

### DIFF
--- a/src/ServiceControl.Transports.RabbitMQ/NoOpQueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/NoOpQueueLengthProvider.cs
@@ -2,14 +2,20 @@ namespace ServiceControl.Transports.RabbitMQ
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
 
-    class NoOpQueueLengthProvider : IProvideQueueLength
+    // Used when DisableBrokerRequirementChecks=true and the RabbitMQ Management API is not available
+    sealed class NoOpQueueLengthProvider(ILogger<NoOpQueueLengthProvider> logger) : IProvideQueueLength
     {
         public void TrackEndpointInputQueue(EndpointToQueueMapping queueToTrack)
         {
         }
 
-        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            logger.LogWarning("Queue length monitoring is disabled because RabbitMQ broker requirement checks are disabled via the connection string. Queue length data will not be available.");
+            return Task.CompletedTask;
+        }
 
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }

--- a/src/ServiceControl.Transports.RabbitMQ/NoOpQueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/NoOpQueueLengthProvider.cs
@@ -1,0 +1,16 @@
+namespace ServiceControl.Transports.RabbitMQ
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class NoOpQueueLengthProvider : IProvideQueueLength
+    {
+        public void TrackEndpointInputQueue(EndpointToQueueMapping queueToTrack)
+        {
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQConventionalRoutingTransportCustomization.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQConventionalRoutingTransportCustomization.cs
@@ -53,11 +53,24 @@
         }
 
         protected override void AddTransportForPrimaryCore(IServiceCollection services, TransportSettings transportSettings)
-            => services.AddSingleton<IBrokerThroughputQuery, RabbitMQQuery>();
+        {
+            if (!RabbitMQTransportExtensions.HasBrokerRequirementChecksDisabled(transportSettings.ConnectionString))
+            {
+                services.AddSingleton<IBrokerThroughputQuery, RabbitMQQuery>();
+            }
+        }
 
         protected sealed override void AddTransportForMonitoringCore(IServiceCollection services, TransportSettings transportSettings)
         {
-            services.AddSingleton<IProvideQueueLength, QueueLengthProvider>();
+            if (RabbitMQTransportExtensions.HasBrokerRequirementChecksDisabled(transportSettings.ConnectionString))
+            {
+                services.AddSingleton<IProvideQueueLength, NoOpQueueLengthProvider>();
+            }
+            else
+            {
+                services.AddSingleton<IProvideQueueLength, QueueLengthProvider>();
+            }
+
             services.AddHostedService(provider => provider.GetRequiredService<IProvideQueueLength>());
         }
     }

--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQDirectRoutingTransportCustomization.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQDirectRoutingTransportCustomization.cs
@@ -53,11 +53,24 @@
         }
 
         protected override void AddTransportForPrimaryCore(IServiceCollection services, TransportSettings transportSettings)
-            => services.AddSingleton<IBrokerThroughputQuery, RabbitMQQuery>();
+        {
+            if (!RabbitMQTransportExtensions.HasBrokerRequirementChecksDisabled(transportSettings.ConnectionString))
+            {
+                services.AddSingleton<IBrokerThroughputQuery, RabbitMQQuery>();
+            }
+        }
 
         protected sealed override void AddTransportForMonitoringCore(IServiceCollection services, TransportSettings transportSettings)
         {
-            services.AddSingleton<IProvideQueueLength, QueueLengthProvider>();
+            if (RabbitMQTransportExtensions.HasBrokerRequirementChecksDisabled(transportSettings.ConnectionString))
+            {
+                services.AddSingleton<IProvideQueueLength, NoOpQueueLengthProvider>();
+            }
+            else
+            {
+                services.AddSingleton<IProvideQueueLength, QueueLengthProvider>();
+            }
+
             services.AddHostedService(provider => provider.GetRequiredService<IProvideQueueLength>());
         }
     }

--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQTransportExtensions.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQTransportExtensions.cs
@@ -49,6 +49,7 @@ static class RabbitMQTransportExtensions
         {
             transport.DisabledBrokerRequirementChecks =
                 BrokerRequirementChecks.Version310OrNewer | BrokerRequirementChecks.StreamsEnabled;
+            transport.ValidateDeliveryLimits = false;
         }
     }
 }

--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQTransportExtensions.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQTransportExtensions.cs
@@ -42,5 +42,13 @@ static class RabbitMQTransportExtensions
             _ = bool.TryParse(useExternalAuthMechanismString, out var useExternalAuthMechanism);
             transport.UseExternalAuthMechanism = useExternalAuthMechanism;
         }
+
+        if (dictionary.TryGetValue("DisableBrokerRequirementChecks", out var disableBrokerRequirementChecksString)
+            && bool.TryParse(disableBrokerRequirementChecksString, out var disableBrokerRequirementChecks)
+            && disableBrokerRequirementChecks)
+        {
+            transport.DisabledBrokerRequirementChecks =
+                BrokerRequirementChecks.Version310OrNewer | BrokerRequirementChecks.StreamsEnabled;
+        }
     }
 }

--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQTransportExtensions.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQTransportExtensions.cs
@@ -8,6 +8,22 @@ using NServiceBus;
 
 static class RabbitMQTransportExtensions
 {
+    public static bool HasBrokerRequirementChecksDisabled(string connectionString)
+    {
+        if (connectionString.StartsWith("amqp", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var dictionary = new DbConnectionStringBuilder { ConnectionString = connectionString }
+            .OfType<KeyValuePair<string, object>>()
+            .ToDictionary(pair => pair.Key, pair => pair.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+
+        return dictionary.TryGetValue("DisableBrokerRequirementChecks", out var value)
+            && bool.TryParse(value, out var disabled)
+            && disabled;
+    }
+
     public static void ApplySettingsFromConnectionString(this RabbitMQTransport transport, string connectionString)
     {
         if (connectionString.StartsWith("amqp", StringComparison.OrdinalIgnoreCase))

--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQTransportExtensions.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQTransportExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace ServiceControl.Transports.RabbitMQ;
+﻿#nullable enable
+namespace ServiceControl.Transports.RabbitMQ;
 
 using System;
 using System.Collections.Generic;
@@ -10,14 +11,11 @@ static class RabbitMQTransportExtensions
 {
     public static bool HasBrokerRequirementChecksDisabled(string connectionString)
     {
-        if (connectionString.StartsWith("amqp", StringComparison.OrdinalIgnoreCase))
+        var dictionary = ParseConnectionString(connectionString);
+        if (dictionary is null)
         {
             return false;
         }
-
-        var dictionary = new DbConnectionStringBuilder { ConnectionString = connectionString }
-            .OfType<KeyValuePair<string, object>>()
-            .ToDictionary(pair => pair.Key, pair => pair.Value.ToString(), StringComparer.OrdinalIgnoreCase);
 
         return dictionary.TryGetValue("DisableBrokerRequirementChecks", out var value)
             && bool.TryParse(value, out var disabled)
@@ -26,14 +24,11 @@ static class RabbitMQTransportExtensions
 
     public static void ApplySettingsFromConnectionString(this RabbitMQTransport transport, string connectionString)
     {
-        if (connectionString.StartsWith("amqp", StringComparison.OrdinalIgnoreCase))
+        var dictionary = ParseConnectionString(connectionString);
+        if (dictionary is null)
         {
             return;
         }
-
-        var dictionary = new DbConnectionStringBuilder { ConnectionString = connectionString }
-            .OfType<KeyValuePair<string, object>>()
-            .ToDictionary(pair => pair.Key, pair => pair.Value.ToString(), StringComparer.OrdinalIgnoreCase);
 
         if (dictionary.TryGetValue("ValidateDeliveryLimits", out var validateDeliveryLimitsString))
         {
@@ -67,5 +62,17 @@ static class RabbitMQTransportExtensions
                 BrokerRequirementChecks.Version310OrNewer | BrokerRequirementChecks.StreamsEnabled;
             transport.ValidateDeliveryLimits = false;
         }
+    }
+
+    static Dictionary<string, string?>? ParseConnectionString(string connectionString)
+    {
+        if (connectionString.StartsWith("amqp", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return new DbConnectionStringBuilder { ConnectionString = connectionString }
+            .OfType<KeyValuePair<string, object>>()
+            .ToDictionary(pair => pair.Key, pair => pair.Value.ToString(), StringComparer.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Motivation

In multi-tenant RabbitMQ deployments, granting management API access to individual tenants is a security risk. ServiceControl currently performs broker requirement checks that depend on management API access, with no way to disable them.

The RabbitMQ transport (v11.0.0) already supports `DisabledBrokerRequirementChecks`, but ServiceControl did not expose it.

### What this does

Adds DisableBrokerRequirementChecks=true as a connection string parameter:

`host=rabbitmq;username=tenant1;password=secret;DisableBrokerRequirementChecks=true`

When enabled, this:
- Disables broker version and stream feature checks at startup
- Disables delivery limit validation (also requires management API)
- Skips registration of `RabbitMQQuery` (broker throughput collection) and `QueueLengthProvider` (queue length monitoring), both of which require management API access
- Registers a `NoOpQueueLengthProvider` to satisfy DI requirements

### What still works without management API access

- Sending and receiving messages
- Usage reports and license validation (via audit and monitoring data sources)

### What becomes unavailable

- Queue length monitoring in ServicePulse
- Broker-sourced throughput data in usage reports