### PR TITLE
Implement retry batch creation

### DIFF
--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260803021015_AddRetryBatches.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260803021015_AddRetryBatches.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ServiceControl.Persistence.EFCore.PostgreSql;
@@ -12,9 +13,11 @@ using ServiceControl.Persistence.EFCore.PostgreSql;
 namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
 {
     [DbContext(typeof(PostgreSqlServiceControlDbContext))]
-    partial class PostgreSqlServiceControlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260803021015_AddRetryBatches")]
+    partial class AddRetryBatches
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -22,60 +25,6 @@ namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
-
-            modelBuilder.Entity("ServiceControl.Persistence.EFCore.Entities.CustomCheckEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid")
-                        .HasColumnName("id");
-
-                    b.Property<string>("Category")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("category");
-
-                    b.Property<string>("CustomCheckId")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("custom_check_id");
-
-                    b.Property<string>("FailureReason")
-                        .HasColumnType("text")
-                        .HasColumnName("failure_reason");
-
-                    b.Property<string>("OriginatingEndpointHost")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("originating_endpoint_host");
-
-                    b.Property<Guid>("OriginatingEndpointHostId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("originating_endpoint_host_id");
-
-                    b.Property<string>("OriginatingEndpointName")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("originating_endpoint_name");
-
-                    b.Property<DateTime>("ReportedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("reported_at");
-
-                    b.Property<int>("Status")
-                        .HasColumnType("integer")
-                        .HasColumnName("status");
-
-                    b.HasKey("Id")
-                        .HasName("pk_custom_checks");
-
-                    b.HasIndex("ReportedAt")
-                        .HasDatabaseName("ix_custom_checks_reported_at");
-
-                    b.HasIndex("Status", "ReportedAt")
-                        .HasDatabaseName("ix_custom_checks_status_reported_at");
-
-                    b.ToTable("custom_checks", (string)null);
-                });
 
             modelBuilder.Entity("ServiceControl.Persistence.EFCore.Entities.EndpointSettingsEntity", b =>
                 {

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260803021015_AddRetryBatches.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260803021015_AddRetryBatches.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRetryBatches : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "retry_id",
+                table: "failed_message_retries");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "retry_batch_id",
+                table: "failed_message_retries",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<int>(
+                name: "stage_attempts",
+                table: "failed_message_retries",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "retry_batch_now_forwarding",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false),
+                    retry_batch_id = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_retry_batch_now_forwarding", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "retry_batches",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    retry_session_id = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    request_id = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    retry_type = table.Column<int>(type: "integer", nullable: false),
+                    initial_batch_size = table.Column<int>(type: "integer", nullable: false),
+                    start_time = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    last = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    staging_id = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    context = table.Column<string>(type: "text", nullable: true),
+                    originator = table.Column<string>(type: "text", nullable: true),
+                    classifier = table.Column<string>(type: "text", nullable: true),
+                    initiated_by_id = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    initiated_by_name = table.Column<string>(type: "text", nullable: true),
+                    operation_id = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_retry_batches", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_failed_message_retries_retry_batch_id",
+                table: "failed_message_retries",
+                column: "retry_batch_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_retry_batches_status_retry_session_id",
+                table: "retry_batches",
+                columns: new[] { "status", "retry_session_id" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "retry_batch_now_forwarding");
+
+            migrationBuilder.DropTable(
+                name: "retry_batches");
+
+            migrationBuilder.DropIndex(
+                name: "ix_failed_message_retries_retry_batch_id",
+                table: "failed_message_retries");
+
+            migrationBuilder.DropColumn(
+                name: "retry_batch_id",
+                table: "failed_message_retries");
+
+            migrationBuilder.DropColumn(
+                name: "stage_attempts",
+                table: "failed_message_retries");
+
+            migrationBuilder.AddColumn<string>(
+                name: "retry_id",
+                table: "failed_message_retries",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlIngestionSqlDialect.cs
@@ -65,6 +65,23 @@ class PostgreSqlIngestionSqlDialect : IIngestionSqlDialect
         }
     }
 
+    public async Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken)
+    {
+        foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
+        {
+            await Execute(
+                dbContext,
+                $"""
+                 INSERT INTO failed_message_retries (unique_message_id, retry_batch_id, stage_attempts)
+                 VALUES
+                 {ParameterRows(chunk.Length, 3)}
+                 ON CONFLICT (unique_message_id) DO NOTHING
+                 """,
+                chunk.Select(retry => new object?[] { retry.UniqueMessageId, retry.RetryBatchId, retry.StageAttempts }),
+                cancellationToken);
+        }
+    }
+
     static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken)
     {
         await using var command = dbContext.Database.GetDbConnection().CreateCommand();

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260803021009_AddRetryBatches.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260803021009_AddRetryBatches.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ServiceControl.Persistence.EFCore.SqlServer;
 
@@ -11,9 +12,11 @@ using ServiceControl.Persistence.EFCore.SqlServer;
 namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
 {
     [DbContext(typeof(SqlServerServiceControlDbContext))]
-    partial class SqlServerServiceControlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260803021009_AddRetryBatches")]
+    partial class AddRetryBatches
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,48 +24,6 @@ namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
-
-            modelBuilder.Entity("ServiceControl.Persistence.EFCore.Entities.CustomCheckEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Category")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("CustomCheckId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("FailureReason")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("OriginatingEndpointHost")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<Guid>("OriginatingEndpointHostId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("OriginatingEndpointName")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime>("ReportedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<int>("Status")
-                        .HasColumnType("int");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ReportedAt");
-
-                    b.HasIndex("Status", "ReportedAt");
-
-                    b.ToTable("CustomChecks");
-                });
 
             modelBuilder.Entity("ServiceControl.Persistence.EFCore.Entities.EndpointSettingsEntity", b =>
                 {

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260803021009_AddRetryBatches.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260803021009_AddRetryBatches.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRetryBatches : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RetryId",
+                table: "FailedMessageRetries");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "RetryBatchId",
+                table: "FailedMessageRetries",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<int>(
+                name: "StageAttempts",
+                table: "FailedMessageRetries",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "RetryBatches",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    RetrySessionId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    RequestId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    RetryType = table.Column<int>(type: "int", nullable: false),
+                    InitialBatchSize = table.Column<int>(type: "int", nullable: false),
+                    StartTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Last = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    StagingId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true),
+                    Context = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Originator = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Classifier = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    InitiatedById = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true),
+                    InitiatedByName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    OperationId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RetryBatches", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RetryBatchNowForwarding",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false),
+                    RetryBatchId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RetryBatchNowForwarding", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FailedMessageRetries_RetryBatchId",
+                table: "FailedMessageRetries",
+                column: "RetryBatchId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RetryBatches_Status_RetrySessionId",
+                table: "RetryBatches",
+                columns: new[] { "Status", "RetrySessionId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RetryBatches");
+
+            migrationBuilder.DropTable(
+                name: "RetryBatchNowForwarding");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FailedMessageRetries_RetryBatchId",
+                table: "FailedMessageRetries");
+
+            migrationBuilder.DropColumn(
+                name: "RetryBatchId",
+                table: "FailedMessageRetries");
+
+            migrationBuilder.DropColumn(
+                name: "StageAttempts",
+                table: "FailedMessageRetries");
+
+            migrationBuilder.AddColumn<string>(
+                name: "RetryId",
+                table: "FailedMessageRetries",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true);
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerIngestionSqlDialect.cs
@@ -76,6 +76,26 @@ class SqlServerIngestionSqlDialect : IIngestionSqlDialect
         }
     }
 
