### PR TITLE
Update LocalStack to version 4.4.0

### DIFF
--- a/src/container-integration-test/sqs.yml
+++ b/src/container-integration-test/sqs.yml
@@ -1,7 +1,8 @@
 services:
 
   localstack:
-    image: localstack/localstack:3
+    # We need to pin the tag to 4.4.0 because after that version LocalStack has become a paid service for commercial use.
+    image: localstack/localstack:4.4.0
     ports:
       - '4566-4597:4566-4597'
       - "8000:5000"


### PR DESCRIPTION
Pin LocalStack to version 4.4.0 for container integration tests to ensure compatibility with the free tier and avoid commercial licensing requirements.