### PR TITLE
Continue cancellation token propagation in persistence layer

### DIFF
--- a/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageLifecycleDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageLifecycleDataStore.cs
@@ -9,7 +9,7 @@ using ServiceControl.MessageFailures;
 /// </summary>
 public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IFailedMessageLifecycleDataStore
 {
-    public async Task MarkAsArchived(string failedMessageId)
+    public async Task MarkAsArchived(string failedMessageId, CancellationToken cancellationToken = default)
     {
         await ExecuteWithDbContext(async dbContext =>
         {
@@ -25,11 +25,11 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
                 .ExecuteUpdateAsync(s => s
                     .SetProperty(fm => fm.Status, FailedMessageStatus.Archived)
                     .SetProperty(fm => fm.StatusChangedAt, now)
-                    .SetProperty(fm => fm.LastModified, now));
+                    .SetProperty(fm => fm.LastModified, now), cancellationToken);
         });
     }
 
-    public async Task<bool> MarkAsResolved(string failedMessageId)
+    public async Task<bool> MarkAsResolved(string failedMessageId, CancellationToken cancellationToken = default)
     {
         return await ExecuteWithDbContext(async dbContext =>
         {
@@ -45,13 +45,13 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
                 .ExecuteUpdateAsync(s => s
                     .SetProperty(fm => fm.Status, FailedMessageStatus.Resolved)
                     .SetProperty(fm => fm.StatusChangedAt, now)
-                    .SetProperty(fm => fm.LastModified, now));
+                    .SetProperty(fm => fm.LastModified, now), cancellationToken);
 
             return affected > 0;
         });
     }
 
-    public async Task<string[]> UnArchiveMessages(IEnumerable<string> failedMessageIds)
+    public async Task<string[]> UnArchiveMessages(IEnumerable<string> failedMessageIds, CancellationToken cancellationToken = default)
     {
         var ids = failedMessageIds
             .Select(id => Guid.TryParse(id, out var guid) ? guid : Guid.Empty)
@@ -71,7 +71,7 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
             var unarchivableIds = await dbContext.FailedMessages
                 .Where(fm => ids.Contains(fm.UniqueMessageId) && fm.Status == FailedMessageStatus.Archived)
                 .Select(fm => fm.UniqueMessageId)
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             if (unarchivableIds.Count == 0)
             {
@@ -83,13 +83,13 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
                 .ExecuteUpdateAsync(s => s
                     .SetProperty(fm => fm.Status, FailedMessageStatus.Unresolved)
                     .SetProperty(fm => fm.StatusChangedAt, now)
-                    .SetProperty(fm => fm.LastModified, now));
+                    .SetProperty(fm => fm.LastModified, now), cancellationToken);
 
             return unarchivableIds.Select(id => id.ToString()).ToArray();
         });
     }
 
-    public async Task<string[]> UnArchiveMessagesByRange(DateTime from, DateTime to)
+    public async Task<string[]> UnArchiveMessagesByRange(DateTime from, DateTime to, CancellationToken cancellationToken = default)
     {
         return await ExecuteWithDbContext(async dbContext =>
         {
@@ -101,7 +101,7 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
                     && fm.LastModified >= from
                     && fm.LastModified <= to)
                 .Select(fm => fm.UniqueMessageId)
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             if (unarchivableIds.Count == 0)
             {
@@ -113,13 +113,13 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
                 .ExecuteUpdateAsync(s => s
                     .SetProperty(fm => fm.Status, FailedMessageStatus.Unresolved)
                     .SetProperty(fm => fm.StatusChangedAt, now)
-                    .SetProperty(fm => fm.LastModified, now));
+                    .SetProperty(fm => fm.LastModified, now), cancellationToken);
 
             return unarchivableIds.Select(id => id.ToString()).ToArray();
         });
     }
 
