### PR TITLE
Update Particular.ServicePulse.Core version to 2.9.1

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -20,7 +20,7 @@
 
   <PropertyGroup>
     <MinVerMinimumMajorMinor>5.7</MinVerMinimumMajorMinor>
-    <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+    <MinVerAutoIncrement>patch</MinVerAutoIncrement>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="Particular.LicensingComponent.Report" Version="1.1.1" />
     <PackageVersion Include="Particular.Licensing.Sources" Version="6.2.1" />
     <PackageVersion Include="Particular.Obsoletes" Version="1.1.0" />
-    <PackageVersion Include="Particular.ServicePulse.Core" Version="2.9.0" />
+    <PackageVersion Include="Particular.ServicePulse.Core" Version="2.9.1" />
     <PackageVersion Include="Polly.Core" Version="8.7.0" />
     <PackageVersion Include="PropertyChanged.Fody" Version="4.1.0" />
     <PackageVersion Include="PropertyChanging.Fody" Version="1.31.0" />


### PR DESCRIPTION
Backport of #5595
Also sets the `<MinVerAutoIncrement>` to patch.