### PR TITLE
Propagate cancellation tokens through transport abstractions and implementations

### DIFF
--- a/src/Particular.LicensingComponent/MonitoringThroughput/MonitoringThroughputHostedService.cs
+++ b/src/Particular.LicensingComponent/MonitoringThroughput/MonitoringThroughputHostedService.cs
@@ -26,7 +26,7 @@ class MonitoringThroughputHostedService(ITransportCustomization transportCustomi
     {
         logger.LogInformation("Starting {ServiceName}", nameof(MonitoringThroughputHostedService));
 
-        transportInfrastructure = await transportCustomization.CreateTransportInfrastructure(ServiceControlSettings.ServiceControlThroughputDataQueue, transportSettings, Handle, (_, __) => Task.FromResult(ErrorHandleResult.Handled), (_, __) => Task.CompletedTask);
+        transportInfrastructure = await transportCustomization.CreateTransportInfrastructure(ServiceControlSettings.ServiceControlThroughputDataQueue, transportSettings, Handle, (_, __) => Task.FromResult(ErrorHandleResult.Handled), (_, __, ___) => Task.CompletedTask, cancellationToken: cancellationToken);
         await transportInfrastructure.Receivers[ServiceControlSettings.ServiceControlThroughputDataQueue].StartReceive(cancellationToken);
     }
 

--- a/src/ServiceControl.Audit.UnitTests/.editorconfig
+++ b/src/ServiceControl.Audit.UnitTests/.editorconfig
@@ -7,5 +7,4 @@ dotnet_diagnostic.CA2007.severity = none
 # They are scheduled work, not accepted exceptions: remove a line once this project has no
 # violations of that rule left, and never add a rule back to this list.
 dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0013.severity = none
 dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Audit.UnitTests/Infrastructure/When_instance_is_setup.cs
+++ b/src/ServiceControl.Audit.UnitTests/Infrastructure/When_instance_is_setup.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Reflection;
     using System.Runtime.Loader;
+    using System.Threading;
     using System.Threading.Tasks;
     using Audit.Infrastructure.Hosting;
     using Audit.Infrastructure.Hosting.Commands;
@@ -73,7 +74,7 @@
 
         public void AddTransportForMonitoring(IServiceCollection services, TransportSettings transportSettings) => throw new NotImplementedException();
 
-        public Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues)
+        public Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues, CancellationToken cancellationToken = default)
         {
             QueuesCreated =
             [
@@ -85,8 +86,9 @@
         }
 
         public Task<TransportInfrastructure> CreateTransportInfrastructure(string name, TransportSettings transportSettings,
-            OnMessage onMessage = null, OnError onError = null, Func<string, Exception, Task> onCriticalError = null,
-            TransportTransactionMode preferredTransactionMode = TransportTransactionMode.ReceiveOnly) =>
+            OnMessage onMessage = null, OnError onError = null, Func<string, Exception, CancellationToken, Task> onCriticalError = null,
+            TransportTransactionMode preferredTransactionMode = TransportTransactionMode.ReceiveOnly,
+            CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
         public string ToTransportQualifiedQueueName(string queueName) => queueName;
     }

--- a/src/ServiceControl.Audit/.editorconfig
+++ b/src/ServiceControl.Audit/.editorconfig
@@ -2,10 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Blocked on the transport abstraction. TransportCustomization.CreateTransportInfrastructure takes
-# Func<string, Exception, Task> for onCriticalError, so the critical-error path here cannot carry a
-# token until that signature gains one in the transports phase.
-[{Auditing/AuditIngestion.cs,Auditing/AuditIngestionFaultPolicy.cs,Auditing/ImportFailureCircuitBreaker.cs}]
-dotnet_diagnostic.PS0013.severity = none
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -68,10 +68,10 @@
             );
         }
 
-        Task OnCriticalError(string failure, Exception exception)
+        Task OnCriticalError(string failure, Exception exception, CancellationToken cancellationToken)
         {
             logger.LogCritical(exception, "OnCriticalError. '{Failure}'", failure);
-            return watchdog.OnFailure(failure);
+            return watchdog.OnFailure(failure, cancellationToken);
         }
 
         async Task EnsureStarted(CancellationToken cancellationToken)
@@ -137,7 +137,8 @@
                     OnMessage,
                     errorHandlingPolicy.OnError,
                     OnCriticalError,
-                    TransportTransactionMode.ReceiveOnly
+                    TransportTransactionMode.ReceiveOnly,
+                    cancellationToken
                 );
 
                 messageReceiver = transportInfrastructure.Receivers[inputEndpoint];

--- a/src/ServiceControl.Audit/Auditing/AuditIngestionFaultPolicy.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestionFaultPolicy.cs
@@ -20,7 +20,7 @@ class AuditIngestionFaultPolicy
     public AuditIngestionFaultPolicy(
         IFailedAuditStorage failedAuditStorage,
         LoggingSettings settings,
-        Func<string, Exception, Task> onCriticalError,
+        Func<string, Exception, CancellationToken, Task> onCriticalError,
         IngestionMetrics metrics,
         ILogger logger)
     {

--- a/src/ServiceControl.Audit/Auditing/ImportFailureCircuitBreaker.cs
+++ b/src/ServiceControl.Audit/Auditing/ImportFailureCircuitBreaker.cs
@@ -7,7 +7,7 @@
     class ImportFailureCircuitBreaker : IDisposable
     {
 
-        public ImportFailureCircuitBreaker(Func<string, Exception, Task> onCriticalError)
+        public ImportFailureCircuitBreaker(Func<string, Exception, CancellationToken, Task> onCriticalError)
         {
             this.onCriticalError = onCriticalError;
             timer = new Timer(_ => FlushHistory(), null, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(20));
@@ -28,11 +28,13 @@
             var result = Interlocked.Increment(ref failureCount);
             if (result > 50)
             {
-                _ = Task.Run(() => onCriticalError("Failed to import too many times", lastException));
+                // Not cancellable: the notification exists to trigger shutdown, so the token
+                // that shutdown cancels must not be able to suppress it.
+                _ = Task.Run(() => onCriticalError("Failed to import too many times", lastException, CancellationToken.None), CancellationToken.None);
             }
         }
 
-        Func<string, Exception, Task> onCriticalError;
+        Func<string, Exception, CancellationToken, Task> onCriticalError;
         Timer timer;
         long failureCount;
     }

--- a/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Hosting/Commands/SetupCommand.cs
@@ -33,7 +33,7 @@
                     transportSettings.RunCustomChecks = false;
                     var transportCustomization = TransportFactory.Create(transportSettings);
 
-                    await transportCustomization.ProvisionQueues(transportSettings, additionalQueues);
+                    await transportCustomization.ProvisionQueues(transportSettings, additionalQueues, cancellationToken);
                 }
             }
 

--- a/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
+++ b/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
@@ -500,13 +500,14 @@
 
             public Task<TransportInfrastructure> CreateTransportInfrastructure(string name,
                 TransportSettings transportSettings, OnMessage onMessage = null, OnError onError = null,
-                Func<string, Exception, Task> onCriticalError = null,
+                Func<string, Exception, CancellationToken, Task> onCriticalError = null,
                 NServiceBus.TransportTransactionMode preferredTransactionMode =
-                    NServiceBus.TransportTransactionMode.ReceiveOnly) => Task.FromResult(TransportInfrastructure);
+                    NServiceBus.TransportTransactionMode.ReceiveOnly,
+                CancellationToken cancellationToken = default) => Task.FromResult(TransportInfrastructure);
             public void CustomizeAuditEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, TransportSettings transportSettings) => throw new NotImplementedException();
             public void CustomizeMonitoringEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, TransportSettings transportSettings) => throw new NotImplementedException();
             public void CustomizePrimaryEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, TransportSettings transportSettings) => throw new NotImplementedException();
-            public Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues) => throw new NotImplementedException();
+            public Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public string ToTransportQualifiedQueueName(string queueName) => queueName;
         }
 

