### PR TITLE
Make test timeouts longer for persistence tests

### DIFF
--- a/src/ServiceControl.Persistence.Tests/EndpointSettingsStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EndpointSettingsStoreTests.cs
@@ -9,7 +9,7 @@ using ServiceControl.Persistence;
 
 class EndpointSettingsStoreTests : PersistenceTestBase
 {
-    [Test, CancelAfter(15_000)]
+    [Test, CancelAfter(30_000)]
     public async Task UpdateEndpointSettings_stores_and_updates_existing_setting(CancellationToken cancellationToken)
     {
         await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = false }, cancellationToken);
@@ -25,7 +25,7 @@ class EndpointSettingsStoreTests : PersistenceTestBase
         }
     }
 
-    [Test, CancelAfter(15_000)]
+    [Test, CancelAfter(30_000)]
     public async Task Delete_removes_only_target_setting(CancellationToken cancellationToken)
     {
         await EndpointSettingsStore.UpdateEndpointSettings(new EndpointSettings { Name = "Sales", TrackInstances = false }, cancellationToken);

--- a/src/ServiceControl.Persistence.Tests/TrialLicenseDataProviderTests.cs
+++ b/src/ServiceControl.Persistence.Tests/TrialLicenseDataProviderTests.cs
@@ -9,7 +9,7 @@ using ServiceControl.Persistence;
 
 class TrialLicenseDataProviderTests : PersistenceTestBase
 {
-    [Test, CancelAfter(15_000)]
+    [Test, CancelAfter(30_000)]
     public async Task GetTrialEndDate_returns_null_by_default(CancellationToken cancellationToken)
     {
         var trialLicenseDataProvider = ServiceProvider.GetRequiredService<ITrialLicenseDataProvider>();
@@ -19,7 +19,7 @@ class TrialLicenseDataProviderTests : PersistenceTestBase
         Assert.That(trialEndDate, Is.Null);
     }
 
-    [Test, CancelAfter(15_000)]
+    [Test, CancelAfter(30_000)]
     public async Task StoreTrialEndDate_persists_value(CancellationToken cancellationToken)
     {
         var trialLicenseDataProvider = ServiceProvider.GetRequiredService<ITrialLicenseDataProvider>();


### PR DESCRIPTION
Tests were failing in master, this should avoid that.