### PR TITLE
Adding endpoint settings stores for Entity Framework

### DIFF
--- a/src/ServiceControl.Audit/Recoverability/QueueAddress.cs
+++ b/src/ServiceControl.Audit/Recoverability/QueueAddress.cs
@@ -1,0 +1,8 @@
+﻿namespace ServiceControl.Audit.Recoverability
+{
+    public class QueueAddress
+    {
+        public string PhysicalAddress { get; set; }
+        public int FailedMessageCount { get; set; }
+    }
+}

--- a/src/ServiceControl.Audit/Recoverability/QueueAddress.cs
+++ b/src/ServiceControl.Audit/Recoverability/QueueAddress.cs
@@ -1,8 +1,0 @@
-﻿namespace ServiceControl.Audit.Recoverability
-{
-    public class QueueAddress
-    {
-        public string PhysicalAddress { get; set; }
-        public int FailedMessageCount { get; set; }
-    }
-}

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260724055936_AddConfiguration.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260724055936_AddConfiguration.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ServiceControl.Persistence.EFCore.PostgreSql;
@@ -11,9 +12,11 @@ using ServiceControl.Persistence.EFCore.PostgreSql;
 namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
 {
     [DbContext(typeof(PostgreSqlServiceControlDbContext))]
-    partial class PostgreSqlServiceControlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724055936_AddConfiguration")]
+    partial class AddConfiguration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260724055936_AddConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260724055936_AddConfiguration.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfiguration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "failing_endpoint_address",
+                table: "failed_messages",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateTable(
+                name: "EndpointSettings",
+                columns: table => new
+                {
+                    name = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    track_instances = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_endpoint_settings", x => x.name);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "trial_metadata",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    trial_end_date = table.Column<DateOnly>(type: "date", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_trial_metadata", x => x.id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "trial_metadata",
+                columns: new[] { "id", "trial_end_date" },
+                values: new object[] { 1, null });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_failed_messages_failing_endpoint_address",
+                table: "failed_messages",
+                column: "failing_endpoint_address");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EndpointSettings");
+
+            migrationBuilder.DropTable(
+                name: "trial_metadata");
+
+            migrationBuilder.DropIndex(
+                name: "ix_failed_messages_failing_endpoint_address",
+                table: "failed_messages");
+
+            migrationBuilder.DropColumn(
+                name: "failing_endpoint_address",
+                table: "failed_messages");
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260727041318_AddConfiguration.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260727041318_AddConfiguration.Designer.cs
@@ -12,7 +12,7 @@ using ServiceControl.Persistence.EFCore.PostgreSql;
 namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
 {
     [DbContext(typeof(PostgreSqlServiceControlDbContext))]
-    [Migration("20260724055936_AddConfiguration")]
+    [Migration("20260727041318_AddConfiguration")]
     partial class AddConfiguration
     {
         /// <inheritdoc />
@@ -39,7 +39,7 @@ namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
                     b.HasKey("Name")
                         .HasName("pk_endpoint_settings");
 
-                    b.ToTable("EndpointSettings", (string)null);
+                    b.ToTable("endpoint_settings", (string)null);
                 });
 
             modelBuilder.Entity("ServiceControl.Persistence.EFCore.Entities.FailedMessageEntity", b =>

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260727041318_AddConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260727041318_AddConfiguration.cs
@@ -21,7 +21,7 @@ namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
                 defaultValue: "");
 
             migrationBuilder.CreateTable(
-                name: "EndpointSettings",
+                name: "endpoint_settings",
                 columns: table => new
                 {
                     name = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
@@ -60,7 +60,7 @@ namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "EndpointSettings");
+                name: "endpoint_settings");
 
             migrationBuilder.DropTable(
                 name: "trial_metadata");

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/PostgreSqlServiceControlDbContextModelSnapshot.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/PostgreSqlServiceControlDbContextModelSnapshot.cs
@@ -36,7 +36,7 @@ namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
                     b.HasKey("Name")
                         .HasName("pk_endpoint_settings");
 
-                    b.ToTable("EndpointSettings", (string)null);
+                    b.ToTable("endpoint_settings", (string)null);
                 });
 
             modelBuilder.Entity("ServiceControl.Persistence.EFCore.Entities.FailedMessageEntity", b =>

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260724055947_AddConfiguration.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260724055947_AddConfiguration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ServiceControl.Persistence.EFCore.SqlServer;
 
@@ -11,9 +12,11 @@ using ServiceControl.Persistence.EFCore.SqlServer;
 namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
 {
     [DbContext(typeof(SqlServerServiceControlDbContext))]
-    partial class SqlServerServiceControlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260724055947_AddConfiguration")]
+    partial class AddConfiguration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260724055947_AddConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260724055947_AddConfiguration.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfiguration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FailingEndpointAddress",
+                table: "FailedMessages",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateTable(
+                name: "EndpointSettings",
+                columns: table => new
+                {
+                    Name = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    TrackInstances = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EndpointSettings", x => x.Name);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TrialMetadata",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    TrialEndDate = table.Column<DateOnly>(type: "date", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrialMetadata", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "TrialMetadata",
+                columns: new[] { "Id", "TrialEndDate" },
+                values: new object[] { 1, null });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FailedMessages_FailingEndpointAddress",
+                table: "FailedMessages",
+                column: "FailingEndpointAddress");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EndpointSettings");
+
+            migrationBuilder.DropTable(
+                name: "TrialMetadata");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FailedMessages_FailingEndpointAddress",
+                table: "FailedMessages");
+
+            migrationBuilder.DropColumn(
+                name: "FailingEndpointAddress",
+                table: "FailedMessages");
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/DbContexts/ServiceControlDbContext.cs
+++ b/src/ServiceControl.Persistence.EFCore/DbContexts/ServiceControlDbContext.cs
@@ -6,6 +6,7 @@ using ServiceControl.Persistence.EFCore.EntityConfigurations;
 
 public abstract class ServiceControlDbContext(DbContextOptions options) : DbContext(options)
 {
+    public DbSet<EndpointSettingsEntity> EndpointSettings { get; set; }
     public DbSet<KnownEndpointEntity> KnownEndpoints { get; set; }
     public DbSet<FailedMessageEntity> FailedMessages { get; set; }
     public DbSet<FailedMessageGroupEntity> FailedMessageGroups { get; set; }

--- a/src/ServiceControl.Persistence.EFCore/DbContexts/ServiceControlDbContext.cs
+++ b/src/ServiceControl.Persistence.EFCore/DbContexts/ServiceControlDbContext.cs
@@ -11,20 +11,21 @@ public abstract class ServiceControlDbContext(DbContextOptions options) : DbCont
     public DbSet<FailedMessageEntity> FailedMessages { get; set; }
     public DbSet<FailedMessageGroupEntity> FailedMessageGroups { get; set; }
     public DbSet<FailedMessageRetryEntity> FailedMessageRetries { get; set; }
+    public DbSet<TrialMetadataEntity> TrialMetadata { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-        optionsBuilder.EnableDetailedErrors();
-    }
+        => optionsBuilder.EnableDetailedErrors();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
 
-        modelBuilder.ApplyConfiguration(new KnownEndpointConfiguration());
+        modelBuilder.ApplyConfiguration(new EndpointSettingsConfiguration());
         modelBuilder.ApplyConfiguration(new FailedMessageConfiguration());
         modelBuilder.ApplyConfiguration(new FailedMessageGroupConfiguration());
         modelBuilder.ApplyConfiguration(new FailedMessageRetryConfiguration());
+        modelBuilder.ApplyConfiguration(new KnownEndpointConfiguration());
+        modelBuilder.ApplyConfiguration(new TrialMetadataConfiguration());
     }
 
     public abstract bool IsDuplicateKeyException(DbUpdateException exception);

--- a/src/ServiceControl.Persistence.EFCore/Entities/EndpointSettingsEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/EndpointSettingsEntity.cs
@@ -1,0 +1,7 @@
+namespace ServiceControl.Persistence.EFCore.Entities;
+
+public class EndpointSettingsEntity
+{
+    public required string Name { get; set; }
+    public bool TrackInstances { get; set; }
+}

--- a/src/ServiceControl.Persistence.EFCore/Entities/FailedMessageEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/FailedMessageEntity.cs
@@ -57,4 +57,6 @@ public class FailedMessageEntity
     public int BodySize { get; set; }
 
     public string? BodyContentType { get; set; }
+
+    public required string FailingEndpointAddress { get; set; }
 }

--- a/src/ServiceControl.Persistence.EFCore/Entities/TrialMetadataEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/TrialMetadataEntity.cs
@@ -1,0 +1,9 @@
+namespace ServiceControl.Persistence.EFCore.Entities;
+
+public class TrialMetadataEntity
+{
+    public const int TrialMetadataId = 1;
+
+    public int Id { get; set; }
+    public DateOnly? TrialEndDate { get; set; }
+}

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/EndpointSettingsConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/EndpointSettingsConfiguration.cs
@@ -10,6 +10,6 @@ public class EndpointSettingsConfiguration : IEntityTypeConfiguration<EndpointSe
     {
         builder.ToTable("EndpointSettings");
         builder.HasKey(x => x.Name);
-        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        builder.Property(x => x.Name).HasMaxLength(ColumnLengths.ShortTextLength).IsRequired();
     }
 }

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/EndpointSettingsConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/EndpointSettingsConfiguration.cs
@@ -4,11 +4,12 @@ using Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-public class EndpointSettingsConfiguration :  IEntityTypeConfiguration<EndpointSettingsEntity>
+public class EndpointSettingsConfiguration : IEntityTypeConfiguration<EndpointSettingsEntity>
 {
     public void Configure(EntityTypeBuilder<EndpointSettingsEntity> builder)
     {
         builder.ToTable("EndpointSettings");
         builder.HasKey(x => x.Name);
+        builder.Property(x => x.Name).HasMaxLength(200).IsRequired();
     }
 }

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/EndpointSettingsConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/EndpointSettingsConfiguration.cs
@@ -8,7 +8,6 @@ public class EndpointSettingsConfiguration : IEntityTypeConfiguration<EndpointSe
 {
     public void Configure(EntityTypeBuilder<EndpointSettingsEntity> builder)
     {
-        builder.ToTable("EndpointSettings");
         builder.HasKey(x => x.Name);
         builder.Property(x => x.Name).HasMaxLength(ColumnLengths.ShortTextLength).IsRequired();
     }

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/EndpointSettingsEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/EndpointSettingsEntity.cs
@@ -1,0 +1,14 @@
+namespace ServiceControl.Persistence.EFCore.EntityConfigurations;
+
+using Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public class EndpointSettingsConfiguration :  IEntityTypeConfiguration<EndpointSettingsEntity>
+{
+    public void Configure(EntityTypeBuilder<EndpointSettingsEntity> builder)
+    {
+        builder.ToTable("EndpointSettings");
+        builder.HasKey(x => x.Name);
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/FailedMessageConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/FailedMessageConfiguration.cs
@@ -26,6 +26,7 @@ class FailedMessageConfiguration : IEntityTypeConfiguration<FailedMessageEntity>
         builder.Property(e => e.SendingEndpointHost).HasMaxLength(ColumnLengths.ShortTextLength);
         builder.Property(e => e.ReceivingEndpointName).HasMaxLength(ColumnLengths.ShortTextLength);
         builder.Property(e => e.ReceivingEndpointHost).HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.FailingEndpointAddress).HasMaxLength(ColumnLengths.ShortTextLength);
         builder.Property(e => e.BodyContentType).HasMaxLength(ColumnLengths.ShortTextLength);
 
         builder.Property(e => e.IsSystemMessage).IsRequired();
@@ -35,6 +36,7 @@ class FailedMessageConfiguration : IEntityTypeConfiguration<FailedMessageEntity>
 
         builder.HasIndex(e => new { e.Status, e.LastModified });
         builder.HasIndex(e => e.ReceivingEndpointName);
+        builder.HasIndex(e => e.FailingEndpointAddress);
         builder.HasIndex(e => e.ConversationId);
         builder.HasIndex(e => e.TimeSent);
         builder.HasIndex(e => e.QueueAddress);

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/TrialMetadataConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/TrialMetadataConfiguration.cs
@@ -1,0 +1,18 @@
+namespace ServiceControl.Persistence.EFCore.EntityConfigurations;
+
+using Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public class TrialMetadataConfiguration : IEntityTypeConfiguration<TrialMetadataEntity>
+{
+    public void Configure(EntityTypeBuilder<TrialMetadataEntity> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.HasData(new TrialMetadataEntity
+        {
+            Id = 1,
+            TrialEndDate = null
+        });
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/Implementation/DataStoreBase.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/DataStoreBase.cs
@@ -36,20 +36,7 @@ public abstract class DataStoreBase(IServiceScopeFactory scopeFactory)
     /// <summary>
     /// Executes an operation with a scoped DbContext, without returning a result
     /// </summary>
-    protected async IAsyncEnumerable<T> ExecuteWithDbContext<T>(Func<ServiceControlDbContext, IAsyncEnumerable<T>> operation)
-    {
-        await using var scope = scopeFactory.CreateAsyncScope();
-        var dbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
-        await foreach (var row in operation(dbContext))
-        {
-            yield return row;
-        }
-    }
-    
-    /// <summary>
-    /// Executes an operation with a scoped DbContext, without returning a result
-    /// </summary>
-    protected async IAsyncEnumerable<T> ExecuteWithDbContext<T>(Func<ServiceControlDbContext, IAsyncEnumerable<T>> operation, [EnumeratorCancellation] CancellationToken cancellationToken)
+    protected async IAsyncEnumerable<T> ExecuteWithDbContext<T>(Func<ServiceControlDbContext, IAsyncEnumerable<T>> operation, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         await using var scope = scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();

--- a/src/ServiceControl.Persistence.EFCore/Implementation/DataStoreBase.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/DataStoreBase.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Persistence.EFCore.Implementation;
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using DbContexts;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +31,32 @@ public abstract class DataStoreBase(IServiceScopeFactory scopeFactory)
         await using var scope = scopeFactory.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
         await operation(dbContext);
+    }
+
+    /// <summary>
+    /// Executes an operation with a scoped DbContext, without returning a result
+    /// </summary>
+    protected async IAsyncEnumerable<T> ExecuteWithDbContext<T>(Func<ServiceControlDbContext, IAsyncEnumerable<T>> operation)
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
+        await foreach (var row in operation(dbContext))
+        {
+            yield return row;
+        }
+    }
+    
+    /// <summary>
+    /// Executes an operation with a scoped DbContext, without returning a result
+    /// </summary>
+    protected async IAsyncEnumerable<T> ExecuteWithDbContext<T>(Func<ServiceControlDbContext, IAsyncEnumerable<T>> operation, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
+        await foreach (var row in operation(dbContext).WithCancellation(cancellationToken))
+        {
+            yield return row;
+        }
     }
 
     /// <summary>

--- a/src/ServiceControl.Persistence.EFCore/Implementation/EndpointSettingsStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/EndpointSettingsStore.cs
@@ -25,20 +25,21 @@ public class EndpointSettingsStore(IServiceScopeFactory scopeFactory) : DataStor
                 await context.SaveChangesAsync(token);
                 return;
             }
-            catch (someexception e) when (condition)
+            catch (DbUpdateException)
             {
-                //this failed because of key conflict so it's a race!
+                //this probably failed because of key conflict so try again
             }
 
             await context.Entry(entity).ReloadAsync(token);
-            entity.TrackInstances = settings.TrackInstances;
-            await context.SaveChangesAsync(token);
         }
+
+        entity.TrackInstances = settings.TrackInstances;
+        await context.SaveChangesAsync(token);
     });
 
     public Task Delete(string name, CancellationToken cancellationToken) => ExecuteWithDbContext(async context =>
     {
-        context.KnownEndpoints.RemoveRange(context.KnownEndpoints.Where(x => x.Name == name));
+        context.EndpointSettings.RemoveRange(context.EndpointSettings.Where(x => x.Name == name));
         await context.SaveChangesAsync(cancellationToken);
     });
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/EndpointSettingsStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/EndpointSettingsStore.cs
@@ -1,13 +1,44 @@
 namespace ServiceControl.Persistence.EFCore.Implementation;
 