--- a/src/ServiceControl.Transports.ASBS.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.ASBS.Tests/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.ASBS.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.ASBS.Tests/TransportTestsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Transport.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Transports;
     using Transports.ASBS;
@@ -11,7 +12,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             TransportCustomization = new ASBSTransportCustomization();
             ConnectionString = Environment.GetEnvironmentVariable(ConnectionStringKey);
@@ -24,7 +25,7 @@
             return Task.CompletedTask;
         }
 
-        public Task Cleanup() => Task.CompletedTask;
+        public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         static string ConnectionStringKey = "ServiceControl_TransportTests_ASBS_ConnectionString";
     }

--- a/src/ServiceControl.Transports.ASBS/.editorconfig
+++ b/src/ServiceControl.Transports.ASBS/.editorconfig
@@ -2,10 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0004.severity = none
-dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Transports.ASBS/ASBSTransportCustomization.cs
+++ b/src/ServiceControl.Transports.ASBS/ASBSTransportCustomization.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using Azure.Messaging.ServiceBus;
     using Azure.Messaging.ServiceBus.Administration;
@@ -99,9 +100,9 @@
             services.AddHostedService(provider => provider.GetRequiredService<IProvideQueueLength>());
         }
 
-        public override async Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues)
+        public override async Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues, CancellationToken cancellationToken = default)
         {
-            await base.ProvisionQueues(transportSettings, additionalQueues);
+            await base.ProvisionQueues(transportSettings, additionalQueues, cancellationToken);
 
             if (transportSettings.EventTypesPublished.Count == 0)
             {
@@ -132,7 +133,7 @@
 
                 try
                 {
-                    await managementClient.CreateTopicAsync(topicToPublishTo).ConfigureAwait(false);
+                    await managementClient.CreateTopicAsync(topicToPublishTo, cancellationToken).ConfigureAwait(false);
                 }
                 catch (ServiceBusException sbe) when (sbe.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists || sbe.IsTransient)
                 {

--- a/src/ServiceControl.Transports.ASBS/AzureQuery.cs
+++ b/src/ServiceControl.Transports.ASBS/AzureQuery.cs
@@ -201,7 +201,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
 
     public override async IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue,
         DateOnly startDate,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         logger.LogInformation($"Gathering metrics for \"{brokerQueue.QueueName}\" queue");
 
@@ -249,7 +249,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
     }
 
     async Task<IReadOnlyList<MonitorMetricValue>> GetMetrics(string queueName, DateOnly startTime, DateOnly endTime,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         var options = new ArmResourceGetMonitorMetricsOptions()
         {
@@ -272,7 +272,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
     }
 
     public override async IAsyncEnumerable<IBrokerQueue> GetQueueNames(
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var validNamespaces = await GetValidNamespaceNames(cancellationToken);
 
@@ -310,7 +310,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
         { ArmEnvironment.AzureChina, "servicebus.chinacloudapi.cn" },
     };
 
-    async Task<HashSet<string>> GetValidNamespaceNames(CancellationToken cancellationToken = default)
+    async Task<HashSet<string>> GetValidNamespaceNames(CancellationToken cancellationToken)
     {
         var validNamespaces = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { serviceBusName };
 
@@ -347,7 +347,7 @@ public class AzureQuery(ILogger<AzureQuery> logger, TimeProvider timeProvider, T
     ];
 
     protected override async Task<(bool Success, List<string> Errors)> TestConnectionCore(
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         await foreach (IBrokerQueue brokerQueue in GetQueueNames(cancellationToken))
         {

--- a/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.ASBS/QueueLengthProvider.cs
@@ -27,24 +27,24 @@ namespace ServiceControl.Transports.ASBS
                 (id, old) => queueToTrack.EndpointName
             );
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken = default)
         {
-            while (!stoppingToken.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
                     logger.LogDebug("Waiting for next interval");
-                    await Task.Delay(queryDelayInterval, stoppingToken);
+                    await Task.Delay(queryDelayInterval, cancellationToken);
 
                     logger.LogDebug("Querying management client");
 
-                    var queueRuntimeInfos = await GetQueueList(stoppingToken);
+                    var queueRuntimeInfos = await GetQueueList(cancellationToken);
 
                     logger.LogDebug("Retrieved details of {QueueCount} queues", queueRuntimeInfos.Count);
 
                     UpdateAllQueueLengths(queueRuntimeInfos);
                 }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     // no-op
                 }

--- a/src/ServiceControl.Transports.ASQ.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.ASQ.Tests/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.ASQ.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.ASQ.Tests/TransportTestsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Transport.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Transports;
     using Transports.ASQ;
@@ -11,7 +12,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             TransportCustomization = new ASQTransportCustomization();
             ConnectionString = Environment.GetEnvironmentVariable(ConnectionStringKey);
@@ -24,7 +25,7 @@
             return Task.CompletedTask;
         }
 
-        public Task Cleanup() => Task.CompletedTask;
+        public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         static string ConnectionStringKey = "ServiceControl_TransportTests_ASQ_ConnectionString";
     }

--- a/src/ServiceControl.Transports.ASQ/.editorconfig
+++ b/src/ServiceControl.Transports.ASQ/.editorconfig
@@ -2,9 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Transports.ASQ/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.ASQ/QueueLengthProvider.cs
@@ -33,19 +33,19 @@
             queueLengths.AddOrUpdate(queueToTrack, _ => emptyQueueLength, (_, existingQueueLength) => existingQueueLength);
         }
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken = default)
         {
-            while (!stoppingToken.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
-                    await FetchQueueSizes(stoppingToken);
+                    await FetchQueueSizes(cancellationToken);
 
                     UpdateQueueLengthStore();
 
-                    await Task.Delay(QueryDelayInterval, stoppingToken);
+                    await Task.Delay(QueryDelayInterval, cancellationToken);
                 }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     // no-op
                 }

--- a/src/ServiceControl.Transports.IBMMQ.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.IBMMQ.Tests/.editorconfig
@@ -1,6 +1,0 @@
-[*.cs]
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.IBMMQ.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.IBMMQ.Tests/TransportTestsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Transport.Tests;
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Transports;
 using Transports.IBMMQ;
@@ -21,7 +22,7 @@ class TransportTestsConfiguration
 
     public ITransportCustomization TransportCustomization { get; private set; }
 
-    public Task Configure()
+    public Task Configure(CancellationToken cancellationToken = default)
     {
         TransportCustomization = new TestIBMMQTransportCustomization();
         ConnectionString = Environment.GetEnvironmentVariable(ConnectionStringKey)
@@ -35,7 +36,7 @@ class TransportTestsConfiguration
         return Task.CompletedTask;
     }
 
-    public Task Cleanup() => Task.CompletedTask;
+    public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
     static string ConnectionStringKey = "ServiceControl_TransportTests_IBMMQ_ConnectionString";
 }

--- a/src/ServiceControl.Transports.IBMMQ/.editorconfig
+++ b/src/ServiceControl.Transports.IBMMQ/.editorconfig
@@ -1,7 +1,0 @@
-[*.cs]
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Transports.IBMMQ/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.IBMMQ/QueueLengthProvider.cs
@@ -29,9 +29,9 @@ class QueueLengthProvider : AbstractQueueLengthProvider
             return queueToTrack.InputQueue;
         });
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        while (!stoppingToken.IsCancellationRequested)
+        while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
@@ -39,9 +39,9 @@ class QueueLengthProvider : AbstractQueueLengthProvider
 
                 UpdateQueueLengthStore();
 
-                await Task.Delay(QueryDelayInterval, stoppingToken).ConfigureAwait(false);
+                await Task.Delay(QueryDelayInterval, cancellationToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // no-op
             }
