### PR TITLE
RabbitMQ: Only set the AuthMechanisms when UseExternalAuthMechanism is set to true

### DIFF
--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQTransportExtensions.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQTransportExtensions.cs
@@ -38,9 +38,8 @@ static class RabbitMQTransportExtensions
             transport.ValidateRemoteCertificate = !disableRemoteCertificateValidation;
         }
 
-        if (dictionary.TryGetValue("UseExternalAuthMechanism", out var useExternalAuthMechanismString))
+        if (dictionary.TryGetValue("UseExternalAuthMechanism", out var useExternalAuthMechanismString) && bool.TryParse(useExternalAuthMechanismString, out var useExternalAuthMechanism) && useExternalAuthMechanism)
         {
-            _ = bool.TryParse(useExternalAuthMechanismString, out var useExternalAuthMechanism);
             transport.AuthMechanisms = [new ExternalMechanismFactory()];
         }
     }


### PR DESCRIPTION
Backport of #5416 to `release-6.14`