### PR TITLE
Revert: Update dependency ReactiveUI.WPF to v23 (#5328)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -70,7 +70,7 @@
     <PackageVersion Include="PropertyChanging.Fody" Version="1.31.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
     <PackageVersion Include="RavenDB.Embedded" Version="6.2.15" />
-    <PackageVersion Include="ReactiveUI.WPF" Version="23.2.27" />
+    <PackageVersion Include="ReactiveUI.WPF" Version="22.3.1" />
     <PackageVersion Include="Seq.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="ServiceControl.Contracts" Version="5.1.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.8" />

--- a/src/ServiceControl.Config/AppBootstrapper.cs
+++ b/src/ServiceControl.Config/AppBootstrapper.cs
@@ -11,7 +11,6 @@
     using Caliburn.Micro;
     using FluentValidation;
     using ReactiveUI;
-    using ReactiveUI.Builder;
     using ServiceControl.Config.Framework;
     using ServiceControlInstaller.Engine.Validation;
     using UI.Shell;
@@ -42,18 +41,17 @@
             DisableRxUIDebuggerBreak();
         }
 
-        // ReactiveUI's default handler calls Debugger.Break() on unhandled reactive exceptions, which pauses at an unhelpful
-        // internal location. This replaces it so exceptions are re-thrown on the main thread with a useful stack trace instead.
         void DisableRxUIDebuggerBreak()
         {
-            _ = RxAppBuilder.CreateReactiveUIBuilder()
-                .WithExceptionHandler(Observer.Create(delegate (Exception ex)
+            RxApp.DefaultExceptionHandler = Observer.Create(delegate (Exception ex)
+            {
+                RxApp.MainThreadScheduler.Schedule(() =>
                 {
-                    _ = RxSchedulers.MainThreadScheduler.Schedule(() => throw new Exception(
-                            "An OnError occurred on an object (usually ObservableAsPropertyHelper) that would break a binding or command. To prevent this, Subscribe to the ThrownExceptions property of your objects",
-                            ex));
-                }))
-            .BuildApp();
+                    throw new Exception(
+                        "An OnError occurred on an object (usually ObservableAsPropertyHelper) that would break a binding or command. To prevent this, Subscribe to the ThrownExceptions property of your objects",
+                        ex);
+                });
+            });
         }
 
         protected override object GetInstance(Type service, string key)


### PR DESCRIPTION
## Summary

Reverts #5328, which upgraded ReactiveUI.WPF from 22.3.1 to 23.2.27.

ReactiveUI.WPF v23 causes exceptions in SCMU. Rolling back to v22.3.1
until a fix-forward approach is identified.

## Changes

- `Directory.Packages.props`: ReactiveUI.WPF pinned back to `22.3.1`
- `AppBootstrapper.cs`: `DisableRxUIDebuggerBreak()` reverted to the v22 API
  (`RxApp.DefaultExceptionHandler`); `using ReactiveUI.Builder` removed