-    public async Task RevertRetry(string messageUniqueId)
+    public async Task RevertRetry(string messageUniqueId, CancellationToken cancellationToken = default)
     {
         await ExecuteWithDbContext(async dbContext =>
         {
@@ -135,7 +135,7 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
                 .ExecuteUpdateAsync(s => s
                     .SetProperty(fm => fm.Status, FailedMessageStatus.Unresolved)
                     .SetProperty(fm => fm.StatusChangedAt, now)
-                    .SetProperty(fm => fm.LastModified, now));
+                    .SetProperty(fm => fm.LastModified, now), cancellationToken);
         });
     }
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageQueryDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageQueryDataStore.cs
@@ -12,36 +12,36 @@ using ServiceControl.Persistence.Infrastructure;
 
 public class FailedMessageQueryDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IFailedMessageQueryDataStore
 {
-    public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessages(string? status, string? modified, string? queueAddress, PagingInfo pagingInfo, SortInfo sortInfo) =>
+    public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessages(string? status, string? modified, string? queueAddress, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(dbContext => dbContext.FailedMessages
             .AsNoTracking()
             .FilterByStatus(status)
             .FilterByLastModifiedRange(modified)
             .FilterByQueueAddress(queueAddress)
-            .ToPagedResult(pagingInfo, sortInfo));
+            .ToPagedResult(pagingInfo, sortInfo, cancellationToken));
 
-    public Task<QueryStatsInfo> GetFailedMessagesStats(string? status, string? modified, string? queueAddress) =>
+    public Task<QueryStatsInfo> GetFailedMessagesStats(string? status, string? modified, string? queueAddress, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(dbContext => dbContext.FailedMessages
             .AsNoTracking()
             .FilterByStatus(status)
             .FilterByLastModifiedRange(modified)
             .FilterByQueueAddress(queueAddress)
-            .ToQueryStatsInfo());
+            .ToQueryStatsInfo(cancellationToken));
 
-    public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessagesByEndpoint(string? status, string endpointName, string? modified, PagingInfo pagingInfo, SortInfo sortInfo) =>
+    public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessagesByEndpoint(string? status, string endpointName, string? modified, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(dbContext => dbContext.FailedMessages
             .AsNoTracking()
             .Where(message => message.ReceivingEndpointName == endpointName)
             .FilterByStatus(status)
             .FilterByLastModifiedRange(modified)
-            .ToPagedResult(pagingInfo, sortInfo));
+            .ToPagedResult(pagingInfo, sortInfo, cancellationToken));
 
-    public Task<IDictionary<string, object>> GetFailedMessagesSummary() =>
+    public Task<IDictionary<string, object>> GetFailedMessagesSummary(CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(async dbContext =>
         {
-            var endpoints = await CountBy(dbContext, message => message.ReceivingEndpointName);
-            var hosts = await CountBy(dbContext, message => message.ReceivingEndpointHost);
-            var messageTypes = await CountBy(dbContext, message => message.MessageType);
+            var endpoints = await CountBy(dbContext, message => message.ReceivingEndpointName, cancellationToken);
+            var hosts = await CountBy(dbContext, message => message.ReceivingEndpointHost, cancellationToken);
+            var messageTypes = await CountBy(dbContext, message => message.MessageType, cancellationToken);
 
             return (IDictionary<string, object>)new Dictionary<string, object>
             {
@@ -51,7 +51,7 @@ public class FailedMessageQueryDataStore(IServiceScopeFactory scopeFactory) : Da
             };
         });
 
-    public Task<FailedMessageView?> GetLatestFailedMessageView(string failedMessageId) =>
+    public Task<FailedMessageView?> GetLatestFailedMessageView(string failedMessageId, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(async dbContext =>
         {
             if (!Guid.TryParse(failedMessageId, out var uniqueMessageId))
@@ -61,12 +61,12 @@ public class FailedMessageQueryDataStore(IServiceScopeFactory scopeFactory) : Da
 
             var entity = await dbContext.FailedMessages
                 .AsNoTracking()
-                .SingleOrDefaultAsync(message => message.UniqueMessageId == uniqueMessageId);
+                .SingleOrDefaultAsync(message => message.UniqueMessageId == uniqueMessageId, cancellationToken);
 
             return entity?.ToFailedMessageView();
         });
 
-    public Task<FailedMessage?> GetFailedMessage(string failedMessageId) =>
+    public Task<FailedMessage?> GetFailedMessage(string failedMessageId, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(async dbContext =>
         {
             if (!Guid.TryParse(failedMessageId, out var uniqueMessageId))
@@ -76,37 +76,37 @@ public class FailedMessageQueryDataStore(IServiceScopeFactory scopeFactory) : Da
 
             var entity = await dbContext.FailedMessages
                 .AsNoTracking()
-                .SingleOrDefaultAsync(message => message.UniqueMessageId == uniqueMessageId);
+                .SingleOrDefaultAsync(message => message.UniqueMessageId == uniqueMessageId, cancellationToken);
 
             if (entity == null)
             {
                 return null;
             }
 
-            var groups = await ReadGroups(dbContext, [uniqueMessageId]);
+            var groups = await ReadGroups(dbContext, [uniqueMessageId], cancellationToken);
 
             return entity.ToFailedMessage(groups.GetValueOrDefault(uniqueMessageId, []));
         });
 
-    public Task<FailedMessage[]> GetFailedMessagesByIds(Guid[] ids) =>
+    public Task<FailedMessage[]> GetFailedMessagesByIds(Guid[] ids, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext<FailedMessage[]>(async dbContext =>
         {
             var entities = await dbContext.FailedMessages
                 .AsNoTracking()
                 .Where(message => ids.Contains(message.UniqueMessageId))
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             if (entities.Count == 0)
             {
                 return [];
             }
 
-            var groups = await ReadGroups(dbContext, [.. entities.Select(entity => entity.UniqueMessageId)]);
+            var groups = await ReadGroups(dbContext, [.. entities.Select(entity => entity.UniqueMessageId)], cancellationToken);
 
             return [.. entities.Select(entity => entity.ToFailedMessage(groups.GetValueOrDefault(entity.UniqueMessageId, [])))];
         });
 
-    static async Task<Dictionary<string, object>> CountBy(ServiceControlDbContext dbContext, Expression<Func<FailedMessageEntity, string?>> selector) =>
+    static async Task<Dictionary<string, object>> CountBy(ServiceControlDbContext dbContext, Expression<Func<FailedMessageEntity, string?>> selector, CancellationToken cancellationToken) =>
         await dbContext.FailedMessages
             .AsNoTracking()
             .Where(message => message.Status == FailedMessageStatus.Unresolved)
@@ -114,14 +114,14 @@ public class FailedMessageQueryDataStore(IServiceScopeFactory scopeFactory) : Da
             .Where(value => value != null && value != string.Empty)
             .GroupBy(value => value)
             .Select(group => new { Value = group.Key, Count = group.Count() })
-            .ToDictionaryAsync(row => row.Value!, row => (object)row.Count);
+            .ToDictionaryAsync(row => row.Value!, row => (object)row.Count, cancellationToken);
 
-    static async Task<Dictionary<Guid, List<FailedMessageGroupEntity>>> ReadGroups(ServiceControlDbContext dbContext, Guid[] uniqueMessageIds)
+    static async Task<Dictionary<Guid, List<FailedMessageGroupEntity>>> ReadGroups(ServiceControlDbContext dbContext, Guid[] uniqueMessageIds, CancellationToken cancellationToken)
     {
         var groups = await dbContext.FailedMessageGroups
             .AsNoTracking()
             .Where(group => uniqueMessageIds.Contains(group.FailedMessageUniqueId))
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
         return groups
             .GroupBy(group => group.FailedMessageUniqueId)

--- a/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageQueryResults.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageQueryResults.cs
@@ -8,14 +8,14 @@ using ServiceControl.Persistence.Infrastructure;
 
 static class FailedMessageQueryResults
 {
-    public static async Task<QueryResult<IList<FailedMessageView>>> ToPagedResult(this IQueryable<FailedMessageEntity> source, PagingInfo pagingInfo, SortInfo sortInfo)
+    public static async Task<QueryResult<IList<FailedMessageView>>> ToPagedResult(this IQueryable<FailedMessageEntity> source, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken = default)
     {
-        var stats = await source.ToQueryStatsInfo();
+        var stats = await source.ToQueryStatsInfo(cancellationToken);
 
         var entities = await source
             .Sort(sortInfo)
             .Page(pagingInfo)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
         IList<FailedMessageView> results = [.. entities.Select(entity => entity.ToFailedMessageView())];
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageRetryDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageRetryDataStore.cs
@@ -4,15 +4,15 @@ using Microsoft.Extensions.DependencyInjection;
 
 public class FailedMessageRetryDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IFailedMessageRetryDataStore
 {
-    public Task ProcessPendingRetries(DateTime periodFrom, DateTime periodTo, string queueAddress, Func<string, Task> processCallback) =>
+    public Task ProcessPendingRetries(DateTime periodFrom, DateTime periodTo, string queueAddress, Func<string, CancellationToken, Task> processCallback, CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
-    public Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress) =>
+    public Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress, CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
-    public Task RemoveFailedMessageRetry(string uniqueMessageId) =>
+    public Task RemoveFailedMessageRetry(string uniqueMessageId, CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
-    public Task<byte[]> GetFailedMessageBody(string uniqueMessageId) =>
+    public Task<byte[]> GetFailedMessageBody(string uniqueMessageId, CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/MessagesViewDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/MessagesViewDataStore.cs
@@ -9,38 +9,38 @@ using ServiceControl.Persistence.Infrastructure;
 
 public class MessagesViewDataStore(IServiceScopeFactory scopeFactory, IFullTextSearchDialect fullTextSearch) : DataStoreBase(scopeFactory), IMessagesViewDataStore
 {
-    public Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange? timeSentRange = null) =>
+    public Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange? timeSentRange = null, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(dbContext => dbContext.FailedMessages
             .AsNoTracking()
             .IncludeSystemMessagesWhere(includeSystemMessages)
             .FilterBySentTimeRange(timeSentRange)
-            .ToPagedMessagesResult(pagingInfo, sortInfo));
+            .ToPagedMessagesResult(pagingInfo, sortInfo, cancellationToken));
 
-    public Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange? timeSentRange = null) =>
+    public Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange? timeSentRange = null, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(dbContext => dbContext.FailedMessages
             .AsNoTracking()
             .Where(message => message.ReceivingEndpointName == endpointName)
             .IncludeSystemMessagesWhere(includeSystemMessages)
             .FilterBySentTimeRange(timeSentRange)
-            .ToPagedMessagesResult(pagingInfo, sortInfo));
+            .ToPagedMessagesResult(pagingInfo, sortInfo, cancellationToken));
 
     // includeSystemMessages is unused here: a conversation is incomplete without the system messages that took part in it.
-    public Task<QueryResult<IList<MessagesView>>> GetAllMessagesByConversation(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages) =>
+    public Task<QueryResult<IList<MessagesView>>> GetAllMessagesByConversation(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(dbContext => dbContext.FailedMessages
             .AsNoTracking()
             .Where(message => message.ConversationId == conversationId)
-            .ToPagedMessagesResult(pagingInfo, sortInfo));
+            .ToPagedMessagesResult(pagingInfo, sortInfo, cancellationToken));
 
-    public Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange? timeSentRange = null) =>
+    public Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange? timeSentRange = null, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(dbContext => Search(dbContext.FailedMessages.AsNoTracking(), searchTerms)
             .FilterBySentTimeRange(timeSentRange)
-            .ToPagedMessagesResult(pagingInfo, sortInfo));
+            .ToPagedMessagesResult(pagingInfo, sortInfo, cancellationToken));
 
-    public Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange? timeSentRange = null) =>
+    public Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange? timeSentRange = null, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(dbContext => Search(dbContext.FailedMessages.AsNoTracking(), searchKeyword)
             .Where(message => message.ReceivingEndpointName == endpointName)
             .FilterBySentTimeRange(timeSentRange)
-            .ToPagedMessagesResult(pagingInfo, sortInfo));
+            .ToPagedMessagesResult(pagingInfo, sortInfo, cancellationToken));
 
     // Neither search hides system messages: a caller who searched
     // for something specific is not helped by hiding the message that matched it.

--- a/src/ServiceControl.Persistence.EFCore/Implementation/MessagesViewQueryResults.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/MessagesViewQueryResults.cs
@@ -8,14 +8,14 @@ using ServiceControl.Persistence.Infrastructure;
 
 static class MessagesViewQueryResults
 {
-    public static async Task<QueryResult<IList<MessagesView>>> ToPagedMessagesResult(this IQueryable<FailedMessageEntity> source, PagingInfo pagingInfo, SortInfo sortInfo)
+    public static async Task<QueryResult<IList<MessagesView>>> ToPagedMessagesResult(this IQueryable<FailedMessageEntity> source, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken = default)
     {
-        var stats = await source.ToQueryStatsInfo();
+        var stats = await source.ToQueryStatsInfo(cancellationToken);
 
         var entities = await source
             .SortMessages(sortInfo)
             .Page(pagingInfo)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
         IList<MessagesView> results = [.. entities.Select(entity => entity.ToMessagesView())];
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/QueueAddressStore.cs
@@ -7,7 +7,7 @@ using ServiceControl.Persistence.Infrastructure;
 
 public class QueueAddressStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IQueueAddressStore
 {
-    public Task<QueryResult<IList<QueueAddress>>> GetAddresses(PagingInfo pagingInfo) =>
+    public Task<QueryResult<IList<QueueAddress>>> GetAddresses(PagingInfo pagingInfo, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(async context =>
         {
             var query = context.FailedMessages
@@ -19,7 +19,7 @@ public class QueueAddressStore(IServiceScopeFactory scopeFactory) : DataStoreBas
                     FailedMessageCount = failuresByEndpoint.Count()
                 });
 
-            var items = await query.Skip(pagingInfo.Offset).Take(pagingInfo.PageSize).ToListAsync();
+            var items = await query.Skip(pagingInfo.Offset).Take(pagingInfo.PageSize).ToListAsync(cancellationToken);
             var eTag = DeterministicGuid.MakeId($"{items.Count}|{string.Join(",", items.Select(x => x.PhysicalAddress))}").ToString();
 
             return new QueryResult<IList<QueueAddress>>(items, new QueryStatsInfo(eTag, query.Count(), false));

--- a/src/ServiceControl.Persistence.RavenDB/ErrorMessagesDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ErrorMessagesDataStore.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Editing;
     using Microsoft.Extensions.Logging;
@@ -37,10 +38,11 @@
             PagingInfo pagingInfo,
             SortInfo sortInfo,
             bool includeSystemMessages,
-            DateTimeRange timeSentRange
+            DateTimeRange timeSentRange,
+            CancellationToken cancellationToken = default
             )
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
                 .IncludeSystemMessagesWhere(includeSystemMessages)
                 .FilterBySentTimeRange(timeSentRange)
@@ -50,7 +52,7 @@
                 .OfType<FailedMessage>()
                 .TransformToMessageView();
 
-            var results = await query.ToListAsync();
+            var results = await query.ToListAsync(cancellationToken);
 
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
@@ -60,10 +62,11 @@
             PagingInfo pagingInfo,
             SortInfo sortInfo,
             bool includeSystemMessages,
-            DateTimeRange timeSentRange
+            DateTimeRange timeSentRange,
+            CancellationToken cancellationToken = default
             )
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
                 .IncludeSystemMessagesWhere(includeSystemMessages)
                 .FilterBySentTimeRange(timeSentRange)
@@ -74,7 +77,7 @@
                 .OfType<FailedMessage>()
                 .TransformToMessageView();
 
-            var results = await query.ToListAsync();
+            var results = await query.ToListAsync(cancellationToken);
 
 
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
@@ -85,10 +88,11 @@
             string searchKeyword,
             PagingInfo pagingInfo,
             SortInfo sortInfo,
-            DateTimeRange timeSentRange
+            DateTimeRange timeSentRange,
+            CancellationToken cancellationToken = default
             )
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
                 .Statistics(out var stats)
                 .Search(x => x.Query, searchKeyword)
@@ -99,7 +103,7 @@
                 .OfType<FailedMessage>()
                 .TransformToMessageView();
 
-            var results = await query.ToListAsync();
+            var results = await query.ToListAsync(cancellationToken);
 
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
@@ -108,10 +112,11 @@
             string conversationId,
             PagingInfo pagingInfo,
             SortInfo sortInfo,
-            bool includeSystemMessages
+            bool includeSystemMessages,
+            CancellationToken cancellationToken = default
             )
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
                 .Statistics(out var stats)
                 .Where(m => m.ConversationId == conversationId)
@@ -120,7 +125,7 @@
                 .OfType<FailedMessage>()
                 .TransformToMessageView();
 
-            var results = await query.ToListAsync();
+            var results = await query.ToListAsync(cancellationToken);
 
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
@@ -129,10 +134,11 @@
             string searchTerms,
             PagingInfo pagingInfo,
             SortInfo sortInfo,
-            DateTimeRange timeSentRange
+            DateTimeRange timeSentRange,
+            CancellationToken cancellationToken = default
             )
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
                 .Statistics(out var stats)
                 .Search(x => x.Query, searchTerms)
@@ -142,15 +148,15 @@
                 .OfType<FailedMessage>()
                 .TransformToMessageView();
 
-            var results = await query.ToListAsync();
+            var results = await query.ToListAsync(cancellationToken);
 
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
 
-        public async Task MarkAsArchived(string failedMessageId)
+        public async Task MarkAsArchived(string failedMessageId, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
-            var failedMessage = await session.LoadAsync<FailedMessage>(FailedMessageIdGenerator.MakeDocumentId(failedMessageId));
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
+            var failedMessage = await session.LoadAsync<FailedMessage>(FailedMessageIdGenerator.MakeDocumentId(failedMessageId), cancellationToken);
 
             if (failedMessage.Status != FailedMessageStatus.Archived)
             {
@@ -159,14 +165,14 @@
                 expirationManager.EnableExpiration(session, failedMessage);
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(cancellationToken);
         }
 
-        public async Task<FailedMessage[]> GetFailedMessagesByIds(Guid[] ids)
+        public async Task<FailedMessage[]> GetFailedMessagesByIds(Guid[] ids, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var docIds = ids.Select(g => FailedMessageIdGenerator.MakeDocumentId(g.ToString()));
-            var results = await session.LoadAsync<FailedMessage>(docIds);
+            var results = await session.LoadAsync<FailedMessage>(docIds, cancellationToken);
             return results.Values.Where(x => x != null).ToArray();
         }
 
@@ -175,10 +181,11 @@
             string modified,
             string queueAddress,
             PagingInfo pagingInfo,
-            SortInfo sortInfo
+            SortInfo sortInfo,
+            CancellationToken cancellationToken = default
             )
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = session.Advanced
                 .AsyncDocumentQuery<FailedMessageViewIndex.SortAndFilterOptions, FailedMessageViewIndex>()
                 .Statistics(out var stats)
@@ -192,7 +199,7 @@
                 .TransformToFailedMessageView();
 
             var results = await query
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             return new QueryResult<IList<FailedMessageView>>(results, stats.ToQueryStatsInfo());
         }
@@ -200,16 +207,17 @@
         public async Task<QueryStatsInfo> GetFailedMessagesStats(
             string status,
             string modified,
-            string queueAddress
+            string queueAddress,
+            CancellationToken cancellationToken = default
             )
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var stats = await session.Advanced
                 .AsyncDocumentQuery<FailedMessageViewIndex.SortAndFilterOptions, FailedMessageViewIndex>()
                 .FilterByStatusWhere(status)
                 .FilterByLastModifiedRange(modified)
                 .FilterByQueueAddress(queueAddress)
-                .GetQueryResultAsync();
+                .GetQueryResultAsync(cancellationToken);
 
             return stats.ToQueryStatsInfo();
         }
@@ -219,10 +227,11 @@
             string endpointName,
             string modified,
             PagingInfo pagingInfo,
-            SortInfo sortInfo
+            SortInfo sortInfo,
+            CancellationToken cancellationToken = default
             )
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = session.Advanced
                 .AsyncDocumentQuery<FailedMessageViewIndex.SortAndFilterOptions, FailedMessageViewIndex>()
                 .Statistics(out var stats)
