### PR TITLE
Removes `RetryHistory.Id`

### DIFF
--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/RetryHistoryDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/RetryHistoryDataStore.cs
@@ -11,10 +11,9 @@
         public async Task<RetryHistory> GetRetryHistory()
         {
             using var session = await sessionProvider.OpenSession();
-            var id = DocumentId;
-            var retryHistory = await session.LoadAsync<RetryHistory>(id);
+            var retryHistory = await session.LoadAsync<RetryHistory>(DocumentId);
 
-            retryHistory ??= new() { Id = DocumentId };
+            retryHistory ??= new();
 
             return retryHistory;
         }
@@ -23,7 +22,7 @@
             string originator, string classifier, bool messageFailed, int numberOfMessagesProcessed, DateTime lastProcessed, int retryHistoryDepth)
         {
             using var session = await sessionProvider.OpenSession();
-            var retryHistory = await session.LoadAsync<RetryHistory>(DocumentId) ?? new() { Id = DocumentId };
+            var retryHistory = await session.LoadAsync<RetryHistory>(DocumentId) ?? new();
 
             retryHistory.AddToUnacknowledged(new UnacknowledgedRetryOperation
             {
@@ -49,7 +48,7 @@
                 NumberOfMessagesProcessed = numberOfMessagesProcessed
             }, retryHistoryDepth);
 
-            await session.StoreAsync(retryHistory);
+            await session.StoreAsync(retryHistory, DocumentId);
             await session.SaveChangesAsync();
         }
 
@@ -61,7 +60,7 @@
             {
                 if (retryHistory.Acknowledge(groupId, RetryType.FailureGroup))
                 {
-                    await session.StoreAsync(retryHistory);
+                    await session.StoreAsync(retryHistory, DocumentId);
                     await session.SaveChangesAsync();
 
                     return true;

--- a/src/ServiceControl.Persistence/RetryHistory.cs
+++ b/src/ServiceControl.Persistence/RetryHistory.cs
@@ -6,7 +6,6 @@
 
     public class RetryHistory
     {
-        public string Id { get; set; }
         public List<HistoricRetryOperation> HistoricOperations { get; set; } = [];
         public List<UnacknowledgedRetryOperation> UnacknowledgedOperations { get; set; } = [];
 


### PR DESCRIPTION
The RavenDB store now passes the document key to `StoreAsync` explicitly rather than stamping it onto the model.

### Why

The property only ever held the constant `"RetryOperations/History"`, the key of the singleton document the retry history lives in. `4966cf21c3` ("move all ravendb specific ID generation into the ravenDB persistence layer") already deleted `RetryHistory.MakeId()` and inlined the string as a private const in the Raven store. The `Id` property was the last piece left behind, and it leaks a document-store concept into a model that the EF Core persisters also have to implement, where there is no document and no key to carry.

### Impact

`GET /api/recoverability/history` no longer returns `id`.
[This](https://github.com/Particular/ServicePulse/pull/3087) PR against ServicePulse ensures we are not using the Id on the frontend code. 