### PR TITLE
Installer incorrectly modifies "external ravendb" audit instance causing them to no longer start

### DIFF
--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/ServiceControlAppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/ServiceControlAppConfig.cs
@@ -4,6 +4,7 @@
     using System.Configuration;
     using System.Data.Common;
     using System.IO;
+    using System.Linq;
     using Instances;
     using NuGet.Versioning;
 
@@ -21,6 +22,9 @@
 
             var settings = Config.AppSettings.Settings;
             var version = details.Version;
+            //ServiceControl.Audit.Persistence.RavenDB.RavenPersistenceConfiguration.ConnectionStringKey
+            var hasOnlyRemoteRavenDbConnection = settings.AllKeys.Contains("RavenDB/ConnectionString")
+                                                 && !settings.AllKeys.Contains(AuditInstanceSettingsList.DBPath.Name);
 
             settings.Set(ServiceControlSettings.InstanceName, details.InstanceName, version);
             settings.Set(ServiceControlSettings.VirtualDirectory, details.VirtualDirectory);
@@ -28,7 +32,10 @@
             settings.Set(ServiceControlSettings.DatabaseMaintenancePort, details.DatabaseMaintenancePort.ToString(), version);
             settings.Set(ServiceControlSettings.HostName, details.HostName);
             settings.Set(ServiceControlSettings.LogPath, details.LogPath);
-            settings.Set(ServiceControlSettings.DBPath, details.DBPath);
+            if (hasOnlyRemoteRavenDbConnection)
+            {
+                settings.Set(ServiceControlSettings.DBPath, details.DBPath);
+            }
             settings.Set(ServiceControlSettings.ForwardErrorMessages, details.ForwardErrorMessages.ToString(), version);
             settings.Set(ServiceControlSettings.TransportType, details.TransportPackage.Name, version);
             settings.Set(ServiceControlSettings.PersistenceType, details.PersistenceManifest.Name); // TODO: Why is it set here AND at ServiceControlInstance.ApplySettingsChanges 🤬

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/ServiceControlAppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/ServiceControlAppConfig.cs
@@ -4,6 +4,7 @@
     using System.Configuration;
     using System.Data.Common;
     using System.IO;
+    using System.Linq;
     using Instances;
     using NuGet.Versioning;
 
@@ -21,6 +22,10 @@
 
             var settings = Config.AppSettings.Settings;
             var version = details.Version;
+            
+            //ServiceControl.Audit.Persistence.RavenDB.RavenPersistenceConfiguration.ConnectionStringKey
+            var hasOnlyRemoteRavenDbConnection = settings.AllKeys.Contains("RavenDB/ConnectionString")
+                                                 && !settings.AllKeys.Contains(AuditInstanceSettingsList.DBPath.Name);
 
             settings.Set(ServiceControlSettings.InstanceName, details.InstanceName, version);
             settings.Set(ServiceControlSettings.VirtualDirectory, details.VirtualDirectory);
@@ -28,7 +33,10 @@
             settings.Set(ServiceControlSettings.DatabaseMaintenancePort, details.DatabaseMaintenancePort.ToString(), version);
             settings.Set(ServiceControlSettings.HostName, details.HostName);
             settings.Set(ServiceControlSettings.LogPath, details.LogPath);
-            settings.Set(ServiceControlSettings.DBPath, details.DBPath);
+            if (hasOnlyRemoteRavenDbConnection)
+            {
+                settings.Set(ServiceControlSettings.DBPath, details.DBPath);
+            }
             settings.Set(ServiceControlSettings.ForwardErrorMessages, details.ForwardErrorMessages.ToString(), version);
             settings.Set(ServiceControlSettings.TransportType, details.TransportPackage.Name, version);
             settings.Set(ServiceControlSettings.PersistenceType, details.PersistenceManifest.Name); // TODO: Why is it set here AND at ServiceControlInstance.ApplySettingsChanges 🤬

--- a/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/ServiceControlAuditAppConfig.cs
+++ b/src/ServiceControlInstaller.Engine/Configuration/ServiceControl/ServiceControlAuditAppConfig.cs
@@ -36,8 +36,18 @@
             // Windows via SCMU or PowerShell
             settings.Set(AuditInstanceSettingsList.ShutdownTimeout, "00:02:00", version);
 
+            //ServiceControl.Audit.Persistence.RavenDB.RavenPersistenceConfiguration.ConnectionStringKey
+            var hasOnlyRemoteRavenDbConnection = settings.AllKeys.Contains("RavenDB/ConnectionString")
+                                                 && !settings.AllKeys.Contains(AuditInstanceSettingsList.DBPath.Name);
+
             foreach (var manifestSetting in instance.PersistenceManifest.Settings)
             {
+                if (manifestSetting.Name == AuditInstanceSettingsList.DBPath.Name
+                    && hasOnlyRemoteRavenDbConnection)
+                {
+                    continue;
+                }
+
                 if (!settings.AllKeys.Contains(manifestSetting.Name))
                 {
                     var value = manifestSetting.DefaultValue;


### PR DESCRIPTION
Fixes

- https://github.com/Particular/ServiceControl/issues/4909