@@ -237,14 +246,14 @@
                 .TransformToFailedMessageView();
 
             var results = await query
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             return new QueryResult<IList<FailedMessageView>>(results, stats.ToQueryStatsInfo());
         }
 
-        public async Task<IDictionary<string, object>> GetFailedMessagesSummary()
+        public async Task<IDictionary<string, object>> GetFailedMessagesSummary(CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
 
             // The facets are named after the index fields and renamed afterwards. Setting
             // DisplayFieldName instead makes the server resolve the field by that name, which then
@@ -255,7 +264,7 @@
                     new Facet { FieldName = "Name" },
                     new Facet { FieldName = "Host" },
                     new Facet { FieldName = "MessageType" }
-                }).ExecuteAsync();
+                }).ExecuteAsync(cancellationToken);
 
             return new Dictionary<string, object>
             {
@@ -268,17 +277,17 @@
         static Dictionary<string, object> Counts(Dictionary<string, FacetResult> facetResults, string fieldName) =>
             facetResults[fieldName].Values.ToDictionary(value => value.Range, value => (object)value.Count);
 
-        public async Task<FailedMessage> GetFailedMessage(string failedMessageId)
+        public async Task<FailedMessage> GetFailedMessage(string failedMessageId, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
-            var message = await session.LoadAsync<FailedMessage>(FailedMessageIdGenerator.MakeDocumentId(failedMessageId));
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
+            var message = await session.LoadAsync<FailedMessage>(FailedMessageIdGenerator.MakeDocumentId(failedMessageId), cancellationToken);
             return message;
         }
 
-        public async Task<FailedMessageView> GetLatestFailedMessageView(string failedMessageId)
+        public async Task<FailedMessageView> GetLatestFailedMessageView(string failedMessageId, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
-            var message = await session.LoadAsync<FailedMessage>(FailedMessageIdGenerator.MakeDocumentId(failedMessageId));
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
+            var message = await session.LoadAsync<FailedMessage>(FailedMessageIdGenerator.MakeDocumentId(failedMessageId), cancellationToken);
             if (message == null)
             {
                 return null;
@@ -336,14 +345,14 @@
         }
 
 
-        public async Task<bool> MarkAsResolved(string failedMessageId)
+        public async Task<bool> MarkAsResolved(string failedMessageId, CancellationToken cancellationToken = default)
         {
             var documentId = FailedMessageIdGenerator.MakeDocumentId(failedMessageId);
 
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             session.Advanced.UseOptimisticConcurrency = true;
 
-            var failedMessage = await session.LoadAsync<FailedMessage>(documentId);
+            var failedMessage = await session.LoadAsync<FailedMessage>(documentId, cancellationToken);
 
             if (failedMessage == null)
             {
@@ -354,14 +363,14 @@
 
             expirationManager.EnableExpiration(session, failedMessage);
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(cancellationToken);
 
             return true;
         }
 
-        public async Task ProcessPendingRetries(DateTime periodFrom, DateTime periodTo, string queueAddress, Func<string, Task> processCallback)
+        public async Task ProcessPendingRetries(DateTime periodFrom, DateTime periodTo, string queueAddress, Func<string, CancellationToken, Task> processCallback, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var prequery = session.Advanced
                 .AsyncDocumentQuery<FailedMessageViewIndex.SortAndFilterOptions, FailedMessageViewIndex>()
                 .WhereEquals("Status", (int)FailedMessageStatus.RetryIssued)
@@ -379,14 +388,14 @@
                 .ToQueryable()
                 .TransformToFailedMessageView();
 
-            await using var ie = await session.Advanced.StreamAsync(query);
+            await using var ie = await session.Advanced.StreamAsync(query, cancellationToken);
             while (await ie.MoveNextAsync())
             {
-                await processCallback(ie.Current.Document.Id);
+                await processCallback(ie.Current.Document.Id, cancellationToken);
             }
         }
 
-        public async Task<string[]> UnArchiveMessagesByRange(DateTime from, DateTime to)
+        public async Task<string[]> UnArchiveMessagesByRange(DateTime from, DateTime to, CancellationToken cancellationToken = default)
         {
             const int Unresolved = (int)FailedMessageStatus.Unresolved;
             const int Archived = (int)FailedMessageStatus.Archived;
@@ -418,8 +427,8 @@
                 RetrieveDetails = true
             });
 
-            var documentStore = await documentStoreProvider.GetDocumentStore();
-            var operation = await documentStore.Operations.SendAsync(patch);
+            var documentStore = await documentStoreProvider.GetDocumentStore(cancellationToken);
+            var operation = await documentStore.Operations.SendAsync(patch, token: cancellationToken);
 
             var result = await operation.WaitForCompletionAsync<BulkOperationResult>();
 
@@ -430,16 +439,16 @@
             return ids;
         }
 
-        public async Task<string[]> UnArchiveMessages(IEnumerable<string> failedMessageIds)
+        public async Task<string[]> UnArchiveMessages(IEnumerable<string> failedMessageIds, CancellationToken cancellationToken = default)
         {
             Dictionary<string, FailedMessage> failedMessages;
 
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             session.Advanced.UseOptimisticConcurrency = true;
 
             var documentIds = failedMessageIds.Select(FailedMessageIdGenerator.MakeDocumentId);
 
-            failedMessages = await session.LoadAsync<FailedMessage>(documentIds);
+            failedMessages = await session.LoadAsync<FailedMessage>(documentIds, cancellationToken);
 
             foreach (var failedMessage in failedMessages.Values)
             {
@@ -450,45 +459,45 @@
                 }
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(cancellationToken);
 
             // Return the unique IDs - the dictionary keys are document ids with a prefix
             return failedMessages.Values.Select(x => x.UniqueMessageId).ToArray();
         }
 
-        public async Task RevertRetry(string messageUniqueId)
+        public async Task RevertRetry(string messageUniqueId, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var failedMessage = await session
-                .LoadAsync<FailedMessage>(FailedMessageIdGenerator.MakeDocumentId(messageUniqueId));
+                .LoadAsync<FailedMessage>(FailedMessageIdGenerator.MakeDocumentId(messageUniqueId), cancellationToken);
             failedMessage?.Status = FailedMessageStatus.Unresolved;
 
             var failedMessageRetry = await session
-                .LoadAsync<FailedMessageRetry>(RetryDocumentDataStore.MakeFailedMessageRetriesDocumentId(messageUniqueId));
+                .LoadAsync<FailedMessageRetry>(RetryDocumentDataStore.MakeFailedMessageRetriesDocumentId(messageUniqueId), cancellationToken);
             if (failedMessageRetry != null)
             {
                 session.Delete(failedMessageRetry);
             }
 
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(cancellationToken);
         }
 
-        public async Task RemoveFailedMessageRetry(string uniqueMessageId)
+        public async Task RemoveFailedMessageRetry(string uniqueMessageId, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
-            await session.Advanced.RequestExecutor.ExecuteAsync(new DeleteDocumentCommand(RetryDocumentDataStore.MakeFailedMessageRetriesDocumentId(uniqueMessageId), null), session.Advanced.Context);
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
+            await session.Advanced.RequestExecutor.ExecuteAsync(new DeleteDocumentCommand(RetryDocumentDataStore.MakeFailedMessageRetriesDocumentId(uniqueMessageId), null), session.Advanced.Context, token: cancellationToken);
         }
 
-        public async Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress)
+        public async Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = session
                 .Query<FailedMessageViewIndex.SortAndFilterOptions, FailedMessageViewIndex>()
                 .Where(o => o.Status == FailedMessageStatus.RetryIssued && o.LastModified >= from.Ticks && o.LastModified <= to.Ticks && o.QueueAddress == queueAddress)
                 .OfType<FailedMessageProjection>();
 
             int index = 0;
