### PR TITLE
Calculate TotalThroughput as the maximum organization-wide daily total

### DIFF
--- a/src/Particular.LicensingComponent.UnitTests/ApprovalFiles/ThroughputCollector_Report_Throughput_Tests.Should_generate_correct_report.approved.txt
+++ b/src/Particular.LicensingComponent.UnitTests/ApprovalFiles/ThroughputCollector_Report_Throughput_Tests.Should_generate_correct_report.approved.txt
@@ -141,7 +141,7 @@
         "DailyThroughputFromMonitoring": []
       }
     ],
-    "TotalThroughput": 249,
+    "TotalThroughput": 238,
     "TotalQueues": 5,
     "IgnoredQueues": [],
     "EnvironmentInformation": {

--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
@@ -147,8 +147,34 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(195), $"Incorrect TotalThroughput recorded");
+            Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(185), $"Incorrect TotalThroughput recorded");
             Assert.That(report.ReportData.TotalQueues, Is.EqualTo(3), $"Incorrect TotalQueues recorded");
+        }
+    }
+
+    [Test]
+    public async Task Should_report_total_throughput_as_maximum_daily_throughput_across_all_endpoints()
+    {
+        // Arrange - endpoints peak on different days; TotalThroughput is the best single day
+        // of the organization-wide sum, not the sum of each endpoint's individual peak
+        var startDate = new DateOnly(2024, 4, 24);
+
+        await DataStore.CreateBuilder()
+            .AddEndpoint("Endpoint1", sources: [ThroughputSource.Broker]).WithThroughput(startDate: startDate, data: [100, 10])
+            .AddEndpoint("Endpoint2", sources: [ThroughputSource.Broker]).WithThroughput(startDate: startDate, data: [20, 100])
+            .Build();
+
+        // Act
+        var report = await ThroughputCollector.GenerateThroughputReport("", null, default);
+
+        // Assert
+        Assert.That(report, Is.Not.Null);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(report.ReportData.Queues.First(w => w.QueueName == "Endpoint1").Throughput, Is.EqualTo(100), $"Incorrect Throughput recorded for Endpoint1");
+            Assert.That(report.ReportData.Queues.First(w => w.QueueName == "Endpoint2").Throughput, Is.EqualTo(100), $"Incorrect Throughput recorded for Endpoint2");
+            Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(120), $"TotalThroughput should be the maximum daily throughput across all endpoints, not the sum of each endpoint's maximum");
         }
     }
 

--- a/src/Particular.LicensingComponent/ThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/ThroughputCollector.cs
@@ -119,6 +119,7 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
 
         var queueThroughputs = new List<QueueThroughput>();
         List<string> ignoredQueueNames = [];
+        var dailyThroughputTotals = new Dictionary<DateOnly, long>();
 
         await foreach (var endpointData in GetDistinctEndpointData(cancellationToken))
         {
@@ -140,6 +141,11 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
             };
 
             queueThroughputs.Add(queueThroughput);
+
+            foreach (var (date, messageCount) in endpointData.ThroughputData.DailyThroughput())
+            {
+                dailyThroughputTotals[date] = dailyThroughputTotals.GetValueOrDefault(date) + messageCount;
+            }
         }
 
         var auditServiceMetadata = await dataStore.GetAuditServiceMetadata(cancellationToken);
@@ -161,7 +167,8 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
             IgnoredQueues = [.. ignoredQueueNames],
             Queues = [.. queueThroughputs],
             TotalQueues = queueThroughputs.Count,
-            TotalThroughput = queueThroughputs.Sum(q => q.Throughput ?? 0),
+            //the maximum number of messages processed across all endpoints in a single day
+            TotalThroughput = dailyThroughputTotals.Count > 0 ? dailyThroughputTotals.Values.Max() : 0,
             EnvironmentInformation = new EnvironmentInformation { AuditServicesData = new AuditServicesData(auditServiceMetadata.Versions, auditServiceMetadata.Transports), EnvironmentData = brokerMetaData.Data }
         };
 

--- a/src/Particular.LicensingComponent/ThroughputDataExtensions.cs
+++ b/src/Particular.LicensingComponent/ThroughputDataExtensions.cs
@@ -23,6 +23,13 @@ static class ThroughputDataExtensions
         return 0;
     }
 
+    // Daily throughput for an endpoint. When multiple sources have data for the same day,
+    // the maximum value is used, since all sources measure the same messages.
+    public static IEnumerable<EndpointDailyThroughput> DailyThroughput(this List<ThroughputData> throughputs) => throughputs
+        .SelectMany(td => td)
+        .GroupBy(kvp => kvp.Key)
+        .Select(group => new EndpointDailyThroughput(group.Key, group.Max(kvp => kvp.Value)));
+
     public static MonthlyThroughput[] MonthlyThroughput(this List<ThroughputData> throughputs) => [.. throughputs
             .SelectMany(data => data)
             .GroupBy(kvp => $"{kvp.Key:yyyy-MM}")


### PR DESCRIPTION
Fixes:

- #5592

## What

`TotalThroughput` in the throughput report is now the maximum over calendar days of the organization-wide daily total, instead of the sum of each endpoint's individual best day. This matches the published definition of *maximum message throughput per day* at [particular.net/pricing/definitions](https://particular.net/pricing/definitions):

> The maximum number of messages processed by all NServiceBus endpoints across the entire organization in a day.

## Why

The previous calculation (`queueThroughputs.Sum(q => q.Throughput)`, where each queue's `Throughput` is its own peak day) counts every endpoint's peak as if they all occurred on the same day. Unless all endpoints peak simultaneously, this is strictly greater than the actual busiest day, and the overstatement grows with the number of queues and the length of the reporting window. Since the report is used in licensing conversations, the reported number should match the definition it is measured against.

Example — two endpoints, two days: A = [100, 10], B = [20, 100]. Previous `TotalThroughput`: 200. Actual busiest day: 120.

## How

- New `DailyThroughput()` extension yields an endpoint's per-day values; when multiple sources have data for the same day, the maximum value is used, consistent with the existing per-endpoint `MaxDailyThroughput()` semantics (all sources measure the same messages).
- `GenerateThroughputReport` accumulates daily totals across all endpoints in the existing loop and sets `TotalThroughput` to the highest daily total (0 when there is no data).
- The per-queue `Throughput` field is unchanged, so `TotalThroughput` remains ≥ every per-queue value. The set of queues contributing to the total is also unchanged.
- Added a test that encodes the definition (endpoints peaking on different days). Updated the one assertion and one approval file that encoded the previous sum-of-peaks behavior (195 → 185, 249 → 238).

All tests in `Particular.LicensingComponent.UnitTests` pass (75/75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
