### PR TITLE
Update SSH.NET to 2026.0.0 to address CVE

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -106,6 +106,7 @@
     <PackageVersion Include="System.Threading.RateLimiting" Version="$(RuntimeFrameworkVersion)" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Azure.Core" Version="1.60.0" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.1.63" />


### PR DESCRIPTION
This dependency comes from the use of TestContainers, which is just test code.