### PR TITLE
Fix failed-message list sort by "Time of failure"

### DIFF
--- a/src/ServiceControl.Audit.Persistence/Infrastructure/SortInfo.cs
+++ b/src/ServiceControl.Audit.Persistence/Infrastructure/SortInfo.cs
@@ -1,5 +1,8 @@
 ﻿namespace ServiceControl.Audit.Infrastructure
 {
+    using System.Collections.Frozen;
+    using System.Collections.Generic;
+
     public class SortInfo
     {
         public string Direction { get; }
@@ -10,5 +13,22 @@
             Sort = sort;
             Direction = direction;
         }
+
+        // Single source of truth for the audit sort tokens the API accepts.
+        // Consumed by SortInfoModelBinder so the web allowlist cannot drift
+        // from the fields the audit message query actually sorts by (anything
+        // not listed here falls back to TimeSent in the persistence layer).
+        public static readonly FrozenSet<string> AllowedSortOptions = new HashSet<string>
+        {
+            "id",
+            "message_id",
+            "message_type",
+            "status",
+            "time_sent",
+            "processed_at",
+            "critical_time",
+            "delivery_time",
+            "processing_time"
+        }.ToFrozenSet();
     }
 }

--- a/src/ServiceControl.Audit.UnitTests/Infrastructure/WebApi/SortInfoModelBinderTests.cs
+++ b/src/ServiceControl.Audit.UnitTests/Infrastructure/WebApi/SortInfoModelBinderTests.cs
@@ -1,0 +1,58 @@
+namespace ServiceControl.UnitTests.Infrastructure.WebApi;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Primitives;
+using NUnit.Framework;
+using ServiceControl.Audit.Infrastructure;
+using ServiceControl.Audit.Infrastructure.WebApi;
+
+[TestFixture]
+public class SortInfoModelBinderTests
+{
+    [TestCase("processed_at")]
+    [TestCase("critical_time")]
+    [TestCase("message_type")]
+    public async Task Preserves_valid_audit_sort_field(string sort)
+    {
+        var sortInfo = await Bind(sort, "asc");
+
+        Assert.That(sortInfo.Sort, Is.EqualTo(sort));
+    }
+
+    [Test]
+    public async Task Falls_back_to_time_sent_for_unknown_sort_field()
+    {
+        var sortInfo = await Bind("not_a_real_field", "asc");
+
+        Assert.That(sortInfo.Sort, Is.EqualTo("time_sent"));
+    }
+
+    static async Task<SortInfo> Bind(string sort, string direction)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            Request =
+            {
+                Query = new QueryCollection(new Dictionary<string, StringValues>
+                {
+                    ["sort"] = sort,
+                    ["direction"] = direction,
+                })
+            }
+        };
+
+        var bindingContext = new DefaultModelBindingContext
+        {
+            ActionContext = new ActionContext { HttpContext = httpContext },
+            ModelName = "sortInfo",
+        };
+
+        await new SortInfoModelBinder().BindModelAsync(bindingContext);
+
+        return (SortInfo)bindingContext.Result.Model;
+    }
+}

--- a/src/ServiceControl.Audit/Infrastructure/WebApi/SortInfoModelBinder.cs
+++ b/src/ServiceControl.Audit/Infrastructure/WebApi/SortInfoModelBinder.cs
@@ -1,8 +1,6 @@
 namespace ServiceControl.Audit.Infrastructure.WebApi;
 
 using System;
-using System.Collections.Frozen;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
@@ -21,7 +19,7 @@ public class SortInfoModelBinder : IModelBinder
 
         bindingContext.HttpContext.Request.Query.TryGetValue("sort", out var sortValue);
         var sort = sortValue.ToString();
-        if (!AllowableSortOptions.Contains(sort))
+        if (!SortInfo.AllowedSortOptions.Contains(sort))
         {
             sort = "time_sent";
         }
@@ -29,17 +27,4 @@ public class SortInfoModelBinder : IModelBinder
         bindingContext.Result = ModelBindingResult.Success(new SortInfo(sort, direction));
         return Task.CompletedTask;
     }
-
-    static readonly FrozenSet<string> AllowableSortOptions = new HashSet<string>
-    {
-        "processed_at",
-        "id",
-        "message_type",
-        "time_sent",
-        "critical_time",
-        "delivery_time",
-        "processing_time",
-        "status",
-        "message_id"
-    }.ToFrozenSet();
 }