@@ -49,7 +49,7 @@ class QueueLengthProvider : AbstractQueueLengthProvider
             {
                 logger.LogError(e, "Queue length query loop failure");
                 CloseConnection();
-                await Task.Delay(ReconnectDelayInterval, stoppingToken).ConfigureAwait(false);
+                await Task.Delay(ReconnectDelayInterval, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/ServiceControl.Transports.Learning/.editorconfig
+++ b/src/ServiceControl.Transports.Learning/.editorconfig
@@ -2,9 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Transports.Learning/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.Learning/QueueLengthProvider.cs
@@ -22,18 +22,18 @@
         public override void TrackEndpointInputQueue(EndpointToQueueMapping queueToTrack)
             => endpointsHash.AddOrUpdate(queueToTrack, queueToTrack, (_, __) => queueToTrack);
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken = default)
         {
-            while (!stoppingToken.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
                     var queueLengths = GetQueueLengths();
                     UpdateStore(queueLengths);
 
-                    await Task.Delay(QueryDelayInterval, stoppingToken);
+                    await Task.Delay(QueryDelayInterval, cancellationToken);
                 }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     // It's OK. We're shutting down
                 }

--- a/src/ServiceControl.Transports.Msmq.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.Msmq.Tests/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.Msmq.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.Msmq.Tests/TransportTestsConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Transport.Tests
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using ServiceControl.Transports;
     using ServiceControl.Transports.Msmq;
@@ -10,7 +11,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             TransportCustomization = new MsmqTransportCustomization();
             ConnectionString = null;
@@ -18,6 +19,6 @@
             return Task.CompletedTask;
         }
 
-        public Task Cleanup() => Task.CompletedTask;
+        public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/src/ServiceControl.Transports.Msmq/.editorconfig
+++ b/src/ServiceControl.Transports.Msmq/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none

--- a/src/ServiceControl.Transports.Msmq/NoOpQueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.Msmq/NoOpQueueLengthProvider.cs
@@ -10,8 +10,8 @@
             //This is a no op for MSMQ since the endpoints report their queue length to SC using custom messages
         }
 
-        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/src/ServiceControl.Transports.PostgreSql.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.PostgreSql.Tests/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.PostgreSql.Tests/PostgreSqlQueryTests.cs
+++ b/src/ServiceControl.Transports.PostgreSql.Tests/PostgreSqlQueryTests.cs
@@ -155,7 +155,7 @@ class PostgreSqlQueryTests : TransportTestFixture
                 // Drop the table mid-way while GetThroughputPerDay is waiting for the next hour
                 if (advanceCount == 3)
                 {
-                    await DropQueueTable(brokerQueueTable.QueueAddress.QualifiedTableName);
+                    await DropQueueTable(brokerQueueTable.QueueAddress.QualifiedTableName, token);
                 }
 
                 provider.Advance(TimeSpan.FromHours(1));
@@ -179,12 +179,12 @@ class PostgreSqlQueryTests : TransportTestFixture
         Assert.That(throughputValues, Has.All.Matches<QueueThroughput>(qt => qt.TotalThroughput >= 0));
     }
 
-    async Task DropQueueTable(string qualifiedTableName)
+    async Task DropQueueTable(string qualifiedTableName, CancellationToken cancellationToken)
     {
         await using var conn = new NpgsqlConnection(configuration.ConnectionString);
-        await conn.OpenAsync();
+        await conn.OpenAsync(cancellationToken);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = $"DROP TABLE IF EXISTS {qualifiedTableName} CASCADE;";
-        await cmd.ExecuteNonQueryAsync();
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
     }
 }

--- a/src/ServiceControl.Transports.PostgreSql.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.PostgreSql.Tests/TransportTestsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Transport.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using ServiceControl.Transports.PostgreSql;
     using Transports;
@@ -11,7 +12,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             TransportCustomization = new PostgreSqlTransportCustomization();
             ConnectionString = Environment.GetEnvironmentVariable(ConnectionStringKey);
@@ -24,7 +25,7 @@
             return Task.CompletedTask;
         }
 
-        public Task Cleanup() => Task.CompletedTask;
+        public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         const string ConnectionStringKey = "ServiceControl_TransportTests_PostgreSQL_ConnectionString";
     }

--- a/src/ServiceControl.Transports.PostgreSql/.editorconfig
+++ b/src/ServiceControl.Transports.PostgreSql/.editorconfig
@@ -2,11 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0004.severity = none
-dotnet_diagnostic.PS0017.severity = none
-dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.Transports.PostgreSql/DatabaseDetails.cs
+++ b/src/ServiceControl.Transports.PostgreSql/DatabaseDetails.cs
@@ -29,7 +29,7 @@ public class DatabaseDetails
         }
     }
 
-    public async Task<string> TestConnection(CancellationToken cancellationToken)
+    public async Task<string> TestConnection(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -117,7 +117,7 @@ public class DatabaseDetails
         return table;
     }
 
-    async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    async Task<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
     {
         var conn = new NpgsqlConnection(connectionString);
         await conn.OpenAsync(cancellationToken);

--- a/src/ServiceControl.Transports.PostgreSql/PostgreSqlQuery.cs
+++ b/src/ServiceControl.Transports.PostgreSql/PostgreSqlQuery.cs
@@ -89,7 +89,7 @@ public class PostgreSqlQuery(
     ];
 
     protected override async Task<(bool Success, List<string> Errors)> TestConnectionCore(
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         List<string> errors = [];
 
@@ -98,6 +98,10 @@ public class PostgreSqlQuery(
             try
             {
                 await db.TestConnection(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/ServiceControl.Transports.PostgreSql/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.PostgreSql/QueueLengthProvider.cs
@@ -38,19 +38,19 @@ class QueueLengthProvider : AbstractQueueLengthProvider
         tableSizes.TryAdd(sqlTable, 0);
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        while (!stoppingToken.IsCancellationRequested)
+        while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
-                await Task.Delay(QueryDelayInterval, stoppingToken);
+                await Task.Delay(QueryDelayInterval, cancellationToken);
 
-                await QueryTableSizes(stoppingToken);
+                await QueryTableSizes(cancellationToken);
 
                 UpdateQueueLengthStore();
             }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 // no-op
             }

--- a/src/ServiceControl.Transports.RabbitMQ/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQ/.editorconfig
@@ -2,10 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0017.severity = none
-dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.Transports.RabbitMQ/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/QueueLengthProvider.cs
@@ -34,19 +34,19 @@
                 return queueToTrack.InputQueue;
             });
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken = default)
         {
-            while (!stoppingToken.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
-                    await FetchQueueLengths(stoppingToken);
+                    await FetchQueueLengths(cancellationToken);
 
                     UpdateQueueLengths();
 
-                    await Task.Delay(QueryDelayInterval, stoppingToken);
+                    await Task.Delay(QueryDelayInterval, cancellationToken);
                 }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     // no-op
                 }
@@ -90,6 +90,10 @@
 
                     var size = queue.MessageCount;
                     sizes.AddOrUpdate(queueName, _ => size, (_, _) => size);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
                 }
                 catch (Exception e)
                 {

--- a/src/ServiceControl.Transports.RabbitMQ/RabbitMQQuery.cs
+++ b/src/ServiceControl.Transports.RabbitMQ/RabbitMQQuery.cs
@@ -66,7 +66,7 @@ public class RabbitMQQuery : BrokerThroughputQuery
         }
     }
 
