### PR TITLE
Implement external integration dispatch requests on EF Core

### DIFF
--- a/src/Particular.LicensingComponent.UnitTests/AuditQuery_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/AuditQuery_Tests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
-using Contracts;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using Particular.Approvals;

--- a/src/ServiceControl.AcceptanceTests.PostgreSql/ServiceControl.AcceptanceTests.PostgreSql.csproj
+++ b/src/ServiceControl.AcceptanceTests.PostgreSql/ServiceControl.AcceptanceTests.PostgreSql.csproj
@@ -35,21 +35,7 @@
     <Compile Include="..\ServiceControl.Persistence.Tests.PostgreSql\StopSharedPostgreSql.cs" />
     <Compile Include="..\ServiceControl.UnitTests\NUnitParallelRunnerSettings.cs" />
 
-    <!-- External integration event dispatch is not implemented by EF persistence. -->
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Monitoring\ExternalIntegration\When_a_custom_check_fails.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Monitoring\ExternalIntegration\When_a_custom_check_succeeds.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Monitoring\ExternalIntegration\When_heartbeat_is_restored.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Monitoring\ExternalIntegration\When_heartbeat_loss_is_detected.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_edit_is_resolved_by_retry.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_message_is_archived.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_message_is_resolved_by_retry.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_message_is_resolved_manually.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_message_is_unarchived.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_msg_is_resolved_by_edit.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_group_is_archived.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_message_has_failed_detected.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_reedit_solves_a_failed_msg.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_encountered_an_error.cs" />
+    <!-- EF does not store body in MessageMetadata dictionary -->
     <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\When_edited_message_fails_to_process.cs" />
   </ItemGroup>
 

--- a/src/ServiceControl.AcceptanceTests.SqlServer/ServiceControl.AcceptanceTests.SqlServer.csproj
+++ b/src/ServiceControl.AcceptanceTests.SqlServer/ServiceControl.AcceptanceTests.SqlServer.csproj
@@ -35,21 +35,7 @@
     <Compile Include="..\ServiceControl.Persistence.Tests.SqlServer\StopSharedSqlServer.cs" />
     <Compile Include="..\ServiceControl.UnitTests\NUnitParallelRunnerSettings.cs" />
 
