### PR TITLE
Propagate cancellation tokens through group data store persistence

### DIFF
--- a/src/ServiceControl.Persistence.EFCore/Implementation/GroupsDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/GroupsDataStore.cs
@@ -12,7 +12,7 @@ using ServiceControl.Recoverability;
 
 public class GroupsDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IGroupsDataStore
 {
-    public Task<IList<FailureGroupView>> GetUnresolvedGroupsByClassifier(string classifier, string classifierFilter) =>
+    public Task<IList<FailureGroupView>> GetUnresolvedGroupsByClassifier(string classifier, string classifierFilter, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(async dbContext =>
         {
             var groups = ByClassifier(dbContext, classifier);
@@ -22,57 +22,58 @@ public class GroupsDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(
                 groups = groups.Where(group => group.Title == classifierFilter);
             }
 
-            var views = await MostRecent(groups.AggregateGroups(WithStatus(dbContext, FailedMessageStatus.Unresolved)));
+            var views = await MostRecent(groups.AggregateGroups(WithStatus(dbContext, FailedMessageStatus.Unresolved)), cancellationToken);
 
-            await AttachComments(dbContext, views);
+            await AttachComments(dbContext, views, cancellationToken);
 
             return views;
         });
 
-    public Task<IList<FailureGroupView>> GetArchivedGroupsByClassifier(string classifier) =>
+    public Task<IList<FailureGroupView>> GetArchivedGroupsByClassifier(string classifier, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(dbContext => MostRecent(
-            ByClassifier(dbContext, classifier).AggregateGroups(WithStatus(dbContext, FailedMessageStatus.Archived))));
+            ByClassifier(dbContext, classifier).AggregateGroups(WithStatus(dbContext, FailedMessageStatus.Archived)), cancellationToken));
 
-    public Task<QueryResult<FailureGroupView>> GetUnresolvedGroup(string groupId, string status, string modified) =>
-        ExecuteWithDbContext(dbContext => SingleGroup(dbContext, groupId, FailedMessageStatus.Unresolved, status, modified));
+    public Task<QueryResult<FailureGroupView>> GetUnresolvedGroup(string groupId, string status, string modified, CancellationToken cancellationToken = default) =>
+        ExecuteWithDbContext(dbContext => SingleGroup(dbContext, groupId, FailedMessageStatus.Unresolved, status, modified, cancellationToken));
 
-    public Task<QueryResult<FailureGroupView>> GetArchivedGroup(string groupId, string status, string modified) =>
-        ExecuteWithDbContext(dbContext => SingleGroup(dbContext, groupId, FailedMessageStatus.Archived, status, modified));
+    public Task<QueryResult<FailureGroupView>> GetArchivedGroup(string groupId, string status, string modified, CancellationToken cancellationToken = default) =>
+        ExecuteWithDbContext(dbContext => SingleGroup(dbContext, groupId, FailedMessageStatus.Archived, status, modified, cancellationToken));
 
-    public Task<QueryResult<IList<FailedMessageView>>> GetGroupErrors(string groupId, string status, string modified, SortInfo sortInfo, PagingInfo pagingInfo) =>
-        ExecuteWithDbContext(dbContext => InGroup(dbContext, groupId, status, modified).ToPagedResult(pagingInfo, sortInfo));
+    public Task<QueryResult<IList<FailedMessageView>>> GetGroupErrors(string groupId, string status, string modified, SortInfo sortInfo, PagingInfo pagingInfo, CancellationToken cancellationToken = default) =>
+        ExecuteWithDbContext(dbContext => InGroup(dbContext, groupId, status, modified).ToPagedResult(pagingInfo, sortInfo, cancellationToken));
 
-    public Task<QueryStatsInfo> GetGroupErrorsCount(string groupId, string status, string modified) =>
-        ExecuteWithDbContext(dbContext => InGroup(dbContext, groupId, status, modified).ToQueryStatsInfo());
+    public Task<QueryStatsInfo> GetGroupErrorsCount(string groupId, string status, string modified, CancellationToken cancellationToken = default) =>
+        ExecuteWithDbContext(dbContext => InGroup(dbContext, groupId, status, modified).ToQueryStatsInfo(cancellationToken));
 
-    public Task EditComment(string groupId, string comment) =>
+    public Task EditComment(string groupId, string comment, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(async dbContext =>
         {
             if (string.IsNullOrWhiteSpace(comment))
             {
-                await RemoveComment(dbContext, groupId);
+                await RemoveComment(dbContext, groupId, cancellationToken);
                 return;
             }
 
             await dbContext.UpsertAsync([groupId],
                 () => new GroupCommentEntity { GroupId = groupId, Comment = comment },
-                entity => entity.Comment = comment);
+                entity => entity.Comment = comment,
+                cancellationToken);
         });
 
-    public Task DeleteComment(string groupId) =>
-        ExecuteWithDbContext(dbContext => RemoveComment(dbContext, groupId));
+    public Task DeleteComment(string groupId, CancellationToken cancellationToken = default) =>
+        ExecuteWithDbContext(dbContext => RemoveComment(dbContext, groupId, cancellationToken));
 
-    static Task<int> RemoveComment(ServiceControlDbContext dbContext, string groupId) =>
+    static Task<int> RemoveComment(ServiceControlDbContext dbContext, string groupId, CancellationToken cancellationToken) =>
         dbContext.GroupComments
             .Where(groupComment => groupComment.GroupId == groupId)
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken);
 
     static IQueryable<FailedMessageGroupEntity> ByClassifier(ServiceControlDbContext dbContext, string classifier) =>
         dbContext.FailedMessageGroups
             .AsNoTracking()
             .Where(group => group.Type == classifier);
 
