### PR TITLE
Remove unused search method

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_message_has_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_message_has_failed.cs
@@ -240,47 +240,6 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
             Assert.That(searchResults.Count, Is.EqualTo(1), "Result count did not match");
         }
 
-        [Test]
-        public async Task Should_only_return_queueaddresses_that_startswith_search()
-        {
-            var searchResults = new List<QueueAddress>();
-            const string searchTerm = "another";
-            const string searchEndpointName = "AnotherFailingEndpoint";
-
-            await Define<QueueSearchContext>()
-                .WithEndpoint<FailingEndpoint>(b =>
-                {
-                    b.DoNotFailOnErrorMessages();
-                    b.When(bus => bus.SendLocal(new MyMessage()));
-                })
-                .WithEndpoint<FailingEndpoint>(b =>
-                {
-                    b.DoNotFailOnErrorMessages();
-                    b.CustomConfig(configuration => configuration.GetSettings().Set("NServiceBus.Routing.EndpointName", searchEndpointName));
-                    b.When(bus => bus.SendLocal(new MyMessage()));
-                })
-                .WithEndpoint<FailingEndpoint>(b =>
-                {
-                    b.DoNotFailOnErrorMessages();
-                    b.CustomConfig(configuration => configuration.GetSettings().Set("NServiceBus.Routing.EndpointName", "YetAnotherEndpoint"));
-                    b.When(bus => bus.SendLocal(new MyMessage()));
-                }).Done(async c =>
-                {
-                    if (c.FailedMessageCount < 3)
-                    {
-                        return false;
-                    }
-
-                    var result = await this.TryGetMany<QueueAddress>($"/api/errors/queues/addresses/search/{searchTerm}");
-                    searchResults = result;
-                    return result;
-                })
-                .Run();
-
-            Assert.That(searchResults.Count, Is.EqualTo(1), "Result count did not match");
-            Assert.That(searchResults[0].PhysicalAddress.StartsWith(searchEndpointName, StringComparison.InvariantCultureIgnoreCase), Is.True);
-        }
-
         public class EndpointThatUsesSignalR : EndpointConfigurationBuilder
         {
             public EndpointThatUsesSignalR() =>

--- a/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
@@ -7,7 +7,4 @@ public class QueueAddressStore : IQueueAddressStore
 {
     public Task<QueryResult<IList<QueueAddress>>> GetAddresses(PagingInfo pagingInfo) =>
         throw new NotImplementedException();
-
-    public Task<QueryResult<IList<QueueAddress>>> GetAddressesBySearchTerm(string search, PagingInfo pagingInfo) =>
-        throw new NotImplementedException();
 }

--- a/src/ServiceControl.Persistence.RavenDB/QueueAddressStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/QueueAddressStore.cs
@@ -22,20 +22,5 @@
             var result = new QueryResult<IList<QueueAddress>>(addresses, stats.ToQueryStatsInfo());
             return result;
         }
-
-        public async Task<QueryResult<IList<QueueAddress>>> GetAddressesBySearchTerm(string search, PagingInfo pagingInfo)
-        {
-            using var session = await sessionProvider.OpenSession();
-            var failedMessageQueues = await session
-                    .Query<QueueAddress, QueueAddressIndex>()
-                    .Statistics(out var stats)
-                    .Paging(pagingInfo)
-                    .Where(q => q.PhysicalAddress.StartsWith(search))
-                    .OrderBy(q => q.PhysicalAddress)
-                    .ToListAsync();
-
-            var result = new QueryResult<IList<QueueAddress>>(failedMessageQueues, stats.ToQueryStatsInfo());
-            return result;
-        }
     }
 }

--- a/src/ServiceControl.Persistence/IQueueAddressStore.cs
+++ b/src/ServiceControl.Persistence/IQueueAddressStore.cs
@@ -8,6 +8,5 @@
     public interface IQueueAddressStore
     {
         Task<QueryResult<IList<QueueAddress>>> GetAddresses(PagingInfo pagingInfo);
-        Task<QueryResult<IList<QueueAddress>>> GetAddressesBySearchTerm(string search, PagingInfo pagingInfo);
     }
 }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.HttpApiRoutes.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.HttpApiRoutes.approved.txt
@@ -33,7 +33,6 @@ GET /errors/groups/{classifier?} => ServiceControl.MessageFailures.Api.ArchiveMe
 GET /errors/last/{failedMessageId:required:minlength(1)} => ServiceControl.MessageFailures.Api.GetErrorByIdController:ErrorLastBy(String failedMessageId)
 POST /errors/queues/{queueAddress:required:minlength(1)}/retry => ServiceControl.MessageFailures.Api.RetryMessagesController:RetryAllBy(String queueAddress)
 GET /errors/queues/addresses => ServiceControl.MessageFailures.Api.QueueAddressController:GetAddresses(PagingInfo pagingInfo)
-GET /errors/queues/addresses/search/{search} => ServiceControl.MessageFailures.Api.QueueAddressController:GetAddressesBySearchTerm(PagingInfo pagingInfo, String search)
 POST /errors/retry => ServiceControl.MessageFailures.Api.RetryMessagesController:RetryAllBy(List<String> messageIds)
 POST /errors/retry/all => ServiceControl.MessageFailures.Api.RetryMessagesController:RetryAll()
 GET /errors/summary => ServiceControl.MessageFailures.Api.GetAllErrorsController:ErrorsSummary()

--- a/src/ServiceControl/MessageFailures/Api/QueueAddressController.cs
+++ b/src/ServiceControl/MessageFailures/Api/QueueAddressController.cs
@@ -1,45 +1,27 @@
-﻿namespace ServiceControl.MessageFailures.Api
+﻿namespace ServiceControl.MessageFailures.Api;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Infrastructure.Auth;
+using Infrastructure.WebApi;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Persistence.Infrastructure;
+using ServiceControl.Persistence;
+
+[ApiController]
+[Route("api")]
+public class QueueAddressController(IQueueAddressStore store) : ControllerBase
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using Infrastructure.Auth;
-    using Infrastructure.WebApi;
-    using Microsoft.AspNetCore.Authorization;
-    using Microsoft.AspNetCore.Mvc;
-    using Persistence.Infrastructure;
-    using ServiceControl.Persistence;
-
-    [ApiController]
-    [Route("api")]
-    public class QueueAddressController(IQueueAddressStore store) : ControllerBase
+    [Authorize(Policy = Permissions.ErrorQueuesView)]
+    [Route("errors/queues/addresses")]
+    [HttpGet]
+    public async Task<IList<QueueAddress>> GetAddresses([FromQuery] PagingInfo pagingInfo)
     {
-        [Authorize(Policy = Permissions.ErrorQueuesView)]
-        [Route("errors/queues/addresses")]
-        [HttpGet]
-        public async Task<IList<QueueAddress>> GetAddresses([FromQuery] PagingInfo pagingInfo)
-        {
-            var result = await store.GetAddresses(pagingInfo);
+        var result = await store.GetAddresses(pagingInfo);
 
-            Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
+        Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
 
-            return result.Results;
-        }
-
-        [Authorize(Policy = Permissions.ErrorQueuesView)]
-        [Route("errors/queues/addresses/search/{search}")]
-        [HttpGet]
-        public async Task<ActionResult<IList<QueueAddress>>> GetAddressesBySearchTerm([FromQuery] PagingInfo pagingInfo, string search = null)
-        {
-            if (string.IsNullOrWhiteSpace(search))
-            {
-                return BadRequest();
-            }
-
-            var result = await store.GetAddressesBySearchTerm(search, pagingInfo);
-
-            Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
-
-            return Ok(result.Results);
-        }
+        return result.Results;
     }
 }


### PR DESCRIPTION
This pull request removes the search functionality for queue addresses from the codebase, including the associated API endpoint, service methods, and tests.

A search of the Particular github turned up no usages of this endpoint across any repositories.

The most important changes include:

### API and Controller Changes

* Removed the `/errors/queues/addresses/search/{search}` API endpoint from `QueueAddressController`, including its route, handler method, and related authorization attributes. [[1]](diffhunk://#diff-e64ac5f736c6340e7e509ee83871bd640d65c3aa0fc2c5fdd2affd94852363f8L27-L44) [[2]](diffhunk://#diff-6d9abe0c29e8dac29a7a2a1aa78a67fb087ff054fafa671f2246ec06f2c5aa2cL36)
* Updated the namespace declaration style in `QueueAddressController.cs` to use file-scoped namespaces.

### Service and Interface Changes

* Removed the `GetAddressesBySearchTerm` method from the `IQueueAddressStore` interface and its implementations in both the EFCore and RavenDB persistence layers. [[1]](diffhunk://#diff-047076069271eda46955e5d81c30fa509aacd9b7533741db06b87ff9d6637bcaL11) [[2]](diffhunk://#diff-02a1dbaac74c6346316f74ec27ef169e544d90ac6ca32172b2aa5b3b4222e955L10-L12) [[3]](diffhunk://#diff-1ffb18a9103fa280fa5d859205dc3d7c3bc8b483ac1765f54193561985f7877eL25-L39)

### Test Changes

* Deleted the test `Should_only_return_queueaddresses_that_startswith_search` from the acceptance tests, as the search feature is no longer supported.