-    public override async IAsyncEnumerable<IBrokerQueue> GetQueueNames([EnumeratorCancellation] CancellationToken cancellationToken)
+    public override async IAsyncEnumerable<IBrokerQueue> GetQueueNames([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var page = 1;
         bool morePages;
@@ -149,7 +149,7 @@ public class RabbitMQQuery : BrokerThroughputQuery
 
     public override KeyDescriptionPair[] Settings => [];
 
-    protected override async Task<(bool Success, List<string> Errors)> TestConnectionCore(CancellationToken cancellationToken)
+    protected override async Task<(bool Success, List<string> Errors)> TestConnectionCore(CancellationToken cancellationToken = default)
     {
         try
         {

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicConventionalRouting.Tests/TransportTestsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Transport.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Transports;
     using Transports.RabbitMQ;
@@ -11,7 +12,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             TransportCustomization = new RabbitMQClassicConventionalRoutingTransportCustomization();
             ConnectionString = Environment.GetEnvironmentVariable(ConnectionStringKey);
@@ -24,7 +25,7 @@
             return Task.CompletedTask;
         }
 
-        public Task Cleanup() => Task.CompletedTask;
+        public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         static string ConnectionStringKey = "ServiceControl_TransportTests_RabbitMQ_ConnectionString";
     }

--- a/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.RabbitMQClassicDirectRouting.Tests/TransportTestsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Transport.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using ServiceControl.Transports.RabbitMQ;
     using Transports;
@@ -11,7 +12,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             TransportCustomization = new RabbitMQClassicDirectRoutingTransportCustomization();
             ConnectionString = Environment.GetEnvironmentVariable(ConnectionStringKey);
@@ -24,7 +25,7 @@
             return Task.CompletedTask;
         }
 
-        public Task Cleanup() => Task.CompletedTask;
+        public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         static string ConnectionStringKey = "ServiceControl_TransportTests_RabbitMQ_ConnectionString";
     }

--- a/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumConventionalRouting.Tests/TransportTestsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Transport.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using ServiceControl.Transports.RabbitMQ;
     using Transports;
@@ -11,7 +12,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             TransportCustomization = new RabbitMQQuorumConventionalRoutingTransportCustomization();
             ConnectionString = Environment.GetEnvironmentVariable(ConnectionStringKey);
@@ -24,7 +25,7 @@
             return Task.CompletedTask;
         }
 
-        public Task Cleanup() => Task.CompletedTask;
+        public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         static string ConnectionStringKey = "ServiceControl_TransportTests_RabbitMQ_ConnectionString";
     }

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.RabbitMQQuorumDirectRouting.Tests/TransportTestsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Transport.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Transports;
     using Transports.RabbitMQ;
@@ -11,7 +12,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             TransportCustomization = new RabbitMQQuorumDirectRoutingTransportCustomization();
             ConnectionString = Environment.GetEnvironmentVariable(ConnectionStringKey);
@@ -24,7 +25,7 @@
             return Task.CompletedTask;
         }
 
-        public Task Cleanup() => Task.CompletedTask;
+        public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         static string ConnectionStringKey = "ServiceControl_TransportTests_RabbitMQ_ConnectionString";
     }

--- a/src/ServiceControl.Transports.SQS.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.SQS.Tests/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.SQS.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.SQS.Tests/TransportTestsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Transport.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Transports;
     using Transports.SQS;
@@ -11,7 +12,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             TransportCustomization = new SQSTransportCustomization();
             ConnectionString = Environment.GetEnvironmentVariable(ConnectionStringKey);
@@ -24,7 +25,7 @@
             return Task.CompletedTask;
         }
 
-        public Task Cleanup() => Task.CompletedTask;
+        public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         static string ConnectionStringKey = "ServiceControl_TransportTests_SQS_ConnectionString";
     }

--- a/src/ServiceControl.Transports.SQS/.editorconfig
+++ b/src/ServiceControl.Transports.SQS/.editorconfig
@@ -2,9 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0017.severity = none

--- a/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
+++ b/src/ServiceControl.Transports.SQS/AmazonSQSQuery.cs
@@ -196,7 +196,7 @@ public class AmazonSQSQuery(ILogger<AmazonSQSQuery> logger, TimeProvider timePro
 
     public override async IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue,
         DateOnly startDate,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var utcNow = timeProvider.GetUtcNow();
         var today = DateOnly.FromDateTime(utcNow.DateTime);
@@ -306,7 +306,7 @@ public class AmazonSQSQuery(ILogger<AmazonSQSQuery> logger, TimeProvider timePro
     ];
 
     protected override async Task<(bool Success, List<string> Errors)> TestConnectionCore(
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         await foreach (IBrokerQueue brokerQueue in GetQueueNames(cancellationToken))
         {

--- a/src/ServiceControl.Transports.SQS/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.SQS/QueueLengthProvider.cs
@@ -52,22 +52,22 @@
             sizes.TryAdd(queue, 0);
         }
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken = default)
         {
             using var client = clientFactory();
             var cache = new QueueAttributesRequestCache(client);
 
-            while (!stoppingToken.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
-                    await FetchQueueSizes(cache, client, stoppingToken);
+                    await FetchQueueSizes(cache, client, cancellationToken);
 
                     UpdateQueueLengthStore();
 
-                    await Task.Delay(QueryDelayInterval, stoppingToken);
+                    await Task.Delay(QueryDelayInterval, cancellationToken);
                 }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     // no-op
                 }

--- a/src/ServiceControl.Transports.SqlServer.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.SqlServer.Tests/.editorconfig
@@ -2,8 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.SqlServer.Tests/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.SqlServer.Tests/TransportTestsConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Transport.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Transports;
     using Transports.SqlServer;
@@ -11,7 +12,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             TransportCustomization = new SqlServerTransportCustomization();
             ConnectionString = Environment.GetEnvironmentVariable(ConnectionStringKey);
@@ -24,7 +25,7 @@
             return Task.CompletedTask;
         }
 
-        public Task Cleanup() => Task.CompletedTask;
+        public Task Cleanup(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         static string ConnectionStringKey = "ServiceControl_TransportTests_SQL_ConnectionString";
     }

--- a/src/ServiceControl.Transports.SqlServer/.editorconfig
+++ b/src/ServiceControl.Transports.SqlServer/.editorconfig
@@ -2,11 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0004.severity = none
-dotnet_diagnostic.PS0017.severity = none
-dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.Transports.SqlServer/DatabaseDetails.cs
+++ b/src/ServiceControl.Transports.SqlServer/DatabaseDetails.cs
@@ -30,7 +30,7 @@
             }
         }
 
-        public async Task<string> TestConnection(CancellationToken cancellationToken)
+        public async Task<string> TestConnection(CancellationToken cancellationToken = default)
         {
             try
             {
@@ -131,7 +131,7 @@
             return table;
         }
 
-        async Task<SqlConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        async Task<SqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
         {
             var conn = new SqlConnection(connectionString);
             await conn.OpenAsync(cancellationToken);

--- a/src/ServiceControl.Transports.SqlServer/QueueLengthProvider.cs
+++ b/src/ServiceControl.Transports.SqlServer/QueueLengthProvider.cs
@@ -53,9 +53,9 @@
             tableSizes.TryAdd(sqlTable, 0);
         }
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken = default)
         {
-            while (!stoppingToken.IsCancellationRequested)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 // Time the whole iteration so the pacing delay below can subtract the work already done this
                 // cycle. The effective cadence is then max(currentDelay, iterationDuration) — the query
@@ -66,7 +66,7 @@
 
                 try
                 {
-                    await QueryTableSizes(stoppingToken);
+                    await QueryTableSizes(cancellationToken);
 
                     UpdateQueueLengthStore();
 
@@ -79,7 +79,7 @@
                     var maxObservedLength = tableSizes.IsEmpty ? 0 : tableSizes.Values.Max();
                     currentDelay = NextDelay(currentDelay, baseDelay, maxDelay, maxObservedLength);
                 }
-                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     break;
                 }
@@ -97,9 +97,9 @@
                 {
                     try
                     {
-                        await Task.Delay(remaining, stoppingToken);
+                        await Task.Delay(remaining, cancellationToken);
                     }
-                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
                         break;
                     }