-    static async Task<QueryResult<FailureGroupView>> SingleGroup(ServiceControlDbContext dbContext, string groupId, FailedMessageStatus baseline, string status, string modified)
+    static async Task<QueryResult<FailureGroupView>> SingleGroup(ServiceControlDbContext dbContext, string groupId, FailedMessageStatus baseline, string status, string modified, CancellationToken cancellationToken)
     {
         var groups = await dbContext.FailedMessageGroups
             .AsNoTracking()
@@ -80,7 +81,7 @@ public class GroupsDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(
             .AggregateGroups(WithStatus(dbContext, baseline)
                 .FilterByStatus(status)
                 .FilterByLastModifiedRange(modified))
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
         return new QueryResult<FailureGroupView>(groups.FirstOrDefault()!, groups.ToQueryStatsInfo());
     }
@@ -97,7 +98,7 @@ public class GroupsDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(
             .FilterByStatus(status)
             .FilterByLastModifiedRange(modified);
 
-    static async Task AttachComments(ServiceControlDbContext dbContext, IList<FailureGroupView> groups)
+    static async Task AttachComments(ServiceControlDbContext dbContext, IList<FailureGroupView> groups, CancellationToken cancellationToken)
     {
         if (groups.Count == 0)
         {
@@ -109,7 +110,7 @@ public class GroupsDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(
         var comments = await dbContext.GroupComments
             .AsNoTracking()
             .Where(groupComment => groupIds.Contains(groupComment.GroupId))
-            .ToDictionaryAsync(groupComment => groupComment.GroupId, groupComment => groupComment.Comment);
+            .ToDictionaryAsync(groupComment => groupComment.GroupId, groupComment => groupComment.Comment, cancellationToken);
 
         foreach (var group in groups)
         {
@@ -117,9 +118,9 @@ public class GroupsDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(
         }
     }
 
-    static async Task<IList<FailureGroupView>> MostRecent(IQueryable<FailureGroupView> groups) =>
+    static async Task<IList<FailureGroupView>> MostRecent(IQueryable<FailureGroupView> groups, CancellationToken cancellationToken) =>
         await groups
             .OrderByDescending(group => group.Last)
             .Take(FailureGroupQueries.MaxGroups)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 }

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/GroupsDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/GroupsDataStore.cs
@@ -14,9 +14,9 @@ namespace ServiceControl.Persistence.RavenDB.Recoverability
 
     class GroupsDataStore(IRavenSessionProvider sessionProvider) : IGroupsDataStore
     {
-        public async Task<IList<FailureGroupView>> GetUnresolvedGroupsByClassifier(string classifier, string classifierFilter)
+        public async Task<IList<FailureGroupView>> GetUnresolvedGroupsByClassifier(string classifier, string classifierFilter, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = Queryable.Where(session.Query<FailureGroupView, FailureGroupsViewIndex>(), v => v.Type == classifier);
 
             if (!string.IsNullOrWhiteSpace(classifierFilter))
@@ -26,11 +26,11 @@ namespace ServiceControl.Persistence.RavenDB.Recoverability
 
             var groups = await query.OrderByDescending(x => x.Last)
                 .Take(200)
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             var commentIds = groups.Select(x => MakeId(x.Id)).ToArray();
             var comments = await session.Query<GroupComment, GroupCommentIndex>().Where(x => x.Id.In(commentIds))
-                .ToListAsync(CancellationToken.None);
+                .ToListAsync(cancellationToken);
 
             foreach (var group in groups)
             {
@@ -40,9 +40,9 @@ namespace ServiceControl.Persistence.RavenDB.Recoverability
             return groups;
         }
 
-        public async Task<IList<FailureGroupView>> GetArchivedGroupsByClassifier(string classifier)
+        public async Task<IList<FailureGroupView>> GetArchivedGroupsByClassifier(string classifier, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var groups = session
                 .Query<FailureGroupView, ArchivedGroupsViewIndex>()
                 .Where(v => v.Type == classifier);
@@ -50,35 +50,35 @@ namespace ServiceControl.Persistence.RavenDB.Recoverability
             var results = await groups
                 .OrderByDescending(x => x.Last)
                 .Take(200) // only show 200 groups
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             return results;
         }
 
-        public async Task<QueryResult<FailureGroupView>> GetUnresolvedGroup(string groupId, string status, string modified)
+        public async Task<QueryResult<FailureGroupView>> GetUnresolvedGroup(string groupId, string status, string modified, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var document = await session.Advanced
                 .AsyncDocumentQuery<FailureGroupView, FailureGroupsViewIndex>()
                 .Statistics(out var stats)
                 .WhereEquals(group => group.Id, groupId)
                 .FilterByStatusWhere(status)
                 .FilterByLastModifiedRange(modified)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(cancellationToken);
 
             return new QueryResult<FailureGroupView>(document, stats.ToQueryStatsInfo());
         }
 
-        public async Task<QueryResult<FailureGroupView>> GetArchivedGroup(string groupId, string status, string modified)
+        public async Task<QueryResult<FailureGroupView>> GetArchivedGroup(string groupId, string status, string modified, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var document = await session.Advanced
                 .AsyncDocumentQuery<FailureGroupView, ArchivedGroupsViewIndex>()
                 .Statistics(out var stats)
                 .WhereEquals(group => group.Id, groupId)
                 .FilterByStatusWhere(status)
                 .FilterByLastModifiedRange(modified)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(cancellationToken);
 
             return new QueryResult<FailureGroupView>(document, stats.ToQueryStatsInfo());
         }
@@ -88,10 +88,11 @@ namespace ServiceControl.Persistence.RavenDB.Recoverability
             string status,
             string modified,
             SortInfo sortInfo,
-            PagingInfo pagingInfo
+            PagingInfo pagingInfo,
+            CancellationToken cancellationToken = default
             )
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var query = session.Advanced
                 .AsyncDocumentQuery<FailureGroupMessageView, FailedMessages_ByGroup>()
                 .Statistics(out var stats)
@@ -105,42 +106,42 @@ namespace ServiceControl.Persistence.RavenDB.Recoverability
                 .TransformToFailedMessageView();
 
             var results = await query
-                .ToListAsync();
+                .ToListAsync(cancellationToken);
 
             return results.ToQueryResult(stats);
         }
 
-        public async Task<QueryStatsInfo> GetGroupErrorsCount(string groupId, string status, string modified)
+        public async Task<QueryStatsInfo> GetGroupErrorsCount(string groupId, string status, string modified, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var queryResult = await session.Advanced
                 .AsyncDocumentQuery<FailureGroupMessageView, FailedMessages_ByGroup>()
                 .WhereEquals(view => view.FailureGroupId, groupId)
                 .FilterByStatusWhere(status)
                 .FilterByLastModifiedRange(modified)
-                .GetQueryResultAsync();
+                .GetQueryResultAsync(cancellationToken);
 
             return queryResult.ToQueryStatsInfo();
         }
 
-        public async Task EditComment(string groupId, string comment)
+        public async Task EditComment(string groupId, string comment, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             var groupComment =
-                await session.LoadAsync<GroupComment>(MakeId(groupId))
+                await session.LoadAsync<GroupComment>(MakeId(groupId), cancellationToken)
                 ?? new GroupComment { Id = MakeId(groupId) };
 
             groupComment.Comment = comment;
 
-            await session.StoreAsync(groupComment);
-            await session.SaveChangesAsync();
+            await session.StoreAsync(groupComment, cancellationToken);
+            await session.SaveChangesAsync(cancellationToken);
         }
 
-        public async Task DeleteComment(string groupId)
+        public async Task DeleteComment(string groupId, CancellationToken cancellationToken = default)
         {
-            using var session = await sessionProvider.OpenSession();
+            using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             session.Delete(MakeId(groupId));
-            await session.SaveChangesAsync();
+            await session.SaveChangesAsync(cancellationToken);
         }
 
         public static string MakeId(string groupId) => $"GroupComment/{groupId}";

--- a/src/ServiceControl.Persistence/IGroupsDataStore.cs
+++ b/src/ServiceControl.Persistence/IGroupsDataStore.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Persistence
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Infrastructure;
     using MessageFailures.Api;
@@ -8,15 +9,15 @@ namespace ServiceControl.Persistence
 
     public interface IGroupsDataStore
     {
-        Task<IList<FailureGroupView>> GetUnresolvedGroupsByClassifier(string classifier, string classifierFilter);
-        Task<IList<FailureGroupView>> GetArchivedGroupsByClassifier(string classifier);
+        Task<IList<FailureGroupView>> GetUnresolvedGroupsByClassifier(string classifier, string classifierFilter, CancellationToken cancellationToken = default);
+        Task<IList<FailureGroupView>> GetArchivedGroupsByClassifier(string classifier, CancellationToken cancellationToken = default);
 
-        Task<QueryResult<FailureGroupView>> GetUnresolvedGroup(string groupId, string status, string modified);
-        Task<QueryResult<FailureGroupView>> GetArchivedGroup(string groupId, string status, string modified);
-        Task<QueryResult<IList<FailedMessageView>>> GetGroupErrors(string groupId, string status, string modified, SortInfo sortInfo, PagingInfo pagingInfo);
-        Task<QueryStatsInfo> GetGroupErrorsCount(string groupId, string status, string modified);
+        Task<QueryResult<FailureGroupView>> GetUnresolvedGroup(string groupId, string status, string modified, CancellationToken cancellationToken = default);
+        Task<QueryResult<FailureGroupView>> GetArchivedGroup(string groupId, string status, string modified, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<FailedMessageView>>> GetGroupErrors(string groupId, string status, string modified, SortInfo sortInfo, PagingInfo pagingInfo, CancellationToken cancellationToken = default);
+        Task<QueryStatsInfo> GetGroupErrorsCount(string groupId, string status, string modified, CancellationToken cancellationToken = default);
 
-        Task EditComment(string groupId, string comment);
-        Task DeleteComment(string groupId);
+        Task EditComment(string groupId, string comment, CancellationToken cancellationToken = default);
+        Task DeleteComment(string groupId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl/MessageFailures/Api/ArchiveMessagesController.cs
+++ b/src/ServiceControl/MessageFailures/Api/ArchiveMessagesController.cs
@@ -48,7 +48,7 @@ namespace ServiceControl.MessageFailures.Api
         [HttpGet]
         public async Task<IActionResult> GetArchiveMessageGroups(string classifier = "Exception Type and Stack Trace", CancellationToken cancellationToken = default)
         {
-            var results = await dataStore.GetArchivedGroupsByClassifier(classifier);
+            var results = await dataStore.GetArchivedGroupsByClassifier(classifier, cancellationToken);
 
             Response.WithDeterministicEtag(EtagHelper.CalculateEtag(results));
 
@@ -75,7 +75,7 @@ namespace ServiceControl.MessageFailures.Api
         [HttpGet]
         public async Task<ActionResult<FailureGroupView>> GetGroup(string groupId, string status = default, string modified = default, CancellationToken cancellationToken = default)
         {
-            var result = await dataStore.GetArchivedGroup(groupId, status, modified);
+            var result = await dataStore.GetArchivedGroup(groupId, status, modified, cancellationToken);
 
             Response.WithEtag(result.QueryStats.ETag);
 

--- a/src/ServiceControl/Recoverability/API/FailureGroupsController.cs
+++ b/src/ServiceControl/Recoverability/API/FailureGroupsController.cs
@@ -41,7 +41,7 @@
         [HttpPost]
         public async Task<IActionResult> EditComment(string groupId, string comment, CancellationToken cancellationToken = default)
         {
-            await store.EditComment(groupId, comment);
+            await store.EditComment(groupId, comment, cancellationToken);
 
             return Accepted();
         }
@@ -51,7 +51,7 @@
         [HttpDelete]
         public async Task<IActionResult> DeleteComment(string groupId, CancellationToken cancellationToken = default)
         {
-            await store.DeleteComment(groupId);
+            await store.DeleteComment(groupId, cancellationToken);
 
             return Accepted();
         }
@@ -76,7 +76,7 @@
         [HttpGet]
         public async Task<IList<FailedMessageView>> GetGroupErrors(string groupId, [FromQuery] SortInfo sortInfo, [FromQuery] PagingInfo pagingInfo, string status = default, string modified = default, CancellationToken cancellationToken = default)
         {
-            var results = await store.GetGroupErrors(groupId, status, modified, sortInfo, pagingInfo);
+            var results = await store.GetGroupErrors(groupId, status, modified, sortInfo, pagingInfo, cancellationToken);
 
             Response.WithQueryStatsAndPagingInfo(results.QueryStats, pagingInfo);
             return results.Results;
@@ -88,7 +88,7 @@
         [HttpHead]
         public async Task GetGroupErrorsCount(string groupId, string status = default, string modified = default, CancellationToken cancellationToken = default)
         {
-            var results = await store.GetGroupErrorsCount(groupId, status, modified);
+            var results = await store.GetGroupErrorsCount(groupId, status, modified, cancellationToken);
 
             Response.WithQueryStatsInfo(results);
         }
@@ -110,7 +110,7 @@
         [HttpGet]
         public async Task<ActionResult<FailureGroupView>> GetGroup(string groupId, string status = default, string modified = default, CancellationToken cancellationToken = default)
         {
-            var result = await store.GetUnresolvedGroup(groupId, status, modified);
+            var result = await store.GetUnresolvedGroup(groupId, status, modified, cancellationToken);
 
             Response.WithEtag(result.QueryStats.ETag);
 

--- a/src/ServiceControl/Recoverability/API/GroupFetcher.cs
+++ b/src/ServiceControl/Recoverability/API/GroupFetcher.cs
@@ -20,7 +20,7 @@
 
         public async Task<GroupOperation[]> GetGroups(string classifier, string classifierFilter, CancellationToken cancellationToken = default)
         {
-            var dbGroups = await store.GetUnresolvedGroupsByClassifier(classifier, classifierFilter);
+            var dbGroups = await store.GetUnresolvedGroupsByClassifier(classifier, classifierFilter, cancellationToken);
             var retryHistory = await retryStore.GetRetryHistory(cancellationToken);
             var unacknowledgedRetries = retryHistory.GetUnacknowledgedByClassifier(classifier);
 

--- a/src/ServiceControl/Recoverability/Retrying/Handlers/RetryAllInGroupHandler.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Handlers/RetryAllInGroupHandler.cs
@@ -27,7 +27,7 @@ namespace ServiceControl.Recoverability
             }
 
 
-            var group = (await dataStore.GetUnresolvedGroup(message.GroupId, null, null)).Results;
+            var group = (await dataStore.GetUnresolvedGroup(message.GroupId, null, null, context.CancellationToken)).Results;
 
             string originator = null;
             if (group?.Title != null)


### PR DESCRIPTION
This change continues the effort to consistently apply optional `CancellationToken` parameters to asynchronous methods within the `IGroupsDataStore` interface, its EFCore and RavenDB implementations, and related consuming services.

Cancellation tokens are now propagated to underlying asynchronous database calls, ensuring proper cancellation of long-running operations and further reducing cancellation analyzer debt.