### PR TITLE
Fallback to `application/octet-stream` content type when for invalid UTF-8 message bodies so ServicePulse will not fail loading the BLOB

### DIFF
--- a/src/ServiceControl.Audit.Persistence/BodyStorageEnricher.cs
+++ b/src/ServiceControl.Audit.Persistence/BodyStorageEnricher.cs
@@ -66,7 +66,9 @@
                     catch (DecoderFallbackException e)
                     {
                         useBodyStore = true;
-                        logger.LogInformation("Body for {BodyId} could not be stored embedded, fallback to body storage ({ErrorMessage})", bodyId, e.Message);
+                        contentType = "application/octet-stream";
+                        processedMessage.MessageMetadata["ContentType"] = contentType;
+                        logger.LogInformation("Body for {BodyId} is not valid UTF-8 despite content type header, storing as binary ({ErrorMessage})", bodyId, e.Message);
                     }
                 }
 

--- a/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
@@ -53,7 +53,8 @@
                     }
                     catch (ArgumentException)
                     {
-                        // If it won't decode to text, don't index it
+                        contentType = "application/octet-stream";
+                        processingAttempt.MessageMetadata["ContentType"] = contentType;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- When a message body claims to be text (via content type header) but contains invalid UTF-8 bytes, the `DecoderFallbackException` handler now updates `MessageMetadata["ContentType"]` to `application/octet-stream` and falls back to body storage
- Only ServiceControl's stored metadata is affected, the original NServiceBus message header is never modified


## Impact on ServicePulse

1. `contentTypeParser.ts` : application/octet-stream falls into the application/ branch but doesn't match +json or +xml, so it returns { isSupported: false }.
2. `BodyView.vue` will show : "Message body cannot be displayed because content type application/octet-stream is not supported." This is an improvement over the current behavior where ServicePulse tries to parse binary data as JSON/XML and crashes.
3. `MessageStore.ts` : the JSON/XML formatting try block won't trigger for application/octet-stream, so no parse errors.
4. `EditRetryDialog.vue` : edit & retry will be disabled with a warning that the content type is not supported. Correct behavior for binary data.