--- a/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
+++ b/src/ServiceControl.Transports.SqlServer/SqlServerQuery.cs
@@ -66,6 +66,10 @@ public class SqlServerQuery(
         {
             startData = await queueTableName.DatabaseDetails.GetSnapshot(queueTableName, cancellationToken);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             logger.LogError(e, "Failed to query throughput starting snapshot for {QueueName}", queueTableName.QueueName);
@@ -81,6 +85,10 @@ public class SqlServerQuery(
             try
             {
                 endData = await queueTableName.DatabaseDetails.GetSnapshot(queueTableName, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception e)
             {
@@ -130,7 +138,7 @@ public class SqlServerQuery(
     ];
 
     protected override async Task<(bool Success, List<string> Errors)> TestConnectionCore(
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         List<string> errors = [];
 
@@ -139,6 +147,10 @@ public class SqlServerQuery(
             try
             {
                 await db.TestConnection(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/ServiceControl.Transports.Tests/.editorconfig
+++ b/src/ServiceControl.Transports.Tests/.editorconfig
@@ -2,9 +2,3 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0013.severity = none
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
+++ b/src/ServiceControl.Transports.Tests/ApprovalFiles/APIApprovals.ServiceControlTransport.approved.txt
@@ -6,7 +6,7 @@ namespace ServiceControl.Transports
         protected AbstractQueueLengthProvider(ServiceControl.Transports.TransportSettings settings, System.Action<ServiceControl.Transports.QueueLengthEntry[], ServiceControl.Transports.EndpointToQueueMapping> store) { }
         protected string ConnectionString { get; }
         protected System.Action<ServiceControl.Transports.QueueLengthEntry[], ServiceControl.Transports.EndpointToQueueMapping> Store { get; }
-        public override System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken) { }
+        public override System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public abstract void TrackEndpointInputQueue(ServiceControl.Transports.EndpointToQueueMapping queueToTrack);
     }
     public class EndpointToQueueMapping
@@ -27,11 +27,11 @@ namespace ServiceControl.Transports
         void AddTransportForAudit(Microsoft.Extensions.DependencyInjection.IServiceCollection services, ServiceControl.Transports.TransportSettings transportSettings);
         void AddTransportForMonitoring(Microsoft.Extensions.DependencyInjection.IServiceCollection services, ServiceControl.Transports.TransportSettings transportSettings);
         void AddTransportForPrimary(Microsoft.Extensions.DependencyInjection.IServiceCollection services, ServiceControl.Transports.TransportSettings transportSettings);
-        System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> CreateTransportInfrastructure(string name, ServiceControl.Transports.TransportSettings transportSettings, NServiceBus.Transport.OnMessage onMessage = null, NServiceBus.Transport.OnError onError = null, System.Func<string, System.Exception, System.Threading.Tasks.Task> onCriticalError = null, NServiceBus.TransportTransactionMode preferredTransactionMode = 1);
+        System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> CreateTransportInfrastructure(string name, ServiceControl.Transports.TransportSettings transportSettings, NServiceBus.Transport.OnMessage onMessage = null, NServiceBus.Transport.OnError onError = null, System.Func<string, System.Exception, System.Threading.CancellationToken, System.Threading.Tasks.Task> onCriticalError = null, NServiceBus.TransportTransactionMode preferredTransactionMode = 1, System.Threading.CancellationToken cancellationToken = default);
         void CustomizeAuditEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, ServiceControl.Transports.TransportSettings transportSettings);
         void CustomizeMonitoringEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, ServiceControl.Transports.TransportSettings transportSettings);
         void CustomizePrimaryEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, ServiceControl.Transports.TransportSettings transportSettings);
-        System.Threading.Tasks.Task ProvisionQueues(ServiceControl.Transports.TransportSettings transportSettings, System.Collections.Generic.IEnumerable<string> additionalQueues);
+        System.Threading.Tasks.Task ProvisionQueues(ServiceControl.Transports.TransportSettings transportSettings, System.Collections.Generic.IEnumerable<string> additionalQueues, System.Threading.CancellationToken cancellationToken = default);
         string ToTransportQualifiedQueueName(string queueName);
     }
     public class QueueLengthEntry
@@ -52,14 +52,14 @@ namespace ServiceControl.Transports
         protected virtual void AddTransportForPrimaryCore(Microsoft.Extensions.DependencyInjection.IServiceCollection services, ServiceControl.Transports.TransportSettings transportSettings) { }
         protected void ConfigureDefaultEndpointSettings(NServiceBus.EndpointConfiguration endpointConfiguration, ServiceControl.Transports.TransportSettings transportSettings) { }
         protected abstract TTransport CreateTransport(ServiceControl.Transports.TransportSettings transportSettings, NServiceBus.TransportTransactionMode preferredTransactionMode = 1);
-        public System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> CreateTransportInfrastructure(string name, ServiceControl.Transports.TransportSettings transportSettings, NServiceBus.Transport.OnMessage onMessage = null, NServiceBus.Transport.OnError onError = null, System.Func<string, System.Exception, System.Threading.Tasks.Task> onCriticalError = null, NServiceBus.TransportTransactionMode preferredTransactionMode = 1) { }
+        public System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> CreateTransportInfrastructure(string name, ServiceControl.Transports.TransportSettings transportSettings, NServiceBus.Transport.OnMessage onMessage = null, NServiceBus.Transport.OnError onError = null, System.Func<string, System.Exception, System.Threading.CancellationToken, System.Threading.Tasks.Task> onCriticalError = null, NServiceBus.TransportTransactionMode preferredTransactionMode = 1, System.Threading.CancellationToken cancellationToken = default) { }
         public void CustomizeAuditEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, ServiceControl.Transports.TransportSettings transportSettings) { }
         public void CustomizeMonitoringEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, ServiceControl.Transports.TransportSettings transportSettings) { }
         public void CustomizePrimaryEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, ServiceControl.Transports.TransportSettings transportSettings) { }
         protected abstract void CustomizeTransportForAuditEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, TTransport transportDefinition, ServiceControl.Transports.TransportSettings transportSettings);
         protected abstract void CustomizeTransportForMonitoringEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, TTransport transportDefinition, ServiceControl.Transports.TransportSettings transportSettings);
         protected abstract void CustomizeTransportForPrimaryEndpoint(NServiceBus.EndpointConfiguration endpointConfiguration, TTransport transportDefinition, ServiceControl.Transports.TransportSettings transportSettings);
-        public virtual System.Threading.Tasks.Task ProvisionQueues(ServiceControl.Transports.TransportSettings transportSettings, System.Collections.Generic.IEnumerable<string> additionalQueues) { }
+        public virtual System.Threading.Tasks.Task ProvisionQueues(ServiceControl.Transports.TransportSettings transportSettings, System.Collections.Generic.IEnumerable<string> additionalQueues, System.Threading.CancellationToken cancellationToken = default) { }
         public string ToTransportQualifiedQueueName(string queueName) { }
         protected virtual string ToTransportQualifiedQueueNameCore(string queueName) { }
     }
@@ -113,8 +113,8 @@ namespace ServiceControl.Transports.BrokerThroughput
         public string MessageTransport { get; }
         public string? ScopeType { get; set; }
         public abstract ServiceControl.Transports.BrokerThroughput.KeyDescriptionPair[] Settings { get; }
-        public abstract System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken);
-        public abstract System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.BrokerThroughput.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken = default);
+        public abstract System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.BrokerThroughput.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken = default);
         public bool HasInitialisationErrors(out string errorMessage) { }
         public void Initialize(System.Collections.ObjectModel.ReadOnlyDictionary<string, string> settings) { }
         protected abstract void InitializeCore(System.Collections.ObjectModel.ReadOnlyDictionary<string, string> settings);
@@ -124,11 +124,11 @@ namespace ServiceControl.Transports.BrokerThroughput
                 "Success",
                 "Errors",
                 "Diagnostics"})]
-        public System.Threading.Tasks.Task<System.ValueTuple<bool, System.Collections.Generic.List<string>, string>> TestConnection(System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<System.ValueTuple<bool, System.Collections.Generic.List<string>, string>> TestConnection(System.Threading.CancellationToken cancellationToken = default) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "Success",
                 "Errors"})]