+    public async Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken)
+    {
+        foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
+        {
+            await Execute(
+                dbContext,
+                $"""
+                 MERGE [FailedMessageRetries] WITH (HOLDLOCK) AS t
+                 USING (VALUES
+                 {ParameterRows(chunk.Length, 3)}
+                 ) AS s ([UniqueMessageId], [RetryBatchId], [StageAttempts])
+                 ON t.[UniqueMessageId] = s.[UniqueMessageId]
+                 WHEN NOT MATCHED THEN INSERT ([UniqueMessageId], [RetryBatchId], [StageAttempts])
+                 VALUES (s.[UniqueMessageId], s.[RetryBatchId], s.[StageAttempts]);
+                 """,
+                chunk.Select(retry => new object?[] { retry.UniqueMessageId, retry.RetryBatchId, retry.StageAttempts }),
+                cancellationToken);
+        }
+    }
+
     static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken)
     {
         await using var command = dbContext.Database.GetDbConnection().CreateCommand();

--- a/src/ServiceControl.Persistence.EFCore/DbContexts/ServiceControlDbContext.cs
+++ b/src/ServiceControl.Persistence.EFCore/DbContexts/ServiceControlDbContext.cs
@@ -13,6 +13,8 @@ public abstract class ServiceControlDbContext(DbContextOptions options) : DbCont
     public DbSet<FailedMessageGroupEntity> FailedMessageGroups { get; set; }
     public DbSet<GroupCommentEntity> GroupComments { get; set; }
     public DbSet<MessageRedirectEntity> MessageRedirects { get; set; }
+    public DbSet<RetryBatchEntity> RetryBatches { get; set; }
+    public DbSet<RetryBatchNowForwardingEntity> RetryBatchNowForwarding { get; set; }
     public DbSet<FailedMessageRetryEntity> FailedMessageRetries { get; set; }
     public DbSet<FailedErrorImportEntity> FailedErrorImports { get; set; }
     public DbSet<TrialMetadataEntity> TrialMetadata { get; set; }
@@ -34,6 +36,8 @@ public abstract class ServiceControlDbContext(DbContextOptions options) : DbCont
         modelBuilder.ApplyConfiguration(new FailedMessageRetryConfiguration());
         modelBuilder.ApplyConfiguration(new GroupCommentConfiguration());
         modelBuilder.ApplyConfiguration(new MessageRedirectConfiguration());
+        modelBuilder.ApplyConfiguration(new RetryBatchConfiguration());
+        modelBuilder.ApplyConfiguration(new RetryBatchNowForwardingConfiguration());
         modelBuilder.ApplyConfiguration(new KnownEndpointConfiguration());
         modelBuilder.ApplyConfiguration(new SubscriptionConfiguration());
         modelBuilder.ApplyConfiguration(new TrialMetadataConfiguration());

--- a/src/ServiceControl.Persistence.EFCore/Entities/FailedMessageRetryEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/FailedMessageRetryEntity.cs
@@ -4,5 +4,7 @@ public class FailedMessageRetryEntity
 {
     public Guid UniqueMessageId { get; set; }
 
-    public string? RetryId { get; set; }
+    public Guid RetryBatchId { get; set; }
+
+    public int StageAttempts { get; set; }
 }

--- a/src/ServiceControl.Persistence.EFCore/Entities/RetryBatchEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/RetryBatchEntity.cs
@@ -1,0 +1,36 @@
+namespace ServiceControl.Persistence.EFCore.Entities;
+
+using ServiceControl.Persistence;
+
+public class RetryBatchEntity
+{
+    public Guid Id { get; set; }
+
+    public RetryBatchStatus Status { get; set; }
+
+    public required string RetrySessionId { get; set; }
+
+    public required string RequestId { get; set; }
+
+    public RetryType RetryType { get; set; }
+
+    public int InitialBatchSize { get; set; }
+
+    public DateTime StartTime { get; set; }
+
+    public DateTime? Last { get; set; }
+
+    public string? StagingId { get; set; }
+
+    public string? Context { get; set; }
+
+    public string? Originator { get; set; }
+
+    public string? Classifier { get; set; }
+
+    public string? InitiatedById { get; set; }
+
+    public string? InitiatedByName { get; set; }
+
+    public string? OperationId { get; set; }
+}

--- a/src/ServiceControl.Persistence.EFCore/Entities/RetryBatchNowForwardingEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/RetryBatchNowForwardingEntity.cs
@@ -1,0 +1,10 @@
+namespace ServiceControl.Persistence.EFCore.Entities;
+
+public class RetryBatchNowForwardingEntity
+{
+    public const int SingleRowId = 1;
+
+    public int Id { get; set; } = SingleRowId;
+
+    public Guid RetryBatchId { get; set; }
+}

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/FailedMessageRetryConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/FailedMessageRetryConfiguration.cs
@@ -10,6 +10,8 @@ class FailedMessageRetryConfiguration : IEntityTypeConfiguration<FailedMessageRe
     {
         builder.HasKey(e => e.UniqueMessageId);
         builder.Property(e => e.UniqueMessageId).ValueGeneratedNever();
-        builder.Property(e => e.RetryId).HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.StageAttempts).IsRequired();
+
+        builder.HasIndex(e => e.RetryBatchId);
     }
 }

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/RetryBatchConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/RetryBatchConfiguration.cs
@@ -1,0 +1,27 @@
+namespace ServiceControl.Persistence.EFCore.EntityConfigurations;
+
+using Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+class RetryBatchConfiguration : IEntityTypeConfiguration<RetryBatchEntity>
+{
+    public void Configure(EntityTypeBuilder<RetryBatchEntity> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).ValueGeneratedNever();
+
+        builder.Property(e => e.Status).IsRequired();
+        builder.Property(e => e.RetryType).IsRequired();
+        builder.Property(e => e.InitialBatchSize).IsRequired();
+        builder.Property(e => e.StartTime).IsRequired();
+
+        builder.Property(e => e.RetrySessionId).IsRequired().HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.RequestId).IsRequired().HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.StagingId).HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.OperationId).HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.InitiatedById).HasMaxLength(ColumnLengths.ShortTextLength);
+
+        builder.HasIndex(e => new { e.Status, e.RetrySessionId });
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/RetryBatchNowForwardingConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/RetryBatchNowForwardingConfiguration.cs
@@ -1,0 +1,15 @@
+namespace ServiceControl.Persistence.EFCore.EntityConfigurations;
+
+using Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+class RetryBatchNowForwardingConfiguration : IEntityTypeConfiguration<RetryBatchNowForwardingEntity>
+{
+    public void Configure(EntityTypeBuilder<RetryBatchNowForwardingEntity> builder)
+    {
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).ValueGeneratedNever();
+        builder.Property(e => e.RetryBatchId).IsRequired();
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/Implementation/RetryBatchMapper.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/RetryBatchMapper.cs
@@ -1,0 +1,27 @@
+namespace ServiceControl.Persistence.EFCore.Implementation;
+
+using ServiceControl.Persistence.EFCore.Entities;
+
+static class RetryBatchMapper
+{
+    public static RetryBatch ToRetryBatch(this RetryBatchEntity entity, IList<string> failureRetries) =>
+        new()
+        {
+            Id = entity.Id.ToString(),
+            Status = entity.Status,
+            RetrySessionId = entity.RetrySessionId,
+            RequestId = entity.RequestId,
+            RetryType = entity.RetryType,
+            InitialBatchSize = entity.InitialBatchSize,
+            StartTime = entity.StartTime,
+            Last = entity.Last,
+            StagingId = entity.StagingId,
+            Context = entity.Context,
+            Originator = entity.Originator,
+            Classifier = entity.Classifier,
+            InitiatedById = entity.InitiatedById,
+            InitiatedByName = entity.InitiatedByName,
+            OperationId = entity.OperationId,
+            FailureRetries = failureRetries
+        };
+}

--- a/src/ServiceControl.Persistence.EFCore/Implementation/RetryBatchStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/RetryBatchStore.cs
@@ -1,41 +1,222 @@
 namespace ServiceControl.Persistence.EFCore.Implementation;
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using ServiceControl.MessageFailures;
+using ServiceControl.Persistence.EFCore.DbContexts;
+using ServiceControl.Persistence.EFCore.Entities;
+using ServiceControl.Persistence.EFCore.Infrastructure;
 using ServiceControl.Persistence.Infrastructure;
-using ServiceControl.Recoverability;
 
-public class RetryBatchStore : IRetryBatchStore
+public class RetryBatchStore(IServiceScopeFactory scopeFactory, IIngestionSqlDialect dialect) : DataStoreBase(scopeFactory), IRetryBatchStore
 {
     public Task<string> CreateBatch(string retrySessionId, string requestId, RetryType retryType,
         string[] failedMessageRetryIds, string originator, DateTime startTime, DateTime? last = null,
         string? batchName = null, string? classifier = null,
         string? initiatedById = null, string? initiatedByName = null, string? operationId = null) =>
-        throw new NotImplementedException();
+        ExecuteWithDbContext(async dbContext =>
+        {
+            var batch = new RetryBatchEntity
+            {
+                Id = Guid.NewGuid(),
+                Status = RetryBatchStatus.MarkingDocuments,
+                RetrySessionId = retrySessionId,
+                RequestId = requestId,
+                RetryType = retryType,
+                InitialBatchSize = failedMessageRetryIds.Length,
+                StartTime = startTime,
+                Last = last,
+                Context = batchName,
+                Originator = originator,
+                Classifier = classifier,
+                InitiatedById = initiatedById,
+                InitiatedByName = initiatedByName,
+                OperationId = operationId
+            };
 
+            dbContext.RetryBatches.Add(batch);
+
+            await dbContext.SaveChangesAsync();
+
+            return batch.Id.ToString();
+        });
+
+    /// <summary>
+    /// Claims the messages for the batch. A message already claimed by another batch keeps that claim, so the batch it is staged with is whichever one got there first.
+    /// </summary>
     public Task AssignMessagesToBatch(string batchId, string[] messageIds) =>
-        throw new NotImplementedException();
+        ExecuteWithDbContext(async dbContext =>
+        {
+            var batch = ParseBatchId(batchId);
 
-    public Task MoveBatchToStaging(string batchId) =>
-        throw new NotImplementedException();
+            // Message ids reach this from the API, so an id that is not a message id is a caller's
+            // typo rather than a fault. It cannot match a stored message, so it is left unclaimed.
+            var uniqueMessageIds = new HashSet<Guid>();
+
+            foreach (var messageId in messageIds)
+            {
+                if (Guid.TryParse(messageId, out var uniqueMessageId))
+                {
+                    uniqueMessageIds.Add(uniqueMessageId);
+                }
+            }
+
+            var claims = uniqueMessageIds
+                .Select(uniqueMessageId => new FailedMessageRetryEntity { UniqueMessageId = uniqueMessageId, RetryBatchId = batch })
+                .ToArray();
+
+            if (claims.Length == 0)
+            {
+                return;
+            }
+
+            // The dialect writes on the connection directly, so it needs a transaction of its own.
+            var strategy = dbContext.Database.CreateExecutionStrategy();
+
+            await strategy.ExecuteAsync(async () =>
+            {
+                await using var transaction = await dbContext.Database.BeginTransactionAsync();
+
+                await dialect.InsertMissingRetryClaims(dbContext, claims, CancellationToken.None);
+
+                await transaction.CommitAsync();
+            });
+        });
+
+    public Task MoveBatchToStaging(string batchId)
+    {
+        var batch = ParseBatchId(batchId);
+
+        return ExecuteWithDbContext(dbContext => dbContext.RetryBatches
+            .Where(row => row.Id == batch)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(row => row.Status, RetryBatchStatus.Staging)));
+    }
+
+    // Batch ids only ever come from CreateBatch, so anything else is a programming error.
+    static Guid ParseBatchId(string batchId) =>
+        Guid.TryParse(batchId, out var parsed)
+            ? parsed
+            : throw new ArgumentException($"'{batchId}' is not a retry batch id issued by this store.", nameof(batchId));
 
     public Task<QueryResult<IList<RetryBatch>>> GetOrphanedBatches(string retrySessionId) =>
-        throw new NotImplementedException();
+        ExecuteWithDbContext(async dbContext =>
+        {
+            var orphaned = await dbContext.RetryBatches
+                .AsNoTracking()
+                .Where(batch => batch.Status == RetryBatchStatus.MarkingDocuments && batch.RetrySessionId != retrySessionId)
+                .ToListAsync();
+
+            var membership = await ReadMembership(dbContext, [.. orphaned.Select(batch => batch.Id)]);
+
+            IList<RetryBatch> batches = [.. orphaned.Select(batch => batch.ToRetryBatch(membership.GetValueOrDefault(batch.Id, [])))];
+
+            return new QueryResult<IList<RetryBatch>>(batches, new QueryStatsInfo(string.Empty, batches.Count, false));
+        });
 
     public Task<IList<RetryBatchGroup>> GetAvailableBatchGroups() =>
-        throw new NotImplementedException();
+        ExecuteWithDbContext<IList<RetryBatchGroup>>(async dbContext =>
+        {
+            var groups = await dbContext.RetryBatches
+                .AsNoTracking()
+                .Where(batch => batch.Status == RetryBatchStatus.Staging || batch.Status == RetryBatchStatus.Forwarding)
+                .GroupBy(batch => new { batch.RequestId, batch.RetryType })
+                .Select(group => new
+                {
+                    group.Key.RequestId,
+                    group.Key.RetryType,
+                    HasStagingBatches = group.Any(batch => batch.Status == RetryBatchStatus.Staging),
+                    HasForwardingBatches = group.Any(batch => batch.Status == RetryBatchStatus.Forwarding),
+                    InitialBatchSize = group.Sum(batch => batch.InitialBatchSize),
+                    StartTime = group.Min(batch => batch.StartTime),
+                    Last = group.Max(batch => batch.Last),
+                    Originator = group.Max(batch => batch.Originator),
+                    Classifier = group.Max(batch => batch.Classifier)
+                })
+                .ToListAsync();
 
-    public Task<ForwardingRetryBatch> GetCurrentForwardingBatch() =>
-        throw new NotImplementedException();
+            return [.. groups.Select(group => new RetryBatchGroup
+            {
+                RequestId = group.RequestId,
+                RetryType = group.RetryType,
+                HasStagingBatches = group.HasStagingBatches,
+                HasForwardingBatches = group.HasForwardingBatches,
+                InitialBatchSize = group.InitialBatchSize,
+                StartTime = group.StartTime,
+                Last = group.Last ?? default,
+                Originator = group.Originator,
+                Classifier = group.Classifier
+            })];
+        });
+
+    public Task<ForwardingRetryBatch?> GetCurrentForwardingBatch() =>
+        ExecuteWithDbContext(async dbContext =>
+        {
+            var nowForwarding = await dbContext.RetryBatchNowForwarding
+                .AsNoTracking()
+                .SingleOrDefaultAsync();
+
+            if (nowForwarding == null)
+            {
+                return null;
+            }
+
+            return await dbContext.RetryBatches
+                .AsNoTracking()
+                .Where(batch => batch.Id == nowForwarding.RetryBatchId)
+                .Select(batch => new ForwardingRetryBatch(batch.RequestId, batch.RetryType, batch.Originator!, batch.Classifier!))
+                .SingleOrDefaultAsync();
+        });
 
     public Task ForEachUnresolvedMessage(Func<string, DateTime, Task> callback) =>
-        throw new NotImplementedException();
+        ForEach(Unresolved, callback);
 
     public Task ForEachUnresolvedMessageForEndpoint(string endpoint, Func<string, DateTime, Task> callback) =>
-        throw new NotImplementedException();
+        ForEach(dbContext => Unresolved(dbContext)
+            .Where(message => message.ReceivingEndpointName == endpoint), callback);
 
     public Task ForEachMessageForQueueAddress(string failedQueueAddress, FailedMessageStatus status, Func<string, DateTime, Task> callback) =>
-        throw new NotImplementedException();
+        ForEach(dbContext => Unresolved(dbContext)
+            .Where(message => message.FailingEndpointAddress == failedQueueAddress && message.Status == status), callback);
 
     public Task ForEachUnresolvedMessageInGroup(string groupId, Func<string, DateTime, Task> callback) =>
-        throw new NotImplementedException();
+        ForEach(dbContext => Unresolved(dbContext)
+            .Where(message => dbContext.FailedMessageGroups.Any(group => group.GroupId == groupId && group.FailedMessageUniqueId == message.UniqueMessageId)), callback);
+
+    Task ForEach(Func<ServiceControlDbContext, IQueryable<FailedMessageEntity>> query, Func<string, DateTime, Task> callback) =>
+        ExecuteWithDbContext(dbContext => Stream(query(dbContext), callback));
+
+    static IQueryable<FailedMessageEntity> Unresolved(ServiceControlDbContext dbContext) =>
+        dbContext.FailedMessages
+            .AsNoTracking()
+            .Where(message => message.Status == FailedMessageStatus.Unresolved);
+
+    static async Task Stream(IQueryable<FailedMessageEntity> messages, Func<string, DateTime, Task> callback)
+    {
+        var rows = messages
+            .Select(message => new { message.UniqueMessageId, message.LastTimeOfFailure })
+            .AsAsyncEnumerable();
+
+        await foreach (var row in rows)
+        {
+            await callback(row.UniqueMessageId.ToString(), row.LastTimeOfFailure);
+        }
+    }
+
+    static async Task<Dictionary<Guid, List<string>>> ReadMembership(ServiceControlDbContext dbContext, Guid[] batchIds)
+    {
+        if (batchIds.Length == 0)
+        {
+            return [];
+        }
+
+        var rows = await dbContext.FailedMessageRetries
+            .AsNoTracking()
+            .Where(retry => batchIds.Contains(retry.RetryBatchId))
+            .Select(retry => new { retry.RetryBatchId, retry.UniqueMessageId })
+            .ToListAsync();
+
+        return rows
+            .GroupBy(row => row.RetryBatchId)
+            .ToDictionary(group => group.Key, group => group.Select(row => row.UniqueMessageId.ToString()).ToList());
+    }
 }