-            await using var streamResults = await session.Advanced.StreamAsync(query, out var streamQueryStatistics);
+            await using var streamResults = await session.Advanced.StreamAsync(query, out var streamQueryStatistics, cancellationToken);
             string[] ids = new string[streamQueryStatistics.TotalResults];
             while (await streamResults.MoveNextAsync())
             {
@@ -499,7 +508,7 @@
 
         record struct FailedMessageProjection(string UniqueMessageId);
 
-        public async Task<byte[]> GetFailedMessageBody(string uniqueMessageId)
+        public async Task<byte[]> GetFailedMessageBody(string uniqueMessageId, CancellationToken cancellationToken = default)
         {
             byte[] body = null;
             var result = await bodyStorage.TryFetch(uniqueMessageId)
@@ -515,7 +524,7 @@
                     // this assumption might change when we stop supporting RavenDB 3.5 but right now this is the most memory efficient way to do things
                     // https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream#getbuffer-and-toarray
                     using var memoryStream = new MemoryStream();
-                    await result.Stream.CopyToAsync(memoryStream);
+                    await result.Stream.CopyToAsync(memoryStream, cancellationToken);
 
                     body = memoryStream.ToArray();
                 }

--- a/src/ServiceControl.Persistence.RavenDB/QueueAddressStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/QueueAddressStore.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Raven.Client.Documents;
     using ServiceControl.MessageFailures;
@@ -10,14 +11,14 @@
 
     class QueueAddressStore(IRavenSessionProvider sessionProvider) : IQueueAddressStore
     {
-        public async Task<QueryResult<IList<QueueAddress>>> GetAddresses(PagingInfo pagingInfo)
+        public async Task<QueryResult<IList<QueueAddress>>> GetAddresses(PagingInfo pagingInfo, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var addresses = await session
                 .Query<QueueAddress, QueueAddressIndex>()
                 .Statistics(out var stats)
                 .Paging(pagingInfo)
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             var result = new QueryResult<IList<QueueAddress>>(addresses, stats.ToQueryStatsInfo());
             return result;

--- a/src/ServiceControl.Persistence.Tests/Recoverability/ReturnToSenderDequeuerTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/ReturnToSenderDequeuerTests.cs
@@ -169,13 +169,13 @@
 
         class FakeErrorMessageDataStore : IFailedMessageRetryDataStore
         {
-            public Task ProcessPendingRetries(DateTime periodFrom, DateTime periodTo, string queueAddress, Func<string, Task> processCallback) => throw new NotImplementedException();
+            public Task ProcessPendingRetries(DateTime periodFrom, DateTime periodTo, string queueAddress, Func<string, CancellationToken, Task> processCallback, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-            public Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress) => throw new NotImplementedException();
+            public Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-            public Task RemoveFailedMessageRetry(string uniqueMessageId) => throw new NotImplementedException();
+            public Task RemoveFailedMessageRetry(string uniqueMessageId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-            public Task<byte[]> GetFailedMessageBody(string bodyId) => Task.FromResult(Encoding.UTF8.GetBytes(bodyId));
+            public Task<byte[]> GetFailedMessageBody(string bodyId, CancellationToken cancellationToken = default) => Task.FromResult(Encoding.UTF8.GetBytes(bodyId));
         }
     }
 }

--- a/src/ServiceControl.Persistence/IFailedMessageLifecycleDataStore.cs
+++ b/src/ServiceControl.Persistence/IFailedMessageLifecycleDataStore.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.Persistence
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -10,10 +11,10 @@ namespace ServiceControl.Persistence
     /// </summary>
     public interface IFailedMessageLifecycleDataStore
     {
-        Task MarkAsArchived(string failedMessageId);
-        Task<bool> MarkAsResolved(string failedMessageId);
-        Task<string[]> UnArchiveMessages(IEnumerable<string> failedMessageIds);
-        Task<string[]> UnArchiveMessagesByRange(DateTime from, DateTime to);
-        Task RevertRetry(string messageUniqueId);
+        Task MarkAsArchived(string failedMessageId, CancellationToken cancellationToken = default);
+        Task<bool> MarkAsResolved(string failedMessageId, CancellationToken cancellationToken = default);
+        Task<string[]> UnArchiveMessages(IEnumerable<string> failedMessageIds, CancellationToken cancellationToken = default);
+        Task<string[]> UnArchiveMessagesByRange(DateTime from, DateTime to, CancellationToken cancellationToken = default);
+        Task RevertRetry(string messageUniqueId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Persistence/IFailedMessageQueryDataStore.cs
+++ b/src/ServiceControl.Persistence/IFailedMessageQueryDataStore.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.Persistence
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Infrastructure;
     using MessageFailures.Api;
@@ -10,13 +11,13 @@ namespace ServiceControl.Persistence
 
     public interface IFailedMessageQueryDataStore
     {
-        Task<QueryResult<IList<FailedMessageView>>> GetFailedMessages(string? status, string? modified, string? queueAddress, PagingInfo pagingInfo, SortInfo sortInfo);
-        Task<QueryStatsInfo> GetFailedMessagesStats(string? status, string? modified, string? queueAddress);
-        Task<QueryResult<IList<FailedMessageView>>> GetFailedMessagesByEndpoint(string? status, string endpointName, string? modified, PagingInfo pagingInfo, SortInfo sortInfo);
-        Task<IDictionary<string, object>> GetFailedMessagesSummary();
-        Task<FailedMessageView?> GetLatestFailedMessageView(string failedMessageId);
-        Task<FailedMessage?> GetFailedMessage(string failedMessageId);
+        Task<QueryResult<IList<FailedMessageView>>> GetFailedMessages(string? status, string? modified, string? queueAddress, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken = default);
+        Task<QueryStatsInfo> GetFailedMessagesStats(string? status, string? modified, string? queueAddress, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<FailedMessageView>>> GetFailedMessagesByEndpoint(string? status, string endpointName, string? modified, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken = default);
+        Task<IDictionary<string, object>> GetFailedMessagesSummary(CancellationToken cancellationToken = default);
+        Task<FailedMessageView?> GetLatestFailedMessageView(string failedMessageId, CancellationToken cancellationToken = default);
+        Task<FailedMessage?> GetFailedMessage(string failedMessageId, CancellationToken cancellationToken = default);
         /// <summary>Ids with no stored failed message are skipped, so the result can be shorter than <paramref name="ids" />.</summary>
-        Task<FailedMessage[]> GetFailedMessagesByIds(Guid[] ids);
+        Task<FailedMessage[]> GetFailedMessagesByIds(Guid[] ids, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Persistence/IFailedMessageRetryDataStore.cs
+++ b/src/ServiceControl.Persistence/IFailedMessageRetryDataStore.cs
@@ -1,13 +1,14 @@
 namespace ServiceControl.Persistence
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public interface IFailedMessageRetryDataStore
     {
-        Task ProcessPendingRetries(DateTime periodFrom, DateTime periodTo, string queueAddress, Func<string, Task> processCallback);
-        Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress);
-        Task RemoveFailedMessageRetry(string uniqueMessageId);
-        Task<byte[]> GetFailedMessageBody(string uniqueMessageId);
+        Task ProcessPendingRetries(DateTime periodFrom, DateTime periodTo, string queueAddress, Func<string, CancellationToken, Task> processCallback, CancellationToken cancellationToken = default);
+        Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress, CancellationToken cancellationToken = default);
+        Task RemoveFailedMessageRetry(string uniqueMessageId, CancellationToken cancellationToken = default);
+        Task<byte[]> GetFailedMessageBody(string uniqueMessageId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Persistence/IMessagesViewDataStore.cs
+++ b/src/ServiceControl.Persistence/IMessagesViewDataStore.cs
@@ -2,16 +2,17 @@ namespace ServiceControl.Persistence
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using CompositeViews.Messages;
     using Infrastructure;
 
     public interface IMessagesViewDataStore
     {
-        Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange timeSentRange = null);
-        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange timeSentRange = null);
-        Task<QueryResult<IList<MessagesView>>> GetAllMessagesByConversation(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages);
-        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null);
-        Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessagesByConversation(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Persistence/IQueueAddressStore.cs
+++ b/src/ServiceControl.Persistence/IQueueAddressStore.cs
@@ -1,12 +1,13 @@
 ﻿namespace ServiceControl.Persistence
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using ServiceControl.MessageFailures;
     using ServiceControl.Persistence.Infrastructure;
 
     public interface IQueueAddressStore
     {
-        Task<QueryResult<IList<QueueAddress>>> GetAddresses(PagingInfo pagingInfo);
+        Task<QueryResult<IList<QueueAddress>>> GetAddresses(PagingInfo pagingInfo, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.UnitTests/MessageFailures/AsyncRangeAndQueueAuditTests.cs
+++ b/src/ServiceControl.UnitTests/MessageFailures/AsyncRangeAndQueueAuditTests.cs
@@ -159,22 +159,22 @@ public class AsyncRangeAndQueueAuditTests
         public string[] UnArchiveMessagesResult { get; set; } = [];
         public FailedMessage ErrorByResult { get; set; } = new();
 
-        public Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress) => Task.FromResult(RetryPendingMessagesResult);
-        public Task RemoveFailedMessageRetry(string uniqueMessageId) => Task.CompletedTask;
-        public Task<string[]> UnArchiveMessagesByRange(DateTime from, DateTime to) => Task.FromResult(UnArchiveByRangeResult);
-        public Task<string[]> UnArchiveMessages(IEnumerable<string> failedMessageIds) => Task.FromResult(UnArchiveMessagesResult);
-        public Task<FailedMessage?> GetFailedMessage(string failedMessageId) => Task.FromResult<FailedMessage?>(ErrorByResult);
-        public Task MarkAsArchived(string failedMessageId) => Task.CompletedTask;
+        public Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress, CancellationToken cancellationToken = default) => Task.FromResult(RetryPendingMessagesResult);
+        public Task RemoveFailedMessageRetry(string uniqueMessageId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<string[]> UnArchiveMessagesByRange(DateTime from, DateTime to, CancellationToken cancellationToken = default) => Task.FromResult(UnArchiveByRangeResult);
+        public Task<string[]> UnArchiveMessages(IEnumerable<string> failedMessageIds, CancellationToken cancellationToken = default) => Task.FromResult(UnArchiveMessagesResult);
+        public Task<FailedMessage?> GetFailedMessage(string failedMessageId, CancellationToken cancellationToken = default) => Task.FromResult<FailedMessage?>(ErrorByResult);
+        public Task MarkAsArchived(string failedMessageId, CancellationToken cancellationToken = default) => Task.CompletedTask;
 
-        public Task<FailedMessage[]> GetFailedMessagesByIds(Guid[] ids) => throw new NotImplementedException();
-        public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessages(string? status, string? modified, string? queueAddress, PagingInfo pagingInfo, SortInfo sortInfo) => throw new NotImplementedException();
-        public Task<QueryStatsInfo> GetFailedMessagesStats(string? status, string? modified, string? queueAddress) => throw new NotImplementedException();
-        public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessagesByEndpoint(string? status, string endpointName, string? modified, PagingInfo pagingInfo, SortInfo sortInfo) => throw new NotImplementedException();
-        public Task<IDictionary<string, object>> GetFailedMessagesSummary() => throw new NotImplementedException();
-        public Task<FailedMessageView?> GetLatestFailedMessageView(string failedMessageId) => throw new NotImplementedException();
-        public Task<bool> MarkAsResolved(string failedMessageId) => throw new NotImplementedException();
-        public Task ProcessPendingRetries(DateTime periodFrom, DateTime periodTo, string queueAddress, Func<string, Task> processCallback) => throw new NotImplementedException();
-        public Task RevertRetry(string messageUniqueId) => throw new NotImplementedException();
-        public Task<byte[]> GetFailedMessageBody(string uniqueMessageId) => throw new NotImplementedException();
+        public Task<FailedMessage[]> GetFailedMessagesByIds(Guid[] ids, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessages(string? status, string? modified, string? queueAddress, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<QueryStatsInfo> GetFailedMessagesStats(string? status, string? modified, string? queueAddress, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessagesByEndpoint(string? status, string endpointName, string? modified, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<IDictionary<string, object>> GetFailedMessagesSummary(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<FailedMessageView?> GetLatestFailedMessageView(string failedMessageId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<bool> MarkAsResolved(string failedMessageId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task ProcessPendingRetries(DateTime periodFrom, DateTime periodTo, string queueAddress, Func<string, CancellationToken, Task> processCallback, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task RevertRetry(string messageUniqueId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<byte[]> GetFailedMessageBody(string uniqueMessageId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 }

--- a/src/ServiceControl.UnitTests/MessageFailures/EditFailedMessagesControllerAuditTests.cs
+++ b/src/ServiceControl.UnitTests/MessageFailures/EditFailedMessagesControllerAuditTests.cs
@@ -4,6 +4,7 @@ namespace ServiceControl.UnitTests.MessageFailures;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CompositeViews.Messages;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -63,13 +64,13 @@ public class EditFailedMessagesControllerAuditTests
         public FakeEditFailedMessagesManager EditManager { get; } = new();
 
         public Task<IEditFailedMessagesManager> CreateEditFailedMessageManager() => Task.FromResult<IEditFailedMessagesManager>(EditManager);
-        public Task<FailedMessage?> GetFailedMessage(string failedMessageId) => Task.FromResult(ErrorByResult);
+        public Task<FailedMessage?> GetFailedMessage(string failedMessageId, CancellationToken cancellationToken = default) => Task.FromResult(ErrorByResult);
 
-        public Task<FailedMessage[]> GetFailedMessagesByIds(Guid[] ids) => throw new NotImplementedException();
-        public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessages(string? status, string? modified, string? queueAddress, PagingInfo pagingInfo, SortInfo sortInfo) => throw new NotImplementedException();
-        public Task<QueryStatsInfo> GetFailedMessagesStats(string? status, string? modified, string? queueAddress) => throw new NotImplementedException();
-        public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessagesByEndpoint(string? status, string endpointName, string? modified, PagingInfo pagingInfo, SortInfo sortInfo) => throw new NotImplementedException();
-        public Task<IDictionary<string, object>> GetFailedMessagesSummary() => throw new NotImplementedException();
-        public Task<FailedMessageView?> GetLatestFailedMessageView(string failedMessageId) => throw new NotImplementedException();
+        public Task<FailedMessage[]> GetFailedMessagesByIds(Guid[] ids, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessages(string? status, string? modified, string? queueAddress, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<QueryStatsInfo> GetFailedMessagesStats(string? status, string? modified, string? queueAddress, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<QueryResult<IList<FailedMessageView>>> GetFailedMessagesByEndpoint(string? status, string endpointName, string? modified, PagingInfo pagingInfo, SortInfo sortInfo, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<IDictionary<string, object>> GetFailedMessagesSummary(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<FailedMessageView?> GetLatestFailedMessageView(string failedMessageId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesApi.cs
@@ -19,7 +19,7 @@ namespace ServiceControl.CompositeViews.Messages
 
         protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(ScatterGatherApiMessageViewWithSystemMessagesContext input, CancellationToken cancellationToken = default)
         {
-            return DataStore.GetAllMessages(input.PagingInfo, input.SortInfo, input.IncludeSystemMessages, input.TimeSentRange);
+            return DataStore.GetAllMessages(input.PagingInfo, input.SortInfo, input.IncludeSystemMessages, input.TimeSentRange, cancellationToken);
         }
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/GetAllMessagesForEndpointApi.cs
@@ -25,6 +25,6 @@ namespace ServiceControl.CompositeViews.Messages
         {
         }
 
-        protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(AllMessagesForEndpointContext input, CancellationToken cancellationToken = default) => DataStore.GetAllMessagesForEndpoint(input.EndpointName, input.PagingInfo, input.SortInfo, input.IncludeSystemMessages, input.TimeSentRange);
+        protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(AllMessagesForEndpointContext input, CancellationToken cancellationToken = default) => DataStore.GetAllMessagesForEndpoint(input.EndpointName, input.PagingInfo, input.SortInfo, input.IncludeSystemMessages, input.TimeSentRange, cancellationToken);
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/MessagesByConversationApi.cs
@@ -26,6 +26,6 @@ namespace ServiceControl.CompositeViews.Messages
 
         protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(MessagesByConversationContext input, CancellationToken cancellationToken = default) =>
             DataStore.GetAllMessagesByConversation(input.ConversationId, input.PagingInfo, input.SortInfo,
-                input.IncludeSystemMessages);
+                input.IncludeSystemMessages, cancellationToken);
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchApi.cs
@@ -25,6 +25,6 @@ namespace ServiceControl.CompositeViews.Messages
         }
 
         protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(SearchApiContext input, CancellationToken cancellationToken = default) =>
-            DataStore.GetAllMessagesForSearch(input.SearchQuery, input.PagingInfo, input.SortInfo, input.TimeSentRange);
+            DataStore.GetAllMessagesForSearch(input.SearchQuery, input.PagingInfo, input.SortInfo, input.TimeSentRange, cancellationToken);
     }
 }

--- a/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
+++ b/src/ServiceControl/CompositeViews/Messages/SearchEndpointApi.cs
@@ -26,6 +26,6 @@ namespace ServiceControl.CompositeViews.Messages
         }
 
         protected override Task<QueryResult<IList<MessagesView>>> LocalQuery(SearchEndpointContext input, CancellationToken cancellationToken = default) =>
-            DataStore.SearchEndpointMessages(input.Endpoint, input.Keyword, input.PagingInfo, input.SortInfo, input.TimeSentRange);
+            DataStore.SearchEndpointMessages(input.Endpoint, input.Keyword, input.PagingInfo, input.SortInfo, input.TimeSentRange, cancellationToken);
     }
 }

--- a/src/ServiceControl/MessageFailures/Api/EditFailedMessagesController.cs
+++ b/src/ServiceControl/MessageFailures/Api/EditFailedMessagesController.cs
@@ -54,7 +54,7 @@
                 return Ok(new EditRetryResponse { EditIgnored = true });
             }
 
-            var failedMessage = await store.GetFailedMessage(failedMessageId);
+            var failedMessage = await store.GetFailedMessage(failedMessageId, cancellationToken);
 
             if (failedMessage == null)
             {

--- a/src/ServiceControl/MessageFailures/Api/GetAllErrorsController.cs
+++ b/src/ServiceControl/MessageFailures/Api/GetAllErrorsController.cs
@@ -24,7 +24,8 @@
                     modified: modified,
                     queueAddress: queueAddress,
                     pagingInfo,
-                    sortInfo
+                    sortInfo,
+                    cancellationToken
                     );
 
             Response.WithQueryStatsAndPagingInfo(results.QueryStats, pagingInfo);
@@ -40,7 +41,8 @@
             var queryResult = await store.GetFailedMessagesStats(
                     status: status,
                     modified: modified,
-                    queueAddress: queueAddress
+                    queueAddress: queueAddress,
+                    cancellationToken: cancellationToken
                     );
 
             Response.WithQueryStatsInfo(queryResult);
@@ -56,7 +58,8 @@
                 endpointName: endpointName,
                 modified: modified,
                 pagingInfo,
-                sortInfo
+                sortInfo,
+                cancellationToken
                 );
 
             Response.WithQueryStatsAndPagingInfo(results.QueryStats, pagingInfo);
@@ -67,6 +70,6 @@
         [Authorize(Policy = Permissions.ErrorMessagesView)]
         [Route("errors/summary")]
         [HttpGet]
-        public async Task<IDictionary<string, object>> ErrorsSummary(CancellationToken cancellationToken = default) => await store.GetFailedMessagesSummary();
+        public async Task<IDictionary<string, object>> ErrorsSummary(CancellationToken cancellationToken = default) => await store.GetFailedMessagesSummary(cancellationToken);
     }
 }

--- a/src/ServiceControl/MessageFailures/Api/GetErrorByIdController.cs
+++ b/src/ServiceControl/MessageFailures/Api/GetErrorByIdController.cs
@@ -16,7 +16,7 @@
         [HttpGet]
         public async Task<ActionResult<FailedMessage>> ErrorBy(string failedMessageId, CancellationToken cancellationToken = default)
         {
-            var result = await store.GetFailedMessage(failedMessageId);
+            var result = await store.GetFailedMessage(failedMessageId, cancellationToken);
 
             return result == null ? NotFound() : result;
         }
@@ -26,7 +26,7 @@
         [HttpGet]
         public async Task<ActionResult<FailedMessageView>> ErrorLastBy(string failedMessageId, CancellationToken cancellationToken = default)
         {
-            var result = await store.GetLatestFailedMessageView(failedMessageId);
+            var result = await store.GetLatestFailedMessageView(failedMessageId, cancellationToken);
 
             return result == null ? NotFound() : result;
         }

--- a/src/ServiceControl/MessageFailures/Api/QueueAddressController.cs
+++ b/src/ServiceControl/MessageFailures/Api/QueueAddressController.cs
@@ -19,7 +19,7 @@ public class QueueAddressController(IQueueAddressStore store) : ControllerBase
     [HttpGet]
     public async Task<IList<QueueAddress>> GetAddresses([FromQuery] PagingInfo pagingInfo, CancellationToken cancellationToken = default)
     {
-        var result = await store.GetAddresses(pagingInfo);
+        var result = await store.GetAddresses(pagingInfo, cancellationToken);
 
         Response.WithQueryStatsAndPagingInfo(result.QueryStats, pagingInfo);
 

--- a/src/ServiceControl/MessageFailures/Handlers/ArchiveMessageHandler.cs
+++ b/src/ServiceControl/MessageFailures/Handlers/ArchiveMessageHandler.cs
@@ -15,7 +15,7 @@
         {
             var failedMessageId = message.FailedMessageId;
 
-            var failedMessage = await queryStore.GetFailedMessage(failedMessageId);
+            var failedMessage = await queryStore.GetFailedMessage(failedMessageId, context.CancellationToken);
 
             if (failedMessage.Status != FailedMessageStatus.Archived)
             {
@@ -24,7 +24,7 @@
                     FailedMessageId = failedMessageId
                 }, context.CancellationToken);
 
-                await lifecycleStore.MarkAsArchived(failedMessageId);
+                await lifecycleStore.MarkAsArchived(failedMessageId, context.CancellationToken);
 
                 var (user, operationId) = AuditHeaders.Read(context.MessageHeaders);
                 if (!string.IsNullOrEmpty(operationId))

--- a/src/ServiceControl/MessageFailures/Handlers/MessageFailureResolvedHandler.cs
+++ b/src/ServiceControl/MessageFailures/Handlers/MessageFailureResolvedHandler.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.MessageFailures.Handlers
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Contracts.MessageFailures;
     using Infrastructure.DomainEvents;
@@ -14,7 +15,7 @@
     {
         public Task Handle(MarkPendingRetriesAsResolved message, IMessageHandlerContext context)
         {
-            Task ProcessCallback(string id)
+            Task ProcessCallback(string id, CancellationToken cancellationToken)
             {
                 var sendOptions = new SendOptions();
                 sendOptions.RouteToThisEndpoint();
@@ -28,13 +29,14 @@
                 message.PeriodFrom,
                 message.PeriodTo,
                 message.QueueAddress,
-                ProcessCallback
+                ProcessCallback,
+                context.CancellationToken
             );
         }
 
         public async Task Handle(MarkPendingRetryAsResolved message, IMessageHandlerContext context)
         {
-            _ = await lifecycleStore.MarkAsResolved(message.FailedMessageId);
+            _ = await lifecycleStore.MarkAsResolved(message.FailedMessageId, context.CancellationToken);
 
             await domainEvents.Raise(new MessageFailureResolvedManually
             {

--- a/src/ServiceControl/MessageFailures/Handlers/UnArchiveMessagesByRangeHandler.cs
+++ b/src/ServiceControl/MessageFailures/Handlers/UnArchiveMessagesByRangeHandler.cs
@@ -14,7 +14,7 @@
     {
         public async Task Handle(UnArchiveMessagesByRange message, IMessageHandlerContext context)
         {
-            var ids = await dataStore.UnArchiveMessagesByRange(message.From, message.To);
+            var ids = await dataStore.UnArchiveMessagesByRange(message.From, message.To, context.CancellationToken);
 
             var (user, operationId) = AuditHeaders.Read(context.MessageHeaders);
             if (!string.IsNullOrEmpty(operationId))

--- a/src/ServiceControl/MessageFailures/Handlers/UnArchiveMessagesHandler.cs
+++ b/src/ServiceControl/MessageFailures/Handlers/UnArchiveMessagesHandler.cs
@@ -15,7 +15,7 @@
     {
         public async Task Handle(UnArchiveMessages messages, IMessageHandlerContext context)
         {
-            var ids = await store.UnArchiveMessages(messages.FailedMessageIds);
+            var ids = await store.UnArchiveMessages(messages.FailedMessageIds, context.CancellationToken);
 
             var (user, operationId) = AuditHeaders.Read(context.MessageHeaders);
             if (!string.IsNullOrEmpty(operationId))

--- a/src/ServiceControl/Recoverability/ExternalIntegration/MessageFailedPublisher.cs
+++ b/src/ServiceControl/Recoverability/ExternalIntegration/MessageFailedPublisher.cs
@@ -29,7 +29,7 @@ namespace ServiceControl.Recoverability.ExternalIntegration
         protected override async Task<IEnumerable<object>> PublishEvents(IEnumerable<DispatchContext> contexts, CancellationToken cancellationToken = default)
         {
             var ids = contexts.Select(x => x.FailedMessageId).ToArray();
-            var results = await dataStore.GetFailedMessagesByIds(ids);
+            var results = await dataStore.GetFailedMessagesByIds(ids, cancellationToken);
             return results.Select(x => x.ToEvent());
         }
 

--- a/src/ServiceControl/Recoverability/Retrying/FailedMessageRetryCleaner.cs
+++ b/src/ServiceControl/Recoverability/Retrying/FailedMessageRetryCleaner.cs
@@ -19,7 +19,7 @@ namespace ServiceControl.Recoverability
         {
             if (message.RepeatedFailure)
             {
-                return dataStore.RemoveFailedMessageRetry(message.FailedMessageId);
+                return dataStore.RemoveFailedMessageRetry(message.FailedMessageId, cancellationToken);
             }
 
             return Task.CompletedTask;

--- a/src/ServiceControl/Recoverability/Retrying/Handlers/PendingRetriesHandler.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Handlers/PendingRetriesHandler.cs
@@ -20,11 +20,11 @@ namespace ServiceControl.Recoverability
         {
             var messageIds = new List<string>();
 
-            var ids = await dataStore.GetRetryPendingMessages(message.PeriodFrom, message.PeriodTo, message.QueueAddress);
+            var ids = await dataStore.GetRetryPendingMessages(message.PeriodFrom, message.PeriodTo, message.QueueAddress, context.CancellationToken);
 
             foreach (var id in ids)
             {
-                await dataStore.RemoveFailedMessageRetry(id);
+                await dataStore.RemoveFailedMessageRetry(id, context.CancellationToken);
                 messageIds.Add(id);
             }
 
@@ -35,7 +35,7 @@ namespace ServiceControl.Recoverability
         {
             foreach (var messageUniqueId in message.MessageUniqueIds)
             {
-                await dataStore.RemoveFailedMessageRetry(messageUniqueId);
+                await dataStore.RemoveFailedMessageRetry(messageUniqueId, context.CancellationToken);
             }
 
             await SendRetryMessagesById(context, message.MessageUniqueIds);

--- a/src/ServiceControl/Recoverability/Retrying/Handlers/RetriesHandler.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Handlers/RetriesHandler.cs
@@ -22,7 +22,7 @@ namespace ServiceControl.Recoverability
         {
             if (message.RepeatedFailure)
             {
-                return dataStore.RemoveFailedMessageRetry(message.FailedMessageId);
+                return dataStore.RemoveFailedMessageRetry(message.FailedMessageId, context.CancellationToken);
             }
 
             return Task.CompletedTask;

--- a/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSender.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSender.cs
@@ -59,7 +59,7 @@ namespace ServiceControl.Recoverability
         async Task<byte[]> FetchFromFailedMessage(Dictionary<string, string> outgoingHeaders, string messageId, string attemptMessageId, CancellationToken cancellationToken)
         {
             var uniqueMessageId = outgoingHeaders["ServiceControl.Retry.UniqueMessageId"];
-            byte[] body = await errorMessageStore.GetFailedMessageBody(uniqueMessageId);
+            byte[] body = await errorMessageStore.GetFailedMessageBody(uniqueMessageId, cancellationToken);
 
             if (body == null)
             {

--- a/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
@@ -190,18 +190,13 @@ class ReturnToSenderDequeuer : IHostedService
 
         public async Task<ErrorHandleResult> OnError(ErrorContext errorContext, CancellationToken cancellationToken = default)
         {
-            // We are currently not propagating the cancellation token further since it would require to change
-            // the data store APIs and domain handlers to take a cancellation token. If this is needed it can be done
-            // at a later time.
-            _ = cancellationToken;
-
             try
             {
                 var destination = errorContext.Headers["ServiceControl.TargetEndpointAddress"];
                 var messageUniqueId = errorContext.Headers["ServiceControl.Retry.UniqueMessageId"];
                 logger.LogWarning(errorContext.Exception, "Failed to send '{UniqueMessageId}' message to '{Destination}' for retry. Attempting to revert message status to unresolved so it can be tried again", messageUniqueId, destination);
 
-                await dataStore.RevertRetry(messageUniqueId);
+                await dataStore.RevertRetry(messageUniqueId, cancellationToken);
 
                 string reason;
                 try


### PR DESCRIPTION
Covers two interface groups together, because `ErrorMessagesDataStore` implements all four of their interfaces and is better converted in one pass than left half-done:

- **Query stores:** `IFailedMessageQueryDataStore` (7), `IMessagesViewDataStore` (5), `IQueueAddressStore` (1)
- **Lifecycle and retry:** `IFailedMessageLifecycleDataStore` (5), `IFailedMessageRetryDataStore` (5)

23 interface methods, both persisters, 15 host call sites, 3 test doubles. The highest actual payoff is `ServiceControl/CompositeViews`, the scatter-gather HTTP fan-out to remote instances, where an abandoned request previously kept running to completion against every remote.

Two things worth a reviewer's attention:

- **`ProcessPendingRetries`' callback became `Func<string, CancellationToken, Task>`** (`PS0013`). The store owns the streaming loop, so it hands each iteration its own token. At the one real caller, `MessageFailureResolvedHandler`, that token is genuinely unused: NServiceBus' `IPipelineContext.Send` overloads deliberately take no `CancellationToken` (the token lives on the context). It is left unused rather than given an invented use.
- **A stale workaround is deleted** in `ReturnToSenderDequeuer.CaptureIfMessageSendingFails.OnError`. It carried `_ = cancellationToken;` under a comment claiming the token could not be propagated "since it would require to change the data store APIs". The comment was already wrong, since the token was in use two lines below at `domainEvents.Raise` and in the catch filter. `RevertRetry` was the last real gap and this closes it.

`DataStoreBase.ExecuteWithDbContext` is deliberately left alone: the lambdas now close over the enclosing `cancellationToken`, so propagation is complete and correct with no blast radius. Changing its `Func` to carry the token would break lambda arity at roughly 40 stores and force `CancellationToken.None` placeholders in the ones not yet converted. Done last instead, it is a mechanical sweep over already-tokenised code.