-        protected abstract System.Threading.Tasks.Task<System.ValueTuple<bool, System.Collections.Generic.List<string>>> TestConnectionCore(System.Threading.CancellationToken cancellationToken);
+        protected abstract System.Threading.Tasks.Task<System.ValueTuple<bool, System.Collections.Generic.List<string>>> TestConnectionCore(System.Threading.CancellationToken cancellationToken = default);
     }
     public class DefaultBrokerQueue : ServiceControl.Transports.BrokerThroughput.IBrokerQueue
     {
@@ -151,8 +151,8 @@ namespace ServiceControl.Transports.BrokerThroughput
         string MessageTransport { get; }
         string? ScopeType { get; }
         ServiceControl.Transports.BrokerThroughput.KeyDescriptionPair[] Settings { get; }
-        System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken);
-        System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.BrokerThroughput.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken);
+        System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.IBrokerQueue> GetQueueNames(System.Threading.CancellationToken cancellationToken = default);
+        System.Collections.Generic.IAsyncEnumerable<ServiceControl.Transports.BrokerThroughput.QueueThroughput> GetThroughputPerDay(ServiceControl.Transports.BrokerThroughput.IBrokerQueue brokerQueue, System.DateOnly startDate, System.Threading.CancellationToken cancellationToken = default);
         bool HasInitialisationErrors(out string errorMessage);
         void Initialize(System.Collections.ObjectModel.ReadOnlyDictionary<string, string> settings);
         string SanitizeEndpointName(string endpointName);
@@ -161,7 +161,7 @@ namespace ServiceControl.Transports.BrokerThroughput
                 "Success",
                 "Errors",
                 "Diagnostics"})]
-        System.Threading.Tasks.Task<System.ValueTuple<bool, System.Collections.Generic.List<string>, string>> TestConnection(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.ValueTuple<bool, System.Collections.Generic.List<string>, string>> TestConnection(System.Threading.CancellationToken cancellationToken = default);
     }
     public readonly struct KeyDescriptionPair
     {

--- a/src/ServiceControl.Transports.Tests/BasicEndpointSetup.cs
+++ b/src/ServiceControl.Transports.Tests/BasicEndpointSetup.cs
@@ -8,6 +8,8 @@
 
     public class BasicEndpointSetup : IEndpointSetupTemplate
     {
+#pragma warning disable PS0018 // IEndpointSetupTemplate declares this without a CancellationToken
+#pragma warning disable PS0013 // IEndpointSetupTemplate declares the callback as Func<EndpointConfiguration, Task>
         public async Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor,
             EndpointCustomizationConfiguration endpointCustomization,
             Func<EndpointConfiguration, Task> configurationBuilderCustomization)
@@ -27,5 +29,7 @@
 
             return endpointConfiguration;
         }
+#pragma warning restore PS0013
+#pragma warning restore PS0018
     }
 }

--- a/src/ServiceControl.Transports.Tests/Learning/TransportTestsConfiguration.cs
+++ b/src/ServiceControl.Transports.Tests/Learning/TransportTestsConfiguration.cs
@@ -2,13 +2,14 @@
 {
     using System;
     using System.IO;
+    using System.Threading;
     using System.Threading.Tasks;
     using ServiceControl.Transports;
     using ServiceControl.Transports.Learning;
 
     partial class TransportTestsConfiguration
     {
-        public Task Configure()
+        public Task Configure(CancellationToken cancellationToken = default)
         {
             basePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, $".test{Path.GetRandomFileName()}");
 
@@ -29,7 +30,7 @@
 
         public ITransportCustomization TransportCustomization { get; private set; }
 
-        public Task Cleanup()
+        public Task Cleanup(CancellationToken cancellationToken = default)
         {
             if (Directory.Exists(basePath))
             {

--- a/src/ServiceControl.Transports.Tests/TestDispatcherExtensions.cs
+++ b/src/ServiceControl.Transports.Tests/TestDispatcherExtensions.cs
@@ -10,14 +10,14 @@
 
     static class TestDispatcherExtensions
     {
-        public static Task SendTestMessage(this IMessageDispatcher dispatcher, string queue, string content, ITransportCustomization transportCustomization)
+        public static Task SendTestMessage(this IMessageDispatcher dispatcher, string queue, string content, ITransportCustomization transportCustomization, CancellationToken cancellationToken = default)
         {
             var transportOperation = new TransportOperation(
              new OutgoingMessage(Guid.NewGuid().ToString(), [],
                  Encoding.UTF8.GetBytes(content)),
              new UnicastAddressTag(transportCustomization.ToTransportQualifiedQueueName(queue)), []);
 
-            return dispatcher.Dispatch(new TransportOperations(transportOperation), new TransportTransaction(), CancellationToken.None);
+            return dispatcher.Dispatch(new TransportOperations(transportOperation), new TransportTransaction(), cancellationToken);
         }
     }
 }

--- a/src/ServiceControl.Transports.Tests/TransportTestFixture.cs
+++ b/src/ServiceControl.Transports.Tests/TransportTestFixture.cs
@@ -44,7 +44,7 @@
 
             await configuration.Configure();
 
-            dispatcherTransportInfrastructure = await CreateDispatcherTransportInfrastructure();
+            dispatcherTransportInfrastructure = await CreateDispatcherTransportInfrastructure(testCancellationTokenSource.Token);
         }
 
         [TearDown]
@@ -98,7 +98,7 @@
 
         protected TransportTestsConfiguration configuration;
 
-        protected async Task<IAsyncDisposable> StartQueueLengthProvider(string queueName, Action<QueueLengthEntry> onQueueLengthReported)
+        protected async Task<IAsyncDisposable> StartQueueLengthProvider(string queueName, Action<QueueLengthEntry> onQueueLengthReported, CancellationToken cancellationToken = default)
         {
             // The transport test fixture abuses the transport seam as if it was stateless can but it isn't really
             // currently working around by creating a service collection per start call and then disposing the provider
@@ -122,7 +122,7 @@
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             queueLengthProvider = serviceProvider.GetRequiredService<IProvideQueueLength>();
-            await queueLengthProvider.StartAsync(CancellationToken.None);
+            await queueLengthProvider.StartAsync(cancellationToken);
             queueLengthProvider.TrackEndpointInputQueue(new EndpointToQueueMapping(queueName, queueName));
 
             return new QueueLengthProviderScope(serviceProvider);
@@ -140,7 +140,8 @@
         protected async Task StartQueueIngestor(
             string queueName,
             OnMessage onMessage,
-            OnError onError)
+            OnError onError,
+            CancellationToken cancellationToken = default)
         {
             var transportSettings = new TransportSettings
             {
@@ -154,18 +155,19 @@
                 transportSettings,
                 onMessage,
                 onError,
-                (_, __) =>
+                (_, __, ___) =>
                 {
                     Assert.Fail("There should be no critical errors");
                     return Task.CompletedTask;
-                });
+                },
+                cancellationToken: cancellationToken);
 
             queueIngestor = transportInfrastructure.Receivers[queueName];
 
-            await queueIngestor.StartReceive();
+            await queueIngestor.StartReceive(cancellationToken);
         }
 
-        protected Task ProvisionQueues(string queueName, string errorQueue, IEnumerable<string> additionalQueues)
+        protected Task ProvisionQueues(string queueName, string errorQueue, IEnumerable<string> additionalQueues, CancellationToken cancellationToken = default)
         {
             var transportSettings = new TransportSettings
             {
@@ -175,10 +177,10 @@
                 MaxConcurrency = 1
             };
 
-            return configuration.TransportCustomization.ProvisionQueues(transportSettings, additionalQueues);
+            return configuration.TransportCustomization.ProvisionQueues(transportSettings, additionalQueues, cancellationToken);
         }
 
-        protected Task CreateTestQueue(string queueName)
+        protected Task CreateTestQueue(string queueName, CancellationToken cancellationToken = default)
         {
             var transportSettings = new TransportSettings
             {
@@ -187,12 +189,12 @@
                 MaxConcurrency = 1
             };
 
-            return configuration.TransportCustomization.ProvisionQueues(transportSettings, []);
+            return configuration.TransportCustomization.ProvisionQueues(transportSettings, [], cancellationToken);
         }
 
         protected static TimeSpan TestTimeout = TimeSpan.FromMinutes(5);
 
