### PR TITLE
Remove unused search method

### DIFF
--- a/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
@@ -24,7 +24,4 @@ public class QueueAddressStore(IServiceScopeFactory scopeFactory) : DataStoreBas
 
             return new QueryResult<IList<QueueAddress>>(items, new QueryStatsInfo(eTag, query.Count(), false));
         });
-
-    public Task<QueryResult<IList<QueueAddress>>> GetAddressesBySearchTerm(string search, PagingInfo pagingInfo) =>
-        throw new NotImplementedException();
 }


### PR DESCRIPTION
The GetAddressesBySearchTerm method was removed from `IQueueAddressStore` in #5657, but was overlooked in this implementation. 

This PR removes it.