### PR TITLE
Extra exception logging for SQL throughput collection

### DIFF
--- a/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
@@ -105,7 +105,16 @@ public class BrokerThroughputCollectorHostedService(
 
             await foreach (var queueThroughput in brokerThroughputQuery.GetThroughputPerDay(queueName, startDate, stoppingToken))
             {
-                await dataStore.RecordEndpointThroughput(queueName.QueueName, ThroughputSource.Broker, queueThroughput.DateUTC, queueThroughput.TotalThroughput, stoppingToken);
+                try
+                {
+                    await dataStore.RecordEndpointThroughput(queueName.QueueName, ThroughputSource.Broker, queueThroughput.DateUTC, queueThroughput.TotalThroughput, stoppingToken);
+                }
+                catch (Exception e)
+                {
+                    logger.LogError(e, "Failed to record throughput for {QueueName}", queueName.QueueName);
+                    Console.WriteLine(e);
+                    throw;
+                }
             }
         }
     }

--- a/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
@@ -60,15 +60,33 @@ public class SqlServerQuery(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var queueTableName = (BrokerQueueTable)brokerQueue;
-        var startData =
-            await queueTableName.DatabaseDetails.GetSnapshot(queueTableName, cancellationToken);
+
+        BrokerQueueTableSnapshot startData;
+        try
+        {
+            startData = await queueTableName.DatabaseDetails.GetSnapshot(queueTableName, cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to query throughput starting snapshot for {QueueName}", queueTableName.QueueName);
+            throw;
+        }
 
         // looping for 24 hours
         for (var i = 0; i < 24; i++)
         {
             await Task.Delay(TimeSpan.FromHours(1), timeProvider, cancellationToken);
-            var endData =
-                await queueTableName.DatabaseDetails.GetSnapshot(queueTableName, cancellationToken);
+
+            BrokerQueueTableSnapshot? endData;
+            try
+            {
+                endData = await queueTableName.DatabaseDetails.GetSnapshot(queueTableName, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Failed to query throughput hour {hour} for {QueueName}", i, queueTableName.QueueName);
+                throw;
+            }
 
             if (endData.RowVersion.HasValue && startData.RowVersion.HasValue)
             {


### PR DESCRIPTION
While exceptions in these locations _should_ be caught by the try/catch in BrokerThroughputCollectorHostedService, it's possible there's something in the long-running async code that could be causing exceptions here to go unobserved. This extra logging would bring that to light if true.