### PR TITLE
ServiceControl reports endpoint as stale when only some instances are stale

### DIFF
--- a/src/ServiceControl.Monitoring/Infrastructure/Api/EndpointMetricsApi.cs
+++ b/src/ServiceControl.Monitoring/Infrastructure/Api/EndpointMetricsApi.cs
@@ -201,7 +201,7 @@
                 {
                     Name = endpoint.Key,
                     EndpointInstanceIds = endpoint.Value.Select(i => i.InstanceId).ToArray(),
-                    IsStale = endpoint.Value.Any(activityTracker.IsStale),
+                    IsStale = endpoint.Value.All(activityTracker.IsStale),
                     ConnectedCount = endpoint.Value.Count(id => !activityTracker.IsStale(id)),
                     DisconnectedCount = endpoint.Value.Count(activityTracker.IsStale)
                 })


### PR DESCRIPTION
### Symptoms

In ServicePulse, the monitoring endpoint list could hide all metrics for an endpoint and show ? placeholders even when some instances were still healthy.

This happened when any instance of the endpoint was stale.

### Who's affected

Users monitoring endpoints with multiple instances where one or more instances become stale while at least one instance remains healthy.

### Root cause

IsStale in GetMonitoredEndpoints was being set to true when any instance was stale.

This caused the whole endpoint to be treated as stale, even if other instances were healthy.

### Confirmed workarounds

None
