### PR TITLE
Pin the my/routes manifest to one wire shape across instances

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_my_routes_are_requested.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_my_routes_are_requested.cs
@@ -13,7 +13,7 @@ using NUnit.Framework;
 using ServiceControl.Infrastructure.Auth;
 
 /// <summary>
-/// my/routes returns the API routes the current token may call, as { method, urlTemplate } entries.
+/// my/routes returns the API routes the current token may call, as { method, url_template } entries.
 /// It is the per-instance authorization contract ServicePulse consumes: it gates UI on routes it
 /// already calls rather than on the server's internal permission vocabulary.
 /// </summary>

--- a/src/ServiceControl.Hosting/Auth/MyRoutesController.cs
+++ b/src/ServiceControl.Hosting/Auth/MyRoutesController.cs
@@ -8,7 +8,7 @@ using ServiceControl.Infrastructure;
 using ServiceControl.Infrastructure.Auth;
 
 /// <summary>
-/// Returns the API routes the current token may call, as <c>{ method, urlTemplate }</c> entries.
+/// Returns the API routes the current token may call, as <c>{ method, url_template }</c> entries.
 /// This is the per-instance authorization contract for clients (ServicePulse): each instance reports
 /// only the routes it serves, so a client matches its outgoing request against the allowed set without
 /// ever learning the server's internal permission vocabulary. The endpoint is the bootstrap of that

--- a/src/ServiceControl.Infrastructure.Tests/Auth/RouteManifestEntrySerializationTests.cs
+++ b/src/ServiceControl.Infrastructure.Tests/Auth/RouteManifestEntrySerializationTests.cs
@@ -1,0 +1,27 @@
+#nullable enable
+namespace ServiceControl.Infrastructure.Tests.Auth;
+
+using System.Text.Json;
+using NUnit.Framework;
+using ServiceControl.Infrastructure.Auth;
+
+[TestFixture]
+class RouteManifestEntrySerializationTests
+{
+    // The my/routes manifest must have ONE wire shape across instances. The Primary instance
+    // serializes snake_case and the Monitoring instance camelCase, so RouteManifestEntry pins its
+    // field names with [JsonPropertyName]. This test guards that contract: even under a camelCase
+    // policy (as on the Monitoring host) the emitted names stay snake_case, so a client merging both
+    // instances never silently drops the differently-cased entries.
+    [Test]
+    public void Emits_snake_case_field_names_even_under_a_camelCase_policy()
+    {
+        var json = JsonSerializer.Serialize(
+            new RouteManifestEntry("GET", "/api/errors"),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        Assert.That(json, Does.Contain("\"method\""));
+        Assert.That(json, Does.Contain("\"url_template\""));
+        Assert.That(json, Does.Not.Contain("urlTemplate"));
+    }
+}

--- a/src/ServiceControl.Infrastructure/Auth/RouteManifest.cs
+++ b/src/ServiceControl.Infrastructure/Auth/RouteManifest.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.Infrastructure.Auth;
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
 /// <summary>
@@ -28,8 +29,16 @@ public static partial class RouteTemplateNormalizer
 /// <summary>A route the server hosts, with the authorization metadata read from its endpoint.</summary>
 public sealed record RouteAuthInfo(string Method, string UrlTemplate, string? RequiredPermission, bool AllowAnonymous);
 
-/// <summary>A single allowed-route entry returned to the client.</summary>
-public sealed record RouteManifestEntry(string Method, string UrlTemplate);
+/// <summary>
+/// A single allowed-route entry returned to the client. The JSON field names are pinned with
+/// <see cref="JsonPropertyName"/> so the manifest has one stable shape regardless of each host's
+/// global JSON naming policy (the Primary instance serializes snake_case, the Monitoring instance
+/// camelCase). Without this the same contract would emit <c>url_template</c> on one instance and
+/// <c>urlTemplate</c> on another, and clients that merge both would silently drop half the routes.
+/// </summary>
+public sealed record RouteManifestEntry(
+    [property: JsonPropertyName("method")] string Method,
+    [property: JsonPropertyName("url_template")] string UrlTemplate);
 
 /// <summary>
 /// Projects the route table down to the entries a caller may invoke. A route is included when it is


### PR DESCRIPTION
## Problem

The `my/routes` manifest is served by a single shared controller (`MyRoutesController`) hosted on the Primary, Audit, and Monitoring instances. Each instance serializes JSON with its own global naming policy: Primary snake_case, Monitoring camelCase. So the same contract emitted `url_template` from Primary and `urlTemplate` from Monitoring. ServicePulse merges both manifests and keys on `url_template`, so every Monitoring entry was silently dropped, denying Monitoring-gated actions regardless of the user's actual permissions.

## Fix

Pin the field names on `RouteManifestEntry` with `[JsonPropertyName]`, which overrides each host's naming policy, so every instance emits an identical `{ method, url_template }`. Added a serialization test asserting snake_case is emitted even under a camelCase policy (the existing acceptance test deserializes into the record and is casing-agnostic, so it could not catch a regression).

`MyRoutesController` is the only controller shared across instances, so `RouteManifestEntry` is the only DTO affected. The `my/routes` endpoint is unreleased, so there is no backward-compatibility impact.

## ServicePulse coordination

This supersedes the client-side dual-casing workaround in Particular/ServicePulse#3053, which can be closed. The one useful part of that PR, discovering the `my/routes` URL from the root document, has been folded into the main ServicePulse feature PR (Particular/ServicePulse#3035). With this fix the ServicePulse client reads snake_case only, so we can ship the two together.
