### PR TITLE
[Usage Reporting] Collect 365 days of data from SQS the first time a queue is seen

### DIFF
--- a/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
@@ -98,12 +98,7 @@ public class BrokerThroughputCollectorHostedService(
                 await dataStore.SaveEndpoint(endpoint, stoppingToken);
             }
 
-            var defaultStartDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime).AddDays(-30);
-            var startDate = endpoint.LastCollectedDate < defaultStartDate
-                ? defaultStartDate
-                : endpoint.LastCollectedDate.AddDays(1);
-
-            await foreach (var queueThroughput in brokerThroughputQuery.GetThroughputPerDay(queueName, startDate, stoppingToken))
+            await foreach (var queueThroughput in brokerThroughputQuery.GetThroughputPerDay(queueName, endpoint.LastCollectedDate.AddDays(1), stoppingToken))
             {
                 try
                 {

--- a/src/ServiceControl.Transports.ASBS/AzureQuery.cs
+++ b/src/ServiceControl.Transports.ASBS/AzureQuery.cs
@@ -27,6 +27,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
 {
     const string CompleteMessageMetricName = "CompleteMessage";
     const string MicrosoftServicebusNamespacesMetricsNamespace = "Microsoft.ServiceBus/Namespaces";
+    const int MaxDaysToCollect = 30;
 
     string serviceBusName = string.Empty;
     ArmClient? armClient;
@@ -201,7 +202,16 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
     {
         logger.LogInformation($"Gathering metrics for \"{brokerQueue.QueueName}\" queue");
 
-        var endDate = DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime).AddDays(-1);
+        var today = DateOnly.FromDateTime(timeProvider.GetUtcNow().DateTime);
+        var earliestStartDate = today.AddDays(-MaxDaysToCollect);
+        if (startDate < earliestStartDate)
+        {
+            startDate = earliestStartDate;
+        }
+
+        // Collect up to yesterday, as today's data is incomplete
+        // We will collect today's data tomorrow
+        var endDate = today.AddDays(-1);
         if (endDate < startDate)
         {
             yield break;

--- a/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
+++ b/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
@@ -26,7 +26,7 @@ public class AmazonSQSQuery(ILogger<AmazonSQSQuery> logger, TimeProvider timePro
     AmazonCloudWatchClient? cloudWatch;
     AmazonSQSClient? sqs;
     string? prefix;
-    const int MaxDaysToCollect = 30;
+    const int MaxDaysToCollect = 365;
 
     protected override void InitializeCore(ReadOnlyDictionary<string, string> settings)
     {

--- a/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
+++ b/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
@@ -26,6 +26,7 @@ public class AmazonSQSQuery(ILogger<AmazonSQSQuery> logger, TimeProvider timePro
     AmazonCloudWatchClient? cloudWatch;
     AmazonSQSClient? sqs;
     string? prefix;
+    const int MaxDaysToCollect = 30;
 
     protected override void InitializeCore(ReadOnlyDictionary<string, string> settings)
     {
@@ -198,7 +199,16 @@ public class AmazonSQSQuery(ILogger<AmazonSQSQuery> logger, TimeProvider timePro
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var utcNow = timeProvider.GetUtcNow();
-        var endDate = DateOnly.FromDateTime(utcNow.DateTime).AddDays(-1); // Query date up to but not including today
+        var today = DateOnly.FromDateTime(utcNow.DateTime);
+        var earliestStartDate = today.AddDays(-MaxDaysToCollect);
+        if (startDate < earliestStartDate)
+        {
+            startDate = earliestStartDate;
+        }
+
+        // Collect up to yesterday, as today's data is incomplete
+        // We will collect today's data tomorrow
+        var endDate = today.AddDays(-1); // Query date up to but not including today
 
         var isBeforeStartDate = endDate < startDate;
 


### PR DESCRIPTION
The first time a queue is seen in SQS, ServiceControl queries for historical data. This change increases the amount of historical data from 30 days to 365 days (the max allowed by SQS). This improves the system's understanding of the historical usage of the queue.

