### PR TITLE
Consistently apply optional cancellation tokens

### DIFF
--- a/src/Particular.LicensingComponent.UnitTests/AuditQuery_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/AuditQuery_Tests.cs
@@ -206,7 +206,7 @@ class AuditQuery_Tests : ThroughputCollectorTestFixture
 
     class AuditCountApi_ReturningThreeAuditCounts : IAuditCountApi
     {
-        public async Task<IList<AuditCount>> GetEndpointAuditCounts(string endpoint, CancellationToken token)
+        public async Task<IList<AuditCount>> GetEndpointAuditCounts(string endpoint, CancellationToken cancellationToken)
         {
             var auditCounts = new List<AuditCount>
             {

--- a/src/Particular.LicensingComponent.UnitTests/Infrastructure/FakeAuditCountApi.cs
+++ b/src/Particular.LicensingComponent.UnitTests/Infrastructure/FakeAuditCountApi.cs
@@ -8,6 +8,6 @@
 
     class FakeAuditCountApi : IAuditCountApi
     {
-        public Task<IList<ServiceControl.Api.Contracts.AuditCount>> GetEndpointAuditCounts(string endpoint, CancellationToken token) => throw new NotImplementedException();
+        public Task<IList<ServiceControl.Api.Contracts.AuditCount>> GetEndpointAuditCounts(string endpoint, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 }

--- a/src/ServiceControl.Api/.editorconfig
+++ b/src/ServiceControl.Api/.editorconfig
@@ -1,7 +1,0 @@
-[*.cs]
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Api/IAuditCountApi.cs
+++ b/src/ServiceControl.Api/IAuditCountApi.cs
@@ -7,6 +7,6 @@
 
     public interface IAuditCountApi
     {
-        Task<IList<AuditCount>> GetEndpointAuditCounts(string endpoint, CancellationToken token);
+        Task<IList<AuditCount>> GetEndpointAuditCounts(string endpoint, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Api/IConfigurationApi.cs
+++ b/src/ServiceControl.Api/IConfigurationApi.cs
@@ -6,10 +6,10 @@
 
     public interface IConfigurationApi
     {
-        Task<RootUrls> GetUrls(string baseUrl, CancellationToken cancellationToken);
+        Task<RootUrls> GetUrls(string baseUrl, CancellationToken cancellationToken = default);
 
-        Task<object> GetConfig(CancellationToken cancellationToken);
+        Task<object> GetConfig(CancellationToken cancellationToken = default);
 
-        Task<RemoteConfiguration[]> GetRemoteConfigs(CancellationToken cancellationToken);
+        Task<RemoteConfiguration[]> GetRemoteConfigs(CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Api/IEndpointsApi.cs
+++ b/src/ServiceControl.Api/IEndpointsApi.cs
@@ -7,6 +7,6 @@
 
     public interface IEndpointsApi
     {
-        Task<List<Endpoint>> GetEndpoints(CancellationToken cancellationToken);
+        Task<List<Endpoint>> GetEndpoints(CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.DomainEvents/.editorconfig
+++ b/src/ServiceControl.DomainEvents/.editorconfig
@@ -1,7 +1,0 @@
-[*.cs]
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.DomainEvents/DomainEvents.cs
+++ b/src/ServiceControl.DomainEvents/DomainEvents.cs
@@ -8,7 +8,7 @@
 
     public class DomainEvents(IServiceProvider serviceProvider, ILogger<DomainEvents> logger) : IDomainEvents
     {
-        public async Task Raise<T>(T domainEvent, CancellationToken cancellationToken) where T : IDomainEvent
+        public async Task Raise<T>(T domainEvent, CancellationToken cancellationToken = default) where T : IDomainEvent
         {
             var handlers = serviceProvider.GetServices<IDomainHandler<T>>();
             foreach (var handler in handlers)
@@ -17,6 +17,10 @@
                 {
                     await handler.Handle(domainEvent, cancellationToken)
                         .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
                 }
                 catch (Exception e)
                 {
@@ -32,6 +36,10 @@
                 {
                     await handler.Handle(domainEvent, cancellationToken)
                     .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
                 }
                 catch (Exception e)
                 {

--- a/src/ServiceControl.Hosting/.editorconfig
+++ b/src/ServiceControl.Hosting/.editorconfig
@@ -1,6 +1,0 @@
-[*.cs]
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Hosting/Auth/PermissionPolicyProvider.cs
+++ b/src/ServiceControl.Hosting/Auth/PermissionPolicyProvider.cs
@@ -52,6 +52,7 @@ public sealed class PermissionPolicyProvider(IOptions<AuthorizationOptions> auth
                 : AllowAll,
             StringComparer.Ordinal);
 
+#pragma warning disable PS0018 // IAuthorizationPolicyProvider declares these without a CancellationToken
     public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName) =>
         Task.FromResult(policies.GetValueOrDefault(policyName));
 
@@ -64,4 +65,5 @@ public sealed class PermissionPolicyProvider(IOptions<AuthorizationOptions> auth
 
     public Task<AuthorizationPolicy?> GetFallbackPolicyAsync()
         => Task.FromResult(authorizationOptions.Value.FallbackPolicy);
+#pragma warning restore PS0018
 }

--- a/src/ServiceControl.Hosting/Auth/RolesClaimsTransformation.cs
+++ b/src/ServiceControl.Hosting/Auth/RolesClaimsTransformation.cs
@@ -27,6 +27,7 @@ public sealed class RolesClaimsTransformation(OpenIdConnectSettings oidcSettings
     // placeholder is required because a Claim value cannot be null.
     const string SentinelClaimValue = "1";
 
+#pragma warning disable PS0018 // IClaimsTransformation declares this without a CancellationToken
     public Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
     {
         var isAuthenticated = principal.Identity?.IsAuthenticated == true;
@@ -49,6 +50,7 @@ public sealed class RolesClaimsTransformation(OpenIdConnectSettings oidcSettings
         transformed.AddIdentity(new ClaimsIdentity(claims));
         return Task.FromResult(transformed);
     }
+#pragma warning restore PS0018
 
     // True once this transformation has stamped its sentinel claim, keeping TransformAsync
     // idempotent across the repeated calls ASP.NET makes for the same principal.

--- a/src/ServiceControl.Infrastructure.Metrics/.editorconfig
+++ b/src/ServiceControl.Infrastructure.Metrics/.editorconfig
@@ -1,7 +1,0 @@
-[*.cs]
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none
-dotnet_diagnostic.PS0020.severity = none

--- a/src/ServiceControl.Infrastructure.Metrics/MetricsReporter.cs
+++ b/src/ServiceControl.Infrastructure.Metrics/MetricsReporter.cs
@@ -32,7 +32,7 @@
                         await Task.Delay(interval, tokenSource.Token).ConfigureAwait(false);
                     }
                 }
-                catch (OperationCanceledException) when (tokenSource.IsCancellationRequested)
+                catch (OperationCanceledException) when (tokenSource.Token.IsCancellationRequested)
                 {
                     //no-op
                 }
@@ -54,14 +54,14 @@
             }
         }
 
-        public Task Stop()
+        public async Task Stop(CancellationToken cancellationToken = default)
         {
             if (tokenSource == null)
             {
-                return Task.CompletedTask;
+                return;
             }
-            tokenSource.Cancel();
-            return task;
+            await tokenSource.CancelAsync().ConfigureAwait(false);
+            await task.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/ServiceControl.Infrastructure/.editorconfig
+++ b/src/ServiceControl.Infrastructure/.editorconfig
@@ -1,10 +1,6 @@
-[*.cs]
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
+# Cancellation analyzer debt, narrowed to the one file still owed. MessageActionAuditLogExtensions
+# takes a Func<Task> callback that has to become Func<CancellationToken, Task>, which changes the
+# lambda at a dozen controller call sites, so it moves with the controllers in Phase 2.
+[Auth/MessageActionAuditLogExtensions.cs]
 dotnet_diagnostic.PS0013.severity = none
 dotnet_diagnostic.PS0018.severity = none
-dotnet_diagnostic.PS0020.severity = none
-dotnet_diagnostic.PS0021.severity = none

--- a/src/ServiceControl.Infrastructure/AsyncTimer.cs
+++ b/src/ServiceControl.Infrastructure/AsyncTimer.cs
@@ -68,7 +68,7 @@ public class TimerJob
         }, CancellationToken.None);
     }
 
-    public async Task Stop(CancellationToken cancellationToken)
+    public async Task Stop(CancellationToken cancellationToken = default)
     {
         if (tokenSource == null)
         {
@@ -87,9 +87,11 @@ public class TimerJob
         {
             await task.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (tokenSource.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            //NOOP
+            // The job's own cancellation is already swallowed inside the loop, so the only way out
+            // here is the caller giving up on waiting. tokenSource is disposed by this point, which
+            // is why the filter must not reach through it for a token.
         }
     }
 

--- a/src/ServiceControl.Infrastructure/IntegratedSetup.cs
+++ b/src/ServiceControl.Infrastructure/IntegratedSetup.cs
@@ -4,6 +4,7 @@
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public static class IntegratedSetup
@@ -11,7 +12,7 @@
         const string SetupAndRunCmd = "--setup-and-run";
         const string SetupCmd = "--setup";
 
-        public static async Task<int> Run()
+        public static async Task<int> Run(CancellationToken cancellationToken = default)
         {
             // Using GetCommandLineArgs instead of the args passed into Main because GetCommandLineArgs provides the entry assembly path
             var args = Environment.GetCommandLineArgs().ToList();
@@ -52,7 +53,7 @@
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            await process.WaitForExitAsync().ConfigureAwait(false);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 
             return process.ExitCode;
         }

--- a/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
+++ b/src/ServiceControl.Infrastructure/ReadOnlyStream.cs
@@ -38,7 +38,7 @@ public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
         destination.Write(source);
     }
 
-    public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+    public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken = default)
     {
         if (cancellationToken.IsCancellationRequested)
         {
@@ -100,7 +100,7 @@ public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
         return bytesToCopy;
     }
 
-    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
     {
         if (cancellationToken.IsCancellationRequested)
         {
@@ -150,13 +150,13 @@ public sealed class ReadOnlyStream(ReadOnlyMemory<byte> memory) : Stream
 
     public override void WriteByte(byte value) => throw new NotSupportedException();
 
-    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException();
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
     public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
     public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException();
 
-    public override Task FlushAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
+    public override Task FlushAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
     public override void Flush() => throw new NotSupportedException();
 

--- a/src/ServiceControl.Infrastructure/Watchdog.cs
+++ b/src/ServiceControl.Infrastructure/Watchdog.cs
@@ -35,13 +35,14 @@
             this.log = log;
         }
 
-        public Task OnFailure(string failure)
+        public async Task OnFailure(string failure, CancellationToken cancellationToken = default)
         {
             reportFailure(failure);
-            return ensureStopped(shutdownTokenSource.Token);
+            using var stopTokenSource = CancellationTokenSource.CreateLinkedTokenSource(shutdownTokenSource.Token, cancellationToken);
+            await ensureStopped(stopTokenSource.Token).ConfigureAwait(false);
         }
 
-        public Task Start(Action onFailedOnStartup, CancellationToken cancellationToken)
+        public Task Start(Action onFailedOnStartup, CancellationToken cancellationToken = default)
         {
             watchdog = Task.Run(async () =>
             {
@@ -51,6 +52,10 @@
 
                 while (!shutdownTokenSource.IsCancellationRequested)
                 {
+                    // Two tokens in play: the shutdown token, and a linked one that additionally trips after
+                    // MaxStartDurationMs. Only shutdown means "stop watching"; the timeout is a startup failure
+                    // and must fall through to the Exception handler so it is reported and retried.
+#pragma warning disable PS0021
                     try
                     {
                         // Host builder start is launching the loop. The watch dog loop task runs in isolation
@@ -65,7 +70,7 @@
                         clearFailure();
                         startup = false;
                     }
-                    catch (OperationCanceledException e) when (shutdownTokenSource.IsCancellationRequested)
+                    catch (OperationCanceledException e) when (shutdownTokenSource.Token.IsCancellationRequested)
                     {
                         log.LogDebug(e, "Cancelled");
                         return;
@@ -83,11 +88,12 @@
 
                         log.LogError(e, "Error while trying to start {TaskName}. Starting will be retried in {TimeToWaitBetweenStartupAttempts}", taskName, timeToWaitBetweenStartupAttempts);
                     }
+#pragma warning restore PS0021
                     try
                     {
                         await Task.Delay(timeToWaitBetweenStartupAttempts, shutdownTokenSource.Token).ConfigureAwait(false);
                     }
-                    catch (OperationCanceledException) when (shutdownTokenSource.IsCancellationRequested)
+                    catch (OperationCanceledException) when (shutdownTokenSource.Token.IsCancellationRequested)
                     {
                         //Ignore, no need to log cancellation of delay
                     }
@@ -97,7 +103,7 @@
             return Task.CompletedTask;
         }
 
-        public async Task Stop(CancellationToken cancellationToken)
+        public async Task Stop(CancellationToken cancellationToken = default)
         {
             try
             {

--- a/src/ServiceControl/Infrastructure/Api/AuditCountApi.cs
+++ b/src/ServiceControl/Infrastructure/Api/AuditCountApi.cs
@@ -10,7 +10,7 @@ using ServiceControl.Api.Contracts;
 
 class AuditCountApi(GetAuditCountsForEndpointApi auditCountsForEndpointApi) : IAuditCountApi
 {
-    public async Task<IList<AuditCount>> GetEndpointAuditCounts(string endpoint, CancellationToken token) =>
+    public async Task<IList<AuditCount>> GetEndpointAuditCounts(string endpoint, CancellationToken cancellationToken) =>
         (await auditCountsForEndpointApi.Execute(new AuditCountsForEndpointContext(new PagingInfo(), endpoint),
             $"/api/endpoints/{endpoint}/audit-count")).Results;
 }

--- a/src/ServiceControl/Infrastructure/Metrics/MetricsReporterHostedService.cs
+++ b/src/ServiceControl/Infrastructure/Metrics/MetricsReporterHostedService.cs
@@ -32,7 +32,7 @@
         {
             try
             {
-                await reporter.Stop();
+                await reporter.Stop(cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {


### PR DESCRIPTION
## Why

Second step in threading `CancellationToken` through the platform: the five leaf libraries every host
project depends on (`ServiceControl.Infrastructure`, `ServiceControl.Api`, `ServiceControl.Hosting`,
`ServiceControl.DomainEvents`, `ServiceControl.Infrastructure.Metrics`). These sit underneath
`ServiceControl`, `ServiceControl.Audit`, `ServiceControl.Monitoring` and the transports/licensing
projects in the reference graph, so getting their signatures settled first means later work is a
one-line change at each call site instead of a redesign.

## What this does

Standardizes `CancellationToken` parameters to the `PS0003`/`PS0004`/`PS0017` convention already
enforced elsewhere in the solution: non-private members take `CancellationToken cancellationToken = default`,
private ones take it required, named `cancellationToken` everywhere (not `token`).

Retires 28 of 30 tracked diagnostics; deletes the debt block from four `.editorconfig` files outright
(`Api`, `Hosting`, `DomainEvents`, `Infrastructure.Metrics`) and narrows `Infrastructure`'s to a single file.

Two categories of exception:
- **Pragmas where the token can't be added.** `ServiceControl.Hosting`'s `PermissionPolicyProvider` and
  `RolesClaimsTransformation` implement ASP.NET Core interfaces (`IAuthorizationPolicyProvider`,
  `IClaimsTransformation`) that declare no `CancellationToken` parameter. `PS0018` is unsatisfiable there;
  suppressed at the site with justification, not fixed.
- **One deferred file.** `MessageActionAuditLogExtensions.AuditedOperation` takes a `Func<Task>` callback
  that needs to become `Func<CancellationToken, Task>`, which touches the lambda at a dozen controller call
  sites that don't have a token yet. Rather than thread `CancellationToken.None` through as a placeholder,
  it's deferred to the controllers PR; `ServiceControl.Infrastructure/.editorconfig` is narrowed to
  `[Auth/MessageActionAuditLogExtensions.cs]` to track just that.

## Bugs fixed along the way

- `MetricsReporterHostedService.StopAsync` caught `OperationCanceledException` on its own token, but
  `MetricsReporter.Stop()` took no token, so nothing could ever throw one — the catch was dead code, and
  shutdown was effectively unbounded. `Stop` now takes a token and awaits the reporter task via `WaitAsync`.
- `DomainEvents.Raise` logged shutdown-triggered cancellation as `"Unexpected error publishing domain event"`
  at `Error` level. It now rethrows `OperationCanceledException` before the generic handler, so a normal
  shutdown doesn't read as an application error.

## Notes for reviewers

- A couple of `PS0020` catch filters read `cancellationTokenSource.IsCancellationRequested`, which the
  analyzer doesn't recognise (it wants the token, not the source). Fixed as
  `.Token.IsCancellationRequested`, except in `AsyncTimer.Stop` where the source is already disposed by
  that point — there the filter uses the caller's token instead, which is also the semantically correct
  one since the timer already swallows its own cancellation internally.
- `Watchdog`'s startup loop legitimately passes two tokens into the same `try` (shutdown, plus a linked
  15s startup timeout), so `PS0021` is suppressed there with an explanation rather than restructured.
