### PR TITLE
Test for mismatched runtime assemblies

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -85,8 +85,12 @@
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup Label="Versions to pin transitive references">
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="8.18.0" />
+    <PackageVersion Include="System.Formats.Cbor" Version="10.0.8" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.8" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.1.63" />

--- a/src/ServiceControlInstaller.Packaging.UnitTests/DeploymentPackageTests.cs
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/DeploymentPackageTests.cs
@@ -4,6 +4,8 @@ namespace Tests
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Runtime.InteropServices;
+    using Microsoft.AspNetCore.Http;
     using NUnit.Framework;
 
     [TestFixtureSource(typeof(DeploymentPackage), nameof(DeploymentPackage.All))]
@@ -30,7 +32,7 @@ namespace Tests
         }
 
         [Test]
-        public void DuplicateAssemblyShouldHaveMatchingVersions()
+        public void DuplicateAssembliesInDeploymentUnitsShouldHaveMatchingVersions()
         {
             var detectedMismatches = new List<string>();
 
@@ -41,6 +43,38 @@ namespace Tests
                 {
                     detectedMismatches.AddRange(GetAssemblyMismatches(leftDeploymentUnit, rightDeploymentUnit));
                 }
+            }
+
+            Assert.That(detectedMismatches, Is.Empty, $"Component assembly version mismatch detected");
+        }
+
+        [Test]
+        public void DuplicateAssembliesFromRuntimeShouldHaveMatchingVersions()
+        {
+            var detectedMismatches = new List<string>();
+
+            var runtimeDirectory = new DirectoryInfo(RuntimeEnvironment.GetRuntimeDirectory());
+            var runtimeDeploymentUnit = new DeploymentPackage.DeploymentUnit(runtimeDirectory, ".NET Runtime");
+
+            foreach (var deploymentUnit in deploymentPackage.DeploymentUnits)
+            {
+                detectedMismatches.AddRange(GetAssemblyMismatches(deploymentUnit, runtimeDeploymentUnit));
+            }
+
+            Assert.That(detectedMismatches, Is.Empty, $"Component assembly version mismatch detected");
+        }
+
+        [Test]
+        public void DuplicateAssembliesFromASPNetCoreShouldHaveMatchingVersions()
+        {
+            var detectedMismatches = new List<string>();
+
+            var aspNetCoreDirectory = new DirectoryInfo(Path.GetDirectoryName(typeof(HttpResponse).Assembly.Location));
+            var aspNetCoreDeploymentUnit = new DeploymentPackage.DeploymentUnit(aspNetCoreDirectory, "ASP.NET Core Runtime");
+
+            foreach (var deploymentUnit in deploymentPackage.DeploymentUnits)
+            {
+                detectedMismatches.AddRange(GetAssemblyMismatches(deploymentUnit, aspNetCoreDeploymentUnit));
             }
 
             Assert.That(detectedMismatches, Is.Empty, $"Component assembly version mismatch detected");

--- a/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
+++ b/src/ServiceControlInstaller.Packaging.UnitTests/ServiceControlInstaller.Packaging.UnitTests.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup Label="Needed for build ordering">
     <ProjectReference Include="..\ServiceControlInstaller.Packaging\ServiceControlInstaller.Packaging.csproj" ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>


### PR DESCRIPTION
We have tests to ensure that we don't have mismatched assembly versions between instances, transports, and persisters.

However, we weren't checking to make sure we had consistent versions of assemblies that are shipped both as packages and in the .NET or ASP.NET runtimes.

This PR adds tests for those scenarios and adds some missing packages to the pinned transitive section to fix the new tests.
