### PR TITLE
Dead code removal

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseConfiguration.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceControl.Audit.Persistence.RavenDB
 {
     using System;
-    using Sparrow.Json;
 
     public class DatabaseConfiguration(
         string name,
@@ -19,8 +18,6 @@
         public int ExpirationProcessTimerInSeconds { get; } = expirationProcessTimerInSeconds;
 
         public bool EnableFullTextSearch { get; } = enableFullTextSearch;
-
-        public Func<string, BlittableJsonReaderObject, string> FindClrType { get; }
 
         public ServerConfiguration ServerConfiguration { get; } = serverConfiguration;
 

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenEmbeddedPersistenceLifecycle.cs
@@ -39,10 +39,7 @@ namespace ServiceControl.Audit.Persistence.RavenDB
 
                 var serverConfig = databaseConfiguration.ServerConfiguration;
 
-                var embeddedConfig = new EmbeddedDatabaseConfiguration(serverConfig.ServerUrl, databaseConfiguration.Name, serverConfig.DbPath, serverConfig.LogPath, serverConfig.LogsMode)
-                {
-                    FindClrType = databaseConfiguration.FindClrType
-                };
+                var embeddedConfig = new EmbeddedDatabaseConfiguration(serverConfig.ServerUrl, databaseConfiguration.Name, serverConfig.DbPath, serverConfig.LogPath, serverConfig.LogsMode);
 
                 database = EmbeddedDatabase.Start(embeddedConfig, lifetime);
 

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenExternalPersistenceLifecycle.cs
@@ -46,11 +46,6 @@ namespace ServiceControl.Audit.Persistence.RavenDB
                     }
                 };
 
-                if (configuration.FindClrType != null)
-                {
-                    store.Conventions.FindClrType += configuration.FindClrType;
-                }
-
                 documentStore = store.Initialize();
 
                 await StartupChecks.EnsureServerVersion(store, cancellationToken);

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -176,11 +176,6 @@ namespace ServiceControl.RavenDB
                 SkipCreatingDatabase = true
             };
 
-            if (configuration.FindClrType != null)
-            {
-                dbOptions.Conventions.FindClrType += configuration.FindClrType;
-            }
-
             var store = await EmbeddedServer.Instance.GetDocumentStoreAsync(dbOptions, cancellationToken);
             return store;
         }

--- a/src/ServiceControl.RavenDB/EmbeddedDatabaseConfiguration.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabaseConfiguration.cs
@@ -1,7 +1,5 @@
 ﻿namespace ServiceControl.RavenDB
 {
-    using Sparrow.Json;
-
     public class EmbeddedDatabaseConfiguration(string serverUrl, string dbName, string dbPath, string logPath, string logsMode)
     {
         public string Name { get; } = dbName;
@@ -11,7 +9,5 @@
         public string LogsMode { get; } = logsMode;
 
         public bool RunInMemory { get; set; }
-
-        public Func<string, BlittableJsonReaderObject, string> FindClrType { get; init; }
     }
 }

--- a/src/ServiceControl/Recoverability/Retrying/RetryDocumentManager.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetryDocumentManager.cs
@@ -54,12 +54,9 @@ namespace ServiceControl.Recoverability
 
             foreach (var group in stagingBatchGroups)
             {
-                if (!string.IsNullOrWhiteSpace(group.RequestId))
-                {
-                    logger.LogDebug("Rebuilt retry operation status for {RetryType}/{RetryRequestId}. Aggregated batchsize: {RetryBatchSize}", group.RetryType, group.RequestId, group.InitialBatchSize);
+                logger.LogDebug("Rebuilt retry operation status for {RetryType}/{RetryRequestId}. Aggregated batchsize: {RetryBatchSize}", group.RetryType, group.RequestId, group.InitialBatchSize);
 
-                    await operationManager.PreparedAdoptedBatch(group.RequestId, group.RetryType, group.InitialBatchSize, group.InitialBatchSize, group.Originator, group.Classifier, group.StartTime, group.Last);
-                }
+                await operationManager.PreparedAdoptedBatch(group.RequestId, group.RetryType, group.InitialBatchSize, group.InitialBatchSize, group.Originator, group.Classifier, group.StartTime, group.Last);
             }
         }
 

--- a/src/ServiceControl/Recoverability/Retrying/RetryingManager.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetryingManager.cs
@@ -18,11 +18,6 @@
 
         public Task Wait(string requestId, RetryType retryType, DateTime started, string originator = null, string classifier = null, DateTime? last = null)
         {
-            if (requestId == null) //legacy support for batches created before operations were introduced
-            {
-                return Task.CompletedTask;
-            }
-
             var summary = GetOrCreate(retryType, requestId);
 
             return summary.Wait(started, originator, classifier, last);
@@ -45,11 +40,6 @@
 
         public async Task Preparing(string requestId, RetryType retryType, int totalNumberOfMessages)
         {
-            if (requestId == null) //legacy support for batches created before operations were introduced
-            {
-                return;
-            }
-
             var summary = GetOrCreate(retryType, requestId);
 
             await summary.Prepare(totalNumberOfMessages);
@@ -57,11 +47,6 @@
 
         public async Task PreparedAdoptedBatch(string requestId, RetryType retryType, int numberOfMessagesPrepared, int totalNumberOfMessages, string originator, string classifier, DateTime startTime, DateTime last)
         {
-            if (requestId == null) //legacy support for batches created before operations were introduced
-            {
-                return;
-            }
-
             var summary = GetOrCreate(retryType, requestId);
 
             await summary.Prepare(totalNumberOfMessages);
@@ -70,11 +55,6 @@
 
         public async Task PreparedBatch(string requestId, RetryType retryType, int numberOfMessagesPrepared)
         {
-            if (requestId == null) //legacy support for batches created before operations were introduced
-            {
-                return;
-            }
-
             var summary = GetOrCreate(retryType, requestId);
 
             await summary.PrepareBatch(numberOfMessagesPrepared);
@@ -82,11 +62,6 @@
 
         public async Task Forwarding(string requestId, RetryType retryType)
         {
-            if (requestId == null) //legacy support for batches created before operations were introduced
-            {
-                return;
-            }
-
             var summary = GetOrCreate(retryType, requestId);
 
             await summary.Forwarding();
@@ -94,11 +69,6 @@
 
         public async Task ForwardedBatch(string requestId, RetryType retryType, int numberOfMessagesForwarded)
         {
-            if (requestId == null) //legacy support for batches created before operations were introduced
-            {
-                return;
-            }
-
             var summary = GetOrCreate(retryType, requestId);
 
             await summary.BatchForwarded(numberOfMessagesForwarded);
@@ -106,11 +76,6 @@
 
         public void Fail(RetryType retryType, string requestId)
         {
-            if (requestId == null) //legacy support for batches created before operations were introduced
-            {
-                return;
-            }
-
             var summary = GetOrCreate(retryType, requestId);
 
             summary.Fail();
@@ -118,17 +83,14 @@
 
         public async Task Skip(string requestId, RetryType retryType, int numberOfMessagesSkipped)
         {
-            if (requestId == null) //legacy support for batches created before operations were introduced
-            {
-                return;
-            }
-
             var summary = GetOrCreate(retryType, requestId);
             await summary.Skip(numberOfMessagesSkipped);
         }
 
         InMemoryRetry GetOrCreate(RetryType retryType, string requestId)
         {
+            ArgumentException.ThrowIfNullOrWhiteSpace(requestId);
+
             var key = InMemoryRetry.MakeOperationId(requestId, retryType);
             return retryOperations.GetOrAdd(key, _ => new InMemoryRetry(requestId, retryType, domainEvents, logger));
         }


### PR DESCRIPTION
Two unrelated pieces of long dead code, both on the Raven/recoverability side.

### `FindClrType`

`DatabaseConfiguration.FindClrType` (audit) and
`EmbeddedDatabaseConfiguration.FindClrType` (shared `ServiceControl.RavenDB`)
were never assigned anywhere. Neither had a constructor parameter feeding it,
and no caller set the `init` property, so the delegate was permanently null and
all three consumers were no-op null checks.

Removed:
- the two properties and their now unused `Sparrow.Json` usings
- the `if (configuration.FindClrType != null)` blocks in
  `RavenExternalPersistenceLifecycle` (audit) and `EmbeddedDatabase.Connect`
- the object initializer in the audit `RavenEmbeddedPersistenceLifecycle`

The error instance had no copy of its own but shares `EmbeddedDatabase` and
`EmbeddedDatabaseConfiguration`, so it is covered by the same change. A repo
wide grep for `FindClrType` and `BlittableJsonReaderObject` now returns nothing.

### Legacy retry batch guards

`RetryingManager` had eight copies of:

```csharp
if (requestId == null) //legacy support for batches created before operations were introduced
{
    return;
}
```

added in fb328c1b (Dec 2016, shipped in 1.30.0) for `RetryBatch` documents
written by 1.29 and earlier, before retry operations existed. For one to fire
today, a database would need an in flight batch document written by 1.29 that
survived to 6.19 and the RavenDB 3.5 to 5 to 6 migrations without ever being
staged and forwarded.

Every path into the manager supplies a non-null `requestId`:

| Source | Value | Guarded by |
|---|---|---|
| `StartRetryForSingleMessage` | `uniqueMessageId` | route `{failedMessageId:required:minlength(1)}` |
| `StartRetryForMessageSelection` | `DeterministicGuid.MakeId(...)` | computed |
| `RetryForAllMessages` | `"All"` | constant |
| `RetryForEndpoint` | `endpoint` | `!string.IsNullOrWhiteSpace(message.Endpoint)` |
| `RetryForFailedQueueAddress` | `queueAddress` | route `{queueAddress:required:minlength(1)}` |
| `RetryForFailureGroup` | `groupId` | route `{groupId:required:minlength(1)}` |

The paths that read `RequestId` back out of persistence (`Skip`, `Forwarding`,
`ForwardedBatch` in `RetryProcessor`, `Fail` in `RetryDocumentManager`) only see
values that `CreateBatch` wrote from that same set. Two existing signals agree:
`RetryDocumentManager.RebuildRetryOperationState` already wrapped its call in a
`!string.IsNullOrWhiteSpace` check, and the EF persister declares
`required string RequestId` with `.IsRequired()` and `nullable: false`.

### Why a throw replaces them

Deleting the guards with nothing in their place would not surface a null.
`MakeOperationId` interpolates, so `null` becomes the key `"<RetryType>/"`,
`GetOrCreate` creates an `InMemoryRetry` with a null `RequestId`, and every such
batch collides on that one key while raising domain events with `RequestId =
null`. That is quieter and worse than the old no-op, so `GetOrCreate` now calls
`ArgumentException.ThrowIfNullOrWhiteSpace(requestId)`. All eight methods route
through it, so one line replaces eight guards at the exact point a null would
otherwise become a bogus dictionary key.

`IsOperationInProgressFor` and `GetStatusForRetryOperation` are unchanged: they
are read only `TryGetValue` lookups that never had a guard.

### Behaviour change

Previously a legacy batch would still be forwarded, just without progress
tracking. It will now throw. Given the reachability analysis above this is the
intended trade: fail loudly on a state that cannot legitimately occur.