-        protected async Task SendAndReceiveMessages(string queueName, int numMessagesToIngest)
+        protected async Task SendAndReceiveMessages(string queueName, int numMessagesToIngest, CancellationToken cancellationToken = default)
         {
             TaskCompletionSource<bool> onMessagesProcessed = CreateTaskCompletionSource<bool>();
             int numMessagesIngested = 0;
@@ -214,11 +216,12 @@
                 {
                     Assert.Fail("There should be no errors");
                     return Task.FromResult(ErrorHandleResult.Handled);
-                });
+                },
+                cancellationToken);
 
             for (int i = 0; i < numMessagesToIngest; i++)
             {
-                await Dispatcher.SendTestMessage(queueName, $"message{i}", configuration.TransportCustomization);
+                await Dispatcher.SendTestMessage(queueName, $"message{i}", configuration.TransportCustomization, cancellationToken);
             }
 
             bool allMessagesProcessed = await onMessagesProcessed.Task;
@@ -226,18 +229,18 @@
 
             if (queueIngestor != null)
             {
-                await queueIngestor.StopReceive();
+                await queueIngestor.StopReceive(cancellationToken);
                 queueIngestor = null;
             }
 
             if (transportInfrastructure != null)
             {
-                await transportInfrastructure.Shutdown();
+                await transportInfrastructure.Shutdown(cancellationToken);
                 transportInfrastructure = null;
             }
         }
 
-        async Task<TransportInfrastructure> CreateDispatcherTransportInfrastructure()
+        async Task<TransportInfrastructure> CreateDispatcherTransportInfrastructure(CancellationToken cancellationToken)
         {
             var transportSettings = new TransportSettings
             {
@@ -246,7 +249,7 @@
                 MaxConcurrency = 1
             };
 
-            return await configuration.TransportCustomization.CreateTransportInfrastructure("TransportTestDispatcher", transportSettings);
+            return await configuration.TransportCustomization.CreateTransportInfrastructure("TransportTestDispatcher", transportSettings, cancellationToken: cancellationToken);
         }
 
         string queueSuffix;

--- a/src/ServiceControl.Transports/.editorconfig
+++ b/src/ServiceControl.Transports/.editorconfig
@@ -2,11 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0013.severity = none
-dotnet_diagnostic.PS0018.severity = none
-dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.Transports/AbstractQueueLengthProvider.cs
+++ b/src/ServiceControl.Transports/AbstractQueueLengthProvider.cs
@@ -12,7 +12,7 @@ namespace ServiceControl.Transports
 
         protected string ConnectionString { get; } = settings.ConnectionString;
 
-        public override async Task StartAsync(CancellationToken cancellationToken)
+        public override async Task StartAsync(CancellationToken cancellationToken = default)
         {
             // BackgroundService in .NET awaits the returned task to be completed. Queue providers might be doing
             // some heavy lifting before yielding so we are forcing things to be offloaded here by default.

--- a/src/ServiceControl.Transports/BrokerThroughput/BrokerThroughputQuery.cs
+++ b/src/ServiceControl.Transports/BrokerThroughput/BrokerThroughputQuery.cs
@@ -47,9 +47,9 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
     protected abstract void InitializeCore(ReadOnlyDictionary<string, string> settings);
 
     public abstract IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue, DateOnly startDate,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken = default);
 
-    public abstract IAsyncEnumerable<IBrokerQueue> GetQueueNames(CancellationToken cancellationToken);
+    public abstract IAsyncEnumerable<IBrokerQueue> GetQueueNames(CancellationToken cancellationToken = default);
 
     public Dictionary<string, string> Data { get; set; } = [];
     public string MessageTransport => transport;
@@ -57,7 +57,7 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
     public abstract KeyDescriptionPair[] Settings { get; }
 
     public async Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         var sb = new StringBuilder();
         if (InitialiseErrors.Count > 0)
@@ -97,6 +97,10 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
 
             return (success, errors, sb.ToString());
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Test connection failed");
@@ -111,7 +115,7 @@ public abstract class BrokerThroughputQuery(ILogger logger, string transport) : 
     }
 
     protected abstract Task<(bool Success, List<string> Errors)>
-        TestConnectionCore(CancellationToken cancellationToken);
+        TestConnectionCore(CancellationToken cancellationToken = default);
 
     public virtual string SanitizeEndpointName(string endpointName) => endpointName;
 

--- a/src/ServiceControl.Transports/BrokerThroughput/IBrokerThroughputQuery.cs
+++ b/src/ServiceControl.Transports/BrokerThroughput/IBrokerThroughputQuery.cs
@@ -12,13 +12,13 @@ public interface IBrokerThroughputQuery
     bool HasInitialisationErrors(out string errorMessage);
     void Initialize(ReadOnlyDictionary<string, string> settings);
     IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue, DateOnly startDate,
-        CancellationToken cancellationToken);
-    IAsyncEnumerable<IBrokerQueue> GetQueueNames(CancellationToken cancellationToken);
+        CancellationToken cancellationToken = default);
+    IAsyncEnumerable<IBrokerQueue> GetQueueNames(CancellationToken cancellationToken = default);
     Dictionary<string, string> Data { get; }
     string MessageTransport { get; }
     string? ScopeType { get; }
     KeyDescriptionPair[] Settings { get; }
-    Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(CancellationToken cancellationToken);
+    Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(CancellationToken cancellationToken = default);
     string SanitizeEndpointName(string endpointName);
     string SanitizedEndpointNameCleanser(string endpointName);
 }

--- a/src/ServiceControl.Transports/TransportCustomization.cs
+++ b/src/ServiceControl.Transports/TransportCustomization.cs
@@ -22,10 +22,10 @@ namespace ServiceControl.Transports
         void CustomizeMonitoringEndpoint(EndpointConfiguration endpointConfiguration, TransportSettings transportSettings);
         void AddTransportForMonitoring(IServiceCollection services, TransportSettings transportSettings);
 
-        Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues);
+        Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues, CancellationToken cancellationToken = default);
         string ToTransportQualifiedQueueName(string queueName);
 
-        Task<TransportInfrastructure> CreateTransportInfrastructure(string name, TransportSettings transportSettings, OnMessage onMessage = null, OnError onError = null, Func<string, Exception, Task> onCriticalError = null, TransportTransactionMode preferredTransactionMode = TransportTransactionMode.ReceiveOnly);
+        Task<TransportInfrastructure> CreateTransportInfrastructure(string name, TransportSettings transportSettings, OnMessage onMessage = null, OnError onError = null, Func<string, Exception, CancellationToken, Task> onCriticalError = null, TransportTransactionMode preferredTransactionMode = TransportTransactionMode.ReceiveOnly, CancellationToken cancellationToken = default);
     }
 
     public abstract class TransportCustomization<TTransport> : ITransportCustomization where TTransport : TransportDefinition
@@ -123,7 +123,7 @@ namespace ServiceControl.Transports
 
         protected virtual string ToTransportQualifiedQueueNameCore(string queueName) => queueName;
 
-        public virtual async Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues)
+        public virtual async Task ProvisionQueues(TransportSettings transportSettings, IEnumerable<string> additionalQueues, CancellationToken cancellationToken = default)
         {
             // For queue provisioning MaxConcurrency is not relevant. Settings it to 1 to avoid null checks
             transportSettings.MaxConcurrency ??= 1;
@@ -155,21 +155,21 @@ namespace ServiceControl.Transports
                 .Distinct()
                 .ToArray();
 
-            var transportInfrastructure = await transport.Initialize(hostSettings, receivers, additionalQueuesToProvision);
-            await transportInfrastructure.Shutdown();
+            var transportInfrastructure = await transport.Initialize(hostSettings, receivers, additionalQueuesToProvision, cancellationToken);
+            await transportInfrastructure.Shutdown(cancellationToken);
         }
 
