### PR TITLE
Split up sql dialects by consuming store

### DIFF
--- a/docs/error-ingestion-design.md
+++ b/docs/error-ingestion-design.md
@@ -11,7 +11,9 @@ ordinary change-tracked entity saves.
 The unit of ingestion is a **batch**: the transport hands the ingester up to `MaximumConcurrency`
 messages at a time, and the whole batch is written in a single database transaction. The relevant
 types are `EFIngestionUnitOfWork` (accumulation), `FailedMessageBatchWriter` (the write), and the
-per-provider `IIngestionSqlDialect` implementations (the statements that differ by provider).
+per-provider `IFailedMessageIngestionSqlDialect` implementations (the statements that differ by
+provider). Retry claim insertion is a separate persistence capability behind
+`IRetryBatchSqlDialect`; it is used by `RetryBatchStore`, not by the ingestion unit of work.
 
 ## Data model
 
@@ -108,8 +110,8 @@ The order matters: a message that both fails and is retry-confirmed in the same 
 Most of ServiceControl prefers standard abstractions, and the portable parts of this write path do
 use them: the group delete and the retry resolution are ordinary set-based EF operations
 (`ExecuteDelete`/`ExecuteUpdate`). The **upserts** are hand-written SQL, per provider, behind the
-`IIngestionSqlDialect` seam. Three requirements together force that, and no ORM-level API satisfies
-all three at once.
+`IFailedMessageIngestionSqlDialect` seam. Three requirements together force that, and no ORM-level
+API satisfies all three at once.
 
 ### 1. The upsert is a conditional merge, not a save
 
@@ -169,10 +171,14 @@ that the database can cache a plan for, with no per-row round trips and no tempo
 ### What stays portable
 
 Only the genuinely divergent statements are raw. The retry resolution and the group delete are set
-based and identical across providers, so they remain EF operations in the shared writer. The raw
-SQL is confined to the two dialect classes, one per provider, each responsible only for the
-upserts. The guard semantics are kept identical between the two dialects; the shared test suite
-runs every ingestion test against both providers to keep them from drifting.
+based and identical across providers, so they remain EF operations in the shared writer. Failed
+message upserts and insert-if-absent group and endpoint writes are owned by each provider's
+`IFailedMessageIngestionSqlDialect` implementation. Insert-if-absent retry claims belong to the
+separate retry-batch persistence seam, `IRetryBatchSqlDialect`. Provider-local base classes share
+only parameter and transaction plumbing between those capabilities; each capability class still
+owns its SQL and domain semantics. The guard semantics are kept identical between providers, and
+the shared test suite runs every ingestion and retry-batch test against both providers to keep them
+from drifting.
 
 ## Transactions and retries
 

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlDialect.cs
@@ -1,0 +1,57 @@
+namespace ServiceControl.Persistence.EFCore.PostgreSql;
+
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using ServiceControl.Persistence.EFCore.DbContexts;
+
+abstract class PostgreSqlDialect
+{
+    protected static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken)
+    {
+        await using var command = dbContext.Database.GetDbConnection().CreateCommand();
+        command.Transaction = (dbContext.Database.CurrentTransaction
+            ?? throw new InvalidOperationException("Dialect statements must run inside a transaction")).GetDbTransaction();
+        command.CommandText = sql;
+
+        var index = 0;
+        foreach (var row in rows)
+        {
+            foreach (var value in row)
+            {
+                var parameter = command.CreateParameter();
+                parameter.ParameterName = $"@p{index++}";
+                parameter.Value = value ?? DBNull.Value;
+                command.Parameters.Add(parameter);
+            }
+        }
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    protected static string ParameterRows(int rowCount, int columnCount)
+    {
+        var sql = new StringBuilder();
+
+        for (var row = 0; row < rowCount; row++)
+        {
+            sql.Append(row == 0 ? "(" : ",\n(");
+
+            for (var column = 0; column < columnCount; column++)
+            {
+                if (column > 0)
+                {
+                    sql.Append(", ");
+                }
+
+                sql.Append("@p").Append((row * columnCount) + column);
+            }
+
+            sql.Append(')');
+        }
+
+        return sql.ToString();
+    }
+
+    protected const int MaxRowsPerStatement = 50;
+}

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlFailedMessageIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlFailedMessageIngestionSqlDialect.cs
@@ -1,18 +1,16 @@
 namespace ServiceControl.Persistence.EFCore.PostgreSql;
 
 using System.Text;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
-using ServiceControl.MessageFailures;
-using ServiceControl.Persistence.EFCore.DbContexts;
-using ServiceControl.Persistence.EFCore.Entities;
-using ServiceControl.Persistence.EFCore.Infrastructure;
+using MessageFailures;
+using DbContexts;
+using Entities;
+using Infrastructure;
 
 // INSERT ... ON CONFLICT rather than MERGE: PostgreSQL's MERGE can fail with unique_violation
 // when two writers insert the same key concurrently, ON CONFLICT cannot. All references to the
 // target table inside DO UPDATE read the pre-update row, so the guards are consistent within one
 // atomic statement. Rows are chunked to keep statement texts down to a few reusable shapes.
-class PostgreSqlIngestionSqlDialect : IIngestionSqlDialect
+class PostgreSqlFailedMessageIngestionSqlDialect : PostgreSqlDialect, IFailedMessageIngestionSqlDialect
 {
     public async Task UpsertFailedMessages(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageEntity> rows, CancellationToken cancellationToken)
     {
@@ -63,45 +61,6 @@ class PostgreSqlIngestionSqlDialect : IIngestionSqlDialect
                 chunk.Select(endpoint => new object?[] { endpoint.Id, endpoint.Name, endpoint.HostId, endpoint.Host, endpoint.Monitored }),
                 cancellationToken);
         }
-    }
-
-    public async Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken)
-    {
-        foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
-        {
-            await Execute(
-                dbContext,
-                $"""
-                 INSERT INTO failed_message_retries (unique_message_id, retry_batch_id, stage_attempts)
-                 VALUES
-                 {ParameterRows(chunk.Length, 3)}
-                 ON CONFLICT (unique_message_id) DO NOTHING
-                 """,
-                chunk.Select(retry => new object?[] { retry.UniqueMessageId, retry.RetryBatchId, retry.StageAttempts }),
-                cancellationToken);
-        }
-    }
-
-    static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken)
-    {
-        await using var command = dbContext.Database.GetDbConnection().CreateCommand();
-        command.Transaction = (dbContext.Database.CurrentTransaction
-            ?? throw new InvalidOperationException("Ingestion statements must run inside the batch transaction")).GetDbTransaction();
-        command.CommandText = sql;
-
-        var index = 0;
-        foreach (var row in rows)
-        {
-            foreach (var value in row)
-            {
-                var parameter = command.CreateParameter();
-                parameter.ParameterName = $"@p{index++}";
-                parameter.Value = value ?? DBNull.Value;
-                command.Parameters.Add(parameter);
-            }
-        }
-
-        await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     // The columns the newer attempt wins wholesale
@@ -163,30 +122,4 @@ class PostgreSqlIngestionSqlDialect : IIngestionSqlDialect
 
         return sql.ToString();
     }
-
-    static string ParameterRows(int rowCount, int columnCount)
-    {
-        var sql = new StringBuilder();
-
-        for (var row = 0; row < rowCount; row++)
-        {
-            sql.Append(row == 0 ? "(" : ",\n(");
-
-            for (var column = 0; column < columnCount; column++)
-            {
-                if (column > 0)
-                {
-                    sql.Append(", ");
-                }
-
-                sql.Append("@p").Append((row * columnCount) + column);
-            }
-
-            sql.Append(')');
-        }
-
-        return sql.ToString();
-    }
-
-    const int MaxRowsPerStatement = 50;
 }

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlPersistence.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlPersistence.cs
@@ -14,7 +14,8 @@ class PostgreSqlPersistence(PostgreSqlPersisterSettings settings) : BasePersiste
         ConfigureDbContext(services);
         RegisterDataStores(services, settings);
 
-        services.AddSingleton<IIngestionSqlDialect, PostgreSqlIngestionSqlDialect>();
+        services.AddSingleton<IFailedMessageIngestionSqlDialect, PostgreSqlFailedMessageIngestionSqlDialect>();
+        services.AddSingleton<IRetryBatchSqlDialect, PostgreSqlRetryBatchSqlDialect>();
     }
 
     public void AddInstaller(IServiceCollection services)

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlRetryBatchSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlRetryBatchSqlDialect.cs
@@ -1,0 +1,25 @@
+namespace ServiceControl.Persistence.EFCore.PostgreSql;
+
+using DbContexts;
+using Entities;
+using Infrastructure;
+
+class PostgreSqlRetryBatchSqlDialect : PostgreSqlDialect, IRetryBatchSqlDialect
+{
+    public async Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken)
+    {
+        foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
+        {
+            await Execute(
+                dbContext,
+                $"""
+                 INSERT INTO failed_message_retries (unique_message_id, retry_batch_id, stage_attempts)
+                 VALUES
+                 {ParameterRows(chunk.Length, 3)}
+                 ON CONFLICT (unique_message_id) DO NOTHING
+                 """,
+                chunk.Select(retry => new object?[] { retry.UniqueMessageId, retry.RetryBatchId, retry.StageAttempts }),
+                cancellationToken);
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerDialect.cs
@@ -1,0 +1,68 @@
+namespace ServiceControl.Persistence.EFCore.SqlServer;
+
+using System.Data;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using ServiceControl.Persistence.EFCore.DbContexts;
+
+abstract class SqlServerDialect
+{
+    const int MaxSqlParameters = 2100;
+
+    protected static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken)
+    {
+        await using var command = dbContext.Database.GetDbConnection().CreateCommand();
+        command.Transaction = (dbContext.Database.CurrentTransaction
+            ?? throw new InvalidOperationException("Dialect statements must run inside a transaction")).GetDbTransaction();
+        command.CommandText = sql;
+
+        var index = 0;
+        foreach (var row in rows)
+        {
+            foreach (var value in row)
+            {
+                var parameter = command.CreateParameter();
+                parameter.ParameterName = $"@p{index++}";
+                parameter.Value = value ?? DBNull.Value;
+
+                // Attempt de-duplication compares LastAttemptedAt for equality, so datetime
+                // parameters must keep datetime2 precision instead of the datetime default.
+                if (value is DateTime)
+                {
+                    parameter.DbType = DbType.DateTime2;
+                }
+
+                command.Parameters.Add(parameter);
+            }
+        }
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    protected static string ParameterRows(int rowCount, int columnCount)
+    {
+        var sql = new StringBuilder();
+
+        for (var row = 0; row < rowCount; row++)
+        {
+            sql.Append(row == 0 ? "(" : ",\n(");
+
+            for (var column = 0; column < columnCount; column++)
+            {
+                if (column > 0)
+                {
+                    sql.Append(", ");
+                }
+
+                sql.Append("@p").Append((row * columnCount) + column);
+            }
+
+            sql.Append(')');
+        }
+
+        return sql.ToString();
+    }
+
+    protected static int MaxRowsPerStatement(int columns) => MaxSqlParameters/columns;
+}

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerDialect.cs
@@ -8,8 +8,6 @@ using ServiceControl.Persistence.EFCore.DbContexts;
 
 abstract class SqlServerDialect
 {
-    const int MaxSqlParameters = 2100;
-
     protected static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken)
     {
         await using var command = dbContext.Database.GetDbConnection().CreateCommand();
@@ -64,5 +62,6 @@ abstract class SqlServerDialect
         return sql.ToString();
     }
 
-    protected static int MaxRowsPerStatement(int columns) => MaxSqlParameters/columns;
+    protected static int MaxRowsPerStatement(int columns) => MaxSqlParameters / columns;
+    const int MaxSqlParameters = 2100;
 }

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerFailedMessageIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerFailedMessageIngestionSqlDialect.cs
@@ -1,23 +1,21 @@
 namespace ServiceControl.Persistence.EFCore.SqlServer;
 
-using System.Data;
 using System.Text;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
-using ServiceControl.MessageFailures;
-using ServiceControl.Persistence.EFCore.DbContexts;
-using ServiceControl.Persistence.EFCore.Entities;
-using ServiceControl.Persistence.EFCore.Infrastructure;
+using MessageFailures;
+using DbContexts;
+using Entities;
+using Infrastructure;
 
 // MERGE WITH (HOLDLOCK) over an inline VALUES source. HOLDLOCK closes the race where two writers
 // both miss a key and collide on the insert, and the single statement keeps every guard reading
 // the same row state. Rows are chunked to stay clear of the 2100 parameter limit while keeping
 // statement texts down to a few reusable shapes.
-class SqlServerIngestionSqlDialect : IIngestionSqlDialect
+class SqlServerFailedMessageIngestionSqlDialect : SqlServerDialect, IFailedMessageIngestionSqlDialect
 {
     public async Task UpsertFailedMessages(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageEntity> rows, CancellationToken cancellationToken)
     {
-        foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
+        var maxRowsPerStatement = MaxRowsPerStatement(FailedMessageColumns.Length);
+        foreach (var chunk in rows.Chunk(maxRowsPerStatement))
         {
             await Execute(
                 dbContext,
@@ -38,7 +36,8 @@ class SqlServerIngestionSqlDialect : IIngestionSqlDialect
 
     public async Task InsertGroups(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageGroupEntity> rows, CancellationToken cancellationToken)
     {
-        foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
+        var maxRowsPerStatement = MaxRowsPerStatement(4);
+        foreach (var chunk in rows.Chunk(maxRowsPerStatement))
         {
             await Execute(
                 dbContext,
@@ -58,7 +57,8 @@ class SqlServerIngestionSqlDialect : IIngestionSqlDialect
 
     public async Task InsertMissingKnownEndpoints(ServiceControlDbContext dbContext, IReadOnlyList<KnownEndpointEntity> rows, CancellationToken cancellationToken)
     {
-        foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
+        var maxRowsPerStatement = MaxRowsPerStatement(5);
+        foreach (var chunk in rows.Chunk(maxRowsPerStatement))
         {
             await Execute(
                 dbContext,
@@ -74,56 +74,6 @@ class SqlServerIngestionSqlDialect : IIngestionSqlDialect
                 chunk.Select(endpoint => new object?[] { endpoint.Id, endpoint.Name, endpoint.HostId, endpoint.Host, endpoint.Monitored }),
                 cancellationToken);
         }
-    }
-
-    public async Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken)
-    {
-        foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
-        {
-            await Execute(
-                dbContext,
-                $"""
-                 MERGE [FailedMessageRetries] WITH (HOLDLOCK) AS t
-                 USING (VALUES
-                 {ParameterRows(chunk.Length, 3)}
-                 ) AS s ([UniqueMessageId], [RetryBatchId], [StageAttempts])
-                 ON t.[UniqueMessageId] = s.[UniqueMessageId]
-                 WHEN NOT MATCHED THEN INSERT ([UniqueMessageId], [RetryBatchId], [StageAttempts])
-                 VALUES (s.[UniqueMessageId], s.[RetryBatchId], s.[StageAttempts]);
-                 """,
-                chunk.Select(retry => new object?[] { retry.UniqueMessageId, retry.RetryBatchId, retry.StageAttempts }),
-                cancellationToken);
-        }
-    }
-
-    static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken)
-    {
-        await using var command = dbContext.Database.GetDbConnection().CreateCommand();
-        command.Transaction = (dbContext.Database.CurrentTransaction
-            ?? throw new InvalidOperationException("Ingestion statements must run inside the batch transaction")).GetDbTransaction();
-        command.CommandText = sql;
-
-        var index = 0;
-        foreach (var row in rows)
-        {
-            foreach (var value in row)
-            {
-                var parameter = command.CreateParameter();
-                parameter.ParameterName = $"@p{index++}";
-                parameter.Value = value ?? DBNull.Value;
-
-                // Attempt de-duplication compares LastAttemptedAt for equality, so datetime
-                // parameters must keep datetime2 precision instead of the datetime default.
-                if (value is DateTime)
-                {
-                    parameter.DbType = DbType.DateTime2;
-                }
-
-                command.Parameters.Add(parameter);
-            }
-        }
-
-        await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     // The columns the newer attempt wins wholesale
@@ -187,31 +137,4 @@ class SqlServerIngestionSqlDialect : IIngestionSqlDialect
 
         return sql.ToString();
     }
-
-    static string ParameterRows(int rowCount, int columnCount)
-    {
-        var sql = new StringBuilder();
-
-        for (var row = 0; row < rowCount; row++)
-        {
-            sql.Append(row == 0 ? "(" : ",\n(");
-
-            for (var column = 0; column < columnCount; column++)
-            {
-                if (column > 0)
-                {
-                    sql.Append(", ");
-                }
-
-                sql.Append("@p").Append((row * columnCount) + column);
-            }
-
-            sql.Append(')');
-        }
-
-        return sql.ToString();
-    }
-
-    // 27 columns * 50 rows stays well below the 2100 parameter limit
-    const int MaxRowsPerStatement = 50;
 }

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerPersistence.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerPersistence.cs
@@ -14,7 +14,8 @@ class SqlServerPersistence(SqlServerPersisterSettings settings) : BasePersistenc
         ConfigureDbContext(services);
         RegisterDataStores(services, settings);
 
-        services.AddSingleton<IIngestionSqlDialect, SqlServerIngestionSqlDialect>();
+        services.AddSingleton<IFailedMessageIngestionSqlDialect, SqlServerFailedMessageIngestionSqlDialect>();
+        services.AddSingleton<IRetryBatchSqlDialect, SqlServerRetryBatchSqlDialect>();
     }
 
     public void AddInstaller(IServiceCollection services)

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerRetryBatchSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerRetryBatchSqlDialect.cs
@@ -1,0 +1,29 @@
+namespace ServiceControl.Persistence.EFCore.SqlServer;
+
+using DbContexts;
+using Entities;
+using Infrastructure;
+
+class SqlServerRetryBatchSqlDialect : SqlServerDialect, IRetryBatchSqlDialect
+{
+    public async Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken)
+    {
+        var maxRowsPerStatement = MaxRowsPerStatement(3);
+        foreach (var chunk in rows.Chunk(maxRowsPerStatement))
+        {
+            await Execute(
+                dbContext,
+                $"""
+                 MERGE [FailedMessageRetries] WITH (HOLDLOCK) AS t
+                 USING (VALUES
+                 {ParameterRows(chunk.Length, 3)}
+                 ) AS s ([UniqueMessageId], [RetryBatchId], [StageAttempts])
+                 ON t.[UniqueMessageId] = s.[UniqueMessageId]
+                 WHEN NOT MATCHED THEN INSERT ([UniqueMessageId], [RetryBatchId], [StageAttempts])
+                 VALUES (s.[UniqueMessageId], s.[RetryBatchId], s.[StageAttempts]);
+                 """,
+                chunk.Select(retry => new object?[] { retry.UniqueMessageId, retry.RetryBatchId, retry.StageAttempts }),
+                cancellationToken);
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/Implementation/RetryBatchStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/RetryBatchStore.cs
@@ -8,7 +8,7 @@ using ServiceControl.Persistence.EFCore.Entities;
 using ServiceControl.Persistence.EFCore.Infrastructure;
 using ServiceControl.Persistence.Infrastructure;
 
-public class RetryBatchStore(IServiceScopeFactory scopeFactory, IIngestionSqlDialect dialect) : DataStoreBase(scopeFactory), IRetryBatchStore
+public class RetryBatchStore(IServiceScopeFactory scopeFactory, IRetryBatchSqlDialect dialect) : DataStoreBase(scopeFactory), IRetryBatchStore
 {
     public Task<string> CreateBatch(string retrySessionId, string requestId, RetryType retryType,
         string[] failedMessageRetryIds, string originator, DateTime startTime, DateTime? last = null,

--- a/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/EFIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/EFIngestionUnitOfWork.cs
@@ -12,14 +12,14 @@ public class EFIngestionUnitOfWork : IIngestionUnitOfWork
 {
     readonly ServiceControlDbContext dbContext;
     readonly IAsyncDisposable scope;
-    readonly IIngestionSqlDialect dialect;
+    readonly IFailedMessageIngestionSqlDialect dialect;
     readonly TimeProvider timeProvider;
     readonly ConcurrentQueue<RecordedFailedProcessingAttempt> failedProcessingAttempts = new();
     readonly ConcurrentQueue<Task> bodyWrites = new();
     readonly ConcurrentQueue<KnownEndpoint> knownEndpoints = new();
     readonly ConcurrentQueue<Guid> confirmedRetries = new();
 
-    public EFIngestionUnitOfWork(IAsyncDisposable scope, ServiceControlDbContext dbContext, IBodyStoragePersistence storagePersistence, EFPersisterSettings settings, IIngestionSqlDialect dialect, TimeProvider timeProvider)
+    public EFIngestionUnitOfWork(IAsyncDisposable scope, ServiceControlDbContext dbContext, IBodyStoragePersistence storagePersistence, EFPersisterSettings settings, IFailedMessageIngestionSqlDialect dialect, TimeProvider timeProvider)
     {
         this.scope = scope;
         this.dbContext = dbContext;

--- a/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/EFIngestionUnitOfWorkFactory.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/EFIngestionUnitOfWorkFactory.cs
@@ -10,7 +10,7 @@ public class EFIngestionUnitOfWorkFactory(
     IServiceProvider serviceProvider,
     MinimumRequiredStorageState storageState,
     IBodyStoragePersistence storagePersistence,
-    IIngestionSqlDialect dialect,
+    IFailedMessageIngestionSqlDialect dialect,
     TimeProvider timeProvider) : IIngestionUnitOfWorkFactory
 {
     public ValueTask<IIngestionUnitOfWork> StartNew()

--- a/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/FailedMessageBatchWriter.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/FailedMessageBatchWriter.cs
@@ -10,7 +10,7 @@ using ServiceControl.Persistence.EFCore.Infrastructure;
 // differ on (the upserts) come from the injected dialect; everything portable stays here as
 // set-based EF operations. Statement order matters: a message that fails and is retry-confirmed
 // in the same batch must end Resolved.
-class FailedMessageBatchWriter(ServiceControlDbContext dbContext, IIngestionSqlDialect dialect)
+class FailedMessageBatchWriter(ServiceControlDbContext dbContext, IFailedMessageIngestionSqlDialect dialect)
 {
     public async Task Write(
         IReadOnlyCollection<RecordedFailedProcessingAttempt> attempts,

--- a/src/ServiceControl.Persistence.EFCore/Infrastructure/IFailedMessageIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore/Infrastructure/IFailedMessageIngestionSqlDialect.cs
@@ -4,11 +4,12 @@ using ServiceControl.Persistence.EFCore.DbContexts;
 using ServiceControl.Persistence.EFCore.Entities;
 
 /// <summary>
-/// The provider specific SQL of the error ingestion batch. Implementations run on the DbContext
-/// connection inside the transaction the caller has already opened, and every statement must stay
-/// correct under concurrent writers: a same-key race between two instances may not fail the batch.
+/// The provider-specific SQL of the failed-message ingestion batch. Implementations run on the
+/// DbContext connection inside the transaction the caller has already opened, and every statement
+/// must stay correct under concurrent writers: a same-key race between two instances may not fail
+/// the batch.
 /// </summary>
-public interface IIngestionSqlDialect
+public interface IFailedMessageIngestionSqlDialect
 {
     /// <summary>
     /// One row per message, distinct by UniqueMessageId. Inserts new rows; for existing rows the
@@ -27,10 +28,4 @@ public interface IIngestionSqlDialect
     /// Insert if absent, never update: existing endpoints keep their Monitored flag.
     /// </summary>
     Task InsertMissingKnownEndpoints(ServiceControlDbContext dbContext, IReadOnlyList<KnownEndpointEntity> rows, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Insert if absent, never update: a message already claimed stays with the batch that claimed
-    /// it first, so two retry requests covering the same message cannot both stage it.
-    /// </summary>
-    Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken);
 }

--- a/src/ServiceControl.Persistence.EFCore/Infrastructure/IRetryBatchSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore/Infrastructure/IRetryBatchSqlDialect.cs
@@ -1,0 +1,16 @@
+namespace ServiceControl.Persistence.EFCore.Infrastructure;
+
+using ServiceControl.Persistence.EFCore.DbContexts;
+using ServiceControl.Persistence.EFCore.Entities;
+
+/// <summary>
+/// The provider-specific SQL used to claim messages for retry batches.
+/// </summary>
+public interface IRetryBatchSqlDialect
+{
+    /// <summary>
+    /// Insert if absent, never update: a message already claimed stays with the batch that claimed
+    /// it first, so two retry requests covering the same message cannot both stage it.
+    /// </summary>
+    Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken);
+}

--- a/src/ServiceControl.Persistence.Tests/EFCore/FailedMessageIngestionSqlDialectTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/FailedMessageIngestionSqlDialectTests.cs
@@ -11,7 +11,7 @@ using ServiceControl.Persistence.EFCore.DbContexts;
 using ServiceControl.Persistence.EFCore.Entities;
 using ServiceControl.Persistence.EFCore.Infrastructure;
 
-class IngestionSqlDialectTests : ErrorIngestionTestBase
+class FailedMessageIngestionSqlDialectTests : ErrorIngestionTestBase
 {
     [Test]
     public async Task Writes_every_mapped_column_of_a_failed_message()
@@ -84,7 +84,7 @@ class IngestionSqlDialectTests : ErrorIngestionTestBase
     {
         using var scope = ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
-        var dialect = scope.ServiceProvider.GetRequiredService<IIngestionSqlDialect>();
+        var dialect = scope.ServiceProvider.GetRequiredService<IFailedMessageIngestionSqlDialect>();
 
         var strategy = dbContext.Database.CreateExecutionStrategy();
 


### PR DESCRIPTION
This pull request refactors the SQL dialect and ingestion infrastructure for both PostgreSQL and SQL Server providers, separating the logic for failed message ingestion and retry batch persistence into distinct, provider-specific classes. This change clarifies responsibilities, improves maintainability, and enables more granular testing. It also introduces shared base classes for common SQL generation and execution logic.

**Functional changes:** 

* Improved chunking logic in SQL Server dialects to dynamically calculate maximum rows per statement based on SQL parameter limits. [[1]](diffhunk://#diff-a9bc653148370b312edde5b4775760deaa0ff1705ceb5c3f8144862289e7f928L3-R18) [[2]](diffhunk://#diff-a9bc653148370b312edde5b4775760deaa0ff1705ceb5c3f8144862289e7f928L41-R40) [[3]](diffhunk://#diff-a9bc653148370b312edde5b4775760deaa0ff1705ceb5c3f8144862289e7f928L61-R61)

**Refactoring of SQL dialects and ingestion infrastructure:**

* Introduced provider-specific base classes (`PostgreSqlDialect`, `SqlServerDialect`) to encapsulate common SQL parameterization and execution logic, reducing code duplication. [[1]](diffhunk://#diff-38ddff4fe2150162c6fe8171dc7c4fd825aaa1a8a906b23a730c3b8ce3129e97R1-R57) [[2]](diffhunk://#diff-13a89e0905c8a3d7e124f1ea983ea87f912ade28dd255676e0b54c6b6ddfc643R1-R68)
* Split the ingestion SQL dialect interfaces and implementations: 
  - Created `IFailedMessageIngestionSqlDialect` and `IRetryBatchSqlDialect` interfaces, with separate implementations for PostgreSQL (`PostgreSqlFailedMessageIngestionSqlDialect`, `PostgreSqlRetryBatchSqlDialect`) and SQL Server (`SqlServerFailedMessageIngestionSqlDialect`, `SqlServerRetryBatchSqlDialect`). [[1]](diffhunk://#diff-9305d6268219afff2daa46a2140a8a5ba9f3a6b15ca9f39349578fcabc68662eL4-R13) [[2]](diffhunk://#diff-aae3bc7b232dfdbc8bd7458a5570905871e01edaebe995d057512ea4e3646878R1-R25) [[3]](diffhunk://#diff-a9bc653148370b312edde5b4775760deaa0ff1705ceb5c3f8144862289e7f928L3-R18)
  - Updated dependency registrations to use the new interfaces and classes. [[1]](diffhunk://#diff-b5303a6143b7f77bceb62180deeaecd63ea99e0fec6a48fc22bac7960444bc52L17-R18) [[2]](diffhunk://#diff-5fb16514be4052482aa5dc95d8423f88eaf60c7f8c32d4f9dc1b407ec8ad8643L17-R18)
* Removed duplicate code for parameter row generation and SQL execution from the dialect classes, centralizing it in the new base classes. [[1]](diffhunk://#diff-9305d6268219afff2daa46a2140a8a5ba9f3a6b15ca9f39349578fcabc68662eL68-L106) [[2]](diffhunk://#diff-9305d6268219afff2daa46a2140a8a5ba9f3a6b15ca9f39349578fcabc68662eL166-L191) [[3]](diffhunk://#diff-a9bc653148370b312edde5b4775760deaa0ff1705ceb5c3f8144862289e7f928L79-L128) [[4]](diffhunk://#diff-a9bc653148370b312edde5b4775760deaa0ff1705ceb5c3f8144862289e7f928L190-L216)

**Documentation updates:**

* Updated `docs/error-ingestion-design.md` to reflect the new separation of dialect responsibilities, clarifying which classes are responsible for which persistence operations. [[1]](diffhunk://#diff-ecf3487ac3fda561b545a4ef585766cd61775c959a13e0510b23bd34fa8532ebL14-R16) [[2]](diffhunk://#diff-ecf3487ac3fda561b545a4ef585766cd61775c959a13e0510b23bd34fa8532ebL111-R114) [[3]](diffhunk://#diff-ecf3487ac3fda561b545a4ef585766cd61775c959a13e0510b23bd34fa8532ebL172-R181)