### PR TITLE
Implement the EF licensing data store

### DIFF
--- a/src/Particular.LicensingComponent.Persistence/ThroughputReporting.cs
+++ b/src/Particular.LicensingComponent.Persistence/ThroughputReporting.cs
@@ -1,0 +1,10 @@
+namespace Particular.LicensingComponent.Persistence;
+
+public static class ThroughputReporting
+{
+    /// <summary>
+    /// How far back a throughput report reaches. Throughput reads are filtered to this window, so it
+    /// has to be the same wherever <see cref="ILicensingDataStore"/> is implemented.
+    /// </summary>
+    public const int ReportedMonths = 14;
+}

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260807053832_AddLicensingThroughput.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260807053832_AddLicensingThroughput.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ServiceControl.Persistence.EFCore.PostgreSql;
@@ -12,9 +13,11 @@ using ServiceControl.Persistence.EFCore.PostgreSql;
 namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
 {
     [DbContext(typeof(PostgreSqlServiceControlDbContext))]
-    partial class PostgreSqlServiceControlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260807053832_AddLicensingThroughput")]
+    partial class AddLicensingThroughput
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260807053832_AddLicensingThroughput.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260807053832_AddLicensingThroughput.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLicensingThroughput : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "licensing_endpoints",
+                columns: table => new
+                {
+                    normalized_name = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    throughput_source = table.Column<int>(type: "integer", nullable: false),
+                    name = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    sanitized_name = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    normalized_sanitized_name = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    user_indicator = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    scope = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    endpoint_indicators = table.Column<List<string>>(type: "text[]", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_licensing_endpoints", x => new { x.normalized_name, x.throughput_source });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "licensing_endpoint_throughput",
+                columns: table => new
+                {
+                    normalized_name = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    throughput_source = table.Column<int>(type: "integer", nullable: false),
+                    date_utc = table.Column<DateOnly>(type: "date", nullable: false),
+                    message_count = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_licensing_endpoint_throughput", x => new { x.normalized_name, x.throughput_source, x.date_utc });
+                    table.ForeignKey(
+                        name: "fk_licensing_endpoint_throughput_licensing_endpoints_normalize",
+                        columns: x => new { x.normalized_name, x.throughput_source },
+                        principalTable: "licensing_endpoints",
+                        principalColumns: new[] { "normalized_name", "throughput_source" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_licensing_endpoint_throughput_date_utc",
+                table: "licensing_endpoint_throughput",
+                column: "date_utc");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_licensing_endpoints_normalized_sanitized_name",
+                table: "licensing_endpoints",
+                column: "normalized_sanitized_name");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "licensing_endpoint_throughput");
+
+            migrationBuilder.DropTable(
+                name: "licensing_endpoints");
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260807053830_AddLicensingThroughput.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260807053830_AddLicensingThroughput.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ServiceControl.Persistence.EFCore.SqlServer;
 
@@ -11,9 +12,11 @@ using ServiceControl.Persistence.EFCore.SqlServer;
 namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
 {
     [DbContext(typeof(SqlServerServiceControlDbContext))]
-    partial class SqlServerServiceControlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260807053830_AddLicensingThroughput")]
+    partial class AddLicensingThroughput
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260807053830_AddLicensingThroughput.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260807053830_AddLicensingThroughput.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLicensingThroughput : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LicensingEndpoints",
+                columns: table => new
+                {
+                    NormalizedName = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: false),
+                    ThroughputSource = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: false),
+                    SanitizedName = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    NormalizedSanitizedName = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    UserIndicator = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    Scope = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true),
+                    EndpointIndicators = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LicensingEndpoints", x => new { x.NormalizedName, x.ThroughputSource });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LicensingEndpointThroughput",
+                columns: table => new
+                {
+                    NormalizedName = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: false),
+                    ThroughputSource = table.Column<int>(type: "int", nullable: false),
+                    DateUtc = table.Column<DateOnly>(type: "date", nullable: false),
+                    MessageCount = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LicensingEndpointThroughput", x => new { x.NormalizedName, x.ThroughputSource, x.DateUtc });
+                    table.ForeignKey(
+                        name: "FK_LicensingEndpointThroughput_LicensingEndpoints_NormalizedName_ThroughputSource",
+                        columns: x => new { x.NormalizedName, x.ThroughputSource },
+                        principalTable: "LicensingEndpoints",
+                        principalColumns: new[] { "NormalizedName", "ThroughputSource" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LicensingEndpoints_NormalizedSanitizedName",
+                table: "LicensingEndpoints",
+                column: "NormalizedSanitizedName");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LicensingEndpointThroughput_DateUtc",
+                table: "LicensingEndpointThroughput",
+                column: "DateUtc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LicensingEndpointThroughput");
+
+            migrationBuilder.DropTable(
+                name: "LicensingEndpoints");
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/DbContexts/ServiceControlDbContext.cs
+++ b/src/ServiceControl.Persistence.EFCore/DbContexts/ServiceControlDbContext.cs
@@ -23,6 +23,8 @@ public abstract class ServiceControlDbContext(DbContextOptions options) : DbCont
     public DbSet<HistoricRetryOperationEntity> HistoricRetryOperations { get; set; }
     public DbSet<UnacknowledgedRetryOperationEntity> UnacknowledgedRetryOperations { get; set; }
     public DbSet<ArchiveOperationEntity> ArchiveOperations { get; set; }
+    public DbSet<LicensingEndpointEntity> LicensingEndpoints { get; set; }
+    public DbSet<LicensingEndpointThroughputEntity> LicensingEndpointThroughput { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         => optionsBuilder.EnableDetailedErrors();
@@ -48,6 +50,8 @@ public abstract class ServiceControlDbContext(DbContextOptions options) : DbCont
         modelBuilder.ApplyConfiguration(new HistoricRetryOperationConfiguration());
         modelBuilder.ApplyConfiguration(new UnacknowledgedRetryOperationConfiguration());
         modelBuilder.ApplyConfiguration(new ArchiveOperationConfiguration());
+        modelBuilder.ApplyConfiguration(new LicensingEndpointConfiguration());
+        modelBuilder.ApplyConfiguration(new LicensingEndpointThroughputConfiguration());
     }
 
     public abstract bool IsDuplicateKeyException(DbUpdateException exception);

--- a/src/ServiceControl.Persistence.EFCore/Entities/LicensingEndpointEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/LicensingEndpointEntity.cs
@@ -1,0 +1,22 @@
+namespace ServiceControl.Persistence.EFCore.Entities;
+
+using Particular.LicensingComponent.Contracts;
+
+public class LicensingEndpointEntity
+{
+    public required string NormalizedName { get; set; }
+
+    public ThroughputSource ThroughputSource { get; set; }
+
+    public required string Name { get; set; }
+
+    public required string SanitizedName { get; set; }
+
+    public required string NormalizedSanitizedName { get; set; }
+
+    public string UserIndicator { get; set; } = string.Empty;
+
+    public string? Scope { get; set; }
+
+    public List<string> EndpointIndicators { get; set; } = [];
+}

--- a/src/ServiceControl.Persistence.EFCore/Entities/LicensingEndpointThroughputEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/LicensingEndpointThroughputEntity.cs
@@ -1,0 +1,14 @@
+namespace ServiceControl.Persistence.EFCore.Entities;
+
+using Particular.LicensingComponent.Contracts;
+
+public class LicensingEndpointThroughputEntity
+{
+    public required string NormalizedName { get; set; }
+
+    public ThroughputSource ThroughputSource { get; set; }
+
+    public DateOnly DateUtc { get; set; }
+
+    public long MessageCount { get; set; }
+}

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/ColumnLengths.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/ColumnLengths.cs
@@ -17,4 +17,10 @@ static class ColumnLengths
     // put it over SQL Server's 900 byte limit. 800 + 4 fits, with room for the queue addresses that
     // ByQueueAddress retries use as their request id.
     public const int RetryRequestIdLength = 400;
+
+    // Applies to both the licensing endpoint name and the normalized name computed from it, which
+    // therefore has to hold anything the name can. The key is this column plus the ThroughputSource
+    // int, and the throughput key adds a date on top, so ShortTextLength would exceed SQL Server's
+    // 900 byte index key limit.
+    public const int LicensingEndpointNameLength = 300;
 }

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/LicensingEndpointConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/LicensingEndpointConfiguration.cs
@@ -1,0 +1,22 @@
+namespace ServiceControl.Persistence.EFCore.EntityConfigurations;
+
+using Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+class LicensingEndpointConfiguration : IEntityTypeConfiguration<LicensingEndpointEntity>
+{
+    public void Configure(EntityTypeBuilder<LicensingEndpointEntity> builder)
+    {
+        builder.HasKey(e => new { e.NormalizedName, e.ThroughputSource });
+        builder.Property(e => e.NormalizedName).HasMaxLength(ColumnLengths.LicensingEndpointNameLength);
+        builder.Property(e => e.Name).IsRequired().HasMaxLength(ColumnLengths.LicensingEndpointNameLength);
+        builder.Property(e => e.SanitizedName).IsRequired().HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.NormalizedSanitizedName).IsRequired().HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.UserIndicator).IsRequired().HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.Scope).HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.EndpointIndicators).IsRequired();
+
+        builder.HasIndex(e => e.NormalizedSanitizedName);
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/LicensingEndpointThroughputConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/LicensingEndpointThroughputConfiguration.cs
@@ -1,0 +1,20 @@
+namespace ServiceControl.Persistence.EFCore.EntityConfigurations;
+
+using Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+class LicensingEndpointThroughputConfiguration : IEntityTypeConfiguration<LicensingEndpointThroughputEntity>
+{
+    public void Configure(EntityTypeBuilder<LicensingEndpointThroughputEntity> builder)
+    {
+        builder.HasKey(e => new { e.NormalizedName, e.ThroughputSource, e.DateUtc });
+        builder.Property(e => e.NormalizedName).HasMaxLength(ColumnLengths.LicensingEndpointNameLength);
+        builder.HasOne<LicensingEndpointEntity>()
+            .WithMany()
+            .HasForeignKey(e => new { e.NormalizedName, e.ThroughputSource })
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(e => e.DateUtc);
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/Implementation/LicensingDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/LicensingDataStore.cs
@@ -1,23 +1,362 @@
+namespace ServiceControl.Persistence.EFCore.Implementation;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Particular.LicensingComponent.Contracts;
 using Particular.LicensingComponent.Persistence;
+using ServiceControl.Persistence.EFCore.DbContexts;
+using ServiceControl.Persistence.EFCore.Entities;
+using ServiceControl.Persistence.EFCore.Infrastructure;
 
-class LicensingDataStore : ILicensingDataStore
+class LicensingDataStore(IServiceScopeFactory scopeFactory, TimeProvider timeProvider) : DataStoreBase(scopeFactory), ILicensingDataStore
 {
-    public Task<IEnumerable<Particular.LicensingComponent.Contracts.Endpoint>> GetAllEndpoints(bool includePlatformEndpoints, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task<AuditServiceMetadata> GetAuditServiceMetadata(CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public Task<BrokerMetadata> GetBrokerMetadata(CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task<Particular.LicensingComponent.Contracts.Endpoint?> GetEndpoint(EndpointIdentifier id, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public Task<IEnumerable<(EndpointIdentifier Id, Particular.LicensingComponent.Contracts.Endpoint? Endpoint)>> GetEndpoints(IList<EndpointIdentifier> endpointIds, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task<IDictionary<string, IEnumerable<ThroughputData>>> GetEndpointThroughputByQueueName(IList<string> queueNames, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task<LicensedEndpointDetails?> GetLicensedEndpointDetails(CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task<List<string>> GetReportMasks(CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task<bool> IsThereThroughputForLastXDays(int days, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task<bool> IsThereThroughputForLastXDaysForSource(int days, ThroughputSource throughputSource, bool includeToday, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task RecordEndpointThroughput(string endpointName, ThroughputSource throughputSource, IList<EndpointDailyThroughput> throughput, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task SaveAuditServiceMetadata(AuditServiceMetadata auditServiceMetadata, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task SaveBrokerMetadata(BrokerMetadata brokerMetadata, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task SaveEndpoint(Particular.LicensingComponent.Contracts.Endpoint endpoint, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task SaveLicensedEndpointDetails(LicensedEndpointDetails result, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task SaveReportMasks(List<string> reportMasks, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public Task UpdateUserIndicatorOnEndpoints(List<UpdateUserIndicator> userIndicatorUpdates, CancellationToken cancellationToken) => throw new NotImplementedException();
+    // A report covers the last 14 months, so older throughput is never read.
+    const int ReportedMonths = 14;
+    const int MaxRecordAttempts = 5;
+
+    static readonly string PlatformEndpointIndicator = EndpointIndicator.PlatformEndpoint.ToString();
+    static readonly AuditServiceMetadata DefaultAuditServiceMetadata = new([], []);
+    static readonly BrokerMetadata DefaultBrokerMetadata = new(null, []);
+
+    public Task<IEnumerable<Endpoint>> GetAllEndpoints(bool includePlatformEndpoints, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(async context =>
+        {
+            var query = context.LicensingEndpoints.AsNoTracking();
+
+            if (!includePlatformEndpoints)
+            {
+                query = query.Where(endpoint => !endpoint.EndpointIndicators.Contains(PlatformEndpointIndicator));
+            }
+
+            var rows = await query.ToListAsync(cancellationToken);
+
+            return rows.Select(ToEndpoint);
+        });
+
+    public Task<Endpoint?> GetEndpoint(EndpointIdentifier id, CancellationToken cancellationToken = default) =>
+        ExecuteWithDbContext(async context =>
+        {
+            var normalizedName = Normalize(id.Name);
+
+            var row = await context.LicensingEndpoints
+                .AsNoTracking()
+                .Where(endpoint => endpoint.NormalizedName == normalizedName && endpoint.ThroughputSource == id.ThroughputSource)
+                .Select(endpoint => new
+                {
+                    Endpoint = endpoint,
+                    LastCollectedDate = context.LicensingEndpointThroughput
+                        .Where(row => row.NormalizedName == endpoint.NormalizedName && row.ThroughputSource == endpoint.ThroughputSource)
+                        .Max<LicensingEndpointThroughputEntity, DateOnly?>(row => row.DateUtc)
+                })
+                .SingleOrDefaultAsync(cancellationToken);
+
+            return row is null ? null : ToEndpoint(row.Endpoint, row.LastCollectedDate);
+        });
+
+    public Task<IEnumerable<(EndpointIdentifier Id, Endpoint? Endpoint)>> GetEndpoints(IList<EndpointIdentifier> endpointIds, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(async context =>
+        {
+            var normalizedNames = endpointIds.Select(id => Normalize(id.Name)).Distinct().ToList();
+
+            // Every requested endpoint in one round trip, then matched up in memory, because the ids
+            // can span several sources of the same name.
+            var rows = await context.LicensingEndpoints
+                .AsNoTracking()
+                .Where(endpoint => normalizedNames.Contains(endpoint.NormalizedName))
+                .Select(endpoint => new
+                {
+                    Endpoint = endpoint,
+                    LastCollectedDate = context.LicensingEndpointThroughput
+                        .Where(row => row.NormalizedName == endpoint.NormalizedName && row.ThroughputSource == endpoint.ThroughputSource)
+                        .Max<LicensingEndpointThroughputEntity, DateOnly?>(row => row.DateUtc)
+                })
+                .ToListAsync(cancellationToken);
+
+            var found = rows.ToDictionary(row => (row.Endpoint.NormalizedName, row.Endpoint.ThroughputSource));
+
+            return endpointIds
+                .Select(id => (id, found.TryGetValue((Normalize(id.Name), id.ThroughputSource), out var row)
+                    ? ToEndpoint(row.Endpoint, row.LastCollectedDate)
+                    : null))
+                .ToList()
+                .AsEnumerable();
+        });
+
+    public Task SaveEndpoint(Endpoint endpoint, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(context =>
+        {
+            var normalizedName = Normalize(endpoint.Id.Name);
+            var sanitizedName = endpoint.SanitizedName ?? string.Empty;
+            var indicators = endpoint.EndpointIndicators?.ToList() ?? [];
+
+            return context.UpsertAsync(
+                [normalizedName, endpoint.Id.ThroughputSource],
+                () => new LicensingEndpointEntity
+                {
+                    NormalizedName = normalizedName,
+                    ThroughputSource = endpoint.Id.ThroughputSource,
+                    Name = endpoint.Id.Name,
+                    SanitizedName = sanitizedName,
+                    NormalizedSanitizedName = Normalize(sanitizedName),
+                    UserIndicator = endpoint.UserIndicator ?? string.Empty,
+                    Scope = endpoint.Scope,
+                    EndpointIndicators = indicators
+                },
+                row =>
+                {
+                    row.Name = endpoint.Id.Name;
+                    row.SanitizedName = sanitizedName;
+                    row.NormalizedSanitizedName = Normalize(sanitizedName);
+                    row.UserIndicator = endpoint.UserIndicator ?? string.Empty;
+                    row.Scope = endpoint.Scope;
+                    row.EndpointIndicators = indicators;
+                },
+                cancellationToken);
+        });
+
+    public Task<IDictionary<string, IEnumerable<ThroughputData>>> GetEndpointThroughputByQueueName(IList<string> queueNames, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(async context =>
+        {
+            var results = queueNames.ToDictionary(queueName => queueName, _ => Enumerable.Empty<ThroughputData>());
+
+            var requestedByNormalizedName = new Dictionary<string, string>();
+            foreach (var queueName in queueNames)
+            {
+                var normalizedName = Normalize(queueName);
+                if (!requestedByNormalizedName.ContainsKey(normalizedName))
+                {
+                    requestedByNormalizedName[normalizedName] = queueName;
+                }
+            }
+
+            var normalizedNames = requestedByNormalizedName.Keys.ToList();
+            var from = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime).AddMonths(-ReportedMonths);
+
+            var rows = await context.LicensingEndpoints
+                .AsNoTracking()
+                .Where(endpoint => normalizedNames.Contains(endpoint.NormalizedSanitizedName))
+                .Join(context.LicensingEndpointThroughput.Where(throughput => throughput.DateUtc >= from),
+                    endpoint => new { endpoint.NormalizedName, endpoint.ThroughputSource },
+                    throughput => new { throughput.NormalizedName, throughput.ThroughputSource },
+                    (endpoint, throughput) => new
+                    {
+                        endpoint.NormalizedSanitizedName,
+                        endpoint.ThroughputSource,
+                        throughput.DateUtc,
+                        throughput.MessageCount
+                    })
+                .ToListAsync(cancellationToken);
+
+            foreach (var endpointRows in rows.GroupBy(row => (row.NormalizedSanitizedName, row.ThroughputSource)))
+            {
+                var throughputData = new ThroughputData(endpointRows
+                    .OrderBy(row => row.DateUtc)
+                    .Select(row => new EndpointDailyThroughput(row.DateUtc, row.MessageCount)))
+                {
+                    ThroughputSource = endpointRows.Key.ThroughputSource
+                };
+
+                var queueName = requestedByNormalizedName[endpointRows.Key.NormalizedSanitizedName];
+                results[queueName] = results[queueName].Append(throughputData);
+            }
+
+            return (IDictionary<string, IEnumerable<ThroughputData>>)results;
+        });
+
+    public async Task RecordEndpointThroughput(string endpointName, ThroughputSource throughputSource, IList<EndpointDailyThroughput> throughput, CancellationToken cancellationToken)
+    {
+        if (throughput.Count == 0)
+        {
+            return;
+        }
+
+        // Only the first recording of a day can lose a race, and once its row exists every later
+        // writer takes the update path, so a couple of attempts is enough.
+        for (var attempt = 1; attempt <= MaxRecordAttempts; attempt++)
+        {
+            var recorded = await ExecuteWithDbContext(context =>
+                TryRecordEndpointThroughput(context, endpointName, throughputSource, throughput, cancellationToken));
+
+            if (recorded)
+            {
+                return;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not record throughput for {endpointName} from {throughputSource} after {MaxRecordAttempts} attempts because of concurrent updates.");
+    }
+
+    static async Task<bool> TryRecordEndpointThroughput(ServiceControlDbContext context, string endpointName, ThroughputSource throughputSource, IList<EndpointDailyThroughput> throughput, CancellationToken cancellationToken)
+    {
+        var normalizedName = Normalize(endpointName);
+
+        // Ordered so that concurrent calls covering overlapping days take the row locks in the same
+        // order and cannot deadlock against each other.
+        var dailyThroughput = throughput.OrderBy(entry => entry.DateUTC).ToList();
+
+        var strategy = context.Database.CreateExecutionStrategy();
+
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+
+            var endpointExists = await context.LicensingEndpoints
+                .AnyAsync(endpoint => endpoint.NormalizedName == normalizedName && endpoint.ThroughputSource == throughputSource, cancellationToken);
+
+            if (!endpointExists)
+            {
+                throw new InvalidOperationException($"Endpoint {endpointName} from {throughputSource} does not exist ");
+            }
+
+            foreach (var (date, messageCount) in dailyThroughput)
+            {
+                // Recording adds to the day's total, because a source can report the same day
+                // repeatedly. The addition happens in the database, so concurrent writers queue up on
+                // the row instead of overwriting each other's totals.
+                var updated = await context.LicensingEndpointThroughput
+                    .Where(row => row.NormalizedName == normalizedName && row.ThroughputSource == throughputSource && row.DateUtc == date)
+                    .ExecuteUpdateAsync(row => row.SetProperty(p => p.MessageCount, p => p.MessageCount + messageCount), cancellationToken);
+
+                if (updated > 0)
+                {
+                    continue;
+                }
+
+                context.LicensingEndpointThroughput.Add(new LicensingEndpointThroughputEntity
+                {
+                    NormalizedName = normalizedName,
+                    ThroughputSource = throughputSource,
+                    DateUtc = date,
+                    MessageCount = messageCount
+                });
+
+                try
+                {
+                    await context.SaveChangesAsync(cancellationToken);
+                }
+                catch (DbUpdateException exception) when (context.IsDuplicateKeyException(exception))
+                {
+                    // Another writer created the day's row first, so this call has to add to it
+                    // instead. The failed insert leaves the transaction unusable, hence the retry.
+                    return false;
+                }
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+            return true;
+        });
+    }
+
+    public Task UpdateUserIndicatorOnEndpoints(List<UpdateUserIndicator> userIndicatorUpdates, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(async context =>
+        {
+            var updates = userIndicatorUpdates.ToDictionary(update => Normalize(update.Name), update => update.UserIndicator);
+            var names = updates.Keys.ToList();
+
+            var rows = await context.LicensingEndpoints
+                .Where(endpoint => names.Contains(endpoint.NormalizedName) || names.Contains(endpoint.NormalizedSanitizedName))
+                .ToListAsync(cancellationToken);
+
+            var indicatorBySanitizedName = new Dictionary<string, string>();
+
+            foreach (var row in rows)
+            {
+                if (updates.TryGetValue(row.NormalizedSanitizedName, out var valueFromSanitizedName))
+                {
+                    row.UserIndicator = valueFromSanitizedName;
+                }
+                else if (updates.TryGetValue(row.NormalizedName, out var valueFromName))
+                {
+                    row.UserIndicator = valueFromName;
+                    indicatorBySanitizedName[row.NormalizedSanitizedName] = valueFromName;
+                }
+            }
+
+            if (indicatorBySanitizedName.Count > 0)
+            {
+                var sanitizedNames = indicatorBySanitizedName.Keys.ToList();
+                var alreadyLoaded = rows.Select(row => (row.NormalizedName, row.ThroughputSource)).ToHashSet();
+
+                var siblings = await context.LicensingEndpoints
+                    .Where(endpoint => sanitizedNames.Contains(endpoint.NormalizedSanitizedName))
+                    .ToListAsync(cancellationToken);
+
+                foreach (var sibling in siblings.Where(row => !alreadyLoaded.Contains((row.NormalizedName, row.ThroughputSource))))
+                {
+                    if (indicatorBySanitizedName.TryGetValue(sibling.NormalizedSanitizedName, out var indicator))
+                    {
+                        sibling.UserIndicator = indicator;
+                    }
+                }
+            }
+
+            await context.SaveChangesAsync(cancellationToken);
+        });
+
+    public Task<bool> IsThereThroughputForLastXDays(int days, CancellationToken cancellationToken) =>
+        IsThereThroughput(days, throughputSource: null, includeToday: false, cancellationToken);
+
+    public Task<bool> IsThereThroughputForLastXDaysForSource(int days, ThroughputSource throughputSource, bool includeToday, CancellationToken cancellationToken) =>
+        IsThereThroughput(days, throughputSource, includeToday, cancellationToken);
+
+    Task<bool> IsThereThroughput(int days, ThroughputSource? throughputSource, bool includeToday, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(context =>
+        {
+            var today = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime);
+            var from = today.AddDays(-days);
+            var to = includeToday ? today : today.AddDays(-1);
+
+            var query = context.LicensingEndpointThroughput
+                .AsNoTracking()
+                .Where(row => row.DateUtc >= from && row.DateUtc <= to);
+
+            if (throughputSource is not null)
+            {
+                query = query.Where(row => row.ThroughputSource == throughputSource);
+            }
+
+            return query.AnyAsync(cancellationToken);
+        });
+
+    public Task<BrokerMetadata> GetBrokerMetadata(CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(async context =>
+            await context.GetSetting<BrokerMetadata>(SettingKeys.BrokerMetadata, cancellationToken) ?? DefaultBrokerMetadata);
+
+    public Task SaveBrokerMetadata(BrokerMetadata brokerMetadata, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(context => context.StoreSetting(SettingKeys.BrokerMetadata, brokerMetadata, cancellationToken));
+
+    public Task<AuditServiceMetadata> GetAuditServiceMetadata(CancellationToken cancellationToken = default) =>
+        ExecuteWithDbContext(async context =>
+            await context.GetSetting<AuditServiceMetadata>(SettingKeys.AuditServiceMetadata, cancellationToken) ?? DefaultAuditServiceMetadata);
+
+    public Task SaveAuditServiceMetadata(AuditServiceMetadata auditServiceMetadata, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(context => context.StoreSetting(SettingKeys.AuditServiceMetadata, auditServiceMetadata, cancellationToken));
+
+    public Task<List<string>> GetReportMasks(CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(async context =>
+            await context.GetSetting<List<string>>(SettingKeys.ReportMasks, cancellationToken) ?? []);
+
+    public Task SaveReportMasks(List<string> reportMasks, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(context => context.StoreSetting(SettingKeys.ReportMasks, reportMasks, cancellationToken));
+
+    public Task<LicensedEndpointDetails?> GetLicensedEndpointDetails(CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(context => context.GetSetting<LicensedEndpointDetails>(SettingKeys.LicensedEndpointDetails, cancellationToken));
+
+    public Task SaveLicensedEndpointDetails(LicensedEndpointDetails result, CancellationToken cancellationToken) =>
+        ExecuteWithDbContext(context => context.StoreSetting(SettingKeys.LicensedEndpointDetails, result, cancellationToken));
+
+    static Endpoint ToEndpoint(LicensingEndpointEntity row) => ToEndpoint(row, lastCollectedDate: null);
+
+    static Endpoint ToEndpoint(LicensingEndpointEntity row, DateOnly? lastCollectedDate) =>
+        new(new EndpointIdentifier(row.Name, row.ThroughputSource))
+        {
+            SanitizedName = row.SanitizedName,
+            EndpointIndicators = [.. row.EndpointIndicators],
+            UserIndicator = row.UserIndicator,
+            Scope = row.Scope,
+            LastCollectedDate = lastCollectedDate ?? default
+        };
+
+    static string Normalize(string name) => name.ToLowerInvariant();
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/LicensingDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/LicensingDataStore.cs
@@ -10,8 +10,6 @@ using ServiceControl.Persistence.EFCore.Infrastructure;
 
 class LicensingDataStore(IServiceScopeFactory scopeFactory, TimeProvider timeProvider) : DataStoreBase(scopeFactory), ILicensingDataStore
 {
-    // A report covers the last 14 months, so older throughput is never read.
-    const int ReportedMonths = 14;
     const int MaxRecordAttempts = 5;
 
     static readonly string PlatformEndpointIndicator = EndpointIndicator.PlatformEndpoint.ToString();
@@ -130,7 +128,7 @@ class LicensingDataStore(IServiceScopeFactory scopeFactory, TimeProvider timePro
             }
 
             var normalizedNames = requestedByNormalizedName.Keys.ToList();
-            var from = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime).AddMonths(-ReportedMonths);
+            var from = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime).AddMonths(-ThroughputReporting.ReportedMonths);
 
             var rows = await context.LicensingEndpoints
                 .AsNoTracking()

--- a/src/ServiceControl.Persistence.EFCore/Infrastructure/SettingKeys.cs
+++ b/src/ServiceControl.Persistence.EFCore/Infrastructure/SettingKeys.cs
@@ -4,4 +4,8 @@ namespace ServiceControl.Persistence.EFCore.Infrastructure;
 static class SettingKeys
 {
     public const string TrialEndDate = "TrialEndDate";
+    public const string BrokerMetadata = "BrokerMetadata";
+    public const string AuditServiceMetadata = "AuditServiceMetadata";
+    public const string ReportMasks = "ReportMasks";
+    public const string LicensedEndpointDetails = "LicensedEndpointDetails";
 }

--- a/src/ServiceControl.Persistence.RavenDB/Throughput/LicensingDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Throughput/LicensingDataStore.cs
@@ -128,7 +128,7 @@ class LicensingDataStore(
         var store = await storeProvider.GetDocumentStore(cancellationToken);
         using IAsyncDocumentSession session = store.OpenAsyncSession(databaseConfiguration.Name);
 
-        var from = DateTime.UtcNow.AddMonths(-14);
+        var from = DateTime.UtcNow.AddMonths(-ThroughputReporting.ReportedMonths);
         var query = session.Query<EndpointDocument>()
             .Where(document => document.SanitizedName.In(queueNames))
             .Include(builder => builder.IncludeTimeSeries(ThroughputTimeSeriesName, from));

--- a/src/ServiceControl.Persistence.Tests.PostgreSql/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.PostgreSql/PersistenceTestsContext.cs
@@ -22,7 +22,7 @@ public partial class PersistenceTestsContext : IPersistenceTestsContext
     string databaseName;
     string bodyStoragePath;
 
-    public FakeTimeProvider FakeTime { get; } = new();
+    public FakeTimeProvider FakeTime { get; } = new(DateTimeOffset.UtcNow);
 
     public async Task Setup(IHostApplicationBuilder hostBuilder)
     {

--- a/src/ServiceControl.Persistence.Tests.PostgreSql/ServiceControl.Persistence.Tests.PostgreSql.csproj
+++ b/src/ServiceControl.Persistence.Tests.PostgreSql/ServiceControl.Persistence.Tests.PostgreSql.csproj
@@ -34,10 +34,6 @@
     <Compile Remove="..\ServiceControl.Persistence.Tests\Recoverability\EditHandlerAuditTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\Recoverability\EditMessageTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\Recoverability\RetryConfirmationProcessorTests.cs" />
-    <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\AuditServiceMetadataTests.cs" />
-    <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\BrokerMetadataTests.cs" />
-    <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\EndpointsTests.cs" />
-    <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\ReportMasksTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\RetryStateTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\NotificationsDataStoreTests.cs" />
   </ItemGroup>

--- a/src/ServiceControl.Persistence.Tests.SqlServer/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.SqlServer/PersistenceTestsContext.cs
@@ -21,7 +21,7 @@ public partial class PersistenceTestsContext : IPersistenceTestsContext
     string databaseName;
     string bodyStoragePath;
 
-    public FakeTimeProvider FakeTime { get; } = new();
+    public FakeTimeProvider FakeTime { get; } = new(DateTimeOffset.UtcNow);
 
     public async Task Setup(IHostApplicationBuilder hostBuilder)
     {

--- a/src/ServiceControl.Persistence.Tests.SqlServer/ServiceControl.Persistence.Tests.SqlServer.csproj
+++ b/src/ServiceControl.Persistence.Tests.SqlServer/ServiceControl.Persistence.Tests.SqlServer.csproj
@@ -34,10 +34,6 @@
     <Compile Remove="..\ServiceControl.Persistence.Tests\Recoverability\EditHandlerAuditTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\Recoverability\EditMessageTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\Recoverability\RetryConfirmationProcessorTests.cs" />
-    <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\AuditServiceMetadataTests.cs" />
-    <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\BrokerMetadataTests.cs" />
-    <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\EndpointsTests.cs" />
-    <Compile Remove="..\ServiceControl.Persistence.Tests\Throughput\ReportMasksTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\RetryStateTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\NotificationsDataStoreTests.cs" />
   </ItemGroup>

--- a/src/ServiceControl.Persistence.Tests/EFCore/LicensingDataStoreEFTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/LicensingDataStoreEFTests.cs
@@ -1,0 +1,214 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Particular.LicensingComponent.Contracts;
+
+class LicensingDataStoreEFTests : PersistenceTestBase
+{
+    static DateOnly Today => DateOnly.FromDateTime(DateTime.UtcNow);
+
+    [Test]
+    public async Task Recording_the_same_day_twice_adds_to_that_day()
+    {
+        await SaveEndpoint("Endpoint", ThroughputSource.Monitoring);
+
+        await LicensingDataStore.RecordEndpointThroughput("Endpoint", ThroughputSource.Monitoring, Today, 30, default);
+        await LicensingDataStore.RecordEndpointThroughput("Endpoint", ThroughputSource.Monitoring, Today, 12, default);
+
+        var throughput = await GetThroughput("Endpoint");
+
+        Assert.That(throughput[Today], Is.EqualTo(42));
+    }
+
+    // Monitoring reports the same day from several instances, so the additions have to survive
+    // landing at the same moment rather than one overwriting the other.
+    [Test]
+    public async Task Concurrent_recordings_of_the_same_day_all_count()
+    {
+        const int writers = 10;
+        await SaveEndpoint("Endpoint", ThroughputSource.Monitoring);
+
+        var recordings = Enumerable.Range(0, writers)
+            .Select(_ => LicensingDataStore.RecordEndpointThroughput("Endpoint", ThroughputSource.Monitoring, Today, 5, default));
+
+        await Task.WhenAll(recordings);
+
+        var throughput = await GetThroughput("Endpoint");
+
+        Assert.That(throughput[Today], Is.EqualTo(writers * 5));
+    }
+
+    [Test]
+    public async Task Endpoints_are_matched_regardless_of_name_casing()
+    {
+        await SaveEndpoint("SalesEndpoint", ThroughputSource.Broker);
+
+        await LicensingDataStore.RecordEndpointThroughput("salesendpoint", ThroughputSource.Broker, Today, 7, default);
+
+        var endpoint = await LicensingDataStore.GetEndpoint("SALESENDPOINT", ThroughputSource.Broker, default);
+
+        Assert.That(endpoint, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(endpoint.Id.Name, Is.EqualTo("SalesEndpoint"), "the reported casing is what is stored");
+            Assert.That(endpoint.LastCollectedDate, Is.EqualTo(Today));
+        }
+    }
+
+    [Test]
+    public async Task Last_collected_date_is_the_newest_recorded_day()
+    {
+        await SaveEndpoint("Endpoint", ThroughputSource.Audit);
+
+        await LicensingDataStore.RecordEndpointThroughput("Endpoint", ThroughputSource.Audit, Today.AddDays(-5), 10, default);
+        await LicensingDataStore.RecordEndpointThroughput("Endpoint", ThroughputSource.Audit, Today.AddDays(-1), 10, default);
+        await LicensingDataStore.RecordEndpointThroughput("Endpoint", ThroughputSource.Audit, Today.AddDays(-3), 10, default);
+
+        var endpoint = await LicensingDataStore.GetEndpoint("Endpoint", ThroughputSource.Audit, default);
+
+        Assert.That(endpoint, Is.Not.Null);
+        Assert.That(endpoint.LastCollectedDate, Is.EqualTo(Today.AddDays(-1)));
+    }
+
+    [Test]
+    public async Task Last_collected_date_is_unset_when_nothing_was_recorded()
+    {
+        await SaveEndpoint("Endpoint", ThroughputSource.Audit);
+
+        var endpoint = await LicensingDataStore.GetEndpoint("Endpoint", ThroughputSource.Audit, default);
+
+        Assert.That(endpoint, Is.Not.Null);
+        Assert.That(endpoint.LastCollectedDate, Is.EqualTo(default(DateOnly)));
+    }
+
+    [Test]
+    public async Task Endpoints_are_returned_for_every_requested_id_including_the_unknown_ones()
+    {
+        await SaveEndpoint("Endpoint", ThroughputSource.Audit);
+        await SaveEndpoint("Endpoint", ThroughputSource.Broker);
+
+        var requested = new[]
+        {
+            new EndpointIdentifier("Endpoint", ThroughputSource.Audit),
+            new EndpointIdentifier("Endpoint", ThroughputSource.Broker),
+            new EndpointIdentifier("Endpoint", ThroughputSource.Monitoring),
+            new EndpointIdentifier("Unknown", ThroughputSource.Audit)
+        };
+
+        var results = (await LicensingDataStore.GetEndpoints(requested, default)).ToList();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(results, Has.Count.EqualTo(requested.Length));
+            Assert.That(results[0].Endpoint, Is.Not.Null);
+            Assert.That(results[1].Endpoint, Is.Not.Null);
+            Assert.That(results[2].Endpoint, Is.Null, "same name, but no endpoint for that source");
+            Assert.That(results[3].Endpoint, Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task Platform_endpoints_are_excluded_when_asked_for()
+    {
+        await LicensingDataStore.SaveEndpoint(
+            new Endpoint("Platform", ThroughputSource.Broker)
+            {
+                SanitizedName = "Platform",
+                EndpointIndicators = [EndpointIndicator.PlatformEndpoint.ToString()]
+            }, default);
+        await SaveEndpoint("Regular", ThroughputSource.Broker);
+
+        var withPlatform = await LicensingDataStore.GetAllEndpoints(true, default);
+        var withoutPlatform = await LicensingDataStore.GetAllEndpoints(false, default);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(withPlatform.Count(), Is.EqualTo(2));
+            Assert.That(withoutPlatform.Single().Id.Name, Is.EqualTo("Regular"));
+        }
+    }
+
+    [Test]
+    public async Task Endpoint_indicators_survive_a_round_trip()
+    {
+        string[] indicators = [EndpointIndicator.KnownEndpoint.ToString(), EndpointIndicator.DelayBinding.ToString()];
+
+        await LicensingDataStore.SaveEndpoint(
+            new Endpoint("Endpoint", ThroughputSource.Broker)
+            {
+                SanitizedName = "Endpoint",
+                EndpointIndicators = indicators,
+                Scope = "vhost",
+                UserIndicator = UserIndicator.NServiceBusEndpoint.ToString()
+            }, default);
+
+        var endpoint = await LicensingDataStore.GetEndpoint("Endpoint", ThroughputSource.Broker, default);
+
+        Assert.That(endpoint, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(endpoint.EndpointIndicators, Is.EquivalentTo(indicators));
+            Assert.That(endpoint.Scope, Is.EqualTo("vhost"));
+            Assert.That(endpoint.UserIndicator, Is.EqualTo(UserIndicator.NServiceBusEndpoint.ToString()));
+        }
+    }
+
+    // A report covers the last 14 months, and older rows are left in place rather than filtered out
+    // by the retention sweep, so the read has to do the filtering.
+    [Test]
+    public async Task Throughput_older_than_the_reported_window_is_not_returned()
+    {
+        await SaveEndpoint("Endpoint", ThroughputSource.Broker);
+
+        await LicensingDataStore.RecordEndpointThroughput("Endpoint", ThroughputSource.Broker, Today.AddMonths(-15), 99, default);
+        await LicensingDataStore.RecordEndpointThroughput("Endpoint", ThroughputSource.Broker, Today.AddDays(-1), 5, default);
+
+        var throughput = await GetThroughput("Endpoint");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(throughput, Has.Count.EqualTo(1));
+            Assert.That(throughput[Today.AddDays(-1)], Is.EqualTo(5));
+        }
+    }
+
+    [Test]
+    public async Task Recording_throughput_for_an_unknown_endpoint_throws()
+    {
+        Assert.That(async () => await LicensingDataStore.RecordEndpointThroughput("Unknown", ThroughputSource.Broker, Today, 1, default),
+            Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public async Task Saving_an_endpoint_again_replaces_it_and_keeps_its_throughput()
+    {
+        await SaveEndpoint("Endpoint", ThroughputSource.Broker);
+        await LicensingDataStore.RecordEndpointThroughput("Endpoint", ThroughputSource.Broker, Today, 11, default);
+
+        await LicensingDataStore.SaveEndpoint(
+            new Endpoint("Endpoint", ThroughputSource.Broker) { SanitizedName = "Endpoint", Scope = "updated" }, default);
+
+        var endpoint = await LicensingDataStore.GetEndpoint("Endpoint", ThroughputSource.Broker, default);
+        var throughput = await GetThroughput("Endpoint");
+
+        Assert.That(endpoint, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(endpoint.Scope, Is.EqualTo("updated"));
+            Assert.That(throughput[Today], Is.EqualTo(11));
+        }
+    }
+
+    Task SaveEndpoint(string name, ThroughputSource source) =>
+        LicensingDataStore.SaveEndpoint(new Endpoint(name, source) { SanitizedName = name }, default);
+
+    async Task<ThroughputData> GetThroughput(string queueName)
+    {
+        var throughput = await LicensingDataStore.GetEndpointThroughputByQueueName([queueName], default);
+
+        return throughput[queueName].Single();
+    }
+}


### PR DESCRIPTION
RavenDB stored throughput as an incremental time series keyed by a case-insensitive document id. The relational equivalent is a row per endpoint per day, with lowercased name columns to keep endpoint identity and sanitized name matching case-insensitive on PostgreSQL. Recording adds to the day's total via ExecuteUpdate so concurrent writers queue on the row rather than overwriting each other, and the four singleton documents share the Settings table.