### PR TITLE
Remove RavenDB specific ID from Notifications persisence contract

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_email_notifications_are_enabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_email_notifications_are_enabled.cs
@@ -64,7 +64,7 @@
         {
             public async Task StartAsync(CancellationToken cancellationToken)
             {
-                using var notificationsManager = await notificationsDataStore.CreateNotificationsManager();
+                await using var notificationsManager = await notificationsDataStore.CreateNotificationsManager();
 
                 var settings = await notificationsManager.LoadSettings();
                 settings.Email.Enabled = true;

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_email_notifications_are_enabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_email_notifications_are_enabled.cs
@@ -67,13 +67,9 @@
                 using var notificationsManager = await notificationsDataStore.CreateNotificationsManager();
 
                 var settings = await notificationsManager.LoadSettings();
-                settings.Email = new EmailNotifications
-                {
-                    Enabled = true,
-                    From = "YouServiceControl@particular.net",
-                    To = "WhoeverMightBeConcerned@particular.net",
-                };
-
+                settings.Email.Enabled = true;
+                settings.Email.From = "YouServiceControl@particular.net";
+                settings.Email.To = "WhoeverMightBeConcerned@particular.net";
                 await notificationsManager.SaveChanges();
             }
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/EditFailedMessagesManager.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/EditFailedMessagesManager.cs
@@ -20,9 +20,10 @@ public class EditFailedMessagesManager : IEditFailedMessagesManager
     public Task SaveChanges() =>
         throw new NotImplementedException();
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         // Nothing to dispose yet
         GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/EditFailedMessagesManager.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/EditFailedMessagesManager.cs
@@ -20,10 +20,5 @@ public class EditFailedMessagesManager : IEditFailedMessagesManager
     public Task SaveChanges() =>
         throw new NotImplementedException();
 
-    public ValueTask DisposeAsync()
-    {
-        // Nothing to dispose yet
-        GC.SuppressFinalize(this);
-        return ValueTask.CompletedTask;
-    }
+    public ValueTask DisposeAsync() => default;
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/NotificationsManager.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/NotificationsManager.cs
@@ -10,10 +10,5 @@ public class NotificationsManager : INotificationsManager
     public Task SaveChanges() =>
         throw new NotImplementedException();
 
-    public ValueTask DisposeAsync()
-    {
-        // Nothing to dispose yet
-        GC.SuppressFinalize(this);
-        return ValueTask.CompletedTask;
-    }
+    public ValueTask DisposeAsync() => default;
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/NotificationsManager.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/NotificationsManager.cs
@@ -4,7 +4,7 @@ using ServiceControl.Notifications;
 
 public class NotificationsManager : INotificationsManager
 {
-    public Task<NotificationsSettings> LoadSettings(TimeSpan? cacheTimeout = null) =>
+    public Task<NotificationsSettings> LoadSettings() =>
         throw new NotImplementedException();
 
     public Task SaveChanges() =>

--- a/src/ServiceControl.Persistence.EFCore/Implementation/NotificationsManager.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/NotificationsManager.cs
@@ -10,9 +10,10 @@ public class NotificationsManager : INotificationsManager
     public Task SaveChanges() =>
         throw new NotImplementedException();
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         // Nothing to dispose yet
         GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/Editing/NotificationSettingsDocument.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Editing/NotificationSettingsDocument.cs
@@ -1,0 +1,9 @@
+namespace ServiceControl.Persistence.RavenDB.Editing;
+
+using Notifications;
+
+class NotificationsSettingsDocument
+{
+    public string Id { get; set; }
+    public EmailNotifications Email { get; set; } = new();
+}

--- a/src/ServiceControl.Persistence.RavenDB/Editing/NotificationsManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Editing/NotificationsManager.cs
@@ -8,11 +8,11 @@
     class NotificationsManager(IAsyncDocumentSession session) : AbstractSessionManager(session), INotificationsManager
     {
         const string SingleDocumentId = "NotificationsSettings/All";
-        static readonly TimeSpan CacheTimeoutDefault = TimeSpan.FromMinutes(5); // Raven requires this to be at least 1 second
+        static readonly TimeSpan CacheTimeout = TimeSpan.FromMinutes(5); // Raven requires this to be at least 1 second
 
-        public async Task<NotificationsSettings> LoadSettings(TimeSpan? cacheTimeout = null)
+        public async Task<NotificationsSettings> LoadSettings()
         {
-            using var aggressivelyCacheFor = await Session.Advanced.DocumentStore.AggressivelyCacheForAsync(cacheTimeout ?? CacheTimeoutDefault);
+            using var aggressivelyCacheFor = await Session.Advanced.DocumentStore.AggressivelyCacheForAsync(CacheTimeout);
             var settings = await Session
                 .LoadAsync<NotificationsSettingsDocument>(SingleDocumentId);
 

--- a/src/ServiceControl.Persistence.RavenDB/Editing/NotificationsManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Editing/NotificationsManager.cs
@@ -14,21 +14,18 @@
         {
             using var aggressivelyCacheFor = await Session.Advanced.DocumentStore.AggressivelyCacheForAsync(cacheTimeout ?? CacheTimeoutDefault);
             var settings = await Session
-                .LoadAsync<NotificationsSettings>(SingleDocumentId);
+                .LoadAsync<NotificationsSettingsDocument>(SingleDocumentId);
 
-            if (settings != null)
+            if (settings == null)
             {
-                return settings;
+                settings = new NotificationsSettingsDocument { Id = SingleDocumentId };
+                await Session.StoreAsync(settings);
             }
 
-            settings = new NotificationsSettings
+            return new NotificationsSettings()
             {
-                Id = SingleDocumentId
+                Email = settings.Email
             };
-
-            await Session.StoreAsync(settings);
-
-            return settings;
         }
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/Transactions/RavenTransactionalDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Transactions/RavenTransactionalDataStore.cs
@@ -8,6 +8,10 @@
         protected IAsyncDocumentSession Session { get; } = session;
 
         public Task SaveChanges() => Session.SaveChangesAsync();
-        public void Dispose() => Session.Dispose();
+        public ValueTask DisposeAsync()
+        {
+            Session.Dispose();
+            return ValueTask.CompletedTask;
+        }
     }
 }

--- a/src/ServiceControl.Persistence.Tests.PostgreSql/ServiceControl.Persistence.Tests.PostgreSql.csproj
+++ b/src/ServiceControl.Persistence.Tests.PostgreSql/ServiceControl.Persistence.Tests.PostgreSql.csproj
@@ -39,6 +39,7 @@
     <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\EndpointsTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\ReportMasksTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\RetryStateTests.cs" />
+    <Compile Remove="..\ServiceControl.Persistence.Tests\NotificationsDataStoreTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Persistence.Tests.SqlServer/ServiceControl.Persistence.Tests.SqlServer.csproj
+++ b/src/ServiceControl.Persistence.Tests.SqlServer/ServiceControl.Persistence.Tests.SqlServer.csproj
@@ -39,6 +39,7 @@
     <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\EndpointsTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\ReportMasksTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\RetryStateTests.cs" />
+    <Compile Remove="..\ServiceControl.Persistence.Tests\NotificationsDataStoreTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Persistence.Tests/NotificationsDataStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/NotificationsDataStoreTests.cs
@@ -1,0 +1,167 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+class NotificationsDataStoreTests : PersistenceTestBase
+{
+    [Test, CancelAfter(30_000)]
+    public async Task LoadSettings_returns_defaults_when_no_settings_exist()
+    {
+        using var manager = await NotificationsStore.CreateNotificationsManager();
+
+        var settings = await manager.LoadSettings();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.Email, Is.Not.Null);
+            Assert.That(settings.Email.Enabled, Is.False);
+            Assert.That(settings.Email.SmtpServer, Is.Null);
+            Assert.That(settings.Email.SmtpPort, Is.Null);
+            Assert.That(settings.Email.EnableTLS, Is.False);
+            Assert.That(settings.Email.From, Is.Null);
+            Assert.That(settings.Email.To, Is.Null);
+            Assert.That(settings.Email.AuthenticationAccount, Is.Null);
+            Assert.That(settings.Email.AuthenticationPassword, Is.Null);
+        }
+    }
+
+    [Test, CancelAfter(30_000)]
+    public async Task SaveChanges_persists_email_settings_round_trip()
+    {
+        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        {
+            var settings = await manager.LoadSettings();
+
+            settings.Email.Enabled = true;
+            settings.Email.SmtpServer = "smtp.example.com";
+            settings.Email.SmtpPort = 587;
+            settings.Email.EnableTLS = true;
+            settings.Email.From = "sc@example.com";
+            settings.Email.To = "ops@example.com";
+            settings.Email.AuthenticationAccount = "user";
+            settings.Email.AuthenticationPassword = "p@ssw0rd";
+
+            await manager.SaveChanges();
+        }
+
+        await CompleteDatabaseOperation();
+
+        using var verifyManager = await NotificationsStore.CreateNotificationsManager();
+        var loaded = await verifyManager.LoadSettings();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(loaded.Email.Enabled, Is.True);
+            Assert.That(loaded.Email.SmtpServer, Is.EqualTo("smtp.example.com"));
+            Assert.That(loaded.Email.SmtpPort, Is.EqualTo(587));
+            Assert.That(loaded.Email.EnableTLS, Is.True);
+            Assert.That(loaded.Email.From, Is.EqualTo("sc@example.com"));
+            Assert.That(loaded.Email.To, Is.EqualTo("ops@example.com"));
+            Assert.That(loaded.Email.AuthenticationAccount, Is.EqualTo("user"));
+            Assert.That(loaded.Email.AuthenticationPassword, Is.EqualTo("p@ssw0rd"));
+        }
+    }
+
+    [Test, CancelAfter(30_000)]
+    public async Task Toggling_enabled_is_persisted()
+    {
+        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        {
+            var settings = await manager.LoadSettings();
+            settings.Email.Enabled = true;
+            await manager.SaveChanges();
+        }
+
+        await CompleteDatabaseOperation();
+
+        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        {
+            var settings = await manager.LoadSettings();
+            Assert.That(settings.Email.Enabled, Is.True);
+
+            settings.Email.Enabled = false;
+            await manager.SaveChanges();
+        }
+
+        await CompleteDatabaseOperation();
+
+        using var verifyManager = await NotificationsStore.CreateNotificationsManager();
+        var final = await verifyManager.LoadSettings();
+        Assert.That(final.Email.Enabled, Is.False);
+    }
+
+    [Test, CancelAfter(30_000)]
+    public async Task LoadSettings_returns_previously_saved_settings()
+    {
+        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        {
+            var settings = await manager.LoadSettings();
+            settings.Email.SmtpServer = "configured.server";
+            settings.Email.SmtpPort = 2525;
+            await manager.SaveChanges();
+        }
+
+        await CompleteDatabaseOperation();
+
+        using var manager2 = await NotificationsStore.CreateNotificationsManager();
+        var loaded = await manager2.LoadSettings();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(loaded.Email.SmtpServer, Is.EqualTo("configured.server"));
+            Assert.That(loaded.Email.SmtpPort, Is.EqualTo(2525));
+            // Untouched fields keep their defaults
+            Assert.That(loaded.Email.Enabled, Is.False);
+            Assert.That(loaded.Email.EnableTLS, Is.False);
+        }
+    }
+
+    [Test, CancelAfter(30_000)]
+    public async Task Updating_individual_fields_preserves_others()
+    {
+        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        {
+            var settings = await manager.LoadSettings();
+            settings.Email.Enabled = true;
+            settings.Email.SmtpServer = "original.smtp";
+            settings.Email.SmtpPort = 25;
+            settings.Email.EnableTLS = false;
+            settings.Email.From = "from@orig";
+            settings.Email.To = "to@orig";
+            settings.Email.AuthenticationAccount = "acct";
+            settings.Email.AuthenticationPassword = "secret";
+            await manager.SaveChanges();
+        }
+
+        await CompleteDatabaseOperation();
+
+        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        {
+            var settings = await manager.LoadSettings();
+            settings.Email.SmtpServer = "updated.smtp";
+            settings.Email.EnableTLS = true;
+            await manager.SaveChanges();
+        }
+
+        await CompleteDatabaseOperation();
+
+        using var verifyManager = await NotificationsStore.CreateNotificationsManager();
+        var loaded = await verifyManager.LoadSettings();
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Updated fields
+            Assert.That(loaded.Email.SmtpServer, Is.EqualTo("updated.smtp"));
+            Assert.That(loaded.Email.EnableTLS, Is.True);
+            // Preserved fields
+            Assert.That(loaded.Email.Enabled, Is.True);
+            Assert.That(loaded.Email.SmtpPort, Is.EqualTo(25));
+            Assert.That(loaded.Email.From, Is.EqualTo("from@orig"));
+            Assert.That(loaded.Email.To, Is.EqualTo("to@orig"));
+            Assert.That(loaded.Email.AuthenticationAccount, Is.EqualTo("acct"));
+            Assert.That(loaded.Email.AuthenticationPassword, Is.EqualTo("secret"));
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.Tests/NotificationsDataStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/NotificationsDataStoreTests.cs
@@ -8,7 +8,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
     [Test, CancelAfter(30_000)]
     public async Task LoadSettings_returns_defaults_when_no_settings_exist()
     {
-        using var manager = await NotificationsStore.CreateNotificationsManager();
+        await using var manager = await NotificationsStore.CreateNotificationsManager();
 
         var settings = await manager.LoadSettings();
 
@@ -30,7 +30,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
     [Test, CancelAfter(30_000)]
     public async Task SaveChanges_persists_email_settings_round_trip()
     {
-        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        await using (var manager = await NotificationsStore.CreateNotificationsManager())
         {
             var settings = await manager.LoadSettings();
 
@@ -48,7 +48,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
 
         await CompleteDatabaseOperation();
 
-        using var verifyManager = await NotificationsStore.CreateNotificationsManager();
+        await using var verifyManager = await NotificationsStore.CreateNotificationsManager();
         var loaded = await verifyManager.LoadSettings();
 
         using (Assert.EnterMultipleScope())
@@ -67,7 +67,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
     [Test, CancelAfter(30_000)]
     public async Task Toggling_enabled_is_persisted()
     {
-        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        await using (var manager = await NotificationsStore.CreateNotificationsManager())
         {
             var settings = await manager.LoadSettings();
             settings.Email.Enabled = true;
@@ -76,7 +76,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
 
         await CompleteDatabaseOperation();
 
-        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        await using (var manager = await NotificationsStore.CreateNotificationsManager())
         {
             var settings = await manager.LoadSettings();
             Assert.That(settings.Email.Enabled, Is.True);
@@ -87,7 +87,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
 
         await CompleteDatabaseOperation();
 
-        using var verifyManager = await NotificationsStore.CreateNotificationsManager();
+        await using var verifyManager = await NotificationsStore.CreateNotificationsManager();
         var final = await verifyManager.LoadSettings();
         Assert.That(final.Email.Enabled, Is.False);
     }
@@ -95,7 +95,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
     [Test, CancelAfter(30_000)]
     public async Task LoadSettings_returns_previously_saved_settings()
     {
-        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        await using (var manager = await NotificationsStore.CreateNotificationsManager())
         {
             var settings = await manager.LoadSettings();
             settings.Email.SmtpServer = "configured.server";
@@ -105,7 +105,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
 
         await CompleteDatabaseOperation();
 
-        using var manager2 = await NotificationsStore.CreateNotificationsManager();
+        await using var manager2 = await NotificationsStore.CreateNotificationsManager();
         var loaded = await manager2.LoadSettings();
 
         using (Assert.EnterMultipleScope())
@@ -121,7 +121,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
     [Test, CancelAfter(30_000)]
     public async Task Updating_individual_fields_preserves_others()
     {
-        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        await using (var manager = await NotificationsStore.CreateNotificationsManager())
         {
             var settings = await manager.LoadSettings();
             settings.Email.Enabled = true;
@@ -137,7 +137,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
 
         await CompleteDatabaseOperation();
 
-        using (var manager = await NotificationsStore.CreateNotificationsManager())
+        await using (var manager = await NotificationsStore.CreateNotificationsManager())
         {
             var settings = await manager.LoadSettings();
             settings.Email.SmtpServer = "updated.smtp";
@@ -147,7 +147,7 @@ class NotificationsDataStoreTests : PersistenceTestBase
 
         await CompleteDatabaseOperation();
 
-        using var verifyManager = await NotificationsStore.CreateNotificationsManager();
+        await using var verifyManager = await NotificationsStore.CreateNotificationsManager();
         var loaded = await verifyManager.LoadSettings();
 
         using (Assert.EnterMultipleScope())

--- a/src/ServiceControl.Persistence.Tests/Recoverability/EditMessageTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/EditMessageTests.cs
@@ -76,7 +76,7 @@
 
             _ = await CreateAndStoreFailedMessage(failedMessageId);
 
-            using (var editFailedMessagesManager = await EditFailedMessagesStore.CreateEditFailedMessageManager())
+            await using (var editFailedMessagesManager = await EditFailedMessagesStore.CreateEditFailedMessageManager())
             {
                 _ = await editFailedMessagesManager.GetFailedMessage(failedMessageId);
                 await editFailedMessagesManager.SetCurrentEditingRequestId(previousEdit);
@@ -88,7 +88,7 @@
             // Act
             await handler.Handle(message, new TestableMessageHandlerContext());
 
-            using (var editFailedMessagesManagerAssert = await EditFailedMessagesStore.CreateEditFailedMessageManager())
+            await using (var editFailedMessagesManagerAssert = await EditFailedMessagesStore.CreateEditFailedMessageManager())
             {
                 var failedMessage = await editFailedMessagesManagerAssert.GetFailedMessage(failedMessageId);
                 var editId = await editFailedMessagesManagerAssert.GetCurrentEditingRequestId(failedMessageId);
@@ -125,18 +125,16 @@
                 Assert.That(dispatchedMessage.Item1.Message.Headers["someKey"], Is.EqualTo("someValue"));
             }
 
-            using (var x = await EditFailedMessagesStore.CreateEditFailedMessageManager())
+            await using var x = await EditFailedMessagesStore.CreateEditFailedMessageManager();
+            var failedMessage2 = await x.GetFailedMessage(failedMessage.UniqueMessageId);
+            Assert.That(failedMessage2, Is.Not.Null, "Edited failed message");
+
+            var editId = await x.GetCurrentEditingRequestId(failedMessage2.UniqueMessageId);
+
+            using (Assert.EnterMultipleScope())
             {
-                var failedMessage2 = await x.GetFailedMessage(failedMessage.UniqueMessageId);
-                Assert.That(failedMessage2, Is.Not.Null, "Edited failed message");
-
-                var editId = await x.GetCurrentEditingRequestId(failedMessage2.UniqueMessageId);
-
-                using (Assert.EnterMultipleScope())
-                {
-                    Assert.That(failedMessage2.Status, Is.EqualTo(FailedMessageStatus.Resolved), "Failed message status");
-                    Assert.That(editId, Is.EqualTo(handlerContent.MessageId), "MessageId");
-                }
+                Assert.That(failedMessage2.Status, Is.EqualTo(FailedMessageStatus.Resolved), "Failed message status");
+                Assert.That(editId, Is.EqualTo(handlerContent.MessageId), "MessageId");
             }
         }
 

--- a/src/ServiceControl.Persistence/IDataSessionManager.cs
+++ b/src/ServiceControl.Persistence/IDataSessionManager.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Threading.Tasks;
 
-    public interface IDataSessionManager : IDisposable
+    public interface IDataSessionManager : IAsyncDisposable
     {
         Task SaveChanges();
     }

--- a/src/ServiceControl.Persistence/INotificationsManager.cs
+++ b/src/ServiceControl.Persistence/INotificationsManager.cs
@@ -1,11 +1,10 @@
 ﻿namespace ServiceControl.Persistence
 {
-    using System;
     using System.Threading.Tasks;
     using Notifications;
 
     public interface INotificationsManager : IDataSessionManager
     {
-        Task<NotificationsSettings> LoadSettings(TimeSpan? cacheTimeout = null);
+        Task<NotificationsSettings> LoadSettings();
     }
 }

--- a/src/ServiceControl.Persistence/NotificationsSettings.cs
+++ b/src/ServiceControl.Persistence/NotificationsSettings.cs
@@ -2,8 +2,6 @@
 {
     public class NotificationsSettings
     {
-        public string Id { get; set; }
-
         public EmailNotifications Email { get; set; } = new EmailNotifications();
     }
 }

--- a/src/ServiceControl.Persistence/NotificationsSettings.cs
+++ b/src/ServiceControl.Persistence/NotificationsSettings.cs
@@ -2,6 +2,6 @@
 {
     public class NotificationsSettings
     {
-        public EmailNotifications Email { get; set; } = new EmailNotifications();
+        public EmailNotifications Email { get; init; } = new EmailNotifications();
     }
 }

--- a/src/ServiceControl.UnitTests/MessageFailures/EditFailedMessagesControllerAuditTests.cs
+++ b/src/ServiceControl.UnitTests/MessageFailures/EditFailedMessagesControllerAuditTests.cs
@@ -48,15 +48,13 @@ public class EditFailedMessagesControllerAuditTests
     {
         public string? CurrentEditingRequestId { get; set; }
 
-        public void Dispose()
-        {
-        }
-
         public Task SaveChanges() => Task.CompletedTask;
         public Task<FailedMessage?> GetFailedMessage(string failedMessageId) => Task.FromResult<FailedMessage?>(null);
         public Task<string?> GetCurrentEditingRequestId(string failedMessageId) => Task.FromResult(CurrentEditingRequestId);
         public Task SetCurrentEditingRequestId(string editingMessageId) => Task.CompletedTask;
         public Task SetFailedMessageAsResolved() => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     sealed class StubErrorMessageDataStore : IFailedMessageQueryDataStore, IEditFailedMessagesDataStore

--- a/src/ServiceControl/Notifications/Api/NotificationsController.cs
+++ b/src/ServiceControl/Notifications/Api/NotificationsController.cs
@@ -19,7 +19,7 @@
         [HttpGet]
         public async Task<EmailNotifications> GetEmailNotificationsSettings()
         {
-            using var manager = await store.CreateNotificationsManager();
+            await using var manager = await store.CreateNotificationsManager();
             var notificationsSettings = await manager.LoadSettings();
 
             return notificationsSettings.Email;
@@ -30,7 +30,7 @@
         [HttpPost]
         public async Task<IActionResult> ToggleEmailNotifications(ToggleEmailNotifications request)
         {
-            using var manager = await store.CreateNotificationsManager();
+            await using var manager = await store.CreateNotificationsManager();
             var notificationsSettings = await manager.LoadSettings();
 
             notificationsSettings.Email.Enabled = request.Enabled;
@@ -45,7 +45,7 @@
         [HttpPost]
         public async Task<IActionResult> UpdateSettings(UpdateEmailNotificationsSettingsRequest request)
         {
-            using var manager = await store.CreateNotificationsManager();
+            await using var manager = await store.CreateNotificationsManager();
             var notificationsSettings = await manager.LoadSettings();
 
             var emailSettings = notificationsSettings.Email;
@@ -70,7 +70,7 @@
         [HttpPost]
         public async Task<IActionResult> SendTestEmail()
         {
-            using var manager = await store.CreateNotificationsManager();
+            await using var manager = await store.CreateNotificationsManager();
             var notificationsSettings = await manager.LoadSettings();
 
             try

--- a/src/ServiceControl/Notifications/Email/SendEmailNotificationHandler.cs
+++ b/src/ServiceControl/Notifications/Email/SendEmailNotificationHandler.cs
@@ -18,7 +18,7 @@
 
             await using (var manager = await store.CreateNotificationsManager())
             {
-                notifications = await manager.LoadSettings(cacheTimeout);
+                notifications = await manager.LoadSettings();
             }
 
             logger.LogInformation("Processing email notification. Subject: {Subject}, Body: {Body}", message.Subject, message.Body);
@@ -85,7 +85,6 @@
 
         static readonly TimeSpan spinDelay = TimeSpan.FromSeconds(1);
         static readonly TimeSpan throttlingDelay = TimeSpan.FromSeconds(30);
-        static readonly TimeSpan cacheTimeout = TimeSpan.FromMinutes(5);
 
         public static RecoverabilityAction RecoverabilityPolicy(RecoverabilityConfig config, ErrorContext context)
         {

--- a/src/ServiceControl/Notifications/Email/SendEmailNotificationHandler.cs
+++ b/src/ServiceControl/Notifications/Email/SendEmailNotificationHandler.cs
@@ -16,7 +16,7 @@
         {
             NotificationsSettings notifications;
 
-            using (var manager = await store.CreateNotificationsManager())
+            await using (var manager = await store.CreateNotificationsManager())
             {
                 notifications = await manager.LoadSettings(cacheTimeout);
             }

--- a/src/ServiceControl/Recoverability/Editing/EditHandler.cs
+++ b/src/ServiceControl/Recoverability/Editing/EditHandler.cs
@@ -24,7 +24,7 @@
         {
             FailedMessage failedMessage;
             string editId;
-            using (var session = await store.CreateEditFailedMessageManager())
+            await using (var session = await store.CreateEditFailedMessageManager())
             {
                 failedMessage = await session.GetFailedMessage(message.FailedMessageId);
 


### PR DESCRIPTION
**Description**

The current Notifications data store is stored as a singleton document in RavenDB, and is returned directly from the INotificationsManager. The Id field on this document is not used or relevant to consumers of this interface.

To remove this field from the contract this change implements a new internal class for Raven to persist, and removes the ID field from the returned object.

**Testing Improvements:**

* Added a new test class `NotificationsDataStoreTests` with comprehensive tests to verify default values, round-trip persistence, field updates, and field preservation for notification settings. (`src/ServiceControl.Persistence.Tests/NotificationsDataStoreTests.cs`)
* Removed inclusion of the new test file from SQL Server and PostgreSQL test project files as they will be implemented in a future change.