### PR TITLE
Include AuthorizationEnabled in auth configuration

### DIFF
--- a/src/ServiceControl.AcceptanceTesting/OpenIdConnect/OpenIdConnectAssertions.cs
+++ b/src/ServiceControl.AcceptanceTesting/OpenIdConnect/OpenIdConnectAssertions.cs
@@ -105,7 +105,8 @@ namespace ServiceControl.AcceptanceTesting.OpenIdConnect
             string expectedClientId = null,
             string expectedAuthority = null,
             string expectedAudience = null,
-            string expectedApiScopes = null)
+            string expectedApiScopes = null,
+            bool expectedRoleBasedAuthorizationEnabled = false)
         {
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK),
                 "Authentication configuration endpoint should return 200 OK");
@@ -120,6 +121,11 @@ namespace ServiceControl.AcceptanceTesting.OpenIdConnect
                             "Response should contain 'enabled' property");
                 Assert.That(enabledProperty.GetBoolean(), Is.EqualTo(expectedEnabled),
                     $"'enabled' should be {expectedEnabled}");
+
+                Assert.That(root.TryGetProperty("role_based_authorization_enabled", out var roleBasedAuthorizationEnabledProperty), Is.True,
+                            "Response should contain 'role_based_authorization_enabled' property");
+                Assert.That(roleBasedAuthorizationEnabledProperty.GetBoolean(), Is.EqualTo(expectedRoleBasedAuthorizationEnabled),
+                    $"'role_based_authorization_enabled' should be {expectedRoleBasedAuthorizationEnabled}");
             }
 
             // Note: API uses snake_case JSON serialization (client_id, api_scopes)

--- a/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_enabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_enabled.cs
@@ -74,7 +74,8 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                 expectedEnabled: true,
                 expectedClientId: TestClientId,
                 expectedAudience: TestAudience,
-                expectedApiScopes: TestApiScopes);
+                expectedApiScopes: TestApiScopes,
+                expectedRoleBasedAuthorizationEnabled: true);
         }
 
         [Test]

--- a/src/ServiceControl.Infrastructure/OpenIdConnectSettings.cs
+++ b/src/ServiceControl.Infrastructure/OpenIdConnectSettings.cs
@@ -154,6 +154,13 @@ public class OpenIdConnectSettings
 
     void Validate(bool requireServicePulseSettings)
     {
+        if (!Enabled && RoleBasedAuthorizationEnabled)
+        {
+            var message = "Authentication.RoleBasedAuthorizationEnabled cannot be true when Authentication.Enabled is false. Role-based authorization requires authentication to be enabled.";
+            logger.LogCritical(message);
+            throw new Exception(message);
+        }
+
         if (Enabled)
         {
             ValidateRequiredSettings(requireServicePulseSettings);

--- a/src/ServiceControl.UnitTests/Infrastructure/Settings/OpenIdConnectSettingsTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/Settings/OpenIdConnectSettingsTests.cs
@@ -29,6 +29,7 @@ public class OpenIdConnectSettingsTests
         Environment.SetEnvironmentVariable("SERVICECONTROL_AUTHENTICATION_VALIDATELIFETIME", null);
         Environment.SetEnvironmentVariable("SERVICECONTROL_AUTHENTICATION_VALIDATEISSUERSIGNINGKEY", null);
         Environment.SetEnvironmentVariable("SERVICECONTROL_AUTHENTICATION_REQUIREHTTPSMETADATA", null);
+        Environment.SetEnvironmentVariable("SERVICECONTROL_AUTHENTICATION_ROLEBASEDAUTHORIZATIONENABLED", null);
         Environment.SetEnvironmentVariable("SERVICECONTROL_AUTHENTICATION_SERVICEPULSE_CLIENTID", null);
         Environment.SetEnvironmentVariable("SERVICECONTROL_AUTHENTICATION_SERVICEPULSE_APISCOPES", null);
         Environment.SetEnvironmentVariable("SERVICECONTROL_AUTHENTICATION_SERVICEPULSE_AUTHORITY", null);
@@ -49,6 +50,7 @@ public class OpenIdConnectSettingsTests
             Assert.That(settings.ValidateLifetime, Is.True);
             Assert.That(settings.ValidateIssuerSigningKey, Is.True);
             Assert.That(settings.RequireHttpsMetadata, Is.True);
+            Assert.That(settings.RoleBasedAuthorizationEnabled, Is.False);
             Assert.That(settings.ServicePulseClientId, Is.Null);
             Assert.That(settings.ServicePulseApiScopes, Is.Null);
             Assert.That(settings.ServicePulseAuthority, Is.Null);
@@ -263,6 +265,16 @@ public class OpenIdConnectSettingsTests
             Assert.That(settings.Authority, Is.EqualTo("https://login.example.com"));
             Assert.That(settings.Audience, Is.EqualTo("my-audience"));
         }
+    }
+
+    [Test]
+    public void Should_throw_when_role_based_authorization_enabled_without_authentication_enabled()
+    {
+        Environment.SetEnvironmentVariable("SERVICECONTROL_AUTHENTICATION_ROLEBASEDAUTHORIZATIONENABLED", "true");
+
+        var ex = Assert.Throws<Exception>(() => new OpenIdConnectSettings(TestNamespace, validateConfiguration: true, requireServicePulseSettings: false));
+
+        Assert.That(ex.Message, Does.Contain("RoleBasedAuthorizationEnabled cannot be true when Authentication.Enabled is false"));
     }
 
     [Test]

--- a/src/ServiceControl/Authentication/AuthenticationController.cs
+++ b/src/ServiceControl/Authentication/AuthenticationController.cs
@@ -17,6 +17,7 @@
             var info = new AuthConfig
             {
                 Enabled = settings.OpenIdConnectSettings.Enabled,
+                RoleBasedAuthorizationEnabled = settings.OpenIdConnectSettings.RoleBasedAuthorizationEnabled,
                 ClientId = settings.OpenIdConnectSettings.ServicePulseClientId,
                 Authority = settings.OpenIdConnectSettings.ServicePulseAuthority,
                 Audience = settings.OpenIdConnectSettings.Audience,
@@ -34,6 +35,7 @@
     public class AuthConfig
     {
         public bool Enabled { get; set; }
+        public bool RoleBasedAuthorizationEnabled { get; set; }
         public string ClientId { get; set; }
         public string Authority { get; set; }
         public string Audience { get; set; }


### PR DESCRIPTION
- Fixes https://github.com/Particular/ServiceControl/issues/5589

----

- Adds a field that ServicePulse can use to determine if authorization is enabled
- Adds validation that authorization is not enabled while authentication is disabled