--- a/src/ServiceControl.Persistence.RavenDB/RavenQueryExtensions.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenQueryExtensions.cs
@@ -82,7 +82,7 @@ namespace ServiceControl.Persistence
             }
 
             var sort = sortInfo.Sort;
-            if (!AsyncDocumentQuerySortOptions.Contains(sort))
+            if (!SortInfo.AllowedSortOptions.Contains(sort))
             {
                 sort = "time_sent";
             }
@@ -206,17 +206,6 @@ namespace ServiceControl.Persistence
 
             return source;
         }
-
-        static HashSet<string> AsyncDocumentQuerySortOptions =
-        [
-            "id",
-            "message_id",
-            "message_type",
-            "time_sent",
-            "status",
-            "modified",
-            "time_of_failure"
-        ];
 
         static string[] SplitChars =
         {

--- a/src/ServiceControl.Persistence/Infrastructure/SortInfo.cs
+++ b/src/ServiceControl.Persistence/Infrastructure/SortInfo.cs
@@ -1,5 +1,7 @@
 ﻿namespace ServiceControl.Persistence.Infrastructure
 {
+    using System.Collections.Frozen;
+    using System.Collections.Generic;
     using System.Diagnostics;
 
     [DebuggerDisplay("{Sort} {Direction}")]
@@ -7,5 +9,28 @@
     {
         public string Direction { get; } = string.IsNullOrWhiteSpace(direction) ? "desc" : direction;
         public string Sort { get; } = string.IsNullOrWhiteSpace(sort) ? "time_sent" : sort;
+
+        // Single source of truth for the sort tokens the API accepts. The model
+        // binder gates incoming requests against this set and the persistence
+        // layer resolves each accepted token to an index field per endpoint
+        // (anything it does not recognise falls back to TimeSent). It is the
+        // union of the fields sortable by the message endpoints (processed_at,
+        // critical_time, delivery_time, processing_time) and the failed-message
+        // endpoints (time_of_failure, modified), so the web allowlist and the
+        // persistence query can no longer drift apart.
+        public static readonly FrozenSet<string> AllowedSortOptions = new HashSet<string>
+        {
+            "id",
+            "message_id",
+            "message_type",
+            "status",
+            "time_sent",
+            "modified",
+            "time_of_failure",
+            "processed_at",
+            "critical_time",
+            "delivery_time",
+            "processing_time"
+        }.ToFrozenSet();
     }
 }

--- a/src/ServiceControl.UnitTests/Infrastructure/WebApi/SortInfoModelBinderTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/WebApi/SortInfoModelBinderTests.cs
@@ -17,11 +17,21 @@ namespace ServiceControl.UnitTests.Infrastructure.WebApi
         // RavenDB layer. The model binder must not silently rewrite them away.
         [TestCase("time_of_failure")]
         [TestCase("modified")]
+        [TestCase("message_type")]
+        [TestCase("processed_at")]
         public async Task Preserves_valid_failed_message_sort_field(string sort)
         {
             var sortInfo = await Bind(sort, "asc");
 
             Assert.That(sortInfo.Sort, Is.EqualTo(sort));
+        }
+
+        [Test]
+        public async Task Falls_back_to_time_sent_for_unknown_sort_field()
+        {
+            var sortInfo = await Bind("not_a_real_field", "asc");
+
+            Assert.That(sortInfo.Sort, Is.EqualTo("time_sent"));
         }
 
         static async Task<SortInfo> Bind(string sort, string direction)

--- a/src/ServiceControl.UnitTests/Infrastructure/WebApi/SortInfoModelBinderTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/WebApi/SortInfoModelBinderTests.cs
@@ -1,0 +1,52 @@
+namespace ServiceControl.UnitTests.Infrastructure.WebApi
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.ModelBinding;
+    using Microsoft.Extensions.Primitives;
+    using NUnit.Framework;
+    using Persistence.Infrastructure;
+    using ServiceControl.Infrastructure.WebApi;
+
+    [TestFixture]
+    public class SortInfoModelBinderTests
+    {
+        // Failed-message endpoints (/api/errors) support these sort fields in the
+        // RavenDB layer. The model binder must not silently rewrite them away.
+        [TestCase("time_of_failure")]
+        [TestCase("modified")]
+        public async Task Preserves_valid_failed_message_sort_field(string sort)
+        {
+            var sortInfo = await Bind(sort, "asc");
+
+            Assert.That(sortInfo.Sort, Is.EqualTo(sort));
+        }
+
+        static async Task<SortInfo> Bind(string sort, string direction)
+        {
+            var httpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Query = new QueryCollection(new Dictionary<string, StringValues>
+                    {
+                        ["sort"] = sort,
+                        ["direction"] = direction,
+                    })
+                }
+            };
+
+            var bindingContext = new DefaultModelBindingContext
+            {
+                ActionContext = new ActionContext { HttpContext = httpContext },
+                ModelName = "sortInfo",
+            };
+
+            await new SortInfoModelBinder().BindModelAsync(bindingContext);
+
+            return (SortInfo)bindingContext.Result.Model;
+        }
+    }
+}

