### PR TITLE
Collect more historical data from cloud-based brokers

### DIFF
--- a/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
@@ -98,12 +98,7 @@ public class BrokerThroughputCollectorHostedService(
                 await dataStore.SaveEndpoint(endpoint, stoppingToken);
             }
 
-            var defaultStartDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime).AddDays(-30);
-            var startDate = endpoint.LastCollectedDate < defaultStartDate
-                ? defaultStartDate
-                : endpoint.LastCollectedDate.AddDays(1);
-
-            await foreach (var queueThroughput in brokerThroughputQuery.GetThroughputPerDay(queueName, startDate, stoppingToken))
+            await foreach (var queueThroughput in brokerThroughputQuery.GetThroughputPerDay(queueName, endpoint.LastCollectedDate.AddDays(1), stoppingToken))
             {
                 try
                 {

--- a/src/ServiceControl.Transports.ASBS/AzureQuery.cs
+++ b/src/ServiceControl.Transports.ASBS/AzureQuery.cs
@@ -27,6 +27,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
 {
     const string CompleteMessageMetricName = "CompleteMessage";
     const string MicrosoftServicebusNamespacesMetricsNamespace = "Microsoft.ServiceBus/Namespaces";
+    const int MaxDaysToQuery = 90;
 
     string serviceBusName = string.Empty;
     ArmClient? armClient;
@@ -202,8 +203,13 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         logger.LogInformation($"Gathering metrics for \"{brokerQueue.QueueName}\" queue");
-
-        var endDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime).AddDays(-1);
+        var today = DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime);
+        var earliestStartDate = today.AddDays(-MaxDaysToQuery);
+        if (startDate < earliestStartDate)
+        {
+            startDate = earliestStartDate;
+        }
+        var endDate = today.AddDays(-1);
         if (endDate < startDate)
         {
             yield break;

--- a/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
+++ b/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
@@ -23,6 +23,8 @@ using Microsoft.Extensions.Logging;
 public class AmazonSQSQuery(ILogger<AmazonSQSQuery> logger, TimeProvider timeProvider, TransportSettings transportSettings)
     : BrokerThroughputQuery(logger, "AmazonSQS")
 {
+    const int MaxDaysToQuery = 365;
+
     AmazonCloudWatchClient? cloudWatch;
     AmazonSQSClient? sqs;
     string? prefix;
@@ -198,7 +200,13 @@ public class AmazonSQSQuery(ILogger<AmazonSQSQuery> logger, TimeProvider timePro
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var utcNow = timeProvider.GetUtcNow();
-        var endDate = DateOnly.FromDateTime(utcNow.DateTime).AddDays(-1); // Query date up to but not including today
+        var today = DateOnly.FromDateTime(utcNow.DateTime);
+        var earliestQueryDate = today.AddDays(-MaxDaysToQuery);
+        if (startDate < earliestQueryDate)
+        {
+            startDate = earliestQueryDate;
+        }
+        var endDate = today.AddDays(-1); // Query date up to but not including today
 
         var isBeforeStartDate = endDate < startDate;
 


### PR DESCRIPTION
- AWS 365 days
- Azure 90 days

Matches [a similar change made in the endpoint throughput tool](https://github.com/Particular/Particular.EndpointThroughputCounter/pull/1086).