-    <!-- External integration event dispatch is not implemented by EF persistence. -->
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Monitoring\ExternalIntegration\When_a_custom_check_fails.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Monitoring\ExternalIntegration\When_a_custom_check_succeeds.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Monitoring\ExternalIntegration\When_heartbeat_is_restored.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Monitoring\ExternalIntegration\When_heartbeat_loss_is_detected.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_edit_is_resolved_by_retry.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_message_is_archived.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_message_is_resolved_by_retry.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_message_is_resolved_manually.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_message_is_unarchived.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_failed_msg_is_resolved_by_edit.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_group_is_archived.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_message_has_failed_detected.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_a_reedit_solves_a_failed_msg.cs" />
-    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\ExternalIntegration\When_encountered_an_error.cs" />
+    <!-- EF does not store body in MessageMetadata dictionary -->
     <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\When_edited_message_fails_to_process.cs" />
   </ItemGroup>
 

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_is_restored.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_is_restored.cs
@@ -34,7 +34,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.ExternalIntegration
 
             ExecuteWhen(() => externalProcessorSubscribed, domainEvents => domainEvents.Raise(new EndpointHeartbeatRestored
             {
-                RestoredAt = new DateTime(2013, 09, 13, 13, 15, 13),
+                RestoredAt = new DateTime(2013, 09, 13, 13, 15, 13, DateTimeKind.Utc),
                 Endpoint = new EndpointDetails
                 {
                     Host = "LuckyHost",

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_loss_is_detected.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_loss_is_detected.cs
@@ -35,8 +35,8 @@ namespace ServiceControl.AcceptanceTests.Monitoring.ExternalIntegration
 
             ExecuteWhen(() => externalProcessorSubscribed, domainEvents => domainEvents.Raise(new EndpointFailedToHeartbeat
             {
-                DetectedAt = new DateTime(2013, 09, 13, 13, 14, 13),
-                LastReceivedAt = new DateTime(2013, 09, 13, 13, 13, 13),
+                DetectedAt = new DateTime(2013, 09, 13, 13, 14, 13, DateTimeKind.Utc),
+                LastReceivedAt = new DateTime(2013, 09, 13, 13, 13, 13, DateTimeKind.Utc),
                 Endpoint = new EndpointDetails
                 {
                     Host = "UnluckyHost",

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/ExternalIntegrationAcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/ExternalIntegrationAcceptanceTest.cs
@@ -9,7 +9,6 @@
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.Routing;
     using NServiceBus.Transport;
-    using TestSupport;
     using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
 
     abstract class ExternalIntegrationAcceptanceTest : AcceptanceTest

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_encountered_an_error.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_encountered_an_error.cs
@@ -44,8 +44,8 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
 
             ExecuteWhen(() => externalProcessorSubscribed, domainEvents => domainEvents.Raise(new EndpointFailedToHeartbeat
             {
-                DetectedAt = new DateTime(2013, 09, 13, 13, 14, 13),
-                LastReceivedAt = new DateTime(2013, 09, 13, 13, 13, 13),
+                DetectedAt = new DateTime(2013, 09, 13, 13, 14, 13, DateTimeKind.Utc),
+                LastReceivedAt = new DateTime(2013, 09, 13, 13, 13, 13, DateTimeKind.Utc),
                 Endpoint = new EndpointDetails
                 {
                     Host = "UnluckyHost",

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260811033225_AddExternalIntegrationDispatchRequests.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260811033225_AddExternalIntegrationDispatchRequests.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ServiceControl.Persistence.EFCore.PostgreSql;
@@ -12,9 +13,11 @@ using ServiceControl.Persistence.EFCore.PostgreSql;
 namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
 {
     [DbContext(typeof(PostgreSqlServiceControlDbContext))]
-    partial class PostgreSqlServiceControlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811033225_AddExternalIntegrationDispatchRequests")]
+    partial class AddExternalIntegrationDispatchRequests
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -277,27 +280,6 @@ namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
                     b.ToTable("failed_error_imports", (string)null);
                 });
 
-            modelBuilder.Entity("ServiceControl.Persistence.EFCore.Entities.FailedMessageEditEntity", b =>
-                {
-                    b.Property<Guid>("UniqueMessageId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("unique_message_id");
-
-                    b.Property<string>("EditId")
-                        .IsRequired()
-                        .HasMaxLength(450)
-                        .HasColumnType("character varying(450)")
-                        .HasColumnName("edit_id");
-
-                    b.HasKey("UniqueMessageId")
-                        .HasName("pk_failed_message_edits");
-
-                    b.HasIndex("EditId")
-                        .HasDatabaseName("ix_failed_message_edits_edit_id");
-
-                    b.ToTable("failed_message_edits", (string)null);
-                });
-
             modelBuilder.Entity("ServiceControl.Persistence.EFCore.Entities.FailedMessageEntity", b =>
                 {
                     b.Property<Guid>("UniqueMessageId")
@@ -335,7 +317,6 @@ namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
                         .HasColumnName("exception_type");
 
                     b.Property<string>("FailingEndpointAddress")
-                        .IsRequired()
                         .HasMaxLength(450)
                         .HasColumnType("character varying(450)")
                         .HasColumnName("failing_endpoint_address");

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260811033225_AddExternalIntegrationDispatchRequests.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260811033225_AddExternalIntegrationDispatchRequests.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalIntegrationDispatchRequests : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExternalIntegrationDispatchRequests",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    dispatch_context_type_name = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: false),
+                    dispatch_context_json = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_external_integration_dispatch_requests", x => x.id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExternalIntegrationDispatchRequests");
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260811033208_AddExternalIntegrationDispatchRequests.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260811033208_AddExternalIntegrationDispatchRequests.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ServiceControl.Persistence.EFCore.SqlServer;
 
@@ -11,9 +12,11 @@ using ServiceControl.Persistence.EFCore.SqlServer;
 namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
 {
     [DbContext(typeof(SqlServerServiceControlDbContext))]
-    partial class SqlServerServiceControlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811033208_AddExternalIntegrationDispatchRequests")]
+    partial class AddExternalIntegrationDispatchRequests
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -225,23 +228,6 @@ namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
                     b.ToTable("FailedErrorImports");
                 });
 
-            modelBuilder.Entity("ServiceControl.Persistence.EFCore.Entities.FailedMessageEditEntity", b =>
-                {
-                    b.Property<Guid>("UniqueMessageId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("EditId")
-                        .IsRequired()
-                        .HasMaxLength(450)
-                        .HasColumnType("nvarchar(450)");
-
-                    b.HasKey("UniqueMessageId");
-
-                    b.HasIndex("EditId");
-
-                    b.ToTable("FailedMessageEdits");
-                });
-
             modelBuilder.Entity("ServiceControl.Persistence.EFCore.Entities.FailedMessageEntity", b =>
                 {
                     b.Property<Guid>("UniqueMessageId")
@@ -271,7 +257,6 @@ namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("FailingEndpointAddress")
-                        .IsRequired()
                         .HasMaxLength(450)
                         .HasColumnType("nvarchar(450)");
 

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260811033208_AddExternalIntegrationDispatchRequests.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260811033208_AddExternalIntegrationDispatchRequests.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalIntegrationDispatchRequests : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExternalIntegrationDispatchRequests",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    DispatchContextTypeName = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                    DispatchContextJson = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExternalIntegrationDispatchRequests", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExternalIntegrationDispatchRequests");
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersistenceConfigurationBase.cs
+++ b/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersistenceConfigurationBase.cs
@@ -27,6 +27,7 @@ public abstract class EFPersistenceConfigurationBase : PersistenceConfiguration,
     const string ErrorRetentionPeriodKey = "ErrorRetentionPeriod";
     const string EventsRetentionPeriodKey = "EventsRetentionPeriod";
     const string SubscriptionCacheDurationKey = "SubscriptionCacheDuration";
+    const string ExternalIntegrationsDispatchingBatchSizeKey = "ExternalIntegrationsDispatchingBatchSize";
 
     public PersistenceSettings CreateSettings(SettingsRootNamespace settingsRootNamespace)
     {
@@ -38,6 +39,7 @@ public abstract class EFPersistenceConfigurationBase : PersistenceConfiguration,
         settings.ErrorRetentionPeriod = GetRequiredSetting<TimeSpan>(settingsRootNamespace, ErrorRetentionPeriodKey);
         settings.EventsRetentionPeriod = SettingsReader.Read(settingsRootNamespace, EventsRetentionPeriodKey, EFPersisterSettings.DefaultEventsRetentionPeriod);
         settings.SubscriptionCacheDuration = SettingsReader.Read(settingsRootNamespace, SubscriptionCacheDurationKey, EFPersisterSettings.DefaultSubscriptionCacheDuration);
+        settings.ExternalIntegrationsDispatchingBatchSize = SettingsReader.Read(settingsRootNamespace, ExternalIntegrationsDispatchingBatchSizeKey, 100);
 
         return settings;
     }

--- a/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersistenceConfigurationBase.cs
+++ b/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersistenceConfigurationBase.cs
@@ -39,7 +39,7 @@ public abstract class EFPersistenceConfigurationBase : PersistenceConfiguration,
         settings.ErrorRetentionPeriod = GetRequiredSetting<TimeSpan>(settingsRootNamespace, ErrorRetentionPeriodKey);
         settings.EventsRetentionPeriod = SettingsReader.Read(settingsRootNamespace, EventsRetentionPeriodKey, EFPersisterSettings.DefaultEventsRetentionPeriod);
         settings.SubscriptionCacheDuration = SettingsReader.Read(settingsRootNamespace, SubscriptionCacheDurationKey, EFPersisterSettings.DefaultSubscriptionCacheDuration);
-        settings.ExternalIntegrationsDispatchingBatchSize = SettingsReader.Read(settingsRootNamespace, ExternalIntegrationsDispatchingBatchSizeKey, 100);
+        settings.ExternalIntegrationsDispatchingBatchSize = ReadExternalIntegrationsDispatchingBatchSize(settingsRootNamespace);
 
         return settings;
     }
@@ -191,5 +191,20 @@ public abstract class EFPersistenceConfigurationBase : PersistenceConfiguration,
         }
 
         return maxBodySizeToStore;
+    }
+
+    static int ReadExternalIntegrationsDispatchingBatchSize(SettingsRootNamespace settingsRootNamespace)
+    {
+        var batchSize = SettingsReader.Read(settingsRootNamespace, ExternalIntegrationsDispatchingBatchSizeKey, EFPersisterSettings.DefaultExternalIntegrationsDispatchingBatchSize);
+
+        if (batchSize <= 0)
+        {
+            LoggerUtil.CreateStaticLogger<EFPersistenceConfigurationBase>()
+                .LogError("ExternalIntegrationsDispatchingBatchSize setting is invalid, 1 is the minimum value. Defaulting to {ExternalIntegrationsDispatchingBatchSizeDefault}", EFPersisterSettings.DefaultExternalIntegrationsDispatchingBatchSize);
+
+            return EFPersisterSettings.DefaultExternalIntegrationsDispatchingBatchSize;
+        }
+
+        return batchSize;
     }
 }

--- a/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersisterSettings.cs
+++ b/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersisterSettings.cs
@@ -18,6 +18,7 @@ public abstract class EFPersisterSettings : PersistenceSettings
     public int MaxRetryDelayInSeconds { get; set; } = 30;
     public bool EnableSensitiveDataLogging { get; set; }
     public bool EnableRetryOnFailure { get; set; } = true;
+    public int ExternalIntegrationsDispatchingBatchSize { get; set; } = 100;
 
     /// <summary>
     /// How long subscriber lookups are cached for. <see cref="TimeSpan.Zero"/> disables caching.

--- a/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersisterSettings.cs
+++ b/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersisterSettings.cs
@@ -5,6 +5,7 @@ public abstract class EFPersisterSettings : PersistenceSettings
     public static readonly TimeSpan MigrationCommandTimeout = TimeSpan.FromMinutes(40);
 
     public const int DefaultCommandTimeout = 30;
+    public const int DefaultExternalIntegrationsDispatchingBatchSize = 100;
     public static readonly TimeSpan DefaultEventsRetentionPeriod = TimeSpan.FromDays(14);
 
     public static readonly TimeSpan DefaultSubscriptionCacheDuration = TimeSpan.FromSeconds(60);
@@ -18,7 +19,7 @@ public abstract class EFPersisterSettings : PersistenceSettings
     public int MaxRetryDelayInSeconds { get; set; } = 30;
     public bool EnableSensitiveDataLogging { get; set; }
     public bool EnableRetryOnFailure { get; set; } = true;
-    public int ExternalIntegrationsDispatchingBatchSize { get; set; } = 100;
+    public int ExternalIntegrationsDispatchingBatchSize { get; set; } = DefaultExternalIntegrationsDispatchingBatchSize;
 
     /// <summary>
     /// How long subscriber lookups are cached for. <see cref="TimeSpan.Zero"/> disables caching.

--- a/src/ServiceControl.Persistence.EFCore/DbContexts/ServiceControlDbContext.cs
+++ b/src/ServiceControl.Persistence.EFCore/DbContexts/ServiceControlDbContext.cs
@@ -26,6 +26,7 @@ public abstract class ServiceControlDbContext(DbContextOptions options) : DbCont
     public DbSet<FailedMessageEditEntity> FailedMessageEdits { get; set; }
     public DbSet<LicensingEndpointEntity> LicensingEndpoints { get; set; }
     public DbSet<LicensingEndpointThroughputEntity> LicensingEndpointThroughput { get; set; }
+    public DbSet<ExternalIntegrationDispatchRequestEntity> ExternalIntegrationDispatchRequests { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         => optionsBuilder.EnableDetailedErrors();
@@ -54,6 +55,7 @@ public abstract class ServiceControlDbContext(DbContextOptions options) : DbCont
         modelBuilder.ApplyConfiguration(new ArchiveOperationConfiguration());
         modelBuilder.ApplyConfiguration(new LicensingEndpointConfiguration());
         modelBuilder.ApplyConfiguration(new LicensingEndpointThroughputConfiguration());
+        modelBuilder.ApplyConfiguration(new ExternalIntegrationDispatchRequestConfiguration());
     }
 
     public abstract bool IsDuplicateKeyException(DbUpdateException exception);

--- a/src/ServiceControl.Persistence.EFCore/Entities/ExternalIntegrationDispatchRequestEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/ExternalIntegrationDispatchRequestEntity.cs
@@ -1,0 +1,11 @@
+namespace ServiceControl.Persistence.EFCore.Entities;
+
+public class ExternalIntegrationDispatchRequestEntity
+{
+    // Auto-increment, so ordering by Id gives natural FIFO dispatch order.
+    public long Id { get; set; }
+
+    public required string DispatchContextTypeName { get; set; }
+
+    public required string DispatchContextJson { get; set; }
+}

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/ExternalIntegrationDispatchRequestConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/ExternalIntegrationDispatchRequestConfiguration.cs
@@ -1,0 +1,17 @@
+namespace ServiceControl.Persistence.EFCore.EntityConfigurations;
+
+using Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+class ExternalIntegrationDispatchRequestConfiguration : IEntityTypeConfiguration<ExternalIntegrationDispatchRequestEntity>
+{
+    public void Configure(EntityTypeBuilder<ExternalIntegrationDispatchRequestEntity> builder)
+    {
+        builder.ToTable("ExternalIntegrationDispatchRequests");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).ValueGeneratedOnAdd();
+        builder.Property(e => e.DispatchContextTypeName).IsRequired().HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.DispatchContextJson).IsRequired();
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/Implementation/DispatchContextSerializer.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/DispatchContextSerializer.cs
@@ -1,0 +1,25 @@
+namespace ServiceControl.Persistence.EFCore.Implementation;
+
+using System.Text.Json;
+
+// DispatchContext's concrete type is only known at runtime, so round-tripping it through a single JSON column needs the type name stored alongside the payload.
+// This has to stay reflection-based. A source-generated JsonSerializerContext isn't possible here because the type isn't known at compile time.
+static class DispatchContextSerializer
+{
+    public static (string TypeName, string Json) Serialize(object dispatchContext)
+    {
+        var type = dispatchContext.GetType();
+
+        var typeName = $"{type.FullName}, {type.Assembly.GetName().Name}";
+        var json = JsonSerializer.Serialize(dispatchContext, type);
+
+        return (typeName, json);
+    }
+
+    public static object Deserialize(string typeName, string json)
+    {
+        var type = Type.GetType(typeName, throwOnError: true)!;
+
+        return JsonSerializer.Deserialize(json, type)!;
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/Implementation/ExternalIntegrationRequestsDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/ExternalIntegrationRequestsDataStore.cs
@@ -1,15 +1,197 @@
 namespace ServiceControl.Persistence.EFCore.Implementation;
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NServiceBus;
 using ServiceControl.ExternalIntegrations;
+using ServiceControl.Persistence.EFCore.Abstractions;
+using ServiceControl.Persistence.EFCore.Entities;
 
-public class ExternalIntegrationRequestsDataStore : IExternalIntegrationRequestsDataStore, IHostedService
+public class ExternalIntegrationRequestsDataStore(
+    IServiceScopeFactory scopeFactory,
+    EFPersisterSettings settings,
+    TimeProvider timeProvider,
+    CriticalError criticalError,
+    ILogger<ExternalIntegrationRequestsDataStore> logger)
+    : DataStoreBase(scopeFactory), IExternalIntegrationRequestsDataStore, IHostedService, IAsyncDisposable
 {
-    public void Subscribe(Func<object[], CancellationToken, Task> callback) { }
+    static readonly TimeSpan PollingInterval = TimeSpan.FromSeconds(30);
 
-    public Task StoreDispatchRequest(IEnumerable<ExternalIntegrationDispatchRequest> dispatchRequests, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    Func<object[], CancellationToken, Task>? callback;
+    Task? task;
+    bool isDisposed;
 
-    public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public async Task StoreDispatchRequest(IEnumerable<ExternalIntegrationDispatchRequest> dispatchRequests, CancellationToken cancellationToken = default)
+    {
+        await ExecuteWithDbContext(async (context, cancellationToken) =>
+        {
+            foreach (var dispatchRequest in dispatchRequests)
+            {
+                var (typeName, json) = DispatchContextSerializer.Serialize(dispatchRequest.DispatchContext);
 
-    public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+                context.ExternalIntegrationDispatchRequests.Add(new ExternalIntegrationDispatchRequestEntity
+                {
+                    DispatchContextTypeName = typeName,
+                    DispatchContextJson = json
+                });
+            }
+
+            await context.SaveChangesAsync(cancellationToken);
+        }, cancellationToken);
+
+        signal.Release();
+    }
+
+    public void Subscribe(Func<object[], CancellationToken, Task> callback)
+    {
+        if (this.callback is not null)
+        {
+            throw new InvalidOperationException("Subscription already exists.");
+        }
+
+        this.callback = callback ?? throw new ArgumentNullException(nameof(callback));
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        task = RunLoop(tokenSource.Token);
+
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken = default) => await DisposeAsync();
+
+    public Task DispatchNow(CancellationToken cancellationToken = default) => DrainAvailableBatches(cancellationToken);
+
+    async Task RunLoop(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await DrainAvailableBatches(cancellationToken);
+                circuitBreaker.Success();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "An exception occurred when dispatching external integration events");
+
+                await circuitBreaker.Failure(ex, cancellationToken);
+                continue;
+            }
+
+            try
+            {
+                await Task.WhenAny(signal.WaitAsync(cancellationToken), Task.Delay(PollingInterval, timeProvider, cancellationToken));
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    async Task DrainAvailableBatches(CancellationToken cancellationToken)
+    {
+        var subscribedCallback = callback;
+
+        if (subscribedCallback is null)
+        {
+            return;
+        }
+
+        await drainLock.WaitAsync(cancellationToken);
+
+        try
+        {
+            while (await TryDispatchBatch(subscribedCallback, cancellationToken) && !cancellationToken.IsCancellationRequested)
+            {
+            }
+        }
+        finally
+        {
+            drainLock.Release();
+        }
+    }
+
+    async Task<bool> TryDispatchBatch(Func<object[], CancellationToken, Task> callback, CancellationToken cancellationToken)
+    {
+        var rows = await ExecuteWithDbContext((context, cancellationToken) =>
+            context.ExternalIntegrationDispatchRequests
+                .AsNoTracking()
+                .OrderBy(row => row.Id)
+                .Take(settings.ExternalIntegrationsDispatchingBatchSize)
+                .ToListAsync(cancellationToken), cancellationToken);
+
+        if (rows.Count == 0)
+        {
+            return false;
+        }
+
+        var contexts = rows
+            .Select(row => DispatchContextSerializer.Deserialize(row.DispatchContextTypeName, row.DispatchContextJson))
+            .ToArray();
+
+        logger.LogDebug("Dispatching {EventCount} events", contexts.Length);
+
+        // Rows are only deleted once the callback has successfully consumed the batch: if it
+        // throws (e.g. a transient failure resolving one of the outgoing contract events), the
+        // rows are left in place so the same batch is retried on the next pass.
+        await callback(contexts, cancellationToken);
+
+        var ids = rows.Select(row => row.Id).ToArray();
+
+        await ExecuteWithDbContext(
+            (context, cancellationToken) => context.ExternalIntegrationDispatchRequests
+                .Where(row => ids.Contains(row.Id))
+                .ExecuteDeleteAsync(cancellationToken),
+            cancellationToken);
+
+        return rows.Count == settings.ExternalIntegrationsDispatchingBatchSize;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (isDisposed)
+        {
+            return;
+        }
+
+        isDisposed = true;
+
+        await tokenSource.CancelAsync();
+
+        if (task is not null)
+        {
+            try
+            {
+                await task;
+            }
+            catch (OperationCanceledException)
+            {
+                // expected during shutdown
+            }
+        }
+
+        tokenSource.Dispose();
+        signal.Dispose();
+        drainLock.Dispose();
+    }
+
+    readonly SemaphoreSlim signal = new(0, int.MaxValue);
+    readonly SemaphoreSlim drainLock = new(1, 1);
+    readonly CancellationTokenSource tokenSource = new();
+
+    readonly RepeatedFailuresOverTimeCircuitBreaker circuitBreaker = new(
+        "ExternalIntegrationEventDispatcher",
+        TimeSpan.FromMinutes(5),
+        ex => criticalError.Raise("Repeated failures when dispatching external integration events.", ex),
+        logger,
+        timeToWaitWhenArmed: TimeSpan.FromSeconds(20));
 }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/ExternalIntegrationRequestsDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/ExternalIntegrationRequestsDataStore.cs
@@ -82,7 +82,16 @@ public class ExternalIntegrationRequestsDataStore(
             {
                 logger.LogError(ex, "An exception occurred when dispatching external integration events");
 
-                await circuitBreaker.Failure(ex, cancellationToken);
+                try
+                {
+                    await circuitBreaker.Failure(ex, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // Shutting down while backing off after a failure - nothing more to do.
+                    break;
+                }
+
                 continue;
             }
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/ExternalIntegrationRequestsDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/ExternalIntegrationRequestsDataStore.cs
@@ -182,6 +182,7 @@ public class ExternalIntegrationRequestsDataStore(
         tokenSource.Dispose();
         signal.Dispose();
         drainLock.Dispose();
+        circuitBreaker.Dispose();
     }
 
     readonly SemaphoreSlim signal = new(0, int.MaxValue);

--- a/src/ServiceControl.Persistence.EFCore/Implementation/ExternalIntegrationRequestsDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/ExternalIntegrationRequestsDataStore.cs
@@ -67,6 +67,8 @@ public class ExternalIntegrationRequestsDataStore(
 
     async Task RunLoop(CancellationToken cancellationToken)
     {
+        Task? pendingSignal = null;
+
         while (!cancellationToken.IsCancellationRequested)
         {
             try
@@ -97,7 +99,17 @@ public class ExternalIntegrationRequestsDataStore(
 
             try
             {
-                await Task.WhenAny(signal.WaitAsync(cancellationToken), Task.Delay(PollingInterval, timeProvider, cancellationToken));
+                pendingSignal ??= signal.WaitAsync(cancellationToken);
+
+                var completed = await Task.WhenAny(pendingSignal, Task.Delay(PollingInterval, timeProvider, cancellationToken));
+
+                // Clear the pending signal if it completed, so that we can wait for a new signal on the next iteration.
+                // If the delay completed first however, we will continue to the next iteration and use the same pending signal again.
+                if (completed == pendingSignal)
+                {
+                    await pendingSignal;
+                    pendingSignal = null;
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/ServiceControl.Persistence.EFCore/Implementation/ExternalIntegrationRequestsDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/ExternalIntegrationRequestsDataStore.cs
@@ -155,24 +155,49 @@ public class ExternalIntegrationRequestsDataStore(
             return false;
         }
 
-        var contexts = rows
-            .Select(row => DispatchContextSerializer.Deserialize(row.DispatchContextTypeName, row.DispatchContextJson))
-            .ToArray();
+        var contexts = new List<object>(rows.Count);
+        var dispatchableRowIds = new List<long>(rows.Count);
+        List<long>? poisonedRowIds = null;
 
-        logger.LogDebug("Dispatching {EventCount} events", contexts.Length);
+        foreach (var row in rows)
+        {
+            try
+            {
+                contexts.Add(DispatchContextSerializer.Deserialize(row.DispatchContextTypeName, row.DispatchContextJson));
+                dispatchableRowIds.Add(row.Id);
+            }
+            catch (Exception ex)
+            {
+                poisonedRowIds ??= [];
+                logger.LogError(ex, "Failed to deserialize external integration dispatch request {DispatchRequestId} of type {DispatchContextTypeName}. The event will be discarded.", row.Id, row.DispatchContextTypeName);
+                poisonedRowIds.Add(row.Id);
+            }
+        }
 
-        // Rows are only deleted once the callback has successfully consumed the batch: if it
-        // throws (e.g. a transient failure resolving one of the outgoing contract events), the
-        // rows are left in place so the same batch is retried on the next pass.
-        await callback(contexts, cancellationToken);
+        if (poisonedRowIds is not null)
+        {
+            await ExecuteWithDbContext((context, cancellationToken) =>
+                context.ExternalIntegrationDispatchRequests
+                    .Where(row => poisonedRowIds.Contains(row.Id))
+                    .ExecuteDeleteAsync(cancellationToken),
+                cancellationToken);
+        }
 
-        var ids = rows.Select(row => row.Id).ToArray();
+        if (contexts.Count > 0)
+        {
+            logger.LogDebug("Dispatching {EventCount} events", contexts.Count);
 
-        await ExecuteWithDbContext(
-            (context, cancellationToken) => context.ExternalIntegrationDispatchRequests
-                .Where(row => ids.Contains(row.Id))
-                .ExecuteDeleteAsync(cancellationToken),
-            cancellationToken);
+            // Rows are only deleted once the callback has successfully consumed the batch: if it
+            // throws (e.g. a transient failure resolving one of the outgoing contract events), the
+            // rows are left in place so the same batch is retried on the next pass.
+            await callback([.. contexts], cancellationToken);
+
+            await ExecuteWithDbContext(
+                (context, cancellationToken) => context.ExternalIntegrationDispatchRequests
+                    .Where(row => dispatchableRowIds.Contains(row.Id))
+                    .ExecuteDeleteAsync(cancellationToken),
+                cancellationToken);
+        }
 
         return rows.Count == settings.ExternalIntegrationsDispatchingBatchSize;
     }

--- a/src/ServiceControl.Persistence.RavenDB/ExternalIntegrationRequestsDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ExternalIntegrationRequestsDataStore.cs
@@ -14,12 +14,8 @@
     using Raven.Client.Documents.Changes;
     using ServiceControl.Infrastructure;
 
-    class ExternalIntegrationRequestsDataStore
-        : IExternalIntegrationRequestsDataStore
-        , IHostedService
-        , IAsyncDisposable
+    class ExternalIntegrationRequestsDataStore : IExternalIntegrationRequestsDataStore, IHostedService, IAsyncDisposable
     {
-
         public ExternalIntegrationRequestsDataStore(
             RavenPersisterSettings settings,
             IRavenSessionProvider sessionProvider,
@@ -187,6 +183,7 @@
             }
 
             tokenSource?.Dispose();
+            circuitBreaker.Dispose();
         }
 
         readonly RavenPersisterSettings settings;
@@ -197,7 +194,7 @@
 
         IDisposable subscription;
         Task task;
-        ManualResetEventSlim signal = new();
+        readonly ManualResetEventSlim signal = new();
         Func<object[], CancellationToken, Task> callback;
         bool isDisposed;
 

--- a/src/ServiceControl.Persistence.RavenDB/ExternalIntegrationRequestsDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ExternalIntegrationRequestsDataStore.cs
@@ -50,13 +50,8 @@
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
             foreach (var dispatchRequest in dispatchRequests)
             {
-                if (dispatchRequest.Id != null)
-                {
-                    throw new ArgumentException("Items cannot have their Id property set");
-                }
-
-                dispatchRequest.Id = KeyPrefix + "/" + Guid.NewGuid();
-                await session.StoreAsync(dispatchRequest, cancellationToken);
+                var id = KeyPrefix + "/" + Guid.NewGuid();
+                await session.StoreAsync(dispatchRequest, id, cancellationToken);
             }
 
             await session.SaveChangesAsync(cancellationToken);
@@ -170,10 +165,7 @@
                 .Changes()
                 .ForDocumentsStartingWith(KeyPrefix)
                 .Where(c => c.Type == DocumentChangeTypes.Put)
-                .Subscribe(d =>
-                {
-                    signal.Set();
-                });
+                .Subscribe(_ => signal.Set());
         }
 
         public async Task StopAsync(CancellationToken cancellationToken = default) => await DisposeAsync();

--- a/src/ServiceControl.Persistence.RavenDB/ExternalIntegrationRequestsDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ExternalIntegrationRequestsDataStore.cs
@@ -95,7 +95,16 @@
             catch (Exception ex)
             {
                 logger.LogError(ex, "An exception occurred when dispatching external integration events");
-                await circuitBreaker.Failure(ex, cancellationToken);
+
+                try
+                {
+                    await circuitBreaker.Failure(ex, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // Shutting down while backing off after a failure - nothing more to do.
+                    return;
+                }
 
                 if (!tokenSource.IsCancellationRequested)
                 {

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -5,6 +5,7 @@
     using System.Reflection;
     using Configuration;
     using CustomChecks;
+    using Microsoft.Extensions.Logging;
     using Particular.LicensingComponent.Contracts;
     using ServiceControl.Infrastructure;
 
@@ -37,7 +38,7 @@
                 ErrorRetentionPeriod = GetRequiredSetting<TimeSpan>(settingsRootNamespace, ErrorRetentionPeriodKey),
                 EventsRetentionPeriod = SettingsReader.Read(settingsRootNamespace, EventsRetentionPeriodKey, TimeSpan.FromDays(14)),
                 AuditRetentionPeriod = SettingsReader.Read(settingsRootNamespace, AuditRetentionPeriodKey, TimeSpan.Zero),
-                ExternalIntegrationsDispatchingBatchSize = SettingsReader.Read(settingsRootNamespace, ExternalIntegrationsDispatchingBatchSizeKey, 100),
+                ExternalIntegrationsDispatchingBatchSize = ReadExternalIntegrationsDispatchingBatchSize(settingsRootNamespace),
                 MaintenanceMode = SettingsReader.Read(settingsRootNamespace, MaintenanceModeKey, false),
                 LogPath = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.LogsPathKey, DefaultLogLocation()),
                 LogsMode = logsMode,
@@ -48,6 +49,21 @@
             CheckFreeDiskSpace.Validate(settings);
             CheckMinimumStorageRequiredForIngestion.Validate(settings);
             return settings;
+        }
+
+        static int ReadExternalIntegrationsDispatchingBatchSize(SettingsRootNamespace settingsRootNamespace)
+        {
+            var batchSize = SettingsReader.Read(settingsRootNamespace, ExternalIntegrationsDispatchingBatchSizeKey, RavenPersisterSettings.ExternalIntegrationsDispatchingBatchSizeDefault);
+
+            if (batchSize <= 0)
+            {
+                LoggerUtil.CreateStaticLogger<RavenPersistenceConfiguration>()
+                    .LogError("ExternalIntegrationsDispatchingBatchSize setting is invalid, 1 is the minimum value. Defaulting to {ExternalIntegrationsDispatchingBatchSizeDefault}", RavenPersisterSettings.ExternalIntegrationsDispatchingBatchSizeDefault);
+
+                return RavenPersisterSettings.ExternalIntegrationsDispatchingBatchSizeDefault;
+            }
+
+            return batchSize;
         }
 
         // SC installer always populates DBPath in app.config on installation/change/upgrade so this will only be used when

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersisterSettings.cs
@@ -13,7 +13,7 @@ class RavenPersisterSettings : PersistenceSettings, IRavenClientCertificateInfo
     public TimeSpan ErrorRetentionPeriod { get; set; }
     public TimeSpan EventsRetentionPeriod { get; set; }
     public TimeSpan? AuditRetentionPeriod { get; set; }
-    public int ExternalIntegrationsDispatchingBatchSize { get; set; } = 100;
+    public int ExternalIntegrationsDispatchingBatchSize { get; set; } = ExternalIntegrationsDispatchingBatchSizeDefault;
 
     /// <summary>
     /// Computed connection string to access embedded RavenDB API and RavenDB Studio
@@ -37,4 +37,5 @@ class RavenPersisterSettings : PersistenceSettings, IRavenClientCertificateInfo
     public const int DatabaseMaintenancePortDefault = 33334;
     public const int ExpirationProcessTimerInSecondsDefault = 600;
     public const string LogsModeDefault = "Operations";
+    public const int ExternalIntegrationsDispatchingBatchSizeDefault = 100;
 }

--- a/src/ServiceControl.Persistence.Tests.SqlServer/SqlServerSharedContainer.cs
+++ b/src/ServiceControl.Persistence.Tests.SqlServer/SqlServerSharedContainer.cs
@@ -3,7 +3,6 @@ namespace ServiceControl.Persistence.Tests;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
 using Testcontainers.MsSql;
 
 static class SqlServerSharedContainer

--- a/src/ServiceControl.Persistence.Tests/EFCore/DispatchContextSerializerTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/DispatchContextSerializerTests.cs
@@ -1,0 +1,65 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System;
+using NUnit.Framework;
+using ServiceControl.Persistence.EFCore.Implementation;
+
+class DispatchContextSerializerTests
+{
+    [Test]
+    public void Round_trips_a_simple_dispatch_context()
+    {
+        var original = new SimpleContext { Name = "endpoint-a", Count = 3 };
+
+        var (typeName, json) = DispatchContextSerializer.Serialize(original);
+        var result = (SimpleContext)DispatchContextSerializer.Deserialize(typeName, json);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Name, Is.EqualTo(original.Name));
+            Assert.That(result.Count, Is.EqualTo(original.Count));
+        }
+    }
+
+    // Two distinct shapes stored side by side (as happens once several IEventPublishers have
+    // written requests) must each resolve back to their own type, not get confused with each other.
+    [Test]
+    public void Round_trips_a_different_dispatch_context_shape_using_its_own_type()
+    {
+        var original = new OtherContext { FailedMessageId = Guid.NewGuid(), Tags = ["a", "b"] };
+
+        var (typeName, json) = DispatchContextSerializer.Serialize(original);
+        var result = (OtherContext)DispatchContextSerializer.Deserialize(typeName, json);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.FailedMessageId, Is.EqualTo(original.FailedMessageId));
+            Assert.That(result.Tags, Is.EqualTo(original.Tags));
+        }
+    }
+
+    [Test]
+    public void Type_name_does_not_include_assembly_version_culture_or_public_key_token()
+    {
+        var (typeName, _) = DispatchContextSerializer.Serialize(new SimpleContext { Name = "x", Count = 1 });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(typeName, Does.Not.Contain("Version="));
+            Assert.That(typeName, Does.Not.Contain("Culture="));
+            Assert.That(typeName, Does.Not.Contain("PublicKeyToken="));
+        }
+    }
+
+    public class SimpleContext
+    {
+        public string Name { get; set; }
+        public int Count { get; set; }
+    }
+
+    public class OtherContext
+    {
+        public Guid FailedMessageId { get; set; }
+        public string[] Tags { get; set; }
+    }
+}

--- a/src/ServiceControl.Persistence.Tests/EFCore/ExternalIntegrationRequestsDataStoreEFTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/ExternalIntegrationRequestsDataStoreEFTests.cs
@@ -1,0 +1,127 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NUnit.Framework;
+using ServiceControl.ExternalIntegrations;
+using ServiceControl.Persistence.EFCore.Abstractions;
+using ServiceControl.Persistence.EFCore.DbContexts;
+using ServiceControl.Persistence.EFCore.Implementation;
+
+// DispatchNow bypasses the timer/signal wait, so these tests are deterministic instead of relying on WaitUntil(...) polling.
+// One caveat: the background dispatch loop is live during these tests so it can race an explicit DispatchNow call for the same batch.
+// `drainLock` stops the two from double-processing it, but not which one gets there first.
+// Tests that care which specific call throws need to tolerate either side of that race.
+class ExternalIntegrationRequestsDataStoreEFTests : PersistenceTestBase
+{
+    EFPersisterSettings EFSettings => (EFPersisterSettings)PersistenceSettings;
+
+    ExternalIntegrationRequestsDataStore Store =>
+        ServiceProvider.GetServices<IHostedService>().OfType<ExternalIntegrationRequestsDataStore>().Single();
+
+    [Test]
+    public async Task DispatchNow_dispatches_available_rows_and_removes_them()
+    {
+        var dispatched = Array.Empty<object>();
+        ExternalIntegrationStore.Subscribe((contexts, cancellationToken) =>
+        {
+            dispatched = contexts;
+            return Task.CompletedTask;
+        });
+
+        await ExternalIntegrationStore.StoreDispatchRequest([Request("one")]);
+
+        await Store.DispatchNow(TestContext.CurrentContext.CancellationToken);
+
+        Assert.That(((TestDispatchContext)dispatched.Single()).Value, Is.EqualTo("one"));
+        Assert.That(await CountRows(), Is.Zero);
+    }
+
+    [Test]
+    public async Task DispatchNow_leaves_a_failed_batch_in_place_and_removes_it_once_a_retry_succeeds()
+    {
+        var attempts = 0;
+        ExternalIntegrationStore.Subscribe((_, cancellationToken) =>
+        {
+            attempts++;
+
+            if (attempts == 1)
+            {
+                throw new InvalidOperationException("Simulated callback failure");
+            }
+
+            return Task.CompletedTask;
+        });
+
+        await ExternalIntegrationStore.StoreDispatchRequest([Request("retry-me")]);
+
+        // The background dispatch loop is live for the whole test (StoreDispatchRequest above
+        // wakes it via the in-process signal), so it races these DispatchNow calls for the row.
+        // `drainLock` stops them double-processing the same batch, but not which of the two performs
+        // the failing first attempt vs. the succeeding retry - so tolerate the one expected failure
+        // landing on whichever call hits it, and keep going until the row is gone.
+        for (var i = 0; i < 5 && await CountRows() > 0; i++)
+        {
+            try
+            {
+                await Store.DispatchNow(TestContext.CurrentContext.CancellationToken);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        Assert.That(attempts, Is.EqualTo(2), "exactly one failed attempt followed by one successful retry");
+        Assert.That(await CountRows(), Is.Zero, "the row should be removed once the retry succeeds");
+    }
+
+    [Test]
+    public async Task DispatchNow_drains_more_than_one_batch_when_the_backlog_exceeds_the_configured_batch_size()
+    {
+        EFSettings.ExternalIntegrationsDispatchingBatchSize = 2;
+
+        var callbackInvocations = 0;
+        var dispatchedCount = 0;
+        ExternalIntegrationStore.Subscribe((contexts, cancellationToken) =>
+        {
+            callbackInvocations++;
+            dispatchedCount += contexts.Length;
+            return Task.CompletedTask;
+        });
+
+        await ExternalIntegrationStore.StoreDispatchRequest(Enumerable.Range(0, 5).Select(i => Request($"item-{i}")).ToList());
+
+        await Store.DispatchNow(TestContext.CurrentContext.CancellationToken);
+
+        Assert.That(dispatchedCount, Is.EqualTo(5));
+        Assert.That(callbackInvocations, Is.EqualTo(3), "5 rows at a batch size of 2 should dispatch as 2 + 2 + 1");
+        Assert.That(await CountRows(), Is.Zero);
+    }
+
+    [Test]
+    public async Task DispatchNow_is_a_noop_when_nothing_is_stored()
+    {
+        ExternalIntegrationStore.Subscribe((_, cancellationToken) => throw new InvalidOperationException("Should not be called"));
+
+        Assert.DoesNotThrowAsync(() => Store.DispatchNow(TestContext.CurrentContext.CancellationToken));
+    }
+
+    static ExternalIntegrationDispatchRequest Request(string value) => new() { DispatchContext = new TestDispatchContext { Value = value } };
+
+    async Task<int> CountRows()
+    {
+        using var scope = ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
+
+        return await dbContext.ExternalIntegrationDispatchRequests.CountAsync(TestContext.CurrentContext.CancellationToken);
+    }
+
+    public class TestDispatchContext
+    {
+        public string Value { get; set; }
+    }
+}

--- a/src/ServiceControl.Persistence.Tests/ExternalIntegrationRequestsDataStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/ExternalIntegrationRequestsDataStoreTests.cs
@@ -1,0 +1,120 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ServiceControl.ExternalIntegrations;
+
+class ExternalIntegrationRequestsDataStoreTests : PersistenceTestBase
+{
+    const int DefaultBatchSize = 100;
+
+    [Test]
+    public async Task Stored_request_is_dispatched_to_the_subscriber_and_removed()
+    {
+        var dispatched = new ConcurrentBag<object>();
+        ExternalIntegrationStore.Subscribe((contexts, _) =>
+        {
+            foreach (var context in contexts)
+            {
+                dispatched.Add(context);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        await ExternalIntegrationStore.StoreDispatchRequest([Request("one")]);
+
+        await WaitUntil(() => Task.FromResult(dispatched.Count == 1), "the stored request to be dispatched");
+
+        Assert.That(((TestDispatchContext)dispatched.Single()).Value, Is.EqualTo("one"));
+    }
+
+    [Test]
+    public async Task More_requests_than_the_batch_size_are_dispatched_across_multiple_callback_invocations()
+    {
+        var callbackInvocations = 0;
+        var dispatched = new ConcurrentBag<object>();
+        ExternalIntegrationStore.Subscribe((contexts, _) =>
+        {
+            Interlocked.Increment(ref callbackInvocations);
+
+            foreach (var context in contexts)
+            {
+                dispatched.Add(context);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var requests = Enumerable.Range(0, DefaultBatchSize + 1).Select(i => Request($"item-{i}")).ToList();
+        await ExternalIntegrationStore.StoreDispatchRequest(requests);
+
+        await WaitUntil(() => Task.FromResult(dispatched.Count == requests.Count), "every stored request to be dispatched");
+
+        Assert.That(callbackInvocations, Is.GreaterThanOrEqualTo(2),
+            "a backlog larger than the configured batch size should be dispatched across more than one callback invocation");
+    }
+
+    [Test]
+    public async Task Concurrent_stores_are_all_eventually_dispatched()
+    {
+        var dispatched = new ConcurrentBag<object>();
+        ExternalIntegrationStore.Subscribe((contexts, _) =>
+        {
+            foreach (var context in contexts)
+            {
+                dispatched.Add(context);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        const int concurrentStores = 20;
+        await Task.WhenAll(Enumerable.Range(0, concurrentStores)
+            .Select(i => ExternalIntegrationStore.StoreDispatchRequest([Request($"concurrent-{i}")])));
+
+        await WaitUntil(() => Task.FromResult(dispatched.Count == concurrentStores), "every concurrently stored request to be dispatched");
+    }
+
+    [Test]
+    public async Task Callback_failure_does_not_stop_future_dispatch()
+    {
+        var attempts = 0;
+        var dispatched = new ConcurrentBag<object>();
+        ExternalIntegrationStore.Subscribe((contexts, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                throw new InvalidOperationException("Simulated callback failure");
+            }
+
+            foreach (var context in contexts)
+            {
+                dispatched.Add(context);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        await ExternalIntegrationStore.StoreDispatchRequest([Request("retry-me")]);
+
+        // The failed first attempt is not removed, so the same request is redelivered once the
+        // dispatcher recovers. Recovery is paced by RepeatedFailuresOverTimeCircuitBreaker's own
+        // ~20s "armed" backoff on both backends, hence the longer-than-usual timeout.
+        await WaitUntil(() => Task.FromResult(dispatched.Count == 1),
+            "the request to be redelivered and dispatched after the failed attempt", TimeSpan.FromSeconds(40));
+
+        Assert.That(attempts, Is.GreaterThanOrEqualTo(2));
+    }
+
+    static ExternalIntegrationDispatchRequest Request(string value) => new() { DispatchContext = new TestDispatchContext { Value = value } };
+
+    public class TestDispatchContext
+    {
+        public string Value { get; set; }
+    }
+}

--- a/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
+++ b/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
@@ -128,4 +128,5 @@ public abstract class PersistenceTestBase
     protected ILicensingDataStore LicensingDataStore => ServiceProvider.GetRequiredService<ILicensingDataStore>();
     protected IQueueAddressStore QueueAddressStore => ServiceProvider.GetRequiredService<IQueueAddressStore>();
     protected IEndpointSettingsStore EndpointSettingsStore => ServiceProvider.GetRequiredService<IEndpointSettingsStore>();
+    protected IExternalIntegrationRequestsDataStore ExternalIntegrationStore => ServiceProvider.GetRequiredService<IExternalIntegrationRequestsDataStore>();
 }

--- a/src/ServiceControl.Persistence/ExternalIntegrations/ExternalIntegrationDispatchRequest.cs
+++ b/src/ServiceControl.Persistence/ExternalIntegrations/ExternalIntegrationDispatchRequest.cs
@@ -2,7 +2,6 @@ namespace ServiceControl.ExternalIntegrations
 {
     public class ExternalIntegrationDispatchRequest
     {
-        public string? Id { get; set; }
         public required object DispatchContext;
     }
 }

--- a/src/ServiceControl/ExternalIntegrations/ExternalIntegrationsServiceCollectionExtensions.cs
+++ b/src/ServiceControl/ExternalIntegrations/ExternalIntegrationsServiceCollectionExtensions.cs
@@ -4,10 +4,7 @@ namespace ServiceControl.ExternalIntegrations
 
     static class ExternalIntegrationsServiceCollectionExtensions
     {
-        public static void AddIntegrationEventPublisher<T>(this IServiceCollection serviceCollection)
-            where T : class, IEventPublisher
-        {
-            serviceCollection.AddSingleton<IEventPublisher, T>();
-        }
+        public static void AddIntegrationEventPublisher<T>(this IServiceCollection serviceCollection) where T : class, IEventPublisher
+            => serviceCollection.AddSingleton<IEventPublisher, T>();
     }
 }

--- a/src/ServiceControl/ExternalIntegrations/IntegrationEventWriter.cs
+++ b/src/ServiceControl/ExternalIntegrations/IntegrationEventWriter.cs
@@ -9,18 +9,11 @@
     using Microsoft.Extensions.Logging;
     using ServiceControl.Persistence;
 
-    class IntegrationEventWriter : IDomainHandler<IDomainEvent>
+    class IntegrationEventWriter(
+        IExternalIntegrationRequestsDataStore store,
+        IEnumerable<IEventPublisher> eventPublishers,
+        ILogger<IntegrationEventWriter> logger) : IDomainHandler<IDomainEvent>
     {
-        public IntegrationEventWriter(
-            IExternalIntegrationRequestsDataStore store,
-            IEnumerable<IEventPublisher> eventPublishers,
-            ILogger<IntegrationEventWriter> logger)
-        {
-            this.store = store;
-            this.eventPublishers = eventPublishers;
-            this.logger = logger;
-        }
-
         public async Task Handle(IDomainEvent message, CancellationToken cancellationToken = default)
         {
             var dispatchContexts = eventPublishers
@@ -42,9 +35,5 @@
 
             await store.StoreDispatchRequest(dispatchRequests, cancellationToken);
         }
-
-        readonly IExternalIntegrationRequestsDataStore store;
-        readonly IEnumerable<IEventPublisher> eventPublishers;
-        readonly ILogger<IntegrationEventWriter> logger;
     }
 }


### PR DESCRIPTION
Implements `IExternalIntegrationRequestsDataStore` for the SQL Server and PostgreSQL persisters, replacing the no-op stub. This is ServiceControl's outbox for publishing NServiceBus events to external subscribers on domain events (message failed, custom check failed, etc.): `StoreDispatchRequest` persists a batch, a background loop wakes up, hands dispatched contexts to the subscribed callback, and deletes the rows once the callback succeeds.

Storage. New `ExternalIntegrationDispatchRequests` table (auto-increment Id for FIFO ordering). DispatchContext's concrete type is only known at runtime and lives in ServiceControl.csproj, which the EF Core project doesn't reference, so there's no way to type this at compile time - a new `DispatchContextSerializer` stores it as a versionless assembly-qualified type name alongside a System.Text.Json blob, and resolves it back via Type.GetType(...) on read. New migrations for both SQL Server and PostgreSQL.

Notification. SQL has no equivalent of RavenDB's server-push Changes API, so the dispatch loop is woken by an in-process signal (SemaphoreSlim) on every `StoreDispatchRequest`, with a 30s PeriodicTimer as a safety net in case a signal is ever missed. This assumes single-process-per-role deployment, same as every other EF Core data store.

Batch dispatch. RavenDB does select → callback → delete inside one document session. There's no relational equivalent, so this is three separate phases, each its own DbContext scope (same shape as RetentionSweeper.Sweep), so no DB transaction is held open across the network call to publish on the bus. Delete only happens if the callback returns without throwing — matching RavenDB's actual behavior (verified by reading TryDispatchEventBatch: it has no try/catch around the callback, so a throw skips the deletes too). This is at-least-once with redelivery on callback failure, not at-most-once.

Settings. Added `ExternalIntegrationsDispatchingBatchSize` (default 100) to EFPersisterSettings, read from the same config key the RavenDB backend already exposes, so switching backends doesn't silently change behavior.

Testing. New shared cross-backend tests (ExternalIntegrationRequestsDataStoreTests, run against RavenDB/SqlServer/PostgreSql) covering store→dispatch→delete, callback-throws-then-retries, batching over ExternalIntegrationsDispatchingBatchSize, and concurrent stores. EF-only tests (ExternalIntegrationRequestsDataStoreEFTests, DispatchContextSerializerTests) exercise the new DispatchNow test hook directly rather than polling on timers, plus a serializer round-trip test.