### PR TITLE
Add option to run tests against an in-memory raven instance

### DIFF
--- a/src/ServiceControl.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/SharedEmbeddedServer.cs
@@ -38,7 +38,7 @@
                 };
 
                 // TODO: See if more refactoring can be done between this and the RavenPersisterSettings above
-                var embeddedConfig = new EmbeddedDatabaseConfiguration(settings.ServerUrl, RavenPersisterSettings.DatabaseNameDefault, dbPath, logPath, logsMode);
+                var embeddedConfig = new EmbeddedDatabaseConfiguration(settings.ServerUrl, RavenPersisterSettings.DatabaseNameDefault, dbPath, logPath, logsMode) { RunInMemory = true };
 
                 embeddedDatabase = EmbeddedDatabase.Start(embeddedConfig, new ApplicationLifetime(new NullLogger<ApplicationLifetime>()));
 

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -69,6 +69,13 @@ namespace ServiceControl.RavenDB
             }
 
             logger.LogInformation("Loading RavenDB license from {LicenseFileName}", licenseFileNameAndServerDirectory.LicenseFileName);
+
+            List<string> optionalArgs = [];
+            if (databaseConfiguration.RunInMemory)
+            {
+                optionalArgs.Add("--RunInMemory=true");
+            }
+
             var serverOptions = new ServerOptions
             {
                 CommandLineArgs =
@@ -76,7 +83,8 @@ namespace ServiceControl.RavenDB
                     $"--Logs.Mode={databaseConfiguration.LogsMode}",
                     // HINT: If this is not set, then Raven will pick a default location relative to the server binaries
                     // See https://github.com/ravendb/ravendb/issues/15694
-                    $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\""
+                    $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\"",
+                    ..optionalArgs
                 ],
                 DataDirectory = databaseConfiguration.DbPath,
                 ServerUrl = databaseConfiguration.ServerUrl,

--- a/src/ServiceControl.RavenDB/EmbeddedDatabaseConfiguration.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabaseConfiguration.cs
@@ -10,6 +10,8 @@
         public string LogPath { get; } = logPath;
         public string LogsMode { get; } = logsMode;
 
+        public bool RunInMemory { get; set; }
+
         public Func<string, BlittableJsonReaderObject, string> FindClrType { get; init; }
     }
 }


### PR DESCRIPTION
CI builds long runtime is currently dominated by RavenDB test categories, this fix changes those tests to make use of the [RunInMemory](https://docs.ravendb.net/4.2/server/configuration/core-configuration#runinmemory) flag. 

This was observed to save about 1minute off an 8.5 minute runtime on a developer workstation.


