### PR TITLE
Allow installing error instance from SCMU without a valid license

### DIFF
--- a/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
@@ -18,7 +18,7 @@
 
         public override async Task ExecuteAsync(object obj)
         {
-            if (!await commandChecks.CanAddInstance())
+            if (!await commandChecks.CanAddInstance(true))
             {
                 return;
             }

--- a/src/ServiceControl.Config/UI/Shell/ShellView.xaml
+++ b/src/ServiceControl.Config/UI/Shell/ShellView.xaml
@@ -126,7 +126,7 @@
                            HorizontalOffset="-288"
                            Placement="Bottom"
                            PlacementTarget="{Binding ElementName=StatusPanel}">
-                        <shell:LicensePopupView cal:Bind.Model="{Binding LicenseStatusManager}" />
+                        <shell:LicensePopupView DataContext="{Binding LicenseStatusManager}" />
                     </Popup>
 
                 </StackPanel>

--- a/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
+++ b/src/ServiceControl.Management.PowerShell/Cmdlets/ServiceControlInstances/NewServiceControlInstance.cs
@@ -184,7 +184,7 @@ namespace ServiceControl.Management.PowerShell
             try
             {
                 var checks = new PowerShellCommandChecks(this, Acknowledgements);
-                if (!checks.CanAddInstance().GetAwaiter().GetResult())
+                if (!checks.CanAddInstance(true).GetAwaiter().GetResult())
                 {
                     return;
                 }

--- a/src/ServiceControlInstaller.Engine/Validation/AbstractCommandChecks.cs
+++ b/src/ServiceControlInstaller.Engine/Validation/AbstractCommandChecks.cs
@@ -23,10 +23,10 @@
         protected abstract Task NotifyForIncompatibleUpgradeVersion(UpgradeInfo upgradeInfo);
         protected abstract Task NotifyError(string title, string message);
 
-        public async Task<bool> CanAddInstance()
+        public async Task<bool> CanAddInstance(bool allowExpiredLicense = false)
         {
             // Check for license
-            if (!await IsLicenseOk().ConfigureAwait(false))
+            if (!allowExpiredLicense && !await IsLicenseOk().ConfigureAwait(false))
             {
                 return false;
             }


### PR DESCRIPTION
To allow for usage report generation in ServicePulse
- also fixed license expired popup message, which had its text binding broken on main