-public class EndpointSettingsStore : IEndpointSettingsStore
+using Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+public class EndpointSettingsStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IEndpointSettingsStore
 {
-    public IAsyncEnumerable<EndpointSettings> GetAllEndpointSettings(CancellationToken cancellationToken) =>
-        throw new NotImplementedException();
+    public IAsyncEnumerable<EndpointSettings> GetAllEndpointSettings(CancellationToken cancellationToken)
+        => ExecuteWithDbContext(context => context.EndpointSettings.Select(row => new EndpointSettings
+        {
+            Name = row.Name,
+            TrackInstances = row.TrackInstances
+        }).AsAsyncEnumerable(), cancellationToken);
 
-    public Task UpdateEndpointSettings(EndpointSettings settings, CancellationToken token) =>
-        throw new NotImplementedException();
+    public Task UpdateEndpointSettings(EndpointSettings settings, CancellationToken token) => ExecuteWithDbContext(async context =>
+    {
+        var entity = context.EndpointSettings.Find(settings.Name);
+        if (entity == null)
+        {
+            entity = new EndpointSettingsEntity() { Name = settings.Name, TrackInstances = settings.TrackInstances };
+            context.EndpointSettings.Add(entity);
+            try
+            {
+                await context.SaveChangesAsync(token);
+                return;
+            }
+            catch (someexception e) when (condition)
+            {
+                //this failed because of key conflict so it's a race!
+            }
 
-    public Task Delete(string name, CancellationToken cancellationToken) =>
-        throw new NotImplementedException();
+            await context.Entry(entity).ReloadAsync(token);
+            entity.TrackInstances = settings.TrackInstances;
+            await context.SaveChangesAsync(token);
+        }
+    });
+
+    public Task Delete(string name, CancellationToken cancellationToken) => ExecuteWithDbContext(async context =>
+    {
+        context.KnownEndpoints.RemoveRange(context.KnownEndpoints.Where(x => x.Name == name));
+        await context.SaveChangesAsync(cancellationToken);
+    });
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/EndpointSettingsStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/EndpointSettingsStore.cs
@@ -9,32 +9,15 @@ public class EndpointSettingsStore(IServiceScopeFactory scopeFactory) : DataStor
     public IAsyncEnumerable<EndpointSettings> GetAllEndpointSettings(CancellationToken cancellationToken)
         => ExecuteWithDbContext(context => context.EndpointSettings.Select(row => new EndpointSettings { Name = row.Name, TrackInstances = row.TrackInstances }).AsAsyncEnumerable(), cancellationToken);
 
-    public Task UpdateEndpointSettings(EndpointSettings settings, CancellationToken token) => ExecuteWithDbContext(async context =>
-    {
-        var entity = await context.EndpointSettings.FindAsync([settings.Name], cancellationToken: token);
-        if (entity == null)
-        {
-            entity = new EndpointSettingsEntity() { Name = settings.Name, TrackInstances = settings.TrackInstances };
-            context.EndpointSettings.Add(entity);
-            try
-            {
-                await context.SaveChangesAsync(token);
-                return;
-            }
-            catch (DbUpdateException)
-            {
-                //this probably failed because of key conflict so try again
-            }
-
-            await context.Entry(entity).ReloadAsync(token);
-        }
-
-        entity.TrackInstances = settings.TrackInstances;
-        await context.SaveChangesAsync(token);
-    });
+    public Task UpdateEndpointSettings(EndpointSettings settings, CancellationToken token) =>
+        ExecuteWithDbContext(async context =>
+            await context.UpsertAsync([settings.Name],
+                () => new EndpointSettingsEntity() { Name = settings.Name, TrackInstances = settings.TrackInstances },
+                entity => entity.TrackInstances = settings.TrackInstances,
+                token
+            ));
 
     public Task Delete(string name, CancellationToken cancellationToken) =>
         ExecuteWithDbContext(context => context.EndpointSettings.Where(x => x.Name == name)
             .ExecuteDeleteAsync(cancellationToken));
-
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/EndpointSettingsStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/EndpointSettingsStore.cs
@@ -7,15 +7,11 @@ using Microsoft.Extensions.DependencyInjection;
 public class EndpointSettingsStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IEndpointSettingsStore
 {
     public IAsyncEnumerable<EndpointSettings> GetAllEndpointSettings(CancellationToken cancellationToken)
-        => ExecuteWithDbContext(context => context.EndpointSettings.Select(row => new EndpointSettings
-        {
-            Name = row.Name,
-            TrackInstances = row.TrackInstances
-        }).AsAsyncEnumerable(), cancellationToken);
+        => ExecuteWithDbContext(context => context.EndpointSettings.Select(row => new EndpointSettings { Name = row.Name, TrackInstances = row.TrackInstances }).AsAsyncEnumerable(), cancellationToken);
 
     public Task UpdateEndpointSettings(EndpointSettings settings, CancellationToken token) => ExecuteWithDbContext(async context =>
     {
-        var entity = context.EndpointSettings.Find(settings.Name);
+        var entity = await context.EndpointSettings.FindAsync([settings.Name], cancellationToken: token);
         if (entity == null)
         {
             entity = new EndpointSettingsEntity() { Name = settings.Name, TrackInstances = settings.TrackInstances };
@@ -37,9 +33,8 @@ public class EndpointSettingsStore(IServiceScopeFactory scopeFactory) : DataStor
         await context.SaveChangesAsync(token);
     });
 
-    public Task Delete(string name, CancellationToken cancellationToken) => ExecuteWithDbContext(async context =>
-    {
-        context.EndpointSettings.RemoveRange(context.EndpointSettings.Where(x => x.Name == name));
-        await context.SaveChangesAsync(cancellationToken);
-    });
+    public Task Delete(string name, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(context => context.EndpointSettings.Where(x => x.Name == name)
+            .ExecuteDeleteAsync(cancellationToken));
+
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/ErrorMessagesDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/ErrorMessagesDataStore.cs
@@ -1,5 +1,8 @@
 namespace ServiceControl.Persistence.EFCore.Implementation;
 
+using Entities;
+using Microsoft.Extensions.DependencyInjection;
+using Persistence.UnitOfWork;
 using ServiceControl.CompositeViews.Messages;
 using ServiceControl.EventLog;
 using ServiceControl.MessageFailures;
@@ -8,7 +11,7 @@ using ServiceControl.Operations;
 using ServiceControl.Persistence.Infrastructure;
 using ServiceControl.Recoverability;
 
-public class ErrorMessagesDataStore : IErrorMessageDataStore
+public class ErrorMessagesDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IErrorMessageDataStore
 {
     public Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange? timeSentRange = null) =>
         throw new NotImplementedException();
@@ -111,6 +114,6 @@ public class ErrorMessagesDataStore : IErrorMessageDataStore
     public Task StoreEventLogItem(EventLogItem logItem) =>
         throw new NotImplementedException();
 
-    public Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages) =>
-        throw new NotImplementedException();
+    public Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages)
+        => throw new NotImplementedException("EF Tests Use the Ingestion pathway to populate this data");
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/ErrorMessagesDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/ErrorMessagesDataStore.cs
@@ -113,7 +113,4 @@ public class ErrorMessagesDataStore(IServiceScopeFactory scopeFactory) : DataSto
 
     public Task StoreEventLogItem(EventLogItem logItem) =>
         throw new NotImplementedException();
-
-    public Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages)
-        => throw new NotImplementedException("EF Tests Use the Ingestion pathway to populate this data");
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
@@ -11,8 +11,6 @@ public class QueueAddressStore(IServiceScopeFactory scopeFactory) : DataStoreBas
         ExecuteWithDbContext(async context =>
         {
             var query = context.FailedMessages
-                .Select(fm => new { fm.UniqueMessageId, fm.FailingEndpointAddress })
-                .Distinct()
                 .GroupBy(failure => failure.FailingEndpointAddress)
                 .OrderBy(failuresByEndpoint => failuresByEndpoint.Key)
                 .Select(failuresByEndpoint => new QueueAddress

--- a/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
@@ -1,10 +1,28 @@
 namespace ServiceControl.Persistence.EFCore.Implementation;
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using ServiceControl.MessageFailures;
 using ServiceControl.Persistence.Infrastructure;
 
-public class QueueAddressStore : IQueueAddressStore
+public class QueueAddressStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IQueueAddressStore
 {
     public Task<QueryResult<IList<QueueAddress>>> GetAddresses(PagingInfo pagingInfo) =>
-        throw new NotImplementedException();
+        ExecuteWithDbContext(async context =>
+        {
+            var query = context.FailedMessages
+                .Select(fm => new { fm.UniqueMessageId, fm.FailingEndpointAddress })
+                .Distinct()
+                .GroupBy(failure => failure.FailingEndpointAddress)
+                .OrderBy(failuresByEndpoint => failuresByEndpoint.Key)
+                .Select(failuresByEndpoint => new QueueAddress
+                {
+                    PhysicalAddress = failuresByEndpoint.Key,
+                    FailedMessageCount = failuresByEndpoint.Count()
+                });
+
+            var items = await query.Skip(pagingInfo.Offset).Take(pagingInfo.PageSize).ToListAsync();
+
+            return new QueryResult<IList<QueueAddress>>(items, new QueryStatsInfo("", query.Count(), false));
+        });
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
@@ -20,8 +20,9 @@ public class QueueAddressStore(IServiceScopeFactory scopeFactory) : DataStoreBas
                 });
 
             var items = await query.Skip(pagingInfo.Offset).Take(pagingInfo.PageSize).ToListAsync();
+            var eTag = DeterministicGuid.MakeId($"{items.Count}|{string.Join(",", items.Select(x => x.PhysicalAddress))}").ToString();
 
-            return new QueryResult<IList<QueueAddress>>(items, new QueryStatsInfo("", query.Count(), false));
+            return new QueryResult<IList<QueueAddress>>(items, new QueryStatsInfo(eTag, query.Count(), false));
         });
 
     public Task<QueryResult<IList<QueueAddress>>> GetAddressesBySearchTerm(string search, PagingInfo pagingInfo) =>

--- a/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
@@ -23,4 +23,7 @@ public class QueueAddressStore(IServiceScopeFactory scopeFactory) : DataStoreBas
 
             return new QueryResult<IList<QueueAddress>>(items, new QueryStatsInfo("", query.Count(), false));
         });