-        public async Task<TransportInfrastructure> CreateTransportInfrastructure(string name, TransportSettings transportSettings, OnMessage onMessage = null, OnError onError = null, Func<string, Exception, Task> onCriticalError = null, TransportTransactionMode preferredTransactionMode = TransportTransactionMode.ReceiveOnly)
+        public async Task<TransportInfrastructure> CreateTransportInfrastructure(string name, TransportSettings transportSettings, OnMessage onMessage = null, OnError onError = null, Func<string, Exception, CancellationToken, Task> onCriticalError = null, TransportTransactionMode preferredTransactionMode = TransportTransactionMode.ReceiveOnly, CancellationToken cancellationToken = default)
         {
             var transport = CreateTransport(transportSettings, preferredTransactionMode);
 
-            onCriticalError ??= (_, __) => Task.CompletedTask;
+            onCriticalError ??= (_, __, ___) => Task.CompletedTask;
 
             var hostSettings = new HostSettings(
                 name,
                 $"TransportInfrastructure for {name}",
                 new StartupDiagnosticEntries(),
-                (msg, exception, cancellationToken) => Task.Run(() => onCriticalError(msg, exception), cancellationToken),
+                (msg, exception, criticalErrorCancellationToken) => Task.Run(() => onCriticalError(msg, exception, criticalErrorCancellationToken), criticalErrorCancellationToken),
                 false,
                 null); //null means "not hosted by core", transport SHOULD adjust accordingly to not assume things
 
@@ -186,7 +186,7 @@ namespace ServiceControl.Transports
                 receivers = [];
             }
 
-            var transportInfrastructure = await transport.Initialize(hostSettings, receivers, new[] { ToTransportQualifiedQueueNameCore(transportSettings.ErrorQueue) });
+            var transportInfrastructure = await transport.Initialize(hostSettings, receivers, new[] { ToTransportQualifiedQueueNameCore(transportSettings.ErrorQueue) }, cancellationToken);
 
             if (createReceiver)
             {
@@ -196,7 +196,7 @@ namespace ServiceControl.Transports
                 }
 
                 var transportInfrastructureReceiver = transportInfrastructure.Receivers[name];
-                await transportInfrastructureReceiver.Initialize(new PushRuntimeSettings(transportSettings.MaxConcurrency.Value), onMessage, onError, CancellationToken.None);
+                await transportInfrastructureReceiver.Initialize(new PushRuntimeSettings(transportSettings.MaxConcurrency.Value), onMessage, onError, cancellationToken);
             }
 
             return transportInfrastructure;

--- a/src/ServiceControl/.editorconfig
+++ b/src/ServiceControl/.editorconfig
@@ -2,10 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Blocked on the transport abstraction. TransportCustomization.CreateTransportInfrastructure takes
-# Func<string, Exception, Task> for onCriticalError, so the critical-error path here cannot carry a
-# token until that signature gains one in the transports phase.
-[{Operations/ErrorIngestion.cs,Operations/ErrorIngestionFaultPolicy.cs,Operations/ImportFailureCircuitBreaker.cs}]
-dotnet_diagnostic.PS0013.severity = none
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl/Hosting/Commands/SetupCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/SetupCommand.cs
@@ -47,7 +47,7 @@
                 transportSettings.RunCustomChecks = false;
                 var transportCustomization = TransportFactory.Create(transportSettings);
 
-                await transportCustomization.ProvisionQueues(transportSettings, componentSetupContext.Queues);
+                await transportCustomization.ProvisionQueues(transportSettings, componentSetupContext.Queues, cancellationToken);
             }
 
             await using (var scope = host.Services.CreateAsyncScope())

--- a/src/ServiceControl/Operations/ErrorIngestion.cs
+++ b/src/ServiceControl/Operations/ErrorIngestion.cs
@@ -221,7 +221,8 @@
                     OnMessage,
                     errorHandlingPolicy.OnError,
                     OnCriticalError,
-                    TransportTransactionMode.ReceiveOnly
+                    TransportTransactionMode.ReceiveOnly,
+                    cancellationToken
                 );
 
                 messageReceiver = transportInfrastructure.Receivers[errorQueue];
@@ -304,10 +305,10 @@
             await taskCompletionSource.Task;
         }
 
-        Task OnCriticalError(string failure, Exception exception)
+        Task OnCriticalError(string failure, Exception exception, CancellationToken cancellationToken)
         {
             logger.LogCritical(exception, "OnCriticalError. '{FailureMessage}'", failure);
-            return watchdog.OnFailure(failure);
+            return watchdog.OnFailure(failure, cancellationToken);
         }
 
         async Task EnsureStopped(CancellationToken cancellationToken)

--- a/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs
+++ b/src/ServiceControl/Operations/ErrorIngestionFaultPolicy.cs
@@ -21,7 +21,7 @@
 
         ImportFailureCircuitBreaker failureCircuitBreaker;
 
-        public ErrorIngestionFaultPolicy(IFailedErrorImportDataStore store, LoggingSettings loggingSettings, Func<string, Exception, Task> onCriticalError, ILogger logger)
+        public ErrorIngestionFaultPolicy(IFailedErrorImportDataStore store, LoggingSettings loggingSettings, Func<string, Exception, CancellationToken, Task> onCriticalError, ILogger logger)
         {
             this.store = store;
             this.logger = logger;

--- a/src/ServiceControl/Operations/ImportFailureCircuitBreaker.cs
+++ b/src/ServiceControl/Operations/ImportFailureCircuitBreaker.cs
@@ -7,7 +7,7 @@
     class ImportFailureCircuitBreaker : IDisposable
     {
 
-        public ImportFailureCircuitBreaker(Func<string, Exception, Task> onCriticalError)
+        public ImportFailureCircuitBreaker(Func<string, Exception, CancellationToken, Task> onCriticalError)
         {
             this.onCriticalError = onCriticalError;
             timer = new Timer(_ => FlushHistory(), null, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(20));
@@ -28,11 +28,13 @@
             var result = Interlocked.Increment(ref failureCount);
             if (result > 50)
             {
-                _ = Task.Run(() => onCriticalError("Failed to import too many times", lastException));
+                // Not cancellable: the notification exists to trigger shutdown, so the token
+                // that shutdown cancels must not be able to suppress it.
+                _ = Task.Run(() => onCriticalError("Failed to import too many times", lastException, CancellationToken.None), CancellationToken.None);
             }
         }
 
-        Func<string, Exception, Task> onCriticalError;
+        Func<string, Exception, CancellationToken, Task> onCriticalError;
         Timer timer;
         long failureCount;
     }

--- a/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Infrastructure/ReturnToSenderDequeuer.cs
@@ -40,7 +40,7 @@ class ReturnToSenderDequeuer : IHostedService
 
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
-        transportInfrastructure = await transportCustomization.CreateTransportInfrastructure(InputAddress, transportSettings, Handle, faultManager.OnError, (_, __) => Task.CompletedTask, TransportTransactionMode.SendsAtomicWithReceive);
+        transportInfrastructure = await transportCustomization.CreateTransportInfrastructure(InputAddress, transportSettings, Handle, faultManager.OnError, (_, __, ___) => Task.CompletedTask, TransportTransactionMode.SendsAtomicWithReceive, cancellationToken);
         messageReceiver = transportInfrastructure.Receivers[InputAddress];
         messageDispatcher = transportInfrastructure.Dispatcher;
 


### PR DESCRIPTION
This change updates the `ITransportCustomization` and `IBrokerThroughputQuery` interfaces, along with their various transport-specific implementations, to consistently accept and propagate `CancellationToken` parameters.

Cancellation tokens are now propagated to underlying asynchronous operations, ensuring proper responsiveness to cancellation and retiring the cancellation analyzer debt for the transport projects.