### PR TITLE
Add flag to license info to indicate whether endpoint metadata is available

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -69,7 +69,7 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="Particular.Approvals" Version="2.0.1" />
     <PackageVersion Include="Particular.LicensingComponent.Report" Version="1.2.0" />
-    <PackageVersion Include="Particular.Licensing.Sources" Version="7.3.0" />
+    <PackageVersion Include="Particular.Licensing.Sources" Version="7.4.0" />
     <PackageVersion Include="Particular.Obsoletes" Version="1.1.0" />
     <PackageVersion Include="Particular.ServicePulse.Core" Version="2.9.2" />
     <PackageVersion Include="Polly.Core" Version="8.7.0" />

--- a/src/ServiceControl.LicenseManagement/LicenseDetails.cs
+++ b/src/ServiceControl.LicenseManagement/LicenseDetails.cs
@@ -40,6 +40,8 @@
 
         public LicensedProduct[] Products { get; private init; }
 
+        public bool HasEndpointMetadata { get; private init; }
+
         public static LicenseDetails TrialFromEndDate(DateOnly endDate)
         {
             return FromLicense(new License
@@ -82,6 +84,7 @@
                 Edition = license.Edition,
                 //strip any internal prefix from what gets displayed to the customer
                 Products = license.LicensedEndpoints?.Select(le => new LicensedProduct(le.Size.EndsWith("U") ? "Unlimited" : Regex.Replace(le.Size, @"^\D*", ""), le.Quantity)).ToArray(),
+                HasEndpointMetadata = license.Capabilities.Contains("EndpointMetadataFile"),
                 ValidForServiceControl = license.ValidForApplication("ServiceControl"),
                 DaysUntilSubscriptionExpires = license.GetDaysUntilLicenseExpires(),
                 WarnUserTrialIsExpiring = licenseStatus == LicenseStatus.ValidWithExpiringTrial,

--- a/src/ServiceControl/Licensing/LicenseController.cs
+++ b/src/ServiceControl/Licensing/LicenseController.cs
@@ -44,6 +44,7 @@ namespace ServiceControl.Licensing
                 InstanceName = settings.InstanceName ?? string.Empty,
                 LicenseStatus = activeLicense.Details.Status,
                 Products = activeLicense.Details.Products,
+                HasEndpointMetadata = activeLicense.Details.HasEndpointMetadata,
                 LicenseExtensionUrl = connectorHeartbeatStatus.LastHeartbeat == null
                     ? $"https://particular.net/extend-your-trial?p={clientName}"
                     : $"https://particular.net/license/mt?p={clientName}&t={(activeLicense.IsEvaluation ? 0 : 1)}"
@@ -57,6 +58,11 @@ namespace ServiceControl.Licensing
         [Route("license/details")]
         public async Task<ActionResult<LicensedEndpointDetails?>> LicenseDetails(CancellationToken cancellationToken)
         {
+            if (activeLicense.Details.Edition != "Endpoint Size" || !activeLicense.Details.HasEndpointMetadata)
+            {
+                return (LicensedEndpointDetails?)null;
+            }
+
             var licenseDetails = await dataStore.GetLicensedEndpointDetails(cancellationToken);
             if (licenseDetails is null)
             {

--- a/src/ServiceControl/Licensing/LicenseControllerTypes.cs
+++ b/src/ServiceControl/Licensing/LicenseControllerTypes.cs
@@ -18,6 +18,8 @@
 
         public LicensedProduct[] Products { get; set; }
 
+        public bool HasEndpointMetadata { get; set; }
+
         public string LicenseType { get; set; }
 
         public string InstanceName { get; set; }


### PR DESCRIPTION
Updated license definition now has a capabilities field, and one of these capabilities is `EndpointMetadataFile`. Only if this capability is present should the new licensedetails functionality be enabled.