### PR TITLE
Add ecs.version to the audit log ECS documents

### DIFF
--- a/src/ServiceControl.Infrastructure.Tests/Auth/AuthorizationAuditLogTests.cs
+++ b/src/ServiceControl.Infrastructure.Tests/Auth/AuthorizationAuditLogTests.cs
@@ -27,6 +27,7 @@ public class AuthorizationAuditLogTests
         Assert.That(ecs.GetProperty("user").GetProperty("id").GetString(), Is.EqualTo("alice-sub-001"));
         Assert.That(ecs.GetProperty("user").GetProperty("name").GetString(), Is.EqualTo("Alice Smith"));
         Assert.That(ecs.GetProperty("event").GetProperty("action").GetString(), Is.EqualTo("error:messages:retry"));
+        Assert.That(ecs.GetProperty("ecs").GetProperty("version").GetString(), Is.EqualTo("8.11.0"));
         Assert.That(entries[0].Level, Is.EqualTo(LogLevel.Information));
     }
 

--- a/src/ServiceControl.Infrastructure.Tests/Auth/MessageActionAuditLogTests.cs
+++ b/src/ServiceControl.Infrastructure.Tests/Auth/MessageActionAuditLogTests.cs
@@ -41,6 +41,7 @@ public class MessageActionAuditLogTests
         Assert.That(ecs.GetProperty("servicecontrol").GetProperty("resource").GetString(), Is.EqualTo("group-1"));
         Assert.That(ecs.GetProperty("servicecontrol").GetProperty("count").GetInt32(), Is.EqualTo(42));
         Assert.That(ecs.GetProperty("servicecontrol").GetProperty("operation").GetProperty("id").GetString(), Is.EqualTo("op-1"));
+        Assert.That(ecs.GetProperty("ecs").GetProperty("version").GetString(), Is.EqualTo("8.11.0"));
     }
 
     [Test]

--- a/src/ServiceControl.Infrastructure/Auth/AuthorizationAuditLog.cs
+++ b/src/ServiceControl.Infrastructure/Auth/AuthorizationAuditLog.cs
@@ -16,6 +16,12 @@ public sealed class AuthorizationAuditLog(ILoggerFactory loggerFactory) : IAutho
 {
     public const string AuditCategory = "ServiceControl.Audit"; // Logger name is used in logging configuration to write audit entries to a separate file.
 
+    // The ECS version the emitted documents conform to, surfaced as the ecs.version field so downstream
+    // pipelines can pick the matching mappings. 8.11.0 is the latest ECS schema release; the fields used
+    // here (event.category/type/outcome, user.*) are stable across the 8.x line. Shared with
+    // MessageActionAuditLog so both streams declare the same version.
+    internal const string EcsVersion = "8.11.0";
+
     readonly ILogger logger = loggerFactory.CreateLogger(AuditCategory);
 
     // Relaxed escaping keeps the JSON readable for log sinks (no \uXXXX for '+', '<', accented names, …);
@@ -49,6 +55,7 @@ public sealed class AuthorizationAuditLog(ILoggerFactory loggerFactory) : IAutho
         var ecs = new Dictionary<string, object?>
         {
             ["@timestamp"] = DateTimeOffset.UtcNow.ToString("O"),
+            ["ecs"] = new { version = EcsVersion },
             ["event"] = new
             {
                 kind = "event",

--- a/src/ServiceControl.Infrastructure/Auth/MessageActionAuditLog.cs
+++ b/src/ServiceControl.Infrastructure/Auth/MessageActionAuditLog.cs
@@ -66,6 +66,7 @@ public sealed class MessageActionAuditLog : IMessageActionAuditLog
         var ecs = new Dictionary<string, object?>
         {
             ["@timestamp"] = DateTimeOffset.UtcNow.ToString("O"),
+            ["ecs"] = new { version = AuthorizationAuditLog.EcsVersion },
             ["event"] = new
             {
                 kind = "event",


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceControl/issues/5590

The authorization and message-action audit documents omitted the `ecs.version` field. ECS-consuming pipelines (Elasticsearch's built-in `logs-*-*` index template, Elastic Security, other SIEMs) use `ecs.version` to select the matching field mappings, so a conformant document should declare it. Both streams now emit `"ecs": { "version": "8.11.0" }`.