+
+    public Task<QueryResult<IList<QueueAddress>>> GetAddressesBySearchTerm(string search, PagingInfo pagingInfo) =>
+        throw new NotImplementedException();
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/TrialLicenseDataProvider.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/TrialLicenseDataProvider.cs
@@ -1,11 +1,23 @@
 namespace ServiceControl.Persistence.EFCore.Implementation;
 
-public class TrialLicenseDataProvider : ITrialLicenseDataProvider
+using Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+public class TrialLicenseDataProvider(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), ITrialLicenseDataProvider
 {
     public Task<DateOnly?> GetTrialEndDate(CancellationToken cancellationToken)
-    {
-    }
+        => ExecuteWithDbContext(async context =>
+        {
+            var trialMetadata = await context.TrialMetadata.SingleAsync(t => t.Id == TrialMetadataEntity.TrialMetadataId, cancellationToken);
+            return trialMetadata.TrialEndDate;
+        });
 
-    public Task StoreTrialEndDate(DateOnly trialEndDate, CancellationToken cancellationToken) =>
-        throw new NotImplementedException();
+    public Task StoreTrialEndDate(DateOnly trialEndDate, CancellationToken cancellationToken)
+        => ExecuteWithDbContext(async context =>
+        {
+            var trialMetadata = await context.TrialMetadata.SingleAsync(t => t.Id == TrialMetadataEntity.TrialMetadataId, cancellationToken);
+            trialMetadata.TrialEndDate = trialEndDate;
+            await (Task)context.SaveChangesAsync(cancellationToken);
+        });
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/TrialLicenseDataProvider.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/TrialLicenseDataProvider.cs
@@ -2,8 +2,9 @@ namespace ServiceControl.Persistence.EFCore.Implementation;
 
 public class TrialLicenseDataProvider : ITrialLicenseDataProvider
 {
-    public Task<DateOnly?> GetTrialEndDate(CancellationToken cancellationToken) =>
-        throw new NotImplementedException();
+    public Task<DateOnly?> GetTrialEndDate(CancellationToken cancellationToken)
+    {
+    }
 
     public Task StoreTrialEndDate(DateOnly trialEndDate, CancellationToken cancellationToken) =>
         throw new NotImplementedException();

--- a/src/ServiceControl.Persistence.EFCore/Implementation/TrialLicenseDataProvider.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/TrialLicenseDataProvider.cs
@@ -14,10 +14,9 @@ public class TrialLicenseDataProvider(IServiceScopeFactory scopeFactory) : DataS
         });
 
     public Task StoreTrialEndDate(DateOnly trialEndDate, CancellationToken cancellationToken)
-        => ExecuteWithDbContext(async context =>
-        {
-            var trialMetadata = await context.TrialMetadata.SingleAsync(t => t.Id == TrialMetadataEntity.TrialMetadataId, cancellationToken);
-            trialMetadata.TrialEndDate = trialEndDate;
-            await (Task)context.SaveChangesAsync(cancellationToken);
-        });
+        => ExecuteWithDbContext(context =>
+            context.TrialMetadata
+                .Where(t => t.Id == TrialMetadataEntity.TrialMetadataId)
+                .ExecuteUpdateAsync(e => e.SetProperty(p => p.TrialEndDate, trialEndDate), cancellationToken: cancellationToken)
+        );
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/EFRecoverabilityIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/EFRecoverabilityIngestionUnitOfWork.cs
@@ -50,6 +50,7 @@ public class EFRecoverabilityIngestionUnitOfWork(EFIngestionUnitOfWork parentUni
             ReceivingEndpointHost = receivingEndpoint?.Host,
             ExceptionType = processingAttempt.FailureDetails.Exception?.ExceptionType,
             ExceptionMessage = processingAttempt.FailureDetails.Exception?.Message,
+            FailingEndpointAddress = processingAttempt.FailureDetails.AddressOfFailingEndpoint,
             IsSystemMessage = GetMetadata<bool>(processingAttempt, "IsSystemMessage"),
             BodyText = bodyText,
             BodyStoredExternally = storeExternally,

--- a/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/FailedMessageBatchWriter.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/FailedMessageBatchWriter.cs
@@ -92,7 +92,8 @@ class FailedMessageBatchWriter(ServiceControlDbContext dbContext, IIngestionSqlD
                 BodyText = last.BodyText,
                 BodyStoredExternally = last.BodyStoredExternally,
                 BodySize = last.BodySize,
-                BodyContentType = last.BodyContentType
+                BodyContentType = last.BodyContentType,
+                FailingEndpointAddress = last.FailingEndpointAddress
             });
 
             groups.AddRange(last.Groups

--- a/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/RecordedFailedProcessingAttempt.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/RecordedFailedProcessingAttempt.cs
@@ -29,4 +29,5 @@ sealed class RecordedFailedProcessingAttempt
     public bool BodyStoredExternally { get; init; }
     public int BodySize { get; init; }
     public string? BodyContentType { get; init; }
+    public required string FailingEndpointAddress { get; set; }
 }

--- a/src/ServiceControl.Persistence.EFCore/ServiceControl.Persistence.EFCore.csproj
+++ b/src/ServiceControl.Persistence.EFCore/ServiceControl.Persistence.EFCore.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="ServiceControl.Persistence.Tests.SqlServer" />
     <InternalsVisibleTo Include="ServiceControl.Persistence.Tests.PostgreSql" />
+    <InternalsVisibleTo Include="ServiceControl.Persistence.Tests.SqlServer" />
   </ItemGroup>
 </Project>

--- a/src/ServiceControl.Persistence.EFCore/ServiceControl.Persistence.EFCore.csproj
+++ b/src/ServiceControl.Persistence.EFCore/ServiceControl.Persistence.EFCore.csproj
@@ -27,4 +27,8 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ServiceControl.Persistence.Tests.SqlServer" />
+    <InternalsVisibleTo Include="ServiceControl.Persistence.Tests.PostgreSql" />
+  </ItemGroup>
 </Project>

--- a/src/ServiceControl.Persistence.RavenDB/ErrorMessagesDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ErrorMessagesDataStore.cs
@@ -666,17 +666,6 @@
             await session.SaveChangesAsync();
         }
 
-        public async Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages)
-        {
-            using var session = await sessionProvider.OpenSession();
-            foreach (var message in failedMessages)
-            {
-                await session.StoreAsync(message);
-            }
-
-            await session.SaveChangesAsync();
-        }
-
         public static string MakeDocumentId(string id) => string.Join("/", CollectionName, id);
         public const string CollectionName = "FailedErrorImports";
     }

--- a/src/ServiceControl.Persistence.Tests.InMemory/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.InMemory/PersistenceTestsContext.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Persistence.Tests;
 
 using System.Threading.Tasks;
+using MessageFailures;
 using Microsoft.Extensions.Hosting;
 using Particular.LicensingComponent.Persistence.InMemory;
 using ServiceControl.Persistence.Tests.InMemory;
@@ -9,6 +10,7 @@ public class PersistenceTestsContext : IPersistenceTestsContext
 {
     public PersistenceSettings PersistenceSettings { get; private set; }
     public string GenerateFailedMessageRecordId(string messageId) => throw new System.NotImplementedException();
+    public Task InsertFailedMessages(params FailedMessage[] messages) => throw new System.NotImplementedException();
 
     public Task Setup(IHostApplicationBuilder hostBuilder)
     {

--- a/src/ServiceControl.Persistence.Tests.PostgreSql/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.PostgreSql/PersistenceTestsContext.cs
@@ -1,4 +1,5 @@
 // ReSharper disable once CheckNamespace
+
 namespace ServiceControl.Persistence.Tests;
 
 using System;
@@ -6,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using EFCore.PostgreSql;
+using MessageFailures;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -14,7 +16,7 @@ using Npgsql;
 using ServiceControl.Persistence.EFCore.Abstractions;
 using ServiceControl.Persistence.EFCore.Infrastructure;
 
-public class PersistenceTestsContext : IPersistenceTestsContext
+public partial class PersistenceTestsContext : IPersistenceTestsContext
 {
     IHost host;
     string databaseName;
@@ -81,6 +83,8 @@ public class PersistenceTestsContext : IPersistenceTestsContext
 
     public string GenerateFailedMessageRecordId(string messageId) => messageId;
 
+    public Task InsertFailedMessages(params FailedMessage[] messages) => InsertFailedMessagesDirect(host.Services, messages);
+	
     void DeleteBodyStorage()
     {
         try

--- a/src/ServiceControl.Persistence.Tests.PostgreSql/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.PostgreSql/PersistenceTestsContext.cs
@@ -84,7 +84,7 @@ public partial class PersistenceTestsContext : IPersistenceTestsContext
     public string GenerateFailedMessageRecordId(string messageId) => messageId;
 
     public Task InsertFailedMessages(params FailedMessage[] messages) => InsertFailedMessagesDirect(host.Services, messages);
-	
+
     void DeleteBodyStorage()
     {
         try

--- a/src/ServiceControl.Persistence.Tests.RavenDB/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/PersistenceTestsContext.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NUnit.Framework;
 using Raven.Client.Documents;
+using ServiceControl.Contracts.Operations;
+using ServiceControl.MessageFailures;
 using ServiceControl.Persistence;
 using ServiceControl.Persistence.RavenDB;
 using ServiceControl.RavenDB;
@@ -54,6 +56,15 @@ public class PersistenceTestsContext : IPersistenceTestsContext
 
     public PersistenceSettings PersistenceSettings { get; private set; }
     public string GenerateFailedMessageRecordId(string messageId) => FailedMessageIdGenerator.MakeDocumentId(messageId);
+    public async Task InsertFailedMessages(params FailedMessage[] messages)
+    {
+        using var session = await SessionProvider.OpenSession();
+        foreach (var message in messages)
+        {
+            await session.StoreAsync(message);
+        }
+        await session.SaveChangesAsync();
+    }
 
     public IDocumentStore DocumentStore { get; private set; }
 

--- a/src/ServiceControl.Persistence.Tests.SqlServer/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.SqlServer/PersistenceTestsContext.cs
@@ -89,7 +89,7 @@ public partial class PersistenceTestsContext : IPersistenceTestsContext
     public string GenerateFailedMessageRecordId(string messageId) => messageId;
 
     public Task InsertFailedMessages(params FailedMessage[] messages) => InsertFailedMessagesDirect(host.Services, messages);
-	
+
     void DeleteBodyStorage()
     {
         try

--- a/src/ServiceControl.Persistence.Tests.SqlServer/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.SqlServer/PersistenceTestsContext.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using EFCore.SqlServer;
+using MessageFailures;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,7 +15,7 @@ using Microsoft.Extensions.Time.Testing;
 using ServiceControl.Persistence.EFCore.Abstractions;
 using ServiceControl.Persistence.EFCore.Infrastructure;
 
-public class PersistenceTestsContext : IPersistenceTestsContext
+public partial class PersistenceTestsContext : IPersistenceTestsContext
 {
     IHost host;
     string databaseName;
@@ -87,6 +88,8 @@ public class PersistenceTestsContext : IPersistenceTestsContext
 
     public string GenerateFailedMessageRecordId(string messageId) => messageId;
 
+    public Task InsertFailedMessages(params FailedMessage[] messages) => InsertFailedMessagesDirect(host.Services, messages);
+	
     void DeleteBodyStorage()
     {
         try

--- a/src/ServiceControl.Persistence.Tests/EFCore/EFCoreExtensionMethodTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/EFCoreExtensionMethodTests.cs
@@ -39,7 +39,7 @@ public class EFCoreExtensionMethodTests : PersistenceTestBase
                 () =>
                 {
                     state = Result.Insert;
-                    return new FailedMessageEntity { UniqueMessageId = key, HeadersJson = "blah", FailingEndpointAddress = "endpoints/sales"};
+                    return new FailedMessageEntity { UniqueMessageId = key, HeadersJson = "blah", FailingEndpointAddress = "endpoints/sales" };
                 },
                 es =>
                 {

--- a/src/ServiceControl.Persistence.Tests/EFCore/EFCoreExtensionMethodTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/EFCoreExtensionMethodTests.cs
@@ -39,7 +39,7 @@ public class EFCoreExtensionMethodTests : PersistenceTestBase
                 () =>
                 {
                     state = Result.Insert;
-                    return new FailedMessageEntity { UniqueMessageId = key, HeadersJson = "blah" };
+                    return new FailedMessageEntity { UniqueMessageId = key, HeadersJson = "blah", FailingEndpointAddress = "endpoints/sales"};
                 },
                 es =>
                 {

--- a/src/ServiceControl.Persistence.Tests/EFCore/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/PersistenceTestsContext.cs
@@ -1,3 +1,4 @@
+#nullable enable
 namespace ServiceControl.Persistence.Tests;
 
 using System;

--- a/src/ServiceControl.Persistence.Tests/EFCore/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/PersistenceTestsContext.cs
@@ -1,0 +1,72 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using EFCore.DbContexts;
+using EFCore.Entities;
+using EFCore.Implementation.UnitOfWork;
+using MessageFailures;
+using Microsoft.Extensions.DependencyInjection;
+using NServiceBus;
+using Operations;
+
+public partial class PersistenceTestsContext
+{
+    static async Task InsertFailedMessagesDirect(IServiceProvider serviceProvider, FailedMessage[] messages)
+    {
+        await using var scope = serviceProvider.CreateAsyncScope();
+        await using var db = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
+
+        static T? GetMetadata<T>(FailedMessage.ProcessingAttempt processingAttempt, string key) =>
+            processingAttempt.MessageMetadata.TryGetValue(key, out var value) && value is T typed ? typed : default;
+
+        foreach (FailedMessage failedMessage in messages)
+        {
+            var now = DateTime.UtcNow;
+            var ordered = failedMessage.ProcessingAttempts
+                .OrderBy(x => x.AttemptedAt)
+                .ThenBy(x => x.MessageId)
+                .ToList();
+            var attempt = ordered.Last();
+            var sendingEndpoint = GetMetadata<EndpointDetails>(attempt, "SendingEndpoint");
+            var receivingEndpoint = GetMetadata<EndpointDetails>(attempt, "ReceivingEndpoint");
+            var contentType = attempt.Headers.GetValueOrDefault(Headers.ContentType, "text/plain");
+            db.FailedMessages.Add(new FailedMessageEntity
+            {
+                UniqueMessageId = Guid.Parse(failedMessage.UniqueMessageId),
+                FirstTimeOfFailure = ordered.Min(pa => pa.FailureDetails.TimeOfFailure),
+                LastTimeOfFailure = ordered.Max(pa => pa.FailureDetails.TimeOfFailure),
+                LastAttemptedAt = attempt.AttemptedAt,
+                HeadersJson = JsonSerializer.Serialize(attempt.Headers, HeadersJsonContext.Default.DictionaryStringString),
+                MessageId = attempt.MessageId,
+                MessageType = GetMetadata<string>(attempt, "MessageType"),
+                TimeSent = GetMetadata<DateTime?>(attempt, "TimeSent"),
+                ConversationId = GetMetadata<string>(attempt, "ConversationId"),
+                QueueAddress = attempt.Headers.GetValueOrDefault(NServiceBus.Faults.FaultsHeaderKeys.FailedQ),
+                SendingEndpointName = sendingEndpoint?.Name,
+                SendingEndpointHostId = sendingEndpoint?.HostId,
+                SendingEndpointHost = sendingEndpoint?.Host,
+                ReceivingEndpointName = receivingEndpoint?.Name,
+                ReceivingEndpointHostId = receivingEndpoint?.HostId,
+                ReceivingEndpointHost = receivingEndpoint?.Host,
+                ExceptionType = attempt.FailureDetails.Exception?.ExceptionType,
+                ExceptionMessage = attempt.FailureDetails.Exception?.Message,
+                FailingEndpointAddress = attempt.FailureDetails.AddressOfFailingEndpoint,
+                IsSystemMessage = GetMetadata<bool>(attempt, "IsSystemMessage"),
+                BodyText = attempt.Body,
+                BodyStoredExternally = false,
+                BodySize = attempt.Body?.Length ?? 0,
+                BodyContentType = contentType,
+                Status = failedMessage.Status,
+                StatusChangedAt = now,
+                LastModified = now,
+                NumberOfProcessingAttempts = ordered.Select(pa => pa.AttemptedAt).Distinct().Count(),
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/src/ServiceControl.Persistence.Tests/EFCore/RetentionSweepTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/RetentionSweepTests.cs
@@ -134,7 +134,8 @@ class RetentionSweepTests : ErrorIngestionTestBase
             IsSystemMessage = false,
             HeadersJson = "{}",
             BodyStoredExternally = bodyStoredExternally,
-            BodySize = 0
+            BodySize = 0,
+            FailingEndpointAddress = "Shipping"
         });
 
         return id;

--- a/src/ServiceControl.Persistence.Tests/EndpointSettingsStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EndpointSettingsStoreTests.cs
@@ -1,0 +1,55 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ServiceControl.Persistence;
+
+class EndpointSettingsStoreTests : PersistenceTestBase
+{
+    [Test]
+    public async Task UpdateEndpointSettings_stores_and_updates_existing_setting()
+    {
+        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = false }, default);
+        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = true }, default);
+
+        var settings = await GetAllEndpointSettings();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(settings, Has.Count.EqualTo(1));
+            Assert.That(settings.Single().Name, Is.EqualTo("Sales"));
+            Assert.That(settings.Single().TrackInstances, Is.True);
+        }
+    }
+
+    [Test]
+    public async Task Delete_removes_only_target_setting()
+    {
+        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = false }, default);
+        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Shipping", TrackInstances = true }, default);
+
+        await EndpointSettingsStore.Delete("Sales", default);
+
+        var settings = await GetAllEndpointSettings();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(settings, Has.Count.EqualTo(1));
+            Assert.That(settings.Single().Name, Is.EqualTo("Shipping"));
+            Assert.That(settings.Single().TrackInstances, Is.True);
+        }
+    }
+
+    async Task<IReadOnlyList<EndpointSettings>> GetAllEndpointSettings()
+    {
+        var settings = new List<EndpointSettings>();
+        await foreach (var setting in EndpointSettingsStore.GetAllEndpointSettings())
+        {
+            settings.Add(setting);
+        }
+
+        return settings;
+    }
+}

--- a/src/ServiceControl.Persistence.Tests/EndpointSettingsStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EndpointSettingsStoreTests.cs
@@ -42,14 +42,5 @@ class EndpointSettingsStoreTests : PersistenceTestBase
         }
     }
 
-    async Task<IReadOnlyList<EndpointSettings>> GetAllEndpointSettings()
-    {
-        var settings = new List<EndpointSettings>();
-        await foreach (var setting in EndpointSettingsStore.GetAllEndpointSettings())
-        {
-            settings.Add(setting);
-        }
-
-        return settings;
-    }
+    async Task<IReadOnlyList<EndpointSettings>> GetAllEndpointSettings() => await EndpointSettingsStore.GetAllEndpointSettings().ToListAsync();
 }

--- a/src/ServiceControl.Persistence.Tests/EndpointSettingsStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EndpointSettingsStoreTests.cs
@@ -2,17 +2,18 @@ namespace ServiceControl.Persistence.Tests;
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using ServiceControl.Persistence;
 
 class EndpointSettingsStoreTests : PersistenceTestBase
 {
-    [Test]
-    public async Task UpdateEndpointSettings_stores_and_updates_existing_setting()
+    [Test, CancelAfter(10_000)]
+    public async Task UpdateEndpointSettings_stores_and_updates_existing_setting(CancellationToken cancellationToken)
     {
-        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = false }, default);
-        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = true }, default);
+        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = false }, cancellationToken);
+        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = true }, cancellationToken);
 
         var settings = await GetAllEndpointSettings();
 
@@ -24,13 +25,13 @@ class EndpointSettingsStoreTests : PersistenceTestBase
         }
     }
 
-    [Test]
-    public async Task Delete_removes_only_target_setting()
+    [Test, CancelAfter(10_000)]
+    public async Task Delete_removes_only_target_setting(CancellationToken cancellationToken)
     {
-        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = false }, default);
-        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Shipping", TrackInstances = true }, default);
+        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = false }, cancellationToken);
+        await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Shipping", TrackInstances = true }, cancellationToken);
 
-        await EndpointSettingsStore.Delete("Sales", default);
+        await EndpointSettingsStore.Delete("Sales", cancellationToken);
 
         var settings = await GetAllEndpointSettings();
 

--- a/src/ServiceControl.Persistence.Tests/IPersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests/IPersistenceTestsContext.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Persistence.Tests;
 
 using System.Threading.Tasks;
+using MessageFailures;
 using Microsoft.Extensions.Hosting;
 
 public interface IPersistenceTestsContext
@@ -16,4 +17,5 @@ public interface IPersistenceTestsContext
     PersistenceSettings PersistenceSettings { get; }
 
     string GenerateFailedMessageRecordId(string messageId);
+    Task InsertFailedMessages(params FailedMessage[] messages);
 }

--- a/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
+++ b/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
@@ -107,4 +107,6 @@ public abstract class PersistenceTestBase
     protected IEventLogDataStore EventLogDataStore => ServiceProvider.GetRequiredService<IEventLogDataStore>();
     protected IRetryDocumentDataStore RetryDocumentDataStore => ServiceProvider.GetRequiredService<IRetryDocumentDataStore>();
     protected ILicensingDataStore LicensingDataStore => ServiceProvider.GetRequiredService<ILicensingDataStore>();
+    protected IQueueAddressStore QueueAddressStore => ServiceProvider.GetRequiredService<IQueueAddressStore>();
+    protected IEndpointSettingsStore EndpointSettingsStore => ServiceProvider.GetRequiredService<IEndpointSettingsStore>();
 }

--- a/src/ServiceControl.Persistence.Tests/QueueAddressStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/QueueAddressStoreTests.cs
@@ -1,0 +1,74 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Contracts.Operations;
+using MessageFailures;
+using NUnit.Framework;
+using ServiceControl.Persistence.Infrastructure;
+
+class QueueAddressStoreTests : PersistenceTestBase
+{
+    [Test]
+    public async Task GetAddresses_groups_failed_messages_by_queue_address()
+    {
+        await SeedFailedMessages();
+
+        await CompleteDatabaseOperation();
+
+        var result = await QueueAddressStore.GetAddresses(new PagingInfo(1, 10));
+        var addresses = result.Results;
+        var physicalAddresses = addresses.Select(address => address.PhysicalAddress).OrderBy(address => address).ToArray();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.QueryStats.TotalCount, Is.EqualTo(4));
+            Assert.That(physicalAddresses, Is.EqualTo(new[] { "alpha", "alpha-child", "beta", "gamma" }));
+            Assert.That(addresses.Single(address => address.PhysicalAddress == "alpha").FailedMessageCount, Is.EqualTo(2));
+            Assert.That(addresses.Single(address => address.PhysicalAddress == "alpha-child").FailedMessageCount, Is.EqualTo(1));
+            Assert.That(addresses.Single(address => address.PhysicalAddress == "beta").FailedMessageCount, Is.EqualTo(1));
+            Assert.That(addresses.Single(address => address.PhysicalAddress == "gamma").FailedMessageCount, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public async Task GetAddressesBySearchTerm_filters_by_prefix()
+    {
+        await SeedFailedMessages();
+
+        await CompleteDatabaseOperation();
+
+        var result = await QueueAddressStore.GetAddressesBySearchTerm("alpha", new PagingInfo(1, 10));
+        var addresses = result.Results;
+        var physicalAddresses = addresses.Select(address => address.PhysicalAddress).OrderBy(address => address).ToArray();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.QueryStats.TotalCount, Is.EqualTo(2));
+            Assert.That(physicalAddresses, Is.EqualTo(new[] { "alpha", "alpha-child" }));
+            Assert.That(addresses.Sum(address => address.FailedMessageCount), Is.EqualTo(3));
+        }
+    }
+
+    async Task SeedFailedMessages() =>
+        await SeedFailedMessages(
+            (new("7F21F22A-44B6-440C-851D-3524645FD083"), "alpha"),
+            (new("E5DF7B16-648E-47F2-A9FD-F2BC1BA5D53C"), "alpha"),
+            (new("8975FE11-DF21-438B-BB65-0006541CA73D"), "beta"),
+            (new("7ED8EEA2-66EA-496C-922F-87D53A699228"), "alpha-child"),
+            (new("D98BDA7B-B3D5-4CD8-A802-E38B57A58041"), "gamma"));
+
+    public Task SeedFailedMessages(params (Guid MessageId, string EndpointAddress)[] failedMessages) =>
+        PersistenceTestsContext.InsertFailedMessages(failedMessages.Select(f => new FailedMessage()
+        {
+            Id = f.MessageId.ToString(),
+            UniqueMessageId = f.MessageId.ToString(),
+            ProcessingAttempts = [
+                new ()
+                {
+                    FailureDetails = new FailureDetails() { AddressOfFailingEndpoint = f.EndpointAddress,}
+                }
+            ]
+        }).ToArray());
+}

--- a/src/ServiceControl.Persistence.Tests/QueueAddressStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/QueueAddressStoreTests.cs
@@ -32,25 +32,6 @@ class QueueAddressStoreTests : PersistenceTestBase
         }
     }
 
-    [Test]
-    public async Task GetAddressesBySearchTerm_filters_by_prefix()
-    {
-        await SeedFailedMessages();
-
-        await CompleteDatabaseOperation();
-
-        var result = await QueueAddressStore.GetAddressesBySearchTerm("alpha", new PagingInfo(1, 10));
-        var addresses = result.Results;
-        var physicalAddresses = addresses.Select(address => address.PhysicalAddress).OrderBy(address => address).ToArray();
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.QueryStats.TotalCount, Is.EqualTo(2));
-            Assert.That(physicalAddresses, Is.EqualTo(["alpha", "alpha-child"]));
-            Assert.That(addresses.Sum(address => address.FailedMessageCount), Is.EqualTo(3));
-        }
-    }
-
     async Task SeedFailedMessages() =>
         await SeedFailedMessages(
             (new("7F21F22A-44B6-440C-851D-3524645FD083"), "alpha"),

--- a/src/ServiceControl.Persistence.Tests/QueueAddressStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/QueueAddressStoreTests.cs
@@ -24,7 +24,7 @@ class QueueAddressStoreTests : PersistenceTestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.QueryStats.TotalCount, Is.EqualTo(4));
-            Assert.That(physicalAddresses, Is.EqualTo(new[] { "alpha", "alpha-child", "beta", "gamma" }));
+            Assert.That(physicalAddresses, Is.EqualTo(["alpha", "alpha-child", "beta", "gamma"]));
             Assert.That(addresses.Single(address => address.PhysicalAddress == "alpha").FailedMessageCount, Is.EqualTo(2));
             Assert.That(addresses.Single(address => address.PhysicalAddress == "alpha-child").FailedMessageCount, Is.EqualTo(1));
             Assert.That(addresses.Single(address => address.PhysicalAddress == "beta").FailedMessageCount, Is.EqualTo(1));
@@ -46,7 +46,7 @@ class QueueAddressStoreTests : PersistenceTestBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.QueryStats.TotalCount, Is.EqualTo(2));
-            Assert.That(physicalAddresses, Is.EqualTo(new[] { "alpha", "alpha-child" }));
+            Assert.That(physicalAddresses, Is.EqualTo(["alpha", "alpha-child"]));
             Assert.That(addresses.Sum(address => address.FailedMessageCount), Is.EqualTo(3));
         }
     }

--- a/src/ServiceControl.Persistence.Tests/Recoverability/EditHandlerAuditTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/EditHandlerAuditTests.cs
@@ -105,7 +105,7 @@ sealed class EditHandlerAuditTests : PersistenceTestBase
                     }
                 ]
         };
-        await ErrorMessageDataStore.StoreFailedMessagesForTestsOnly(new[] { failedMessage });
+        await PersistenceTestsContext.InsertFailedMessages(failedMessage);
         return failedMessage;
     }
 }

--- a/src/ServiceControl.Persistence.Tests/Recoverability/EditMessageTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/EditMessageTests.cs
@@ -262,7 +262,7 @@
                         }
                     ]
             };
-            await ErrorMessageDataStore.StoreFailedMessagesForTestsOnly(new[] { failedMessage });
+            await PersistenceTestsContext.InsertFailedMessages(failedMessage);
             return failedMessage;
         }
     }

--- a/src/ServiceControl.Persistence.Tests/Recoverability/RetryConfirmationProcessorTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/RetryConfirmationProcessorTests.cs
@@ -25,7 +25,7 @@
 
             Handler = new LegacyMessageFailureResolvedHandler(ErrorMessageDataStore, domainEvents);
 
-            await ErrorMessageDataStore.StoreFailedMessagesForTestsOnly(
+            await PersistenceTestsContext.InsertFailedMessages(
                 new FailedMessage
                 {
                     Id = MessageId,

--- a/src/ServiceControl.Persistence.Tests/Recoverability/ReturnToSenderDequeuerTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/ReturnToSenderDequeuerTests.cs
@@ -243,8 +243,6 @@
 
             public Task<byte[]> FetchFromFailedMessage(string bodyId) => Task.FromResult(Encoding.UTF8.GetBytes(bodyId));
             public Task StoreEventLogItem(EventLogItem logItem) => throw new NotImplementedException();
-
-            public Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages) => throw new NotImplementedException();
         }
     }
 }

--- a/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
+++ b/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
@@ -254,7 +254,7 @@
                 ]
             }).ToArray();
 
-            await ErrorStore.StoreFailedMessagesForTestsOnly(messages);
+            await PersistenceTestsContext.InsertFailedMessages(messages);
             await CompleteDatabaseOperation();
 
             var gateway = new CustomRetriesGateway(true, RetryStore, retryManager);
@@ -342,7 +342,7 @@
                 ]
             }).ToArray();
 
-            await ErrorStore.StoreFailedMessagesForTestsOnly(messages);
+            await PersistenceTestsContext.InsertFailedMessages(messages);
 
             // Needs index FailedMessages_ByGroup
             // Needs index FailedMessages_UniqueMessageIdAndTimeOfFailures

--- a/src/ServiceControl.Persistence.Tests/TrialLicenseDataProviderTests.cs
+++ b/src/ServiceControl.Persistence.Tests/TrialLicenseDataProviderTests.cs
@@ -1,0 +1,33 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using ServiceControl.Persistence;
+
+class TrialLicenseDataProviderTests : PersistenceTestBase
+{
+    [Test]
+    public async Task GetTrialEndDate_returns_null_by_default()
+    {
+        var trialLicenseDataProvider = ServiceProvider.GetRequiredService<ITrialLicenseDataProvider>();
+
+        var trialEndDate = await trialLicenseDataProvider.GetTrialEndDate(default);
+
+        Assert.That(trialEndDate, Is.Null);
+    }
+
+    [Test]
+    public async Task StoreTrialEndDate_persists_value()
+    {
+        var trialLicenseDataProvider = ServiceProvider.GetRequiredService<ITrialLicenseDataProvider>();
+        var expectedEndDate = DateOnly.FromDateTime(DateTime.UtcNow.Date.AddDays(13));
+
+        await trialLicenseDataProvider.StoreTrialEndDate(expectedEndDate, default);
+
+        var trialEndDate = await trialLicenseDataProvider.GetTrialEndDate(default);
+
+        Assert.That(trialEndDate, Is.EqualTo(expectedEndDate));
+    }
+}

--- a/src/ServiceControl.Persistence.Tests/TrialLicenseDataProviderTests.cs
+++ b/src/ServiceControl.Persistence.Tests/TrialLicenseDataProviderTests.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Persistence.Tests;
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
@@ -8,25 +9,25 @@ using ServiceControl.Persistence;
 
 class TrialLicenseDataProviderTests : PersistenceTestBase
 {
-    [Test]
-    public async Task GetTrialEndDate_returns_null_by_default()
+    [Test, CancelAfter(10_000)]
+    public async Task GetTrialEndDate_returns_null_by_default(CancellationToken cancellationToken)
     {
         var trialLicenseDataProvider = ServiceProvider.GetRequiredService<ITrialLicenseDataProvider>();
 
-        var trialEndDate = await trialLicenseDataProvider.GetTrialEndDate(default);
+        var trialEndDate = await trialLicenseDataProvider.GetTrialEndDate(cancellationToken);
 
         Assert.That(trialEndDate, Is.Null);
     }
 
-    [Test]
-    public async Task StoreTrialEndDate_persists_value()
+    [Test, CancelAfter(10_000)]
+    public async Task StoreTrialEndDate_persists_value(CancellationToken cancellationToken)
     {
         var trialLicenseDataProvider = ServiceProvider.GetRequiredService<ITrialLicenseDataProvider>();
         var expectedEndDate = DateOnly.FromDateTime(DateTime.UtcNow.Date.AddDays(13));
 
-        await trialLicenseDataProvider.StoreTrialEndDate(expectedEndDate, default);
+        await trialLicenseDataProvider.StoreTrialEndDate(expectedEndDate, cancellationToken);
 
-        var trialEndDate = await trialLicenseDataProvider.GetTrialEndDate(default);
+        var trialEndDate = await trialLicenseDataProvider.GetTrialEndDate(cancellationToken);
 
         Assert.That(trialEndDate, Is.EqualTo(expectedEndDate));
     }

--- a/src/ServiceControl.Persistence/IEndpointSettingsStore.cs
+++ b/src/ServiceControl.Persistence/IEndpointSettingsStore.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 public interface IEndpointSettingsStore
 {
-    IAsyncEnumerable<EndpointSettings> GetAllEndpointSettings(CancellationToken cancellationToken);
+    IAsyncEnumerable<EndpointSettings> GetAllEndpointSettings(CancellationToken cancellationToken = default);
 
     Task UpdateEndpointSettings(EndpointSettings settings, CancellationToken token);
     Task Delete(string name, CancellationToken cancellationToken);

--- a/src/ServiceControl.Persistence/IEndpointSettingsStore.cs
+++ b/src/ServiceControl.Persistence/IEndpointSettingsStore.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 public interface IEndpointSettingsStore
 {
-    IAsyncEnumerable<EndpointSettings> GetAllEndpointSettings(CancellationToken token);
+    IAsyncEnumerable<EndpointSettings> GetAllEndpointSettings(CancellationToken cancellationToken);
 
     Task UpdateEndpointSettings(EndpointSettings settings, CancellationToken token);
     Task Delete(string name, CancellationToken cancellationToken);

--- a/src/ServiceControl.Persistence/IErrorMessageDatastore.cs
+++ b/src/ServiceControl.Persistence/IErrorMessageDatastore.cs
@@ -71,7 +71,5 @@
 
         // AuditEventLogWriter
         Task StoreEventLogItem(EventLogItem logItem);
-
-        Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages);
     }
 }

--- a/src/ServiceControl.UnitTests/MessageFailures/AsyncRangeAndQueueAuditTests.cs
+++ b/src/ServiceControl.UnitTests/MessageFailures/AsyncRangeAndQueueAuditTests.cs
@@ -192,6 +192,5 @@ public class AsyncRangeAndQueueAuditTests
         public Task RevertRetry(string messageUniqueId) => throw new NotImplementedException();
         public Task<byte[]> FetchFromFailedMessage(string uniqueMessageId) => throw new NotImplementedException();
         public Task StoreEventLogItem(EventLogItem logItem) => throw new NotImplementedException();
-        public Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages) => throw new NotImplementedException();
     }
 }

--- a/src/ServiceControl.UnitTests/MessageFailures/EditFailedMessagesControllerAuditTests.cs
+++ b/src/ServiceControl.UnitTests/MessageFailures/EditFailedMessagesControllerAuditTests.cs
@@ -97,6 +97,5 @@ public class EditFailedMessagesControllerAuditTests
         public Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress) => throw new NotImplementedException();
         public Task<byte[]> FetchFromFailedMessage(string uniqueMessageId) => throw new NotImplementedException();
         public Task StoreEventLogItem(EventLogItem logItem) => throw new NotImplementedException();
-        public Task StoreFailedMessagesForTestsOnly(params FailedMessage[] failedMessages) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
* Implement `IQueueAddressStore` for EF persisters
* Implement `ITrialLicenseDataProvider` for EF persisters
* Implement `IEndpointSettingsStore` for EF persisters
* Move test-only error insertion into test project
* Improve test  coverage on `IQueueAddressStore`, `ITrialLicenseDataProvider`, `IEndpointSettingsStore`