### PR TITLE
Propagate cancellation tokens through persistence dialects, licensing and acceptance test infrastructure

### DIFF
--- a/src/Particular.LicensingComponent/.editorconfig
+++ b/src/Particular.LicensingComponent/.editorconfig
@@ -12,11 +12,3 @@ dotnet_diagnostic.IDE0010.severity = suggestion
 
 csharp_style_var_elsewhere = true:error
 csharp_style_var_for_built_in_types = true:error
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0008.severity = none
-dotnet_diagnostic.PS0017.severity = none
-dotnet_diagnostic.PS0019.severity = none

--- a/src/Particular.LicensingComponent/AuditThroughput/AuditQuery.cs
+++ b/src/Particular.LicensingComponent/AuditThroughput/AuditQuery.cs
@@ -17,7 +17,7 @@
             r.SemanticVersion >= MinAuditCountsVersion &&
             r.Retention >= TimeSpan.FromDays(2);
 
-        public async Task<IEnumerable<ServiceControlEndpoint>> GetKnownEndpoints(CancellationToken cancellationToken)
+        public async Task<IEnumerable<ServiceControlEndpoint>> GetKnownEndpoints(CancellationToken cancellationToken = default)
         {
             var endpoints = await endpointsApi.GetEndpoints(cancellationToken);
 
@@ -36,9 +36,9 @@
             return scEndpoints ?? [];
         }
 
-        public async Task<IEnumerable<AuditCount>> GetAuditCountForEndpoint(string endpointUrlName, CancellationToken cancellationToken) => (await auditCountApi.GetEndpointAuditCounts(endpointUrlName, cancellationToken)).Select(s => new AuditCount { Count = s.Count, UtcDate = DateOnly.FromDateTime(s.UtcDate) });
+        public async Task<IEnumerable<AuditCount>> GetAuditCountForEndpoint(string endpointUrlName, CancellationToken cancellationToken = default) => (await auditCountApi.GetEndpointAuditCounts(endpointUrlName, cancellationToken)).Select(s => new AuditCount { Count = s.Count, UtcDate = DateOnly.FromDateTime(s.UtcDate) });
 
-        public async Task<List<RemoteInstanceInformation>> GetAuditRemotes(CancellationToken cancellationToken)
+        public async Task<List<RemoteInstanceInformation>> GetAuditRemotes(CancellationToken cancellationToken = default)
         {
             try
             {
@@ -101,6 +101,10 @@
 
                 return remotesInfo;
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed to get Audit Remotes");
@@ -108,7 +112,7 @@
             }
         }
 
-        public async Task<ConnectionSettingsTestResult> TestAuditConnection(CancellationToken cancellationToken)
+        public async Task<ConnectionSettingsTestResult> TestAuditConnection(CancellationToken cancellationToken = default)
         {
             var connectionTestResult = new ConnectionSettingsTestResult { ConnectionSuccessful = true };
 

--- a/src/Particular.LicensingComponent/AuditThroughput/AuditThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/AuditThroughput/AuditThroughputCollectorHostedService.cs
@@ -18,7 +18,7 @@ public class AuditThroughputCollectorHostedService(
     public TimeSpan DelayStart { get; set; } = TimeSpan.FromSeconds(40);
     public static List<string> AuditQueues { get; set; } = [];
 
-    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
         logger.LogInformation("Starting {ServiceName}", nameof(AuditThroughputCollectorHostedService));
 
@@ -34,7 +34,11 @@ public class AuditThroughputCollectorHostedService(
                 {
                     await GatherThroughput(cancellationToken);
                 }
-                catch (Exception ex) when (ex is not OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
                 {
                     logger.LogError(ex, "Failed to gather throughput from audit");
                 }

--- a/src/Particular.LicensingComponent/AuditThroughput/IAuditQuery.cs
+++ b/src/Particular.LicensingComponent/AuditThroughput/IAuditQuery.cs
@@ -8,11 +8,11 @@
         SemanticVersion MinAuditCountsVersion { get; }
         Func<RemoteInstanceInformation, bool> ValidRemoteInstances { get; }
 
-        Task<IEnumerable<ServiceControlEndpoint>> GetKnownEndpoints(CancellationToken cancellationToken);
+        Task<IEnumerable<ServiceControlEndpoint>> GetKnownEndpoints(CancellationToken cancellationToken = default);
 
-        Task<IEnumerable<AuditCount>> GetAuditCountForEndpoint(string endpointUrlName, CancellationToken cancellationToken);
-        Task<List<RemoteInstanceInformation>> GetAuditRemotes(CancellationToken cancellationToken);
-        Task<ConnectionSettingsTestResult> TestAuditConnection(CancellationToken cancellationToken);
+        Task<IEnumerable<AuditCount>> GetAuditCountForEndpoint(string endpointUrlName, CancellationToken cancellationToken = default);
+        Task<List<RemoteInstanceInformation>> GetAuditRemotes(CancellationToken cancellationToken = default);
+        Task<ConnectionSettingsTestResult> TestAuditConnection(CancellationToken cancellationToken = default);
 
     }
 }

--- a/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
+++ b/src/Particular.LicensingComponent/BrokerThroughput/BrokerThroughputCollectorHostedService.cs
@@ -19,7 +19,7 @@ public class BrokerThroughputCollectorHostedService(
 {
     public TimeSpan DelayStart { get; set; } = TimeSpan.FromSeconds(40);
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
         static ReadOnlyDictionary<string, string> LoadBrokerSettingValues(IEnumerable<KeyDescriptionPair> brokerKeys)
             => new(brokerKeys.Select(pair => KeyValuePair.Create(pair.Key, SettingsReader.Read<string>(ThroughputSettings.SettingsNamespace, pair.Key)))
@@ -37,7 +37,7 @@ public class BrokerThroughputCollectorHostedService(
 
         try
         {
-            await Task.Delay(DelayStart, stoppingToken);
+            await Task.Delay(DelayStart, cancellationToken);
 
             using PeriodicTimer timer = new(TimeSpan.FromDays(1), timeProvider);
 
@@ -45,28 +45,32 @@ public class BrokerThroughputCollectorHostedService(
             {
                 try
                 {
-                    await GatherThroughput(stoppingToken);
+                    await GatherThroughput(cancellationToken);
                 }
-                catch (Exception ex) when (ex is not OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
                 {
                     logger.LogError(ex, "Failed to gather throughput from broker");
                 }
-            } while (await timer.WaitForNextTickAsync(stoppingToken));
+            } while (await timer.WaitForNextTickAsync(cancellationToken));
         }
-        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             logger.LogInformation("Stopping {ServiceName}", nameof(BrokerThroughputCollectorHostedService));
         }
     }
 
-    async Task GatherThroughput(CancellationToken stoppingToken)
+    async Task GatherThroughput(CancellationToken cancellationToken)
     {
         logger.LogInformation("Gathering throughput from broker");
 
         var waitingTasks = new List<Task>();
         var postfixGenerator = new PostfixGenerator();
 
-        await foreach (var queueName in brokerThroughputQuery.GetQueueNames(stoppingToken))
+        await foreach (var queueName in brokerThroughputQuery.GetQueueNames(cancellationToken))
         {
             if (PlatformEndpointHelper.IsPlatformEndpoint(queueName.SanitizedName, throughputSettings))
             {
@@ -78,13 +82,13 @@ public class BrokerThroughputCollectorHostedService(
         }
 
         await Task.WhenAll(waitingTasks);
-        await dataStore.SaveBrokerMetadata(new BrokerMetadata(brokerThroughputQuery.ScopeType, brokerThroughputQuery.Data), stoppingToken);
+        await dataStore.SaveBrokerMetadata(new BrokerMetadata(brokerThroughputQuery.ScopeType, brokerThroughputQuery.Data), cancellationToken);
         return;
 
         async Task Exec(IBrokerQueue queueName, string postfix)
         {
             var endpointId = new EndpointIdentifier(queueName.QueueName, ThroughputSource.Broker);
-            var endpoint = await dataStore.GetEndpoint(endpointId, stoppingToken);
+            var endpoint = await dataStore.GetEndpoint(endpointId, cancellationToken);
 
             if (endpoint == null)
             {
@@ -95,14 +99,18 @@ public class BrokerThroughputCollectorHostedService(
                     EndpointIndicators = [.. queueName.EndpointIndicators]
                 };
 
-                await dataStore.SaveEndpoint(endpoint, stoppingToken);
+                await dataStore.SaveEndpoint(endpoint, cancellationToken);
             }
 
-            await foreach (var queueThroughput in brokerThroughputQuery.GetThroughputPerDay(queueName, endpoint.LastCollectedDate.AddDays(1), stoppingToken))
+            await foreach (var queueThroughput in brokerThroughputQuery.GetThroughputPerDay(queueName, endpoint.LastCollectedDate.AddDays(1), cancellationToken))
             {
                 try
                 {
-                    await dataStore.RecordEndpointThroughput(queueName.QueueName, ThroughputSource.Broker, queueThroughput.DateUTC, queueThroughput.TotalThroughput, stoppingToken);
+                    await dataStore.RecordEndpointThroughput(queueName.QueueName, ThroughputSource.Broker, queueThroughput.DateUTC, queueThroughput.TotalThroughput, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
                 }
                 catch (Exception e)
                 {

--- a/src/Particular.LicensingComponent/IThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/IThroughputCollector.cs
@@ -5,13 +5,13 @@
 
     public interface IThroughputCollector
     {
-        Task<List<EndpointThroughputSummary>> GetThroughputSummary(CancellationToken cancellationToken);
-        Task UpdateUserIndicatorsOnEndpoints(List<UpdateUserIndicator> userIndicatorUpdates, CancellationToken cancellationToken);
-        Task<ThroughputConnectionSettings> GetThroughputConnectionSettingsInformation(CancellationToken cancellationToken);
-        Task<ConnectionTestResults> TestConnectionSettings(CancellationToken cancellationToken);
-        Task<SignedReport> GenerateThroughputReport(string spVersion, DateTime? reportEndDate, CancellationToken cancellationToken);
-        Task<ReportGenerationState> GetReportGenerationState(CancellationToken cancellationToken);
-        Task<List<string>> GetReportMasks(CancellationToken cancellationToken);
-        Task UpdateReportMasks(List<string> reportMaskUpdates, CancellationToken cancellationToken);
+        Task<List<EndpointThroughputSummary>> GetThroughputSummary(CancellationToken cancellationToken = default);
+        Task UpdateUserIndicatorsOnEndpoints(List<UpdateUserIndicator> userIndicatorUpdates, CancellationToken cancellationToken = default);
+        Task<ThroughputConnectionSettings> GetThroughputConnectionSettingsInformation(CancellationToken cancellationToken = default);
+        Task<ConnectionTestResults> TestConnectionSettings(CancellationToken cancellationToken = default);
+        Task<SignedReport> GenerateThroughputReport(string spVersion, DateTime? reportEndDate, CancellationToken cancellationToken = default);
+        Task<ReportGenerationState> GetReportGenerationState(CancellationToken cancellationToken = default);
+        Task<List<string>> GetReportMasks(CancellationToken cancellationToken = default);
+        Task UpdateReportMasks(List<string> reportMaskUpdates, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Particular.LicensingComponent/MonitoringThroughput/MonitoringService.cs
+++ b/src/Particular.LicensingComponent/MonitoringThroughput/MonitoringService.cs
@@ -10,7 +10,7 @@ using Shared;
 
 public class MonitoringService(ILicensingDataStore dataStore, IBrokerThroughputQuery? brokerThroughputQuery = null)
 {
-    public async Task RecordMonitoringThroughput(byte[] throughputMessage, CancellationToken cancellationToken)
+    public async Task RecordMonitoringThroughput(byte[] throughputMessage, CancellationToken cancellationToken = default)
     {
         RecordEndpointThroughputData? message;
         using (Stream stream = new MemoryStream(throughputMessage))
@@ -45,7 +45,7 @@ public class MonitoringService(ILicensingDataStore dataStore, IBrokerThroughputQ
         }
     }
 
-    public async Task<ConnectionSettingsTestResult> TestMonitoringConnection(CancellationToken cancellationToken)
+    public async Task<ConnectionSettingsTestResult> TestMonitoringConnection(CancellationToken cancellationToken = default)
     {
         //NOTE can't actually test the monitoring connection apart from seeing if there has been any throughput recorded from Monitoring
 

--- a/src/Particular.LicensingComponent/MonitoringThroughput/MonitoringThroughputHostedService.cs
+++ b/src/Particular.LicensingComponent/MonitoringThroughput/MonitoringThroughputHostedService.cs
@@ -16,13 +16,17 @@ class MonitoringThroughputHostedService(ITransportCustomization transportCustomi
         {
             await monitoringService.RecordMonitoringThroughput(message.Body.ToArray(), cancellationToken);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Error receiving throughput data from Monitoring");
         }
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken = default)
     {
         logger.LogInformation("Starting {ServiceName}", nameof(MonitoringThroughputHostedService));
 
@@ -30,7 +34,7 @@ class MonitoringThroughputHostedService(ITransportCustomization transportCustomi
         await transportInfrastructure.Receivers[ServiceControlSettings.ServiceControlThroughputDataQueue].StartReceive(cancellationToken);
     }
 
-    public async Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken = default)
     {
         logger.LogInformation("Stopping {ServiceName}", nameof(MonitoringThroughputHostedService));
 

--- a/src/Particular.LicensingComponent/ThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/ThroughputCollector.cs
@@ -16,7 +16,7 @@ using QueueThroughput = Report.QueueThroughput;
 public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettings throughputSettings, IAuditQuery auditQuery, MonitoringService monitoringService, IEnumerable<IEnvironmentDataProvider> environmentDataProviders, IBrokerThroughputQuery? throughputQuery = null)
     : IThroughputCollector
 {
-    public async Task<ThroughputConnectionSettings> GetThroughputConnectionSettingsInformation(CancellationToken cancellationToken)
+    public async Task<ThroughputConnectionSettings> GetThroughputConnectionSettingsInformation(CancellationToken cancellationToken = default)
     {
         var throughputConnectionSettings = new ThroughputConnectionSettings
         {
@@ -27,7 +27,7 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
         return await Task.FromResult(throughputConnectionSettings);
     }
 
-    public async Task<ConnectionTestResults> TestConnectionSettings(CancellationToken cancellationToken)
+    public async Task<ConnectionTestResults> TestConnectionSettings(CancellationToken cancellationToken = default)
     {
         var tasks = new List<Task>();
         var brokerTask = Task.FromResult(new ConnectionSettingsTestResult { ConnectionSuccessful = false, ConnectionErrorMessages = [] });
@@ -55,13 +55,13 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
         return await Task.FromResult(connectionTestResults);
     }
 
-    public async Task UpdateUserIndicatorsOnEndpoints(List<UpdateUserIndicator> userIndicatorUpdates, CancellationToken cancellationToken) =>
+    public async Task UpdateUserIndicatorsOnEndpoints(List<UpdateUserIndicator> userIndicatorUpdates, CancellationToken cancellationToken = default) =>
         await dataStore.UpdateUserIndicatorOnEndpoints(userIndicatorUpdates, cancellationToken);
 
-    public async Task<List<string>> GetReportMasks(CancellationToken cancellationToken) => await dataStore.GetReportMasks(cancellationToken);
-    public async Task UpdateReportMasks(List<string> reportMaskUpdates, CancellationToken cancellationToken) => await dataStore.SaveReportMasks(reportMaskUpdates, cancellationToken);
+    public async Task<List<string>> GetReportMasks(CancellationToken cancellationToken = default) => await dataStore.GetReportMasks(cancellationToken);
+    public async Task UpdateReportMasks(List<string> reportMaskUpdates, CancellationToken cancellationToken = default) => await dataStore.SaveReportMasks(reportMaskUpdates, cancellationToken);
 
-    public async Task<List<EndpointThroughputSummary>> GetThroughputSummary(CancellationToken cancellationToken)
+    public async Task<List<EndpointThroughputSummary>> GetThroughputSummary(CancellationToken cancellationToken = default)
     {
         var endpointSummaries = new List<EndpointThroughputSummary>();
 
@@ -86,7 +86,7 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
         return endpointSummaries;
     }
 
-    public async Task<ReportGenerationState> GetReportGenerationState(CancellationToken cancellationToken) =>
+    public async Task<ReportGenerationState> GetReportGenerationState(CancellationToken cancellationToken = default) =>
         throughputQuery == null ?
             await GetReportGenerationStateForNonBroker(cancellationToken) :
             await GetReportGenerationStateForBroker(cancellationToken);
@@ -115,7 +115,7 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
         };
     }
 
-    public async Task<SignedReport> GenerateThroughputReport(string spVersion, DateTime? reportEndDate, CancellationToken cancellationToken)
+    public async Task<SignedReport> GenerateThroughputReport(string spVersion, DateTime? reportEndDate, CancellationToken cancellationToken = default)
     {
         var reportMasks = await dataStore.GetReportMasks(cancellationToken);
         var masker = new Masker([.. reportMasks]);

--- a/src/Particular.LicensingComponent/WebApi/LicensingController.cs
+++ b/src/Particular.LicensingComponent/WebApi/LicensingController.cs
@@ -24,7 +24,7 @@
         [Authorize(Policy = Permissions.ErrorThroughputView)]
         [Route("endpoints")]
         [HttpGet]
-        public async Task<List<EndpointThroughputSummary>> GetEndpointThroughput(CancellationToken cancellationToken)
+        public async Task<List<EndpointThroughputSummary>> GetEndpointThroughput(CancellationToken cancellationToken = default)
         {
             return await throughputCollector.GetThroughputSummary(cancellationToken);
         }
@@ -32,7 +32,7 @@
         [Authorize(Policy = Permissions.ErrorThroughputManage)]
         [Route("endpoints/update")]
         [HttpPost]
-        public async Task<IActionResult> UpdateUserSelectionOnEndpointThroughput(List<UpdateUserIndicator> updateUserIndicators, CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateUserSelectionOnEndpointThroughput(List<UpdateUserIndicator> updateUserIndicators, CancellationToken cancellationToken = default)
         {
             await throughputCollector.UpdateUserIndicatorsOnEndpoints(updateUserIndicators, cancellationToken);
             return Ok();
@@ -41,7 +41,7 @@
         [Authorize(Policy = Permissions.ErrorThroughputView)]
         [Route("report/available")]
         [HttpGet]
-        public async Task<ReportGenerationState> CanThroughputReportBeGenerated(CancellationToken cancellationToken)
+        public async Task<ReportGenerationState> CanThroughputReportBeGenerated(CancellationToken cancellationToken = default)
         {
             return await throughputCollector.GetReportGenerationState(cancellationToken);
         }
@@ -49,7 +49,7 @@
         [Authorize(Policy = Permissions.ErrorThroughputView)]
         [Route("report/file")]
         [HttpGet]
-        public async Task GetThroughputReportFile([FromQuery(Name = "spVersion")] string? spVersion, CancellationToken cancellationToken)
+        public async Task GetThroughputReportFile([FromQuery(Name = "spVersion")] string? spVersion, CancellationToken cancellationToken = default)
         {
             var reportStatus = await CanThroughputReportBeGenerated(cancellationToken);
             if (!reportStatus.ReportCanBeGenerated)
@@ -86,7 +86,7 @@
         [Authorize(Policy = Permissions.ErrorThroughputView)]
         [Route("settings/info")]
         [HttpGet]
-        public async Task<ThroughputConnectionSettings> GetThroughputSettingsInformation(CancellationToken cancellationToken)
+        public async Task<ThroughputConnectionSettings> GetThroughputSettingsInformation(CancellationToken cancellationToken = default)
         {
             return await throughputCollector.GetThroughputConnectionSettingsInformation(cancellationToken);
         }
@@ -94,12 +94,12 @@
         [Authorize(Policy = Permissions.ErrorThroughputView)]
         [Route("settings/test")]
         [HttpGet]
-        public async Task<ConnectionTestResults> TestThroughputConnectionSettings(CancellationToken cancellationToken) => await throughputCollector.TestConnectionSettings(cancellationToken);
+        public async Task<ConnectionTestResults> TestThroughputConnectionSettings(CancellationToken cancellationToken = default) => await throughputCollector.TestConnectionSettings(cancellationToken);
 
         [Authorize(Policy = Permissions.ErrorThroughputView)]
         [Route("settings/masks")]
         [HttpGet]
-        public async Task<List<string>> GetMasks(CancellationToken cancellationToken)
+        public async Task<List<string>> GetMasks(CancellationToken cancellationToken = default)
         {
             return await throughputCollector.GetReportMasks(cancellationToken);
         }
@@ -107,7 +107,7 @@
         [Authorize(Policy = Permissions.ErrorThroughputManage)]
         [Route("settings/masks/update")]
         [HttpPost]
-        public async Task<IActionResult> UpdateMasks(List<string> updateMasks, CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateMasks(List<string> updateMasks, CancellationToken cancellationToken = default)
         {
             await throughputCollector.UpdateReportMasks(updateMasks, cancellationToken);
             return Ok();

--- a/src/ServiceControl.AcceptanceTesting/.editorconfig
+++ b/src/ServiceControl.AcceptanceTesting/.editorconfig
@@ -3,9 +3,10 @@
 # Justification: Usage is from test projects
 dotnet_diagnostic.CA2007.severity = none
 
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
+# These types sit on NServiceBus.AcceptanceTesting's extension points, which drive them without a
+# CancellationToken: IEndpointSetupTemplate, IComponentBehavior/ComponentRunner, and the scenario
+# Done/When callbacks whose delegate shapes the framework fixes. A token added here could only ever
+# be CancellationToken.None. Everything else in this project takes and forwards one.
+[{EndpointTemplates/*.cs,InfrastructureConfig/*.cs,ScenarioWithEndpointBehaviorExtensions.cs,Sequence.cs,DispatchRawMessages.cs}]
 dotnet_diagnostic.PS0013.severity = none
 dotnet_diagnostic.PS0018.severity = none
-dotnet_diagnostic.PS0019.severity = none

--- a/src/ServiceControl.AcceptanceTesting/Cors/CorsAssertions.cs
+++ b/src/ServiceControl.AcceptanceTesting/Cors/CorsAssertions.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTesting.Cors
 {
     using System.Net;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using NUnit.Framework;
 
@@ -22,13 +23,14 @@ namespace ServiceControl.AcceptanceTesting.Cors
         public static async Task<HttpResponseMessage> SendPreflightRequest(
             HttpClient httpClient,
             string origin,
-            string requestMethod = "GET")
+            string requestMethod = "GET",
+            CancellationToken cancellationToken = default)
         {
             using var request = new HttpRequestMessage(HttpMethod.Options, "/api");
             request.Headers.Add("Origin", origin);
             request.Headers.Add("Access-Control-Request-Method", requestMethod);
 
-            return await httpClient.SendAsync(request);
+            return await httpClient.SendAsync(request, cancellationToken);
         }
 
         /// <summary>
@@ -37,12 +39,13 @@ namespace ServiceControl.AcceptanceTesting.Cors
         public static async Task<HttpResponseMessage> SendRequestWithOrigin(
             HttpClient httpClient,
             string origin,
-            string endpoint = "/api")
+            string endpoint = "/api",
+            CancellationToken cancellationToken = default)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
             request.Headers.Add("Origin", origin);
 
-            return await httpClient.SendAsync(request);
+            return await httpClient.SendAsync(request, cancellationToken);
         }
 
         /// <summary>

--- a/src/ServiceControl.AcceptanceTesting/EndpointConfigurationExtensions.cs
+++ b/src/ServiceControl.AcceptanceTesting/EndpointConfigurationExtensions.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Threading;
     using System.Threading.Tasks;
     using InfrastructureConfig;
     using NServiceBus;
@@ -54,7 +55,7 @@
             }
         }
 
-        public static async Task DefinePersistence(this EndpointConfiguration config, RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
+        public static async Task DefinePersistence(this EndpointConfiguration config, RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration, CancellationToken cancellationToken = default)
         {
             var persistenceConfiguration = new ConfigureEndpointInMemoryPersistence();
             await persistenceConfiguration.Configure(endpointCustomizationConfiguration.EndpointName, config, runDescriptor.Settings, endpointCustomizationConfiguration.PublisherMetadata);

--- a/src/ServiceControl.AcceptanceTesting/ForwardedHeaders/ForwardedHeadersAssertions.cs
+++ b/src/ServiceControl.AcceptanceTesting/ForwardedHeaders/ForwardedHeadersAssertions.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTesting.ForwardedHeaders
 {
     using System.Net.Http;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using NUnit.Framework;
 
@@ -20,7 +21,8 @@ namespace ServiceControl.AcceptanceTesting.ForwardedHeaders
             string xForwardedFor = null,
             string xForwardedProto = null,
             string xForwardedHost = null,
-            string testRemoteIp = null)
+            string testRemoteIp = null,
+            CancellationToken cancellationToken = default)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, "/debug/request-info");
 
@@ -41,10 +43,10 @@ namespace ServiceControl.AcceptanceTesting.ForwardedHeaders
                 request.Headers.Add(TestRemoteIpMiddleware.HeaderName, testRemoteIp);
             }
 
-            var response = await httpClient.SendAsync(request);
+            var response = await httpClient.SendAsync(request, cancellationToken);
             _ = response.EnsureSuccessStatusCode();
 
-            var content = await response.Content.ReadAsStringAsync();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
             return JsonSerializer.Deserialize<RequestInfoResponse>(content, serializerOptions);
         }
 

--- a/src/ServiceControl.AcceptanceTesting/HttpClientExtensions.cs
+++ b/src/ServiceControl.AcceptanceTesting/HttpClientExtensions.cs
@@ -1,11 +1,12 @@
 namespace ServiceControl.AcceptanceTesting
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public static class HttpClientExtensions
     {
-        public static async Task<HttpResponseMessage> PatchAsync(this HttpClient client, string requestUri, HttpContent iContent)
+        public static async Task<HttpResponseMessage> PatchAsync(this HttpClient client, string requestUri, HttpContent iContent, CancellationToken cancellationToken = default)
         {
             var method = new HttpMethod("PATCH");
             var request = new HttpRequestMessage(method, requestUri)
@@ -13,7 +14,7 @@ namespace ServiceControl.AcceptanceTesting
                 Content = iContent
             };
 
-            var response = await client.SendAsync(request);
+            var response = await client.SendAsync(request, cancellationToken);
 
             return response;
         }

--- a/src/ServiceControl.AcceptanceTesting/HttpExtensions.cs
+++ b/src/ServiceControl.AcceptanceTesting/HttpExtensions.cs
@@ -6,16 +6,17 @@ namespace ServiceControl.AcceptanceTesting
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Json;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public static class HttpExtensions
     {
-        public static async Task Put<T>(this IAcceptanceTestInfrastructureProvider provider, string url, T payload = null, Func<HttpStatusCode, bool> requestHasFailed = null) where T : class
+        public static async Task Put<T>(this IAcceptanceTestInfrastructureProvider provider, string url, T payload = null, Func<HttpStatusCode, bool> requestHasFailed = null, CancellationToken cancellationToken = default) where T : class
         {
             requestHasFailed ??= statusCode => statusCode is not HttpStatusCode.OK and not HttpStatusCode.Accepted;
 
             var httpClient = provider.HttpClient;
-            var response = await httpClient.PutAsJsonAsync(url, payload, provider.SerializerOptions);
+            var response = await httpClient.PutAsJsonAsync(url, payload, provider.SerializerOptions, cancellationToken);
 
             if (requestHasFailed(response.StatusCode))
             {
@@ -23,24 +24,24 @@ namespace ServiceControl.AcceptanceTesting
             }
         }
 
-        public static Task<HttpResponseMessage> GetRaw(this IAcceptanceTestInfrastructureProvider provider, string url)
+        public static Task<HttpResponseMessage> GetRaw(this IAcceptanceTestInfrastructureProvider provider, string url, CancellationToken cancellationToken = default)
         {
             var httpClient = provider.HttpClient;
-            return httpClient.GetAsync(url);
+            return httpClient.GetAsync(url, cancellationToken);
         }
 
-        public static Task<HttpResponseMessage> Options(this IAcceptanceTestInfrastructureProvider provider, string url)
+        public static Task<HttpResponseMessage> Options(this IAcceptanceTestInfrastructureProvider provider, string url, CancellationToken cancellationToken = default)
         {
             var httpClient = provider.HttpClient;
             var request = new HttpRequestMessage(HttpMethod.Options, url);
-            return httpClient.SendAsync(request);
+            return httpClient.SendAsync(request, cancellationToken);
         }
 
-        public static async Task<ManyResult<T>> TryGetMany<T>(this IAcceptanceTestInfrastructureProvider provider, string url, Predicate<T> condition = null) where T : class
+        public static async Task<ManyResult<T>> TryGetMany<T>(this IAcceptanceTestInfrastructureProvider provider, string url, Predicate<T> condition = null, CancellationToken cancellationToken = default) where T : class
         {
             condition ??= _ => true;
 
-            var response = await provider.GetInternal<List<T>>(url);
+            var response = await provider.GetInternal<List<T>>(url, cancellationToken);
 
             if (response == null || !response.Any(m => condition(m)))
             {
@@ -50,25 +51,25 @@ namespace ServiceControl.AcceptanceTesting
             return ManyResult<T>.New(true, response.Where(m => condition(m)).ToList());
         }
 
-        public static async Task<HttpStatusCode> Patch<T>(this IAcceptanceTestInfrastructureProvider provider, string url, T payload = null) where T : class
+        public static async Task<HttpStatusCode> Patch<T>(this IAcceptanceTestInfrastructureProvider provider, string url, T payload = null, CancellationToken cancellationToken = default) where T : class
         {
             var httpClient = provider.HttpClient;
-            var response = await httpClient.PatchAsJsonAsync(url, payload, provider.SerializerOptions);
+            var response = await httpClient.PatchAsJsonAsync(url, payload, provider.SerializerOptions, cancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
                 throw new InvalidOperationException($"Call failed: {(int)response.StatusCode} - {response.ReasonPhrase} - {body}");
             }
 
             return response.StatusCode;
         }
 
-        public static async Task<SingleResult<T>> TryGet<T>(this IAcceptanceTestInfrastructureProvider provider, string url, Predicate<T> condition = null) where T : class
+        public static async Task<SingleResult<T>> TryGet<T>(this IAcceptanceTestInfrastructureProvider provider, string url, Predicate<T> condition = null, CancellationToken cancellationToken = default) where T : class
         {
             condition ??= _ => true;
 
-            var response = await provider.GetInternal<T>(url);
+            var response = await provider.GetInternal<T>(url, cancellationToken);
 
             if (response == null || !condition(response))
             {
@@ -78,11 +79,11 @@ namespace ServiceControl.AcceptanceTesting
             return SingleResult<T>.New(response);
         }
 
-        public static async Task<SingleResult<T>> TryGet<T>(this IAcceptanceTestInfrastructureProvider provider, string url, Func<T, Task<bool>> condition) where T : class
+        public static async Task<SingleResult<T>> TryGet<T>(this IAcceptanceTestInfrastructureProvider provider, string url, Func<T, CancellationToken, Task<bool>> condition, CancellationToken cancellationToken = default) where T : class
         {
-            var response = await provider.GetInternal<T>(url);
+            var response = await provider.GetInternal<T>(url, cancellationToken);
 
-            if (response == null || !await condition(response))
+            if (response == null || !await condition(response, cancellationToken))
             {
                 return SingleResult<T>.Empty;
             }
@@ -90,11 +91,11 @@ namespace ServiceControl.AcceptanceTesting
             return SingleResult<T>.New(response);
         }
 
-        public static async Task<SingleResult<T>> TryGetSingle<T>(this IAcceptanceTestInfrastructureProvider provider, string url, Predicate<T> condition = null) where T : class
+        public static async Task<SingleResult<T>> TryGetSingle<T>(this IAcceptanceTestInfrastructureProvider provider, string url, Predicate<T> condition = null, CancellationToken cancellationToken = default) where T : class
         {
             condition ??= _ => true;
 
-            var response = await provider.GetInternal<List<T>>(url);
+            var response = await provider.GetInternal<List<T>>(url, cancellationToken);
             T item = null;
             if (response != null)
             {
@@ -116,17 +117,17 @@ namespace ServiceControl.AcceptanceTesting
             return SingleResult<T>.Empty;
         }
 
-        public static async Task<HttpStatusCode> Get(this IAcceptanceTestInfrastructureProvider provider, string url)
+        public static async Task<HttpStatusCode> Get(this IAcceptanceTestInfrastructureProvider provider, string url, CancellationToken cancellationToken = default)
         {
             var httpClient = provider.HttpClient;
-            var response = await httpClient.GetAsync(url);
+            var response = await httpClient.GetAsync(url, cancellationToken);
             return response.StatusCode;
         }
 
-        public static async Task Post<T>(this IAcceptanceTestInfrastructureProvider provider, string url, T payload = null, Func<HttpStatusCode, bool> requestHasFailed = null) where T : class
+        public static async Task Post<T>(this IAcceptanceTestInfrastructureProvider provider, string url, T payload = null, Func<HttpStatusCode, bool> requestHasFailed = null, CancellationToken cancellationToken = default) where T : class
         {
             var httpClient = provider.HttpClient;
-            var response = await httpClient.PostAsJsonAsync(url, payload, provider.SerializerOptions);
+            var response = await httpClient.PostAsJsonAsync(url, payload, provider.SerializerOptions, cancellationToken);
 
             if (requestHasFailed != null)
             {
@@ -140,39 +141,39 @@ namespace ServiceControl.AcceptanceTesting
 
             if (!response.IsSuccessStatusCode)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
                 throw new InvalidOperationException($"Call failed: {(int)response.StatusCode} - {response.ReasonPhrase} - {body}");
             }
         }
 
-        public static async Task Delete(this IAcceptanceTestInfrastructureProvider provider, string url)
+        public static async Task Delete(this IAcceptanceTestInfrastructureProvider provider, string url, CancellationToken cancellationToken = default)
         {
             var httpClient = provider.HttpClient;
-            var response = await httpClient.DeleteAsync(url);
+            var response = await httpClient.DeleteAsync(url, cancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
                 throw new InvalidOperationException($"Call failed: {(int)response.StatusCode} - {response.ReasonPhrase} - {body}");
             }
         }
 
-        public static async Task<byte[]> DownloadData(this IAcceptanceTestInfrastructureProvider provider, string url, HttpStatusCode successCode = HttpStatusCode.OK)
+        public static async Task<byte[]> DownloadData(this IAcceptanceTestInfrastructureProvider provider, string url, HttpStatusCode successCode = HttpStatusCode.OK, CancellationToken cancellationToken = default)
         {
             var httpClient = provider.HttpClient;
-            var response = await httpClient.GetAsync(url);
+            var response = await httpClient.GetAsync(url, cancellationToken);
 
             if (response.StatusCode != successCode)
             {
                 throw new Exception($"Expected status code of {successCode}, but instead got {response.StatusCode}.");
             }
 
-            return await response.Content.ReadAsByteArrayAsync();
+            return await response.Content.ReadAsByteArrayAsync(cancellationToken);
         }
 
-        static async Task<T> GetInternal<T>(this IAcceptanceTestInfrastructureProvider provider, string url) where T : class
+        static async Task<T> GetInternal<T>(this IAcceptanceTestInfrastructureProvider provider, string url, CancellationToken cancellationToken) where T : class
         {
-            var response = await provider.GetRaw(url);
+            var response = await provider.GetRaw(url, cancellationToken);
 
             //for now
             if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.NoContent or HttpStatusCode.ServiceUnavailable)
@@ -183,12 +184,12 @@ namespace ServiceControl.AcceptanceTesting
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
-                var content = await response.Content.ReadAsStringAsync();
+                var content = await response.Content.ReadAsStringAsync(cancellationToken);
                 LogRequest(response.ReasonPhrase + content);
                 throw new InvalidOperationException($"Call failed: {(int)response.StatusCode} - {response.ReasonPhrase} {Environment.NewLine} {content}");
             }
 
-            var payload = await response.Content.ReadFromJsonAsync<T>(provider.SerializerOptions);
+            var payload = await response.Content.ReadFromJsonAsync<T>(provider.SerializerOptions, cancellationToken);
             LogRequest();
             return payload;
 

--- a/src/ServiceControl.AcceptanceTesting/OpenIdConnect/OpenIdConnectAssertions.cs
+++ b/src/ServiceControl.AcceptanceTesting/OpenIdConnect/OpenIdConnectAssertions.cs
@@ -4,6 +4,7 @@ namespace ServiceControl.AcceptanceTesting.OpenIdConnect
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using NUnit.Framework;
 
@@ -74,9 +75,9 @@ namespace ServiceControl.AcceptanceTesting.OpenIdConnect
         /// <summary>
         /// Asserts that the response body contains the expected error response format.
         /// </summary>
-        public static async Task AssertAuthErrorResponse(HttpResponseMessage response, string expectedError = "unauthorized")
+        public static async Task AssertAuthErrorResponse(HttpResponseMessage response, string expectedError = "unauthorized", CancellationToken cancellationToken = default)
         {
-            var content = await response.Content.ReadAsStringAsync();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
             Assert.That(content, Is.Not.Null.And.Not.Empty, "Response should have a body");
 
             var jsonDoc = JsonDocument.Parse(content);
@@ -107,12 +108,13 @@ namespace ServiceControl.AcceptanceTesting.OpenIdConnect
             string expectedAudience = null,
             string expectedApiScopes = null,
             string expectedScopes = null,
-            bool expectedRoleBasedAuthorizationEnabled = false)
+            bool expectedRoleBasedAuthorizationEnabled = false,
+            CancellationToken cancellationToken = default)
         {
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK),
                 "Authentication configuration endpoint should return 200 OK");
 
-            var content = await response.Content.ReadAsStringAsync();
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
             var jsonDoc = JsonDocument.Parse(content);
             var root = jsonDoc.RootElement;
 
@@ -201,11 +203,12 @@ namespace ServiceControl.AcceptanceTesting.OpenIdConnect
             HttpClient client,
             HttpMethod method,
             string path,
-            string token)
+            string token,
+            CancellationToken cancellationToken = default)
         {
             using var request = new HttpRequestMessage(method, path);
             request.Headers.Authorization = CreateBearerToken(token);
-            return await client.SendAsync(request);
+            return await client.SendAsync(request, cancellationToken);
         }
 
         /// <summary>
@@ -214,10 +217,11 @@ namespace ServiceControl.AcceptanceTesting.OpenIdConnect
         public static async Task<HttpResponseMessage> SendRequestWithoutAuth(
             HttpClient client,
             HttpMethod method,
-            string path)
+            string path,
+            CancellationToken cancellationToken = default)
         {
             using var request = new HttpRequestMessage(method, path);
-            return await client.SendAsync(request);
+            return await client.SendAsync(request, cancellationToken);
         }
     }
 }

--- a/src/ServiceControl.AcceptanceTesting/ScenarioWithEndpointBehaviorExtensions.cs
+++ b/src/ServiceControl.AcceptanceTesting/ScenarioWithEndpointBehaviorExtensions.cs
@@ -104,11 +104,12 @@
             public override Task ComponentsStarted(CancellationToken cancellationToken = default)
             {
                 tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var checkToken = tokenSource.Token;
                 checkTask = Task.Run(async () =>
                 {
                     try
                     {
-                        while (!tokenSource.IsCancellationRequested)
+                        while (!checkToken.IsCancellationRequested)
                         {
                             if (await isDone(scenarioContext))
                             {
@@ -116,14 +117,18 @@
                                 return;
                             }
 
-                            await Task.Delay(100, tokenSource.Token);
+                            await Task.Delay(100, checkToken);
                         }
+                    }
+                    catch (OperationCanceledException) when (checkToken.IsCancellationRequested)
+                    {
+                        // Stopping the run cancels the poll; that is not a test failure
                     }
                     catch (Exception e)
                     {
                         setException(ExceptionDispatchInfo.Capture(e));
                     }
-                }, tokenSource.Token);
+                }, checkToken);
                 return Task.CompletedTask;
             }
 

--- a/src/ServiceControl.AcceptanceTests.RavenDB/AcceptanceTestStorageConfiguration.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/AcceptanceTestStorageConfiguration.cs
@@ -34,7 +34,7 @@ public class AcceptanceTestStorageConfiguration : IAcceptanceTestStorageConfigur
             return;
         }
         using var _ = await UseDatabaseLifecycleLock(cancellationToken);
-        await databaseInstance.DeleteDatabase(databaseName);
+        await databaseInstance.DeleteDatabase(databaseName, cancellationToken);
     }
 
     /// <summary>

--- a/src/ServiceControl.Audit.Persistence.RavenDB/.editorconfig
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/.editorconfig
@@ -2,9 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# WaitForLicenseOrThrow passes only the linked cts.Token into its try, so PS0020 cannot recognise a
-# filter on the caller's token. Removing this needs the license-check exception mapping reworked, not
-# a token added, so it is deliberately scoped to the one file rather than the project.
-[LicenseStatusCheck.cs]
-dotnet_diagnostic.PS0020.severity = none

--- a/src/ServiceControl.Audit.Persistence.RavenDB/LicenseStatusCheck.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/LicenseStatusCheck.cs
@@ -37,7 +37,9 @@ static class LicenseStatusCheck
                 await Task.Delay(200, cts.Token);
             }
         }
+#pragma warning disable PS0020 // The try runs on the linked cts.Token, which is always cancelled in the timeout case this maps. Filtering on it instead of the caller's token would make the filter unreachable
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+#pragma warning restore PS0020
         {
             throw new InvalidOperationException("Cannot validate the current RavenDB license. Please, contact support");
         }

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/.editorconfig
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/.editorconfig
@@ -3,11 +3,6 @@
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
 
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-
 # Disable style rules for auto-generated EF migrations
 [Migrations/**.cs]
 dotnet_diagnostic.IDE0065.severity = none

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlDialect.cs
@@ -7,7 +7,7 @@ using ServiceControl.Persistence.EFCore.DbContexts;
 
 abstract class PostgreSqlDialect
 {
-    protected static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken)
+    protected static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken = default)
     {
         await using var command = dbContext.Database.GetDbConnection().CreateCommand();
         command.Transaction = (dbContext.Database.CurrentTransaction

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlFailedMessageIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlFailedMessageIngestionSqlDialect.cs
@@ -12,7 +12,7 @@ using Infrastructure;
 // atomic statement. Rows are chunked to keep statement texts down to a few reusable shapes.
 class PostgreSqlFailedMessageIngestionSqlDialect : PostgreSqlDialect, IFailedMessageIngestionSqlDialect
 {
-    public async Task UpsertFailedMessages(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageEntity> rows, CancellationToken cancellationToken)
+    public async Task UpsertFailedMessages(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageEntity> rows, CancellationToken cancellationToken = default)
     {
         foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
         {
@@ -29,7 +29,7 @@ class PostgreSqlFailedMessageIngestionSqlDialect : PostgreSqlDialect, IFailedMes
         }
     }
 
-    public async Task InsertGroups(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageGroupEntity> rows, CancellationToken cancellationToken)
+    public async Task InsertGroups(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageGroupEntity> rows, CancellationToken cancellationToken = default)
     {
         foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
         {
@@ -46,7 +46,7 @@ class PostgreSqlFailedMessageIngestionSqlDialect : PostgreSqlDialect, IFailedMes
         }
     }
 
-    public async Task InsertMissingKnownEndpoints(ServiceControlDbContext dbContext, IReadOnlyList<KnownEndpointEntity> rows, CancellationToken cancellationToken)
+    public async Task InsertMissingKnownEndpoints(ServiceControlDbContext dbContext, IReadOnlyList<KnownEndpointEntity> rows, CancellationToken cancellationToken = default)
     {
         foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
         {

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlRetryBatchSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlRetryBatchSqlDialect.cs
@@ -6,7 +6,7 @@ using Infrastructure;
 
 class PostgreSqlRetryBatchSqlDialect : PostgreSqlDialect, IRetryBatchSqlDialect
 {
-    public async Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken)
+    public async Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken = default)
     {
         foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
         {

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/.editorconfig
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/.editorconfig
@@ -3,11 +3,6 @@
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
 
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-
 # Disable style rules for auto-generated EF migrations
 [Migrations/**.cs]
 dotnet_diagnostic.IDE0065.severity = none

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerDialect.cs
@@ -8,7 +8,7 @@ using ServiceControl.Persistence.EFCore.DbContexts;
 
 abstract class SqlServerDialect
 {
-    protected static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken)
+    protected static async Task Execute(ServiceControlDbContext dbContext, string sql, IEnumerable<object?[]> rows, CancellationToken cancellationToken = default)
     {
         await using var command = dbContext.Database.GetDbConnection().CreateCommand();
         command.Transaction = (dbContext.Database.CurrentTransaction

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerFailedMessageIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerFailedMessageIngestionSqlDialect.cs
@@ -12,7 +12,7 @@ using Infrastructure;
 // statement texts down to a few reusable shapes.
 class SqlServerFailedMessageIngestionSqlDialect : SqlServerDialect, IFailedMessageIngestionSqlDialect
 {
-    public async Task UpsertFailedMessages(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageEntity> rows, CancellationToken cancellationToken)
+    public async Task UpsertFailedMessages(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageEntity> rows, CancellationToken cancellationToken = default)
     {
         var maxRowsPerStatement = MaxRowsPerStatement(FailedMessageColumns.Length);
         foreach (var chunk in rows.Chunk(maxRowsPerStatement))
@@ -34,7 +34,7 @@ class SqlServerFailedMessageIngestionSqlDialect : SqlServerDialect, IFailedMessa
         }
     }
 
-    public async Task InsertGroups(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageGroupEntity> rows, CancellationToken cancellationToken)
+    public async Task InsertGroups(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageGroupEntity> rows, CancellationToken cancellationToken = default)
     {
         var maxRowsPerStatement = MaxRowsPerStatement(4);
         foreach (var chunk in rows.Chunk(maxRowsPerStatement))
@@ -55,7 +55,7 @@ class SqlServerFailedMessageIngestionSqlDialect : SqlServerDialect, IFailedMessa
         }
     }
 
-    public async Task InsertMissingKnownEndpoints(ServiceControlDbContext dbContext, IReadOnlyList<KnownEndpointEntity> rows, CancellationToken cancellationToken)
+    public async Task InsertMissingKnownEndpoints(ServiceControlDbContext dbContext, IReadOnlyList<KnownEndpointEntity> rows, CancellationToken cancellationToken = default)
     {
         var maxRowsPerStatement = MaxRowsPerStatement(5);
         foreach (var chunk in rows.Chunk(maxRowsPerStatement))

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerRetryBatchSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerRetryBatchSqlDialect.cs
@@ -6,7 +6,7 @@ using Infrastructure;
 
 class SqlServerRetryBatchSqlDialect : SqlServerDialect, IRetryBatchSqlDialect
 {
-    public async Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken)
+    public async Task InsertMissingRetryClaims(ServiceControlDbContext dbContext, IReadOnlyList<FailedMessageRetryEntity> rows, CancellationToken cancellationToken = default)
     {
         var maxRowsPerStatement = MaxRowsPerStatement(3);
         foreach (var chunk in rows.Chunk(maxRowsPerStatement))

--- a/src/ServiceControl.RavenDB/.editorconfig
+++ b/src/ServiceControl.RavenDB/.editorconfig
@@ -2,9 +2,3 @@
 
 # Justification: ServiceControl app has no synchronization context
 dotnet_diagnostic.CA2007.severity = none
-
-# Cancellation analyzer debt. These fire because Particular.Analyzers is no longer pinned to 0.9.0.
-# They are scheduled work, not accepted exceptions: remove a line once this project has no
-# violations of that rule left, and never add a rule back to this list.
-dotnet_diagnostic.PS0003.severity = none
-dotnet_diagnostic.PS0018.severity = none

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -165,7 +165,7 @@ namespace ServiceControl.RavenDB
             }
         }
 
-        public async Task<IDocumentStore> Connect(CancellationToken cancellationToken)
+        public async Task<IDocumentStore> Connect(CancellationToken cancellationToken = default)
         {
             var dbOptions = new DatabaseOptions(configuration.Name)
             {
@@ -180,16 +180,16 @@ namespace ServiceControl.RavenDB
             return store;
         }
 
-        public async Task DeleteDatabase(string dbName)
+        public async Task DeleteDatabase(string dbName, CancellationToken cancellationToken = default)
         {
             using var store = await EmbeddedServer.Instance.GetDocumentStoreAsync(new DatabaseOptions(dbName)
             {
                 SkipCreatingDatabase = true
-            });
-            await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(dbName, true));
+            }, cancellationToken);
+            await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(dbName, true), cancellationToken);
         }
 
-        public async Task Stop(CancellationToken cancellationToken)
+        public async Task Stop(CancellationToken cancellationToken = default)
         {
             logger.LogDebug("Stopping RavenDB server");
             EmbeddedServer.Instance.ServerProcessExited -= OnServerProcessExited;


### PR DESCRIPTION
Retires the cancellation analyzer debt blocks in six projects, which is
Phase 7 of the propagation work.

ServiceControl.Persistence.EFCore.SqlServer / .PostgreSql: the dialect
implementations now match their interfaces, whose tokens are already
optional.

ServiceControl.RavenDB: EmbeddedDatabase.DeleteDatabase takes a token and
forwards it, so deleting a database can be cancelled.

Particular.LicensingComponent: IAuditQuery and IThroughputCollector and
their implementations, plus BrokerThroughputCollectorHostedService's
stoppingToken renamed to cancellationToken. Five catch blocks now catch
OperationCanceledException filtered on the token before catching
Exception, so shutdown cancellation is no longer reported as a failure to
gather throughput or to reach the audit remotes.

ServiceControl.AcceptanceTesting: the HTTP helpers and assertion helpers
take and forward optional tokens. The scenario poll loop captured
cancellation as a test failure on shutdown, so it now swallows its own
cancellation and holds the linked token in a local rather than reading a
disposed source. The project block is narrowed to the types that sit on
NServiceBus.AcceptanceTesting extension points, which drive them without
a token.

ServiceControl.Audit.Persistence.RavenDB: the PS0020 carve-out on
LicenseStatusCheck moves from the project editorconfig to an inline
pragma. The filter is deliberate, since the try runs on a linked token
that is always cancelled in the timeout case being mapped.