--- a/src/ServiceControl/Infrastructure/WebApi/SortInfoModelBinder.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/SortInfoModelBinder.cs
@@ -41,6 +41,8 @@ public class SortInfoModelBinder : IModelBinder
         "delivery_time",
         "processing_time",
         "status",
-        "message_id"
+        "message_id",
+        "modified",
+        "time_of_failure"
     }.ToFrozenSet();
 }

--- a/src/ServiceControl/Infrastructure/WebApi/SortInfoModelBinder.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/SortInfoModelBinder.cs
@@ -1,8 +1,6 @@
 namespace ServiceControl.Infrastructure.WebApi;
 
 using System;
-using System.Collections.Frozen;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Persistence.Infrastructure;
@@ -22,7 +20,7 @@ public class SortInfoModelBinder : IModelBinder
 
         bindingContext.HttpContext.Request.Query.TryGetValue("sort", out var sortValue);
         var sort = sortValue.ToString();
-        if (!AllowableSortOptions.Contains(sort))
+        if (!SortInfo.AllowedSortOptions.Contains(sort))
         {
             sort = "time_sent";
         }
@@ -30,19 +28,4 @@ public class SortInfoModelBinder : IModelBinder
         bindingContext.Result = ModelBindingResult.Success(new SortInfo(sort, direction));
         return Task.CompletedTask;
     }
-
-    static readonly FrozenSet<string> AllowableSortOptions = new HashSet<string>
-    {
-        "processed_at",
-        "id",
-        "message_type",
-        "time_sent",
-        "critical_time",
-        "delivery_time",
-        "processing_time",
-        "status",
-        "message_id",
-        "modified",
-        "time_of_failure"
-    }.ToFrozenSet();
 }


### PR DESCRIPTION
Resolves:

- #5475

## Problem

The Primary instance's globally-registered `SortInfoModelBinder` validates the incoming `sort` query-string token against a hardcoded allowlist that did **not** contain `time_of_failure` (nor `modified`). Unrecognised tokens are silently rewritten to `time_sent`.

So when ServicePulse requests the failed-message list sorted by **Time of failure** (`GET /api/errors?sort=time_of_failure&direction=…`), the token was rewritten to `time_sent` before reaching the RavenDB query — even though the RavenDB layer already maps `time_of_failure` → `TimeOfFailure` and the index exposes that field as sortable. The asc/desc direction was preserved, so the list visibly reordered on toggle but was always keyed on Time sent.

ServicePulse and the RavenDB index/query were both correct; the defect was entirely the web-layer model binder allowlist drifting from the persistence layer's actual sort capabilities.

## Fix

Added a `SortInfoModelBinder` unit test proving `sort=time_of_failure`/`modified` were rewritten to `time_sent`.
Added the two missing keys to the Primary binder allowlist.

Introduced `SortInfo.AllowedSortOptions` as a single source of truth per instance:
   - Primary: consumed by both `SortInfoModelBinder` and the RavenDB `AsyncDocumentQuery` sort (its duplicate private set removed).
   - Audit: consumed by its `SortInfoModelBinder`. Audit had **no functional defect** (its allowlist already matched its query) but shared the same drift-prone duplicated-literal anti-pattern.
   - Behaviour-preserving: tokens unknown to a given endpoint still fall back to `TimeSent` in the persistence switch exactly as before.

Added Audit binder characterization tests and extended the Primary binder tests (valid message + failed-message fields preserved, unknown → `time_sent`) so the allowlists cannot silently diverge again.
