### PR TITLE
Provide monthly throughput values to the licensing API

### DIFF
--- a/src/Particular.LicensingComponent.Contracts/EndpointThroughputSummary.cs
+++ b/src/Particular.LicensingComponent.Contracts/EndpointThroughputSummary.cs
@@ -7,6 +7,7 @@ public class EndpointThroughputSummary
     public bool IsKnownEndpoint { get; set; }
     public string UserIndicator { get; set; }
     public long MaxDailyThroughput { get; set; }
+    public MonthlyThroughput[] MonthlyThroughput { get; set; }
     public long MaxMonthlyThroughput { get; set; }
 }
 
@@ -15,3 +16,5 @@ public class UpdateUserIndicator
     public string Name { get; set; }
     public string UserIndicator { get; set; }
 }
+
+public record MonthlyThroughput(string Month, long Throughput);

--- a/src/Particular.LicensingComponent/ThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/ThroughputCollector.cs
@@ -73,6 +73,7 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
                 UserIndicator = endpointData.UserIndicator ?? (endpointData.IsKnownEndpoint ? Contracts.UserIndicator.NServiceBusEndpoint.ToString() : string.Empty),
                 IsKnownEndpoint = endpointData.IsKnownEndpoint,
                 MaxDailyThroughput = endpointData.ThroughputData.MaxDailyThroughput(),
+                MonthlyThroughput = endpointData.ThroughputData.MonthlyThroughput(),
                 MaxMonthlyThroughput = endpointData.ThroughputData.MaxMonthlyThroughput()
             };
 

--- a/src/Particular.LicensingComponent/ThroughputDataExtensions.cs
+++ b/src/Particular.LicensingComponent/ThroughputDataExtensions.cs
@@ -23,6 +23,11 @@ static class ThroughputDataExtensions
         return 0;
     }
 
+    public static MonthlyThroughput[] MonthlyThroughput(this List<ThroughputData> throughputs) => [.. throughputs
+            .SelectMany(data => data)
+            .GroupBy(kvp => $"{kvp.Key.Year}-{kvp.Key.Month.ToString().PadLeft(2, '0')}")
+            .Select(group => new MonthlyThroughput(group.Key, group.Sum(kvp => kvp.Value)))];
+
     public static long MaxMonthlyThroughput(this List<ThroughputData> throughputs)
     {
         var monthlySums = throughputs

--- a/src/Particular.LicensingComponent/ThroughputDataExtensions.cs
+++ b/src/Particular.LicensingComponent/ThroughputDataExtensions.cs
@@ -25,7 +25,7 @@ static class ThroughputDataExtensions
 
     public static MonthlyThroughput[] MonthlyThroughput(this List<ThroughputData> throughputs) => [.. throughputs
             .SelectMany(data => data)
-            .GroupBy(kvp => $"{kvp.Key.Year}-{kvp.Key.Month.ToString().PadLeft(2, '0')}")
+            .GroupBy(kvp => $"{kvp.Key:yyyy-MM}")
             .Select(group => new MonthlyThroughput(group.Key, group.Sum(kvp => kvp.Value)))];
 
     public static long MaxMonthlyThroughput(this List<ThroughputData> throughputs)

--- a/src/ServiceControl.Persistence.RavenDB/Throughput/LicensingDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Throughput/LicensingDataStore.cs
@@ -140,7 +140,7 @@ class LicensingDataStore(
                 .IncrementalTimeSeriesFor(document.GenerateDocumentId(), ThroughputTimeSeriesName)
                 .GetAsync(from, token: cancellationToken);
 
-            if (results.TryGetValue(document.SanitizedName, out var throughputDatas) &&
+            if (timeSeries is not null && results.TryGetValue(document.SanitizedName, out var throughputDatas) &&
                 throughputDatas is List<ThroughputData> throughputDataList)
             {
                 var endpointDailyThroughputs = timeSeries.Select(entry => new EndpointDailyThroughput(DateOnly.FromDateTime(entry.Timestamp), (long)entry.Value));


### PR DESCRIPTION
Supports [monthly throughput graphs in ServicePulse](https://github.com/Particular/ServicePulse/pull/3030) released in ServicePulse 2.8.1