### PR TITLE
Enable EF database migrations and advanced persistence configuration

### DIFF
--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlDatabaseMigrator.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlDatabaseMigrator.cs
@@ -1,0 +1,23 @@
+namespace ServiceControl.Persistence.EFCore.PostgreSql;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ServiceControl.Persistence.EFCore.Abstractions;
+using ServiceControl.Persistence.EFCore.DbContexts;
+
+class PostgreSqlDatabaseMigrator(ServiceControlDbContext dbContext, ILogger<PostgreSqlDatabaseMigrator> logger) : IDatabaseMigrator
+{
+    public async Task ApplyMigrations(CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Starting PostgreSQL database migration");
+
+        var previousTimeout = dbContext.Database.GetCommandTimeout();
+        dbContext.Database.SetCommandTimeout(EFPersisterSettings.MigrationCommandTimeout);
+
+        await dbContext.Database.MigrateAsync(cancellationToken);
+
+        dbContext.Database.SetCommandTimeout(previousTimeout);
+
+        logger.LogInformation("PostgreSQL database migration completed");
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlPersistence.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlPersistence.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.Persistence.EFCore.PostgreSql;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceControl.Persistence.EFCore.Abstractions;
+using ServiceControl.Persistence.EFCore.DbContexts;
 
 class PostgreSqlPersistence(PostgreSqlPersisterSettings settings) : BasePersistence, IPersistence
 {
@@ -17,6 +18,8 @@ class PostgreSqlPersistence(PostgreSqlPersisterSettings settings) : BasePersiste
     {
         RegisterSettings(services);
         ConfigureDbContext(services);
+
+        services.AddScoped<IDatabaseMigrator, PostgreSqlDatabaseMigrator>();
     }
 
     void RegisterSettings(IServiceCollection services)
@@ -26,7 +29,28 @@ class PostgreSqlPersistence(PostgreSqlPersisterSettings settings) : BasePersiste
         services.AddSingleton(settings);
     }
 
-    void ConfigureDbContext(IServiceCollection services) =>
-        services.AddPooledDbContextFactory<PostgreSqlServiceControlDbContext>(options =>
-            options.UseNpgsql(settings.ConnectionString, npgsql => npgsql.CommandTimeout(settings.CommandTimeout)));
+    void ConfigureDbContext(IServiceCollection services)
+    {
+        services.AddDbContext<PostgreSqlServiceControlDbContext>((serviceProvider, options) =>
+        {
+            options.UseNpgsql(settings.ConnectionString, npgsqlOptions =>
+            {
+                npgsqlOptions.CommandTimeout(settings.CommandTimeout);
+                if (settings.EnableRetryOnFailure)
+                {
+                    npgsqlOptions.EnableRetryOnFailure(
+                        maxRetryCount: settings.MaxRetryCount,
+                        maxRetryDelay: TimeSpan.FromSeconds(settings.MaxRetryDelayInSeconds),
+                        errorCodesToAdd: null);
+                }
+            });
+
+            if (settings.EnableSensitiveDataLogging)
+            {
+                options.EnableSensitiveDataLogging();
+            }
+        }, ServiceLifetime.Scoped);
+
+        services.AddScoped<ServiceControlDbContext>(provider => provider.GetRequiredService<PostgreSqlServiceControlDbContext>());
+    }
 }

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerDatabaseMigrator.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerDatabaseMigrator.cs
@@ -1,0 +1,23 @@
+namespace ServiceControl.Persistence.EFCore.SqlServer;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ServiceControl.Persistence.EFCore.Abstractions;
+using ServiceControl.Persistence.EFCore.DbContexts;
+
+class SqlServerDatabaseMigrator(ServiceControlDbContext dbContext, ILogger<SqlServerDatabaseMigrator> logger) : IDatabaseMigrator
+{
+    public async Task ApplyMigrations(CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Starting SQL Server database migration");
+
+        var previousTimeout = dbContext.Database.GetCommandTimeout();
+        dbContext.Database.SetCommandTimeout(EFPersisterSettings.MigrationCommandTimeout);
+
+        await dbContext.Database.MigrateAsync(cancellationToken);
+
+        dbContext.Database.SetCommandTimeout(previousTimeout);
+
+        logger.LogInformation("SQL Server database migration completed");
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerPersistence.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerPersistence.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.Persistence.EFCore.SqlServer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceControl.Persistence.EFCore.Abstractions;
+using ServiceControl.Persistence.EFCore.DbContexts;
 
 class SqlServerPersistence(SqlServerPersisterSettings settings) : BasePersistence, IPersistence
 {
@@ -17,6 +18,8 @@ class SqlServerPersistence(SqlServerPersisterSettings settings) : BasePersistenc
     {
         RegisterSettings(services);
         ConfigureDbContext(services);
+
+        services.AddScoped<IDatabaseMigrator, SqlServerDatabaseMigrator>();
     }
 
     void RegisterSettings(IServiceCollection services)
@@ -26,7 +29,28 @@ class SqlServerPersistence(SqlServerPersisterSettings settings) : BasePersistenc
         services.AddSingleton(settings);
     }
 
-    void ConfigureDbContext(IServiceCollection services) =>
-        services.AddPooledDbContextFactory<SqlServerServiceControlDbContext>(options =>
-            options.UseSqlServer(settings.ConnectionString, sqlServer => sqlServer.CommandTimeout(settings.CommandTimeout)));
+    void ConfigureDbContext(IServiceCollection services)
+    {
+        services.AddDbContext<SqlServerServiceControlDbContext>((serviceProvider, options) =>
+        {
+            options.UseSqlServer(settings.ConnectionString, sqlOptions =>
+            {
+                sqlOptions.CommandTimeout(settings.CommandTimeout);
+                if (settings.EnableRetryOnFailure)
+                {
+                    sqlOptions.EnableRetryOnFailure(
+                        maxRetryCount: settings.MaxRetryCount,
+                        maxRetryDelay: TimeSpan.FromSeconds(settings.MaxRetryDelayInSeconds),
+                        errorNumbersToAdd: null);
+                }
+            });
+
+            if (settings.EnableSensitiveDataLogging)
+            {
+                options.EnableSensitiveDataLogging();
+            }
+        }, ServiceLifetime.Scoped);
+
+        services.AddScoped<ServiceControlDbContext>(provider => provider.GetRequiredService<SqlServerServiceControlDbContext>());
+    }
 }

--- a/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersisterSettings.cs
+++ b/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersisterSettings.cs
@@ -2,9 +2,15 @@ namespace ServiceControl.Persistence.EFCore.Abstractions;
 
 public abstract class EFPersisterSettings : PersistenceSettings
 {
+    public static readonly TimeSpan MigrationCommandTimeout = TimeSpan.FromMinutes(40);
+
     public required string ConnectionString { get; set; }
     public int CommandTimeout { get; set; } = 30;
     public TimeSpan ErrorRetentionPeriod { get; set; }
     public string? MessageBodyStoragePath { get; set; }
     public int MinBodySizeForCompression { get; set; } = 4096;
+    public int MaxRetryCount { get; set; } = 5;
+    public int MaxRetryDelayInSeconds { get; set; } = 30;
+    public bool EnableSensitiveDataLogging { get; set; }
+    public bool EnableRetryOnFailure { get; set; } = true;
 }

--- a/src/ServiceControl.Persistence/IDatabaseMigrator.cs
+++ b/src/ServiceControl.Persistence/IDatabaseMigrator.cs
@@ -1,0 +1,9 @@
+namespace ServiceControl.Persistence;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+public interface IDatabaseMigrator
+{
+    Task ApplyMigrations(CancellationToken cancellationToken = default);
+}

--- a/src/ServiceControl/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/SetupCommand.cs
@@ -2,6 +2,7 @@
 {
     using System.Runtime.InteropServices;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
     using Particular.ServiceControl;
@@ -9,6 +10,7 @@
     using ServiceBus.Management.Infrastructure.Installers;
     using ServiceBus.Management.Infrastructure.Settings;
     using ServiceControl.Infrastructure;
+    using ServiceControl.Persistence;
     using Transports;
 
     class SetupCommand : AbstractCommand
@@ -45,6 +47,14 @@
                 var transportCustomization = TransportFactory.Create(transportSettings);
 
                 await transportCustomization.ProvisionQueues(transportSettings, componentSetupContext.Queues);
+            }
+
+            await using (var scope = host.Services.CreateAsyncScope())
+            {
+                if (scope.ServiceProvider.GetService<IDatabaseMigrator>() is { } databaseMigrator)
+                {
+                    await databaseMigrator.ApplyMigrations();
+                }
             }
 
             await host.StopAsync();


### PR DESCRIPTION
Allows ServiceControl to automatically apply EF Core database migrations during the `setup` command. 
Configures EF Core to use retry-on-failure for transient errors, enhancing database connection stability. 
Adds an option to enable sensitive data logging for debugging purposes. 
Switches from `AddPooledDbContextFactory` to `AddDbContext` for direct `DbContext` access and improved flexibility.