### PR TITLE
Failed-message list cannot be sorted by "Time of failure" — silently falls back to "Time sent"

### DIFF
--- a/src/ServiceControl.UnitTests/Infrastructure/WebApi/SortInfoModelBinderTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/WebApi/SortInfoModelBinderTests.cs
@@ -1,0 +1,52 @@
+namespace ServiceControl.UnitTests.Infrastructure.WebApi
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.ModelBinding;
+    using Microsoft.Extensions.Primitives;
+    using NUnit.Framework;
+    using Persistence.Infrastructure;
+    using ServiceControl.Infrastructure.WebApi;
+
+    [TestFixture]
+    public class SortInfoModelBinderTests
+    {
+        // Failed-message endpoints (/api/errors) support these sort fields in the
+        // RavenDB layer. The model binder must not silently rewrite them away.
+        [TestCase("time_of_failure")]
+        [TestCase("modified")]
+        public async Task Preserves_valid_failed_message_sort_field(string sort)
+        {
+            var sortInfo = await Bind(sort, "asc");
+
+            Assert.That(sortInfo.Sort, Is.EqualTo(sort));
+        }
+
+        static async Task<SortInfo> Bind(string sort, string direction)
+        {
+            var httpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Query = new QueryCollection(new Dictionary<string, StringValues>
+                    {
+                        ["sort"] = sort,
+                        ["direction"] = direction,
+                    })
+                }
+            };
+
+            var bindingContext = new DefaultModelBindingContext
+            {
+                ActionContext = new ActionContext { HttpContext = httpContext },
+                ModelName = "sortInfo",
+            };
+
+            await new SortInfoModelBinder().BindModelAsync(bindingContext);
+
+            return (SortInfo)bindingContext.Result.Model;
+        }
+    }
+}

--- a/src/ServiceControl/Infrastructure/WebApi/SortInfoModelBinder.cs
+++ b/src/ServiceControl/Infrastructure/WebApi/SortInfoModelBinder.cs
@@ -41,6 +41,8 @@ public class SortInfoModelBinder : IModelBinder
         "delivery_time",
         "processing_time",
         "status",
-        "message_id"
+        "message_id",
+        "modified",
+        "time_of_failure"
     }.ToFrozenSet();
 }


### PR DESCRIPTION

Backport of:
- #5477

Which fixes for the `release-6.14` branch:
- #5475
