### PR TITLE
SCMU retention slider not  showing correct value from config file

### DIFF
--- a/src/ServiceControl.Config.Tests/FormSliderTests.cs
+++ b/src/ServiceControl.Config.Tests/FormSliderTests.cs
@@ -1,0 +1,40 @@
+namespace ServiceControl.Config.Tests;
+
+using System.Threading;
+using NUnit.Framework;
+using ServiceControl.Config.Xaml.Controls;
+
+[TestFixture]
+[Apartment(ApartmentState.STA)]
+public class FormSliderTests
+{
+    [Test]
+    public void Summary_is_in_days_when_value_equals_minimum()
+    {
+        // Mirrors the order in which the retention slider bindings are applied in XAML
+        // (initializer members assign in source order): Minimum coerces Value (0 -> 1) and
+        // renders the summary before Units and Value are set. With a stored retention equal
+        // to the minimum, the Value assignment causes no further change event, so the summary
+        // rendered during coercion is the one the user sees.
+        var slider = new FormSlider
+        {
+            Minimum = 1,
+            Units = TimeSpanUnits.Days,
+            Value = 1
+        };
+
+        Assert.That(slider.Summary, Is.EqualTo("1 Day"));
+    }
+
+    [Test]
+    public void Summary_refreshes_when_units_change()
+    {
+        var slider = new FormSlider { Minimum = 2 };
+
+        Assert.That(slider.Summary, Is.EqualTo("2 Days"));
+
+        slider.Units = TimeSpanUnits.Hours;
+
+        Assert.That(slider.Summary, Is.EqualTo("2 Hours"));
+    }
+}

--- a/src/ServiceControl.Config/Xaml/Controls/FormSlider.cs
+++ b/src/ServiceControl.Config/Xaml/Controls/FormSlider.cs
@@ -70,6 +70,11 @@
         {
             base.OnValueChanged(oldValue, newValue);
 
+            RefreshSummary();
+        }
+
+        void RefreshSummary()
+        {
             var period = Units == TimeSpanUnits.Days
                 ? TimeSpan.FromDays(Math.Truncate(Value))
                 : TimeSpan.FromHours(Math.Truncate(Value));
@@ -107,8 +112,12 @@
         public static readonly DependencyProperty HeaderProperty =
             DependencyProperty.Register("Header", typeof(string), typeof(FormSlider), new PropertyMetadata(string.Empty));
 
+        // The summary label is computed in OnValueChanged, which can fire before the Units binding is
+        // applied (e.g. when the Minimum binding coerces Value). Refresh the summary when Units changes
+        // so the label never sticks with a unit it was not meant to use.
         public static readonly DependencyProperty UnitsProperty =
-            DependencyProperty.Register("Units", typeof(TimeSpanUnits), typeof(FormSlider));
+            DependencyProperty.Register("Units", typeof(TimeSpanUnits), typeof(FormSlider),
+                new PropertyMetadata(TimeSpanUnits.Days, (d, _) => ((FormSlider)d).RefreshSummary()));
     }
 
     public enum TimeSpanUnits


### PR DESCRIPTION
Resolves SCMU incorrectly showing the deserialized TimeSpan value from config.

<img width="1244" height="215" alt="image" src="https://github.com/user-attachments/assets/a99f69c9-ad51-49ef-ac1e-29f7d06b341b" />

Root cause is that the FormSlider is not initialized correctly.
