### PR TITLE
Remove version pinning of az cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,24 +62,6 @@ jobs:
           # The action defaults to 4GB. The runner has 16GB and the build runs concurrently with the
           # container starting up, so give the VM real headroom.
           memory: 8GB
-
-      # there is an issue with az cli and python 3.14, so for now we need to pin it
-      # once the issue is resolved it should be able to be re-floated
-      # https://github.com/Azure/azure-cli/issues/32980. 
-      # This can be removed once https://github.com/Azure/azure-cli/issues/32869 is supported.
-      - name: Set Python 3.13 (Linux)
-        if: matrix.os-name == 'Linux' && matrix.test-category == 'AzureServiceBus'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-      - name: Install pinned Azure CLI on Python 3.13 (Linux)
-        if: matrix.os-name == 'Linux' && matrix.test-category == 'AzureServiceBus'
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --user "azure-cli==2.64.0"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
       - name: Setup SQL Server
         uses: Particular/install-sql-server-action@v3.0.0
         if: matrix.test-category == 'SqlServer'


### PR DESCRIPTION
A previous pr (#5621) introduced version pinning to resolve ASB test issues.

A better fix was found and implemented in the action, this PR removes the version pinning and updates the action.