### PR TITLE
Use specific .NET runtime version

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -46,6 +46,16 @@ jobs:
         uses: ./.github/actions/validate-version
         with:
           version: ${{ env.MinVerVersion }}
+      - name: Determine runtime version
+        shell: pwsh
+        run: |
+          # Read settings from Custom.Build.props
+          [xml]$xml = Get-Content ./src/Custom.Build.props
+          $runtimeVersion = $xml.selectNodes('/Project/PropertyGroup/RuntimeFrameworkVersion').InnerText
+          if (-not ($runtimeVersion)) {
+            throw "Missing RuntimeFrameworkVersion setting in Custom.Build.props"
+          }
+          echo "RuntimeVersion=$runtimeVersion" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.0.0
       - name: Log in to GitHub container registry
@@ -64,6 +74,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           sbom: true
+          build-args: |
+            RUNTIMEVERSION=${{ env.RuntimeVersion }}
           labels: |
             org.opencontainers.image.source=https://github.com/Particular/ServiceControl/tree/${{ github.sha }}
             org.opencontainers.image.authors="Particular Software"
@@ -75,7 +87,7 @@ jobs:
             org.opencontainers.image.created=${{ steps.date.outputs.date }}
             org.opencontainers.image.title=${{ matrix.title }}
             org.opencontainers.image.description=${{ matrix.description }}
-            org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite-extra
+            org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:${{ env.RuntimeVersion }}-noble-chiseled-composite-extra
           annotations: |
             index:org.opencontainers.image.source=https://github.com/Particular/ServiceControl/tree/${{ github.sha }}
             index:org.opencontainers.image.authors="Particular Software"
@@ -87,6 +99,6 @@ jobs:
             index:org.opencontainers.image.created=${{ steps.date.outputs.date }}
             index:org.opencontainers.image.title=${{ matrix.title }}
             index:org.opencontainers.image.description=${{ matrix.description }}
-            index:org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite-extra
+            index:org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/aspnet:${{ env.RuntimeVersion }}-noble-chiseled-composite-extra
           file: src/${{ matrix.project }}/Dockerfile
           tags: ghcr.io/particular/${{ matrix.name }}:${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || env.MinVerVersion }}

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -14,6 +14,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <RuntimeFrameworkVersion>10.0.9</RuntimeFrameworkVersion>
+    <RollForward>Disable</RollForward>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <MinVerMinimumMajorMinor>5.7</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
   </PropertyGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Autofac" Version="9.3.0" />
     <PackageVersion Include="AWSSDK.CloudWatch" Version="4.0.10.5" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
-   <PackageVersion Include="Azure.ResourceManager.Monitor" Version="1.3.1" />
+    <PackageVersion Include="Azure.ResourceManager.Monitor" Version="1.3.1" />
     <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="ByteSize" Version="2.1.2" />
     <PackageVersion Include="Caliburn.Micro" Version="5.0.258" />
@@ -16,17 +16,17 @@
     <PackageVersion Include="Fody" Version="6.9.3" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
     <PackageVersion Include="HdrHistogram" Version="2.5.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(RuntimeFrameworkVersion)" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
@@ -72,25 +72,25 @@
     <PackageVersion Include="ReactiveUI.WPF" Version="22.3.1" />
     <PackageVersion Include="Seq.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="ServiceControl.Contracts" Version="5.1.0" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.9" />
-    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="10.0.9" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="$(RuntimeFrameworkVersion)" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
-    <PackageVersion Include="System.Management" Version="10.0.9" />
+    <PackageVersion Include="System.Management" Version="$(RuntimeFrameworkVersion)" />
     <PackageVersion Include="System.Management.Automation" Version="7.6.1" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
-    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.9" />
-    <PackageVersion Include="System.ServiceProcess.ServiceController" Version="10.0.9" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="System.ServiceProcess.ServiceController" Version="$(RuntimeFrameworkVersion)" />
     <PackageVersion Include="Validar.Fody" Version="1.9.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup Label="Versions to pin transitive references">
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(RuntimeFrameworkVersion)" />
     <PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="8.19.1" />
-    <PackageVersion Include="System.Formats.Cbor" Version="10.0.9" />
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.9" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.9" />
-    <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.9" />
+    <PackageVersion Include="System.Formats.Cbor" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="System.IO.Hashing" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="$(RuntimeFrameworkVersion)" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="$(RuntimeFrameworkVersion)" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.1.63" />

--- a/src/ServiceControl.Audit/Dockerfile
+++ b/src/ServiceControl.Audit/Dockerfile
@@ -1,3 +1,5 @@
+ARG RUNTIMEVERSION=10.0
+
 # Build image
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG TARGETARCH
@@ -9,7 +11,7 @@ RUN dotnet build src/ServiceControl.Audit/ServiceControl.Audit.csproj --configur
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite-extra
+FROM mcr.microsoft.com/dotnet/aspnet:$RUNTIMEVERSION-noble-chiseled-composite-extra
 WORKDIR /app
 
 EXPOSE 44444

--- a/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
+++ b/src/ServiceControl.Config.Tests/ServiceControl.Config.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.57" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ServiceControl.Config\ServiceControl.Config.csproj" />
     <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
   </ItemGroup>

--- a/src/ServiceControl.Config/ServiceControl.Config.csproj
+++ b/src/ServiceControl.Config/ServiceControl.Config.csproj
@@ -16,6 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.57" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ServiceControlInstaller.Engine\ServiceControlInstaller.Engine.csproj" />
   </ItemGroup>
 

--- a/src/ServiceControl.Monitoring/Dockerfile
+++ b/src/ServiceControl.Monitoring/Dockerfile
@@ -1,3 +1,5 @@
+ARG RUNTIMEVERSION=10.0
+
 # Build image
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG TARGETARCH
@@ -9,7 +11,7 @@ RUN dotnet build src/ServiceControl.Monitoring/ServiceControl.Monitoring.csproj 
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite-extra
+FROM mcr.microsoft.com/dotnet/aspnet:$RUNTIMEVERSION-noble-chiseled-composite-extra
 WORKDIR /app
 
 EXPOSE 33633

--- a/src/ServiceControl/Dockerfile
+++ b/src/ServiceControl/Dockerfile
@@ -1,3 +1,5 @@
+ARG RUNTIMEVERSION=10.0
+
 # Build image
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG TARGETARCH
@@ -9,7 +11,7 @@ RUN dotnet build src/ServiceControl/ServiceControl.csproj --configuration Releas
 RUN dotnet publish src/HealthCheckApp/HealthCheckApp.csproj --arch $TARGETARCH --output /healthcheck
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite-extra
+FROM mcr.microsoft.com/dotnet/aspnet:$RUNTIMEVERSION-noble-chiseled-composite-extra
 WORKDIR /app
 
 EXPOSE 33333


### PR DESCRIPTION
By default, when doing a self-contained publish, the latest runtime on the machine is chosen to be the bundled runtime. This means that building the same commit can result in a different runtime being chosen each time. With the tests added in #5521 this becomes even more apparent because the tests will start failing when a new runtime has been released but the matching packages haven't been updated yet.

This PR changes the behavior so that a specific runtime is always chosen regardless of the state of the build machine.

This is achieved by setting the `RuntimeFrameworkVersion` property in `Custom.Build.props`. `RollForward` is disabled as well so that when running in framework-dependent mode (for example, F5 in VS), it will require the specific version and not use something newer on the machine.

The `RuntimeFrameworkVersion` property is now also used in `Directory.Packages.props` to set the version for all packages that tied to the runtime version, making it easy to keep them in sync.

Follow-up to #5521