### PR TITLE
Implement email notification config on top of config store

### DIFF
--- a/src/ServiceControl.Persistence.EFCore/Implementation/NotificationsDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/NotificationsDataStore.cs
@@ -1,7 +1,14 @@
 namespace ServiceControl.Persistence.EFCore.Implementation;
 
-public class NotificationsDataStore : INotificationsDataStore
+using DbContexts;
+using Microsoft.Extensions.DependencyInjection;
+
+public class NotificationsDataStore(IServiceProvider serviceProvider) : INotificationsDataStore
 {
-    public Task<INotificationsManager> CreateNotificationsManager() =>
-        throw new NotImplementedException();
+    public Task<INotificationsManager> CreateNotificationsManager()
+    {
+        var scope = serviceProvider.CreateAsyncScope();
+        ServiceControlDbContext serviceControlDbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
+        return Task.FromResult<INotificationsManager>(new NotificationsManager(scope, serviceControlDbContext));
+    }
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/NotificationsManager.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/NotificationsManager.cs
@@ -1,14 +1,35 @@
 namespace ServiceControl.Persistence.EFCore.Implementation;
 
-using ServiceControl.Notifications;
+using DbContexts;
+using Infrastructure;
+using Notifications;
 
-public class NotificationsManager : INotificationsManager
+public class NotificationsManager(IAsyncDisposable scope, ServiceControlDbContext dbContext) : INotificationsManager
 {
-    public Task<NotificationsSettings> LoadSettings() =>
-        throw new NotImplementedException();
+    NotificationsSettings? _settings;
 
-    public Task SaveChanges() =>
-        throw new NotImplementedException();
+    public Task SaveChanges()
+    {
+        if (_settings == null)
+        {
+            return Task.CompletedTask;
+        }
 
-    public ValueTask DisposeAsync() => default;
+        return dbContext.StoreSetting(SettingKeys.NotificationEmails, _settings.Email, CancellationToken.None);
+    }
+
+    public async Task<NotificationsSettings> LoadSettings()
+    {
+        var settings = await dbContext.GetSetting<EmailNotifications>(SettingKeys.NotificationEmails, CancellationToken.None);
+        _settings = new NotificationsSettings() { Email = settings ?? new EmailNotifications() };
+        return _settings;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await dbContext.DisposeAsync();
+        await scope.DisposeAsync();
+
+        GC.SuppressFinalize(this);
+    }
 }

--- a/src/ServiceControl.Persistence.EFCore/Infrastructure/SettingKeys.cs
+++ b/src/ServiceControl.Persistence.EFCore/Infrastructure/SettingKeys.cs
@@ -8,4 +8,5 @@ static class SettingKeys
     public const string AuditServiceMetadata = "AuditServiceMetadata";
     public const string ReportMasks = "ReportMasks";
     public const string LicensedEndpointDetails = "LicensedEndpointDetails";
+    public const string NotificationEmails = "NotificationEmails";
 }

--- a/src/ServiceControl.Persistence.Tests.PostgreSql/ServiceControl.Persistence.Tests.PostgreSql.csproj
+++ b/src/ServiceControl.Persistence.Tests.PostgreSql/ServiceControl.Persistence.Tests.PostgreSql.csproj
@@ -36,7 +36,6 @@
     <Compile Remove="..\ServiceControl.Persistence.Tests\Recoverability\EditMessageTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\Recoverability\RetryConfirmationProcessorTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\RetryStateTests.cs" />
-    <Compile Remove="..\ServiceControl.Persistence.Tests\NotificationsDataStoreTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ServiceControl.Persistence.Tests.SqlServer/ServiceControl.Persistence.Tests.SqlServer.csproj
+++ b/src/ServiceControl.Persistence.Tests.SqlServer/ServiceControl.Persistence.Tests.SqlServer.csproj
@@ -36,7 +36,6 @@
     <Compile Remove="..\ServiceControl.Persistence.Tests\Recoverability\EditMessageTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\Recoverability\RetryConfirmationProcessorTests.cs" />
     <Compile Remove="..\ServiceControl.Persistence.Tests\RetryStateTests.cs" />
-    <Compile Remove="..\ServiceControl.Persistence.Tests\NotificationsDataStoreTests.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request implements the notifications data store and manager for the EFCore persistence layer, enabling notifications settings to be loaded and saved using the database context. It also updates related infrastructure and cleans up unused test references.

### Notifications infrastructure implementation

* Implemented the `NotificationsDataStore` and `NotificationsManager` classes to support loading and saving notification settings using the EFCore database context (`ServiceControlDbContext`). This includes proper resource disposal and dependency injection support. [[1]](diffhunk://#diff-5082d6fde6720e283ec6ad7f374abdda7a89d9ad480d67725a3bcfe135112efbL3-R13) [[2]](diffhunk://#diff-640d1e46e0b2d2ce378cdd919d73cac13b82de88cc061d331f3f7ef7ab28d04fL3-R34)
* Added a new constant `NotificationEmails` to the `SettingKeys` class for storing notification email settings.