--- a/src/ServiceControl.Persistence.EFCore/Infrastructure/IIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore/Infrastructure/IIngestionSqlDialect.cs
@@ -27,4 +27,10 @@ public interface IIngestionSqlDialect
     /// Insert if absent, never update: existing endpoints keep their Monitored flag.
     /// </summary>
     Task InsertMissingKnownEndpoints(ServiceControlDbContext dbContext, IReadOnlyList<KnownEndpointEntity> rows, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Insert if absent, never update: a message already claimed stays with the batch that claimed
+    /// it first, so two retry requests covering the same message cannot both stage it.
+    /// </summary>
+    Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken);
 }

--- a/src/ServiceControl.Persistence.Tests/EFCore/ErrorIngestionTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/ErrorIngestionTests.cs
@@ -218,7 +218,7 @@ class ErrorIngestionTests : ErrorIngestionTestBase
     {
         var failure = new IngestedFailure();
         await Ingest(failure);
-        await Store(new FailedMessageRetryEntity { UniqueMessageId = failure.UniqueMessageId, RetryId = "RetryBatches/1" });
+        await Store(new FailedMessageRetryEntity { UniqueMessageId = failure.UniqueMessageId, RetryBatchId = Guid.NewGuid() });
 
         await ConfirmRetry(failure.UniqueMessageIdString);
 

--- a/src/ServiceControl.Persistence.Tests/EFCore/RetryBatchStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/RetryBatchStoreTests.cs
@@ -1,0 +1,248 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ServiceControl.Persistence.EFCore.Entities;
+using ServiceControl.Recoverability;
+
+class RetryBatchStoreTests : ErrorIngestionTestBase
+{
+    const string OtherSession = "another-session";
+
+    static readonly DateTime Noon = new(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public async Task Creates_a_batch()
+    {
+        var batchId = await CreateBatch("request-1", RetryType.FailureGroup, ["OrderPlaced failures"], messageCount: 3);
+
+        var orphaned = await Orphaned();
+
+        var batch = orphaned.Single();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(batch.Id, Is.EqualTo(batchId));
+            Assert.That(batch.Status, Is.EqualTo(RetryBatchStatus.MarkingDocuments));
+            Assert.That(batch.RequestId, Is.EqualTo("request-1"));
+            Assert.That(batch.RetryType, Is.EqualTo(RetryType.FailureGroup));
+            Assert.That(batch.InitialBatchSize, Is.EqualTo(3));
+            Assert.That(batch.Originator, Is.EqualTo("OrderPlaced failures"));
+            Assert.That(batch.StartTime, Is.EqualTo(Noon));
+        }
+    }
+
+    [Test]
+    public async Task Does_not_report_batches_of_the_current_session_as_orphaned()
+    {
+        await CreateBatch("request-1", retrySessionId: OtherSession);
+
+        var orphaned = await RetryBatchStore.GetOrphanedBatches(OtherSession);
+
+        Assert.That(orphaned.Results, Is.Empty);
+    }
+
+    [Test]
+    public async Task Does_not_report_staged_batches_as_orphaned()
+    {
+        var batchId = await CreateBatch("request-1");
+
+        await RetryBatchStore.MoveBatchToStaging(batchId);
+
+        Assert.That(await Orphaned(), Is.Empty);
+    }
+
+    [Test]
+    public async Task Claims_the_messages_of_a_batch()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var batchId = await CreateBatch("request-1");
+
+        await RetryBatchStore.AssignMessagesToBatch(batchId, [first.ToString(), second.ToString()]);
+
+        var batch = (await Orphaned()).Single();
+
+        Assert.That(batch.FailureRetries, Is.EquivalentTo(new[] { first.ToString(), second.ToString() }));
+    }
+
+    [Test]
+    public async Task Leaves_a_message_claimed_by_an_earlier_batch_alone()
+    {
+        var shared = Guid.NewGuid().ToString();
+        var firstBatch = await CreateBatch("request-1");
+        var secondBatch = await CreateBatch("request-2");
+
+        await RetryBatchStore.AssignMessagesToBatch(firstBatch, [shared]);
+        await RetryBatchStore.AssignMessagesToBatch(secondBatch, [shared]);
+
+        var batches = (await Orphaned()).ToDictionary(batch => batch.Id);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(batches[firstBatch].FailureRetries, Is.EquivalentTo(new[] { shared }));
+            Assert.That(batches[secondBatch].FailureRetries, Is.Empty);
+        }
+    }
+
+    [Test]
+    public async Task Claims_each_message_once_when_two_batches_race_for_them()
+    {
+        var shared = Enumerable.Range(0, 25).Select(_ => Guid.NewGuid().ToString()).ToArray();
+        var firstBatch = await CreateBatch("request-1");
+        var secondBatch = await CreateBatch("request-2");
+
+        await Task.WhenAll(
+            RetryBatchStore.AssignMessagesToBatch(firstBatch, shared),
+            RetryBatchStore.AssignMessagesToBatch(secondBatch, shared));
+
+        var batches = (await Orphaned()).ToDictionary(batch => batch.Id);
+        var claimed = batches[firstBatch].FailureRetries.Concat(batches[secondBatch].FailureRetries);
+
+        Assert.That(claimed, Is.EquivalentTo(shared));
+    }
+
+    [Test]
+    public async Task Reports_staged_batches_as_available()
+    {
+        var batchId = await CreateBatch("request-1", RetryType.FailureGroup, ["OrderPlaced failures"], messageCount: 2);
+
+        await RetryBatchStore.MoveBatchToStaging(batchId);
+
+        var group = (await RetryBatchStore.GetAvailableBatchGroups()).Single();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(group.RequestId, Is.EqualTo("request-1"));
+            Assert.That(group.RetryType, Is.EqualTo(RetryType.FailureGroup));
+            Assert.That(group.HasStagingBatches, Is.True);
+            Assert.That(group.HasForwardingBatches, Is.False);
+            Assert.That(group.InitialBatchSize, Is.EqualTo(2));
+            Assert.That(group.Originator, Is.EqualTo("OrderPlaced failures"));
+        }
+    }
+
+    [Test]
+    public async Task Adds_up_the_batches_of_one_request()
+    {
+        var first = await CreateBatch("request-1", messageCount: 2);
+        var second = await CreateBatch("request-1", messageCount: 5);
+
+        await RetryBatchStore.MoveBatchToStaging(first);
+        await RetryBatchStore.MoveBatchToStaging(second);
+
+        var group = (await RetryBatchStore.GetAvailableBatchGroups()).Single();
+
+        Assert.That(group.InitialBatchSize, Is.EqualTo(7));
+    }
+
+    [Test]
+    public async Task Does_not_report_batches_still_marking_documents_as_available()
+    {
+        await CreateBatch("request-1");
+
+        Assert.That(await RetryBatchStore.GetAvailableBatchGroups(), Is.Empty);
+    }
+
+    [Test]
+    public async Task Returns_no_forwarding_batch_when_none_is_in_flight()
+    {
+        await CreateBatch("request-1");
+
+        Assert.That(await RetryBatchStore.GetCurrentForwardingBatch(), Is.Null);
+    }
+
+    [Test]
+    public async Task Returns_the_batch_being_forwarded()
+    {
+        var batchId = await CreateBatch("request-1", RetryType.FailureGroup, ["OrderPlaced failures"]);
+
+        await Store(new RetryBatchNowForwardingEntity { RetryBatchId = Guid.Parse(batchId) });
+
+        var batch = await RetryBatchStore.GetCurrentForwardingBatch();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(batch.RequestId, Is.EqualTo("request-1"));
+            Assert.That(batch.RetryType, Is.EqualTo(RetryType.FailureGroup));
+            Assert.That(batch.Originator, Is.EqualTo("OrderPlaced failures"));
+            Assert.That(batch.Classifier, Is.EqualTo("Message Type"));
+        }
+    }
+
+    [Test]
+    public async Task Streams_every_unresolved_message()
+    {
+        var unresolved = new IngestedFailure();
+        await Ingest(unresolved);
+        await Insert(new IngestedFailure(), MessageFailures.FailedMessageStatus.Archived);
+
+        var streamed = await Collect(callback => RetryBatchStore.ForEachUnresolvedMessage(callback));
+
+        Assert.That(streamed, Is.EquivalentTo(new[] { unresolved.UniqueMessageIdString }));
+    }
+
+    [Test]
+    public async Task Streams_the_unresolved_messages_of_an_endpoint()
+    {
+        var sales = new IngestedFailure { ReceivingEndpoint = new() { Name = "Sales", Host = "H", HostId = Guid.NewGuid() } };
+        var shipping = new IngestedFailure { ReceivingEndpoint = new() { Name = "Shipping", Host = "H", HostId = Guid.NewGuid() } };
+
+        await Ingest(sales, shipping);
+
+        var streamed = await Collect(callback => RetryBatchStore.ForEachUnresolvedMessageForEndpoint("Sales", callback));
+
+        Assert.That(streamed, Is.EquivalentTo(new[] { sales.UniqueMessageIdString }));
+    }
+
+    [Test]
+    public async Task Streams_the_unresolved_messages_of_a_group()
+    {
+        var group = new MessageFailures.FailedMessage.FailureGroup { Id = Guid.NewGuid().ToString(), Title = "OrderPlaced", Type = "Message Type" };
+        var inGroup = new IngestedFailure { Groups = [group] };
+        var outsideGroup = new IngestedFailure();
+
+        await Ingest(inGroup, outsideGroup);
+
+        var streamed = await Collect(callback => RetryBatchStore.ForEachUnresolvedMessageInGroup(group.Id, callback));
+
+        Assert.That(streamed, Is.EquivalentTo(new[] { inGroup.UniqueMessageIdString }));
+    }
+
+    Task<string> CreateBatch(string requestId, RetryType retryType = RetryType.MultipleMessages, string[] originator = null, int messageCount = 1, string retrySessionId = "this-session") =>
+        RetryBatchStore.CreateBatch(
+            retrySessionId,
+            requestId,
+            retryType,
+            [.. Enumerable.Range(0, messageCount).Select(_ => Guid.NewGuid().ToString())],
+            originator?.Single(),
+            Noon,
+            classifier: "Message Type");
+
+    async Task<IList<RetryBatch>> Orphaned() => (await RetryBatchStore.GetOrphanedBatches(OtherSession)).Results;
+
+    static async Task<List<string>> Collect(Func<Func<string, DateTime, Task>, Task> stream)
+    {
+        var streamed = new List<string>();
+
+        await stream((uniqueMessageId, _) =>
+        {
+            streamed.Add(uniqueMessageId);
+            return Task.CompletedTask;
+        });
+
+        return streamed;
+    }
+
+    async Task Insert(IngestedFailure failure, MessageFailures.FailedMessageStatus status)
+    {
+        var message = failure.ToFailedMessage(status);
+        message.Id = PersistenceTestsContext.GenerateFailedMessageRecordId(message.UniqueMessageId);
+
+        await PersistenceTestsContext.InsertFailedMessages(message);
+        await CompleteDatabaseOperation();
+    }
+}


### PR DESCRIPTION
Retry batch creation for the SQL Server and PostgreSQL persisters: create a batch, claim its, move it to staging, adopt orphans, rebuild operation state. Staging and forwarding follow the next PR.

## Decisions worth a look

- **No membership table.** A message belongs to at most one batch, so `FailedMessageRetries.RetryBatchId` the membership and `FailureRetries` is a query over it.
- **Claiming is one statement**, insert if absent via the provider dialect, the same seam ingestion for known endpoints. The database decides who wins a contested message.
- **The forwarding pointer stays.** After a crash a batch can carry `Forwarding` status without the one in flight, so the pointer is what recovery trusts.
- **Unparseable message ids are skipped**, since they arrive from the API and cannot match anything. ids come from `CreateBatch`, so those throw.
- **Renames**: `IRetryBatchStore` and members named for what they do. `GetBatchesFor*` returned no, so they are now `ForEach*` over messages, minus three parameters dead in both persisters. 
GetCurrentForwardingBatch` returns a `ForwardingRetryBatch` rather than a batch with an empty list.