### PR TITLE
[Usage Reporting] Collect 90 days of data from Azure Service Bus the first time a queue is seen

### DIFF
--- a/src/ServiceControl.Transports.ASBS.Tests/ReportingWindowTests.cs
+++ b/src/ServiceControl.Transports.ASBS.Tests/ReportingWindowTests.cs
@@ -1,0 +1,58 @@
+﻿namespace ServiceControl.Transports.ASBS.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+[TestFixture]
+public class ReportingWindowTests
+{
+    [TestCase(90, 30)]
+    [TestCase(87, 30)]
+    [TestCase(100, 30)]
+    [TestCase(1, 30)]
+    public void CanHandle90Days(int totalDays, int reportingWindowDays)
+    {
+        var now = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        var startDate = now.AddDays(-totalDays);
+
+        List<DateOnly> expectedCoveredDates = [];
+        for (var currentDate = startDate; currentDate <= now; currentDate = currentDate.AddDays(1))
+        {
+            expectedCoveredDates.Add(currentDate);
+        }
+
+        var reportingWindow = ReportingWindow.GetReportingWindow(startDate, now, reportingWindowDays).ToArray();
+
+        using (Assert.EnterMultipleScope())
+        {
+            List<DateOnly> coveredDates = [];
+
+            foreach (var window in reportingWindow)
+            {
+                // Everything in the reporting window must be greater than zero days and less than or equal to reportingWindowDays
+                var numberOfDays = (window.End.ToDateTime(TimeOnly.MinValue) - window.Start.ToDateTime(TimeOnly.MaxValue)).TotalDays;
+                Assert.That(numberOfDays, Is.LessThanOrEqualTo(reportingWindowDays), $"Window from {window.Start} to {window.End} has {numberOfDays} days, which exceeds the reporting window of {reportingWindowDays} days.");
+                Assert.That(numberOfDays, Is.GreaterThan(0), $"Window from {window.Start} to {window.End} has {numberOfDays} days, which is not greater than zero.");
+
+                // None of the reportingWindows start or end after the endDate
+                Assert.That(window.Start, Is.LessThanOrEqualTo(now), $"Window from {window.Start} to {window.End} starts after the end date.");
+                Assert.That(window.End, Is.LessThanOrEqualTo(now), $"Window from {window.Start} to {window.End} ends after the end date.");
+
+                // None of the reportingWindows start or end before the startDate
+                Assert.That(window.Start, Is.GreaterThanOrEqualTo(startDate), $"Window from {window.Start} to {window.End} starts before the start date.");
+                Assert.That(window.End, Is.GreaterThanOrEqualTo(startDate), $"Window from {window.Start} to {window.End} ends before the start date.");
+
+                for (var currentDate = window.Start; currentDate <= window.End; currentDate = currentDate.AddDays(1))
+                {
+                    coveredDates.Add(currentDate);
+                }
+            }
+
+            // None of the reportingWindows overlap
+            // There are no gaps
+            Assert.That(coveredDates, Is.EquivalentTo(expectedCoveredDates), "The covered dates do not match the expected dates.");
+        }
+    }
+}

--- a/src/ServiceControl.Transports.ASBS/AzureQuery.cs
+++ b/src/ServiceControl.Transports.ASBS/AzureQuery.cs
@@ -27,7 +27,10 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
 {
     const string CompleteMessageMetricName = "CompleteMessage";
     const string MicrosoftServicebusNamespacesMetricsNamespace = "Microsoft.ServiceBus/Namespaces";
-    const int MaxDaysToCollect = 30;
+
+    // ASB keeps 90 days of data but will only return 30 days in a single query
+    const int MaxDaysToCollect = 90;
+    const int MaxDaysToCollectInOneQuery = 30;
 
     string serviceBusName = string.Empty;
     ArmClient? armClient;
@@ -217,9 +220,6 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
             yield break;
         }
 
-        var metrics = await GetMetrics(brokerQueue.QueueName, startDate,
-            endDate, cancellationToken);
-
         DateOnly currentDate = startDate;
         var data = new Dictionary<DateOnly, QueueThroughput>();
         while (currentDate <= endDate)
@@ -232,9 +232,14 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
             currentDate = currentDate.AddDays(1);
         }
 
-        foreach (var metricValue in metrics)
+        foreach (var (periodStart, periodEnd) in ReportingWindow.GetReportingWindow(startDate, endDate, MaxDaysToCollectInOneQuery))
         {
-            data[DateOnly.FromDateTime(metricValue.TimeStamp.UtcDateTime)].TotalThroughput = (long)(metricValue.Total ?? 0);
+            var metrics = await GetMetrics(brokerQueue.QueueName, periodStart, periodEnd, cancellationToken);
+
+            foreach (var metricValue in metrics)
+            {
+                data[DateOnly.FromDateTime(metricValue.TimeStamp.UtcDateTime)].TotalThroughput = (long)(metricValue.Total ?? 0);
+            }
         }
 
         foreach (QueueThroughput queueThroughput in data.Values)

--- a/src/ServiceControl.Transports.ASBS/ReportingWindow.cs
+++ b/src/ServiceControl.Transports.ASBS/ReportingWindow.cs
@@ -1,0 +1,23 @@
+#nullable enable
+namespace ServiceControl.Transports.ASBS;
+
+using System;
+using System.Collections.Generic;
+
+public static class ReportingWindow
+{
+    public static IEnumerable<(DateOnly Start, DateOnly End)> GetReportingWindow(DateOnly startDate, DateOnly endDate, int maxDaysPerPeriod)
+    {
+        DateOnly currentStart = startDate;
+        while (currentStart <= endDate)
+        {
+            DateOnly currentEnd = currentStart.AddDays(maxDaysPerPeriod);
+            if (currentEnd > endDate)
+            {
+                currentEnd = endDate;
+            }
+            yield return (currentStart, currentEnd);
+            currentStart = currentEnd.AddDays(1);
+        }
+    }
+}


### PR DESCRIPTION
The first time a queue is seen in Azure Service Bus, ServiceControl queries for historical data. This change increases the amount of historical data from 30 days to 90 days (the max allowed by Azure Service Bus). This improves the system's understanding of the historical usage of the queue.

NOTE: Azure keeps data for 90 days but only returns 30 days of data in a single query, so this change queries in 30 day reporting windows