### PR TITLE
Usage report calculates negative endpoint throughput after queue table deletion

### DIFF
--- a/src/ServiceControl.Transports.SqlServer/QueueTableSnapshot.cs
+++ b/src/ServiceControl.Transports.SqlServer/QueueTableSnapshot.cs
@@ -2,5 +2,5 @@ namespace ServiceControl.Transports.SqlServer;
 
 public class BrokerQueueTableSnapshot(BrokerQueueTable details) : BrokerQueueTable(details.DatabaseDetails, details.Schema, details.Name)
 {
-    public long RowVersion { get; set; }
+    public long? RowVersion { get; set; }
 }

--- a/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
@@ -70,11 +70,14 @@ public class SqlServerQuery(
             var endData =
                 await queueTableName.DatabaseDetails.GetSnapshot(queueTableName, cancellationToken);
 
-            yield return new QueueThroughput
+            if (endData.RowVersion.HasValue && startData.RowVersion.HasValue)
             {
-                DateUTC = DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime),
-                TotalThroughput = endData.RowVersion - startData.RowVersion
-            };
+                yield return new QueueThroughput
+                {
+                    DateUTC = DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime),
+                    TotalThroughput = endData.RowVersion.Value - startData.RowVersion.Value
+                };
+            }
 
             startData = endData;
         }


### PR DESCRIPTION
### Symptoms

Usage reports can contain negative throughput values for an endpoint/queue.

This can happen when a queue table is deleted between throughput snapshots.

### Who's affected

Users generating usage reports where queue tables may have been deleted during the reporting period.

### Root cause

Throughput is calculated by comparing two snapshots taken an hour apart.

When a queue table is deleted, the end-of-hour total is not set and defaults to 0, causing the calculation to produce a negative throughput value.

### Confirmed workarounds

None

<details>
<summary>Original bug report</summary>
<!-- Original issue description as raised by the user. -->
While calculating throughput, when a queue table is deleted, we see a negative throughput entry recorded in the usage report for the day.

This happens because we take two snapshots, an hour apart, and then this to figure out how many messages have been processed:

```
totalThroughputForHour = totalMessagesEndOfHour - totalMessagesStartOfHour
```

When a table gets deleted, we do not set the `totalMessagesEndOfHour` which results in the default value of zero. This ends up looking like this:

```
totalThroughputForHour = 0 - totalMessagesStartOfHour
```

That is always going to be a negative number, and one that is not representative of the throughput in that hour.
</details>

