### PR TITLE
Add System.Management.Automation renovate rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,6 +37,12 @@
       matchFileNames: ["**/ServiceControl.Management.PowerShell.csproj"],
       matchPackageNames: ["Microsoft.Extensions.DependencyModel"],
       allowedVersions: "<9.0.0"
+    },
+    {
+      description: "Keep ServiceControl.Management.PowerShell on PowerShell 7.4",
+      matchFileNames: ["**/ServiceControl.Management.PowerShell.csproj"],
+      matchPackageNames: ["System.Management.Automation"],
+      allowedVersions: "<7.5.0"
     }
   ]
 }


### PR DESCRIPTION
This PR adds a renovate rule to keep the version of System.Management.Automation in the ServiceControl.Management.PowerShell project locked to the PowerShell 7.4 version.

PowerShell 7.4 LTS goes out of support in November 2026, so we'll want to update to the latest LTS (7.6) at some point around this time.