### PR TITLE
Fix Windows-RabbitMQ RunScenario test timeout and cascade failures

### DIFF
--- a/src/ServiceControl.Transports.Tests/TransportTestFixture.cs
+++ b/src/ServiceControl.Transports.Tests/TransportTestFixture.cs
@@ -185,7 +185,7 @@
             return configuration.TransportCustomization.ProvisionQueues(transportSettings, []);
         }
 
-        protected static TimeSpan TestTimeout = TimeSpan.FromSeconds(60);
+        protected static TimeSpan TestTimeout = TimeSpan.FromMinutes(5);
 
         protected async Task SendAndReceiveMessages(string queueName, int numMessagesToIngest)
         {
@@ -200,7 +200,7 @@
 
                     if (numMessagesIngested == numMessagesToIngest)
                     {
-                        onMessagesProcessed.SetResult(true);
+                        onMessagesProcessed.TrySetResult(true);
                     }
 
                     return Task.CompletedTask;


### PR DESCRIPTION
## Summary

- `GetThroughputPerDay` loops 96 times (24×4), each requiring an HTTP call to the RabbitMQ management API plus sending and receiving 15 messages. On Windows CI this consistently exceeds the 60-second `TestTimeout` that bounds all `CreateTaskCompletionSource` instances, causing the test to time out mid-run.
- When the timeout fires while the message pump is still running, the next message delivery calls `SetResult` on an already-faulted TCS, throwing `InvalidOperationException`. This propagates through the RabbitMQ pump as a processing error → `onError` → `Assert.Fail` → critical-error handler → a second `Assert.Fail`, producing three apparent failures from one root cause.

**Changes:**
- Raise `TestTimeout` from 60 s to 5 minutes to accommodate the test's 3-minute design budget with margin for slower Windows CI runners
- Change `SetResult` → `TrySetResult` to stop the cascade when a concurrent timeout and message delivery race

Fixes the consistently failing `Windows-RabbitMQ` job in PR #5446.

## Test plan

- [x] CI `Windows-RabbitMQ` passes on this branch
- [x] All other transport matrix jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)