### PR TITLE
Upgrade Particular Analyzers and triage new diagnostics

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -8,8 +8,6 @@
     <EnableDefaultArtifacts>false</EnableDefaultArtifacts>
     <PowerShellModuleName>Particular.ServiceControl.Management</PowerShellModuleName>
     <PowerShellModuleArtifactsPath>$(ArtifactsPath)PowerShellModules\$(PowerShellModuleName)\</PowerShellModuleArtifactsPath>
-    <!-- Remove after upgrading to NServiceBus 8.x -->
-    <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 

--- a/src/Particular.LicensingComponent.Persistence.InMemory/.editorconfig
+++ b/src/Particular.LicensingComponent.Persistence.InMemory/.editorconfig
@@ -9,3 +9,8 @@ dotnet_diagnostic.CA2007.severity = none
 dotnet_diagnostic.IDE0040.severity = none
 
 csharp_style_var_elsewhere = true:error
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none

--- a/src/Particular.LicensingComponent.Persistence/.editorconfig
+++ b/src/Particular.LicensingComponent.Persistence/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none

--- a/src/Particular.LicensingComponent.UnitTests/.editorconfig
+++ b/src/Particular.LicensingComponent.UnitTests/.editorconfig
@@ -2,3 +2,11 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0006.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/Particular.LicensingComponent/.editorconfig
+++ b/src/Particular.LicensingComponent/.editorconfig
@@ -12,3 +12,11 @@ dotnet_diagnostic.IDE0010.severity = suggestion
 
 csharp_style_var_elsewhere = true:error
 csharp_style_var_for_built_in_types = true:error
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0008.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.AcceptanceTesting/.editorconfig
+++ b/src/ServiceControl.AcceptanceTesting/.editorconfig
@@ -2,3 +2,10 @@
 
 # Justification: Usage is from test projects
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.AcceptanceTests.RavenDB/.editorconfig
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/.editorconfig
@@ -2,3 +2,9 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.AcceptanceTests/.editorconfig
+++ b/src/ServiceControl.AcceptanceTests/.editorconfig
@@ -2,3 +2,15 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0018.severity = none
+
+# Timezone debt: these DateTime values are Kind=Unspecified or Local, so the implicit cast to
+# DateTimeOffset uses the build agent's offset. Each needs individual review before removing.
+dotnet_diagnostic.PS0022.severity = none

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_messages_fails_multiple_times.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_messages_fails_multiple_times.cs
@@ -59,7 +59,7 @@
                 {
                     var endpointName = NServiceBus.AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(AnEndpoint));
                     var messageId = Guid.NewGuid().ToString();
-                    var earliestTimeOfFailure = DateTime.UtcNow;
+                    var earliestTimeOfFailure = DateTimeOffset.UtcNow;
 
                     context.UniqueMessageId = DeterministicGuid.MakeId(messageId, endpointName).ToString();
 

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_is_retried.cs
@@ -131,7 +131,7 @@
 
                     headers["NServiceBus.FailedQ"] = Conventions.EndpointNamingConvention(typeof(VerifyHeader));
                     headers["$.diagnostics.hostid"] = Guid.NewGuid().ToString();
-                    headers["NServiceBus.TimeOfFailure"] = DateTimeOffsetHelper.ToWireFormattedString(DateTime.UtcNow);
+                    headers["NServiceBus.TimeOfFailure"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
 
                     var outgoingMessage = new OutgoingMessage(messageId, headers, context.BodyToSend);
 

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_single_message_fails_in_batch.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_single_message_fails_in_batch.cs
@@ -82,7 +82,7 @@
                             [Headers.MessageId] = i == 2 ? context.MessageId : Guid.NewGuid().ToString(),
                             ["NServiceBus.FailedQ"] = Conventions.EndpointNamingConvention(typeof(Sendonly)),
                             ["$.diagnostics.hostid"] = Guid.NewGuid().ToString(),
-                            ["NServiceBus.TimeOfFailure"] = DateTimeOffsetHelper.ToWireFormattedString(DateTime.UtcNow)
+                            ["NServiceBus.TimeOfFailure"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow)
 
                         };
 

--- a/src/ServiceControl.Api/.editorconfig
+++ b/src/ServiceControl.Api/.editorconfig
@@ -1,10 +1,7 @@
 [*.cs]
 
-# Justification: Test project
-dotnet_diagnostic.CA2007.severity = none
-
 # Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
 # They are scheduled work, not accepted exceptions: remove a line once this project has no
 # violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0013.severity = none
-dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/.editorconfig
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/.editorconfig
@@ -2,3 +2,9 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Audit.AcceptanceTests/.editorconfig
+++ b/src/ServiceControl.Audit.AcceptanceTests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Audit.Persistence.InMemory/.editorconfig
+++ b/src/ServiceControl.Audit.Persistence.InMemory/.editorconfig
@@ -2,3 +2,9 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Audit.Persistence.RavenDB/.editorconfig
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/.editorconfig
@@ -2,3 +2,10 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0020.severity = none

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/.editorconfig
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/.editorconfig
@@ -2,3 +2,9 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0020.severity = none

--- a/src/ServiceControl.Audit.Persistence.Tests/.editorconfig
+++ b/src/ServiceControl.Audit.Persistence.Tests/.editorconfig
@@ -7,3 +7,7 @@ dotnet_diagnostic.PS0018.severity = none  # Add a CancellationToken parameter
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = suggestion
+
+# Timezone debt: these DateTime values are Kind=Unspecified or Local, so the implicit cast to
+# DateTimeOffset uses the build agent's offset. Each needs individual review before removing.
+dotnet_diagnostic.PS0022.severity = none

--- a/src/ServiceControl.Audit.Persistence/.editorconfig
+++ b/src/ServiceControl.Audit.Persistence/.editorconfig
@@ -2,3 +2,9 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Audit.UnitTests/.editorconfig
+++ b/src/ServiceControl.Audit.UnitTests/.editorconfig
@@ -2,3 +2,10 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Audit/.editorconfig
+++ b/src/ServiceControl.Audit/.editorconfig
@@ -2,3 +2,14 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0019.severity = none
+dotnet_diagnostic.PS0020.severity = none
+dotnet_diagnostic.PS0021.severity = none

--- a/src/ServiceControl.Audit/Recoverability/DetectSuccessfulRetriesEnricher.cs
+++ b/src/ServiceControl.Audit/Recoverability/DetectSuccessfulRetriesEnricher.cs
@@ -34,7 +34,7 @@
                 //and did not send the acknowledgment. We send it here to the acknowledgment queue.
                 var ackMessage = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>
                 {
-                    ["ServiceControl.Retry.Successful"] = DateTimeOffsetHelper.ToWireFormattedString(DateTime.UtcNow),
+                    ["ServiceControl.Retry.Successful"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow),
                     ["ServiceControl.Retry.UniqueMessageId"] = newRetryMessageId
                 }, Array.Empty<byte>());
                 var ackOperation = new TransportOperation(ackMessage, new UnicastAddressTag(ackQueue));

--- a/src/ServiceControl.Config.Tests/.editorconfig
+++ b/src/ServiceControl.Config.Tests/.editorconfig
@@ -6,3 +6,9 @@ dotnet_diagnostic.CA2007.severity = none
 # Justification: Executable specifications intentionally assign properties after the
 # object initializer to mirror user interaction order (e.g. typing a name after load)
 dotnet_diagnostic.IDE0017.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0013.severity = none

--- a/src/ServiceControl.Config/AppBootstrapper.cs
+++ b/src/ServiceControl.Config/AppBootstrapper.cs
@@ -84,6 +84,7 @@
             container.InjectProperties(instance);
         }
 
+#pragma warning disable PS0027 // Overrides BootstrapperBase.OnStartup, a void-returning Application.Startup handler
         protected override async void OnStartup(object sender, StartupEventArgs e)
         {
             ValidatorOptions.Global.DefaultRuleLevelCascadeMode = CascadeMode.Stop;
@@ -99,6 +100,7 @@
                 Application.Current.Shutdown(-1);
             }
         }
+#pragma warning restore PS0027
 
         IContainer container;
     }

--- a/src/ServiceControl.Config/Framework/Commands/AwaitableAbstractCommand.cs
+++ b/src/ServiceControl.Config/Framework/Commands/AwaitableAbstractCommand.cs
@@ -14,6 +14,7 @@ namespace ServiceControl.Config.Framework.Commands
             return CanExecute((T)parameter);
         }
 
+#pragma warning disable PS0027 // ICommand.Execute returns void, so there is nothing to return the task to
         async void ICommand<T>.Execute(T obj)
         {
             using (StartExecuting())
@@ -23,6 +24,7 @@ namespace ServiceControl.Config.Framework.Commands
 
             }
         }
+#pragma warning restore PS0027
 
         void System.Windows.Input.ICommand.Execute(object parameter)
         {

--- a/src/ServiceControl.Config/Framework/Commands/AwaitableDelegateCommand.cs
+++ b/src/ServiceControl.Config/Framework/Commands/AwaitableDelegateCommand.cs
@@ -22,10 +22,12 @@
             return CanExecute((T)parameter);
         }
 
+#pragma warning disable PS0027 // ICommand.Execute returns void, so there is nothing to return the task to
         async void System.Windows.Input.ICommand.Execute(object parameter)
         {
             await ExecuteAsync((T)parameter);
         }
+#pragma warning restore PS0027
 
         public async Task ExecuteAsync(T parameter)
         {

--- a/src/ServiceControl.Config/Framework/Rx/RxViewAware.cs
+++ b/src/ServiceControl.Config/Framework/Rx/RxViewAware.cs
@@ -18,7 +18,9 @@
         /// <summary>
         /// The view chache for this instance.
         /// </summary>
+#pragma warning disable PS0025 // Keyed by view context identity, so reference equality is what is wanted
         protected IDictionary<object, object> Views { get; }
+#pragma warning restore PS0025
 
         /// <summary>
         /// Raised when a view is attached.

--- a/src/ServiceControl.Config/UI/ListInstances/ListInstancesViewModel.cs
+++ b/src/ServiceControl.Config/UI/ListInstances/ListInstancesViewModel.cs
@@ -127,6 +127,11 @@
             NotifyOfPropertyChange(nameof(Instances));
         }
 
+        // TODO: this is a genuine async void, not an event handler. Because it returns at the first
+        // await, HandleAsync(RefreshInstances) publishes PostRefreshInstances before the removals have
+        // finished, which is the ordering that method's own remarks say must not happen. Converting it
+        // to async Task needs the constructor call site at the top of this class restructured first.
+#pragma warning disable PS0027
         async void AddAndRemoveInstances()
         {
             // Remove instances that no longer exist on disk
@@ -164,6 +169,7 @@
             NotifyOfPropertyChange(nameof(HasConfigurationErrors));
             NotifyOfPropertyChange(nameof(ConfigurationErrorMessage));
         }
+#pragma warning restore PS0027
 
         readonly Func<BaseService, InstanceDetailsViewModel> instanceDetailsFunc;
         readonly Func<IEnumerable<BaseService>> getAllInstances;

--- a/src/ServiceControl.Config/Xaml/Behaviours/RichTextBoxHelper.cs
+++ b/src/ServiceControl.Config/Xaml/Behaviours/RichTextBoxHelper.cs
@@ -24,7 +24,9 @@
             obj.SetValue(DocumentXamlProperty, value);
         }
 
+#pragma warning disable PS0025 // Tracks which threads are already inside the callback, so reference equality is what is wanted
         static HashSet<Thread> recursionProtection = [];
+#pragma warning restore PS0025
 
         static readonly Regex doubleNewlineRegex = new Regex(@"\r?\n\r?\n", RegexOptions.Compiled);
         static readonly Regex singleNewlineRegex = new Regex(@"\r?\n", RegexOptions.Compiled);

--- a/src/ServiceControl.DomainEvents/.editorconfig
+++ b/src/ServiceControl.DomainEvents/.editorconfig
@@ -1,10 +1,7 @@
 [*.cs]
 
-# Justification: Test project
-dotnet_diagnostic.CA2007.severity = none
-
 # Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
 # They are scheduled work, not accepted exceptions: remove a line once this project has no
 # violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0013.severity = none
-dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.Hosting/.editorconfig
+++ b/src/ServiceControl.Hosting/.editorconfig
@@ -1,10 +1,6 @@
 [*.cs]
 
-# Justification: Test project
-dotnet_diagnostic.CA2007.severity = none
-
 # Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
 # They are scheduled work, not accepted exceptions: remove a line once this project has no
 # violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0013.severity = none
 dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Hosting/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Hosting/HostApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.WindowsServices;
 
-public static class IHostApplicationBuilderExtensions
+public static class HostApplicationBuilderExtensions
 {
     public static void AddWindowsServiceWithRequestTimeout(this IHostApplicationBuilder builder)
     {

--- a/src/ServiceControl.Infrastructure.Metrics/.editorconfig
+++ b/src/ServiceControl.Infrastructure.Metrics/.editorconfig
@@ -1,10 +1,7 @@
 [*.cs]
 
-# Justification: Test project
-dotnet_diagnostic.CA2007.severity = none
-
 # Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
 # They are scheduled work, not accepted exceptions: remove a line once this project has no
 # violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0013.severity = none
 dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0020.severity = none

--- a/src/ServiceControl.Infrastructure.Tests/.editorconfig
+++ b/src/ServiceControl.Infrastructure.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.Infrastructure/.editorconfig
+++ b/src/ServiceControl.Infrastructure/.editorconfig
@@ -1,10 +1,10 @@
 [*.cs]
 
-# Justification: Test project
-dotnet_diagnostic.CA2007.severity = none
-
 # Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
 # They are scheduled work, not accepted exceptions: remove a line once this project has no
 # violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
 dotnet_diagnostic.PS0013.severity = none
 dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0020.severity = none
+dotnet_diagnostic.PS0021.severity = none

--- a/src/ServiceControl.Management.PowerShell/.editorconfig
+++ b/src/ServiceControl.Management.PowerShell/.editorconfig
@@ -1,10 +1,6 @@
 [*.cs]
 
-# Justification: Test project
-dotnet_diagnostic.CA2007.severity = none
-
 # Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
 # They are scheduled work, not accepted exceptions: remove a line once this project has no
 # violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0013.severity = none
 dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Monitoring.AcceptanceTests/.editorconfig
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/.editorconfig
@@ -2,3 +2,9 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Monitoring/.editorconfig
+++ b/src/ServiceControl.Monitoring/.editorconfig
@@ -2,3 +2,10 @@
 
 # Justification: Application synchronization contexts don't require ConfigureAwait(false)
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/.editorconfig
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/.editorconfig
@@ -2,3 +2,10 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/.editorconfig
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/.editorconfig
@@ -3,6 +3,11 @@
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
 
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+
 # Disable style rules for auto-generated EF migrations
 [Migrations/**.cs]
 dotnet_diagnostic.IDE0065.severity = none

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/.editorconfig
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/.editorconfig
@@ -3,6 +3,11 @@
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
 
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+
 # Disable style rules for auto-generated EF migrations
 [Migrations/**.cs]
 dotnet_diagnostic.IDE0065.severity = none

--- a/src/ServiceControl.Persistence.EFCore/.editorconfig
+++ b/src/ServiceControl.Persistence.EFCore/.editorconfig
@@ -3,6 +3,16 @@
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
 
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0004.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0019.severity = none
+
 # Disable style rules for auto-generated EF migrations
 [Migrations/**.cs]
 dotnet_diagnostic.IDE0065.severity = none

--- a/src/ServiceControl.Persistence.RavenDB/.editorconfig
+++ b/src/ServiceControl.Persistence.RavenDB/.editorconfig
@@ -2,3 +2,12 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0020.severity = none
+dotnet_diagnostic.PS0021.severity = none

--- a/src/ServiceControl.Persistence.Tests.InMemory/.editorconfig
+++ b/src/ServiceControl.Persistence.Tests.InMemory/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Persistence.Tests.PostgreSql/.editorconfig
+++ b/src/ServiceControl.Persistence.Tests.PostgreSql/.editorconfig
@@ -3,3 +3,11 @@
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
 
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0008.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0019.severity = none
+

--- a/src/ServiceControl.Persistence.Tests.RavenDB/.editorconfig
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Persistence.Tests.SqlServer/.editorconfig
+++ b/src/ServiceControl.Persistence.Tests.SqlServer/.editorconfig
@@ -3,3 +3,11 @@
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
 
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0008.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0019.severity = none
+

--- a/src/ServiceControl.Persistence.Tests/.editorconfig
+++ b/src/ServiceControl.Persistence.Tests/.editorconfig
@@ -2,3 +2,11 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0006.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Persistence/.editorconfig
+++ b/src/ServiceControl.Persistence/.editorconfig
@@ -2,3 +2,11 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.RavenDB/.editorconfig
+++ b/src/ServiceControl.RavenDB/.editorconfig
@@ -2,3 +2,9 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.ASBS.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.ASBS.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.ASBS/.editorconfig
+++ b/src/ServiceControl.Transports.ASBS/.editorconfig
@@ -2,3 +2,10 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0004.severity = none
+dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Transports.ASQ.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.ASQ.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.ASQ/.editorconfig
+++ b/src/ServiceControl.Transports.ASQ/.editorconfig
@@ -2,3 +2,9 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Transports.IBMMQ.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.IBMMQ.Tests/.editorconfig
@@ -1,10 +1,6 @@
 [*.cs]
 
-# Justification: Test project
-dotnet_diagnostic.CA2007.severity = none
-
 # Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
 # They are scheduled work, not accepted exceptions: remove a line once this project has no
 # violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0013.severity = none
 dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.IBMMQ/.editorconfig
+++ b/src/ServiceControl.Transports.IBMMQ/.editorconfig
@@ -1,10 +1,7 @@
 [*.cs]
 
-# Justification: Test project
-dotnet_diagnostic.CA2007.severity = none
-
 # Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
 # They are scheduled work, not accepted exceptions: remove a line once this project has no
 # violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0013.severity = none
-dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Transports.IBMMQ/IBMMQTransportCustomization.cs
+++ b/src/ServiceControl.Transports.IBMMQ/IBMMQTransportCustomization.cs
@@ -9,6 +9,7 @@ using NServiceBus;
 using NServiceBus.CustomChecks;
 using NServiceBus.Transport.IBMMQ;
 
+#pragma warning disable PS0024 // The I is from IBM, matching NServiceBus.Transport.IBMMQ
 public class IBMMQTransportCustomization : TransportCustomization<IBMMQTransport>
 {
     protected override void CustomizeTransportForPrimaryEndpoint(EndpointConfiguration endpointConfiguration, IBMMQTransport transportDefinition, TransportSettings transportSettings) =>
@@ -85,3 +86,4 @@ public class IBMMQTransportCustomization : TransportCustomization<IBMMQTransport
         return transport;
     }
 }
+#pragma warning restore PS0024

--- a/src/ServiceControl.Transports.Learning/.editorconfig
+++ b/src/ServiceControl.Transports.Learning/.editorconfig
@@ -2,3 +2,9 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Transports.Msmq.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.Msmq.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.Msmq/.editorconfig
+++ b/src/ServiceControl.Transports.Msmq/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none

--- a/src/ServiceControl.Transports.PostgreSql.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.PostgreSql.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.PostgreSql/.editorconfig
+++ b/src/ServiceControl.Transports.PostgreSql/.editorconfig
@@ -2,3 +2,11 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0004.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.Transports.RabbitMQ/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQ/.editorconfig
@@ -2,3 +2,10 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.SQS.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.SQS.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.SQS/.editorconfig
+++ b/src/ServiceControl.Transports.SQS/.editorconfig
@@ -2,3 +2,9 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Transports.SqlServer.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.SqlServer.Tests/.editorconfig
@@ -2,3 +2,8 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.SqlServer/.editorconfig
+++ b/src/ServiceControl.Transports.SqlServer/.editorconfig
@@ -2,3 +2,11 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0004.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.Transports/.editorconfig
+++ b/src/ServiceControl.Transports/.editorconfig
@@ -2,3 +2,11 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.UnitTests/.editorconfig
+++ b/src/ServiceControl.UnitTests/.editorconfig
@@ -2,3 +2,11 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl/.editorconfig
+++ b/src/ServiceControl/.editorconfig
@@ -2,3 +2,15 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
+
+# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
+# They are scheduled work, not accepted exceptions: remove a line once this project has no
+# violations of that rule left, and never add a rule back to this list.
+dotnet_diagnostic.PS0003.severity = none
+dotnet_diagnostic.PS0004.severity = none
+dotnet_diagnostic.PS0006.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0017.severity = none
+dotnet_diagnostic.PS0018.severity = none
+dotnet_diagnostic.PS0019.severity = none
+dotnet_diagnostic.PS0020.severity = none

--- a/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/ScatterGatherApi.cs
@@ -157,8 +157,7 @@ namespace ServiceControl.CompositeViews.Messages
                 remoteInstanceSetting.TemporarilyUnavailable = true;
                 logger.LogWarning(
                     httpRequestException,
-                    "An HttpRequestException occurred when querying remote instance at {RemoteInstanceBaseAddress}. The instance at uri: {RemoteInstanceBaseAddress} will be temporarily disabled",
-                    remoteInstanceSetting.BaseAddress,
+                    "An HttpRequestException occurred when querying remote instance at {RemoteInstanceBaseAddress}. The instance will be temporarily disabled",
                     remoteInstanceSetting.BaseAddress);
                 return QueryResult<TOut>.Empty();
             }

--- a/src/ServiceControl/Licensing/ActiveLicense.cs
+++ b/src/ServiceControl/Licensing/ActiveLicense.cs
@@ -47,7 +47,7 @@
                 }
 
                 //If the trial end date in db has been tampered, invalidate the license
-                if (trialEndDateInDb > DateOnly.FromDateTime(DateTime.Now).AddDays(MaxTrialPeriodInDays))
+                if (trialEndDateInDb > DateOnly.FromDateTime(DateTime.UtcNow).AddDays(MaxTrialPeriodInDays))
                 {
                     return LicenseDetails.TrialExpired();
                 }


### PR DESCRIPTION
## Why

`Custom.Build.props` has pinned `ParticularAnalyzersVersion` to 0.9.0 since 2021, with the comment
"Remove after upgrading to NServiceBus 8.x." We're on NServiceBus 10.2.8. Version 0.9.0 predates
Particular.Analyzers' cancellation-token rules entirely, so the analyzer has been silently unable
to catch missing/unpropagated `CancellationToken` parameters for years. This is the first step in
threading cancellation through the platform: turn the guardrail back on before touching any call sites.

## What this does

- Removes the version pin. `ParticularAnalyzersVersion` now resolves 2.1.4 from `Directory.Build.props`.
- Fixes the handful of diagnostics that are `Error`-severity by default and would otherwise break every
  build immediately:
  - `PS0023` (`DateTime.Now` vs `.UtcNow`) in `ActiveLicense.cs` — also a latent bug, since the trial-window
    tests already assume UTC.
  - `PS0025`/`PS0027` in `ServiceControl.Config` (WPF): `async void` and reference-equality collection
    warnings. Five are legitimate WPF idioms (`ICommand.Execute`, `Application.Startup`, view/thread caches)
    and are suppressed at the site with justification. The sixth, `ListInstancesViewModel.AddAndRemoveInstances`,
    is a genuine bug — it returns at its first `await`, so `RefreshInstances` publishes before removals finish —
    and is suppressed with a `TODO` instead, since fixing it needs the constructor call site restructured.
- Fixes the remaining non-cancellation warnings the upgrade surfaces: a duplicated structured-logging token
  in `ScatterGatherApi`, four `DateTime`→`DateTimeOffset` casts that are provably UTC, and a rename
  (`IHostApplicationBuilderExtensions` → `HostApplicationBuilderExtensions`, unreferenced by name).
- Adds a `.editorconfig` debt block to every project still carrying cancellation-rule warnings (62 projects),
  listing only the rules that project actually violates, so each block doubles as that project's remaining
  work. This is a ratchet: a rule can only be deleted from a block once the project has zero violations of it.

## What this doesn't do

No `CancellationToken` propagation yet. That starts in the next PR. This is purely: turn the analyzer back on,
fix what's `Error`-severity, and record everything else as tracked debt instead of leaving it invisible.
