### PR TITLE
Add rule exception for Central Package Management rule

### DIFF
--- a/.repointegrity.yml
+++ b/.repointegrity.yml
@@ -1,0 +1,4 @@
+ignore:
+  # It's okay to use central package management in this repo
+  - test: DoNotUseCentralPackageManagement
+    path: src/Directory.Packages.props


### PR DESCRIPTION
This PR adds a rule exception for the "Don't use Central Package Management" rule for the `release-6.15` branch.