### PR TITLE
Fix flaky ETag validation in event log acceptance tests

### DIFF
--- a/src/ServiceControl.AcceptanceTests/EventLogs/When_the_event_log_is_polled_with_an_etag.cs
+++ b/src/ServiceControl.AcceptanceTests/EventLogs/When_the_event_log_is_polled_with_an_etag.cs
@@ -52,12 +52,9 @@ namespace ServiceControl.AcceptanceTests.EventLogs
                         return false;
                     }
 
-                    var current = await Poll(currentEtag);
+                    var current = await PollUntilTheLogGoesQuiet(currentEtag);
 
-                    // The endpoint keeps writing startup events, so a 200 here means either the
-                    // validator went stale between the two requests, or the server ignored
-                    // If-None-Match. Only the second is a failure, and the ETag tells them apart.
-                    if (current.StatusCode == HttpStatusCode.OK && ReadEtag(current) != currentEtag)
+                    if (current == null)
                     {
                         return false;
                     }
@@ -96,6 +93,35 @@ namespace ServiceControl.AcceptanceTests.EventLogs
         static string ReadEtag(HttpResponseMessage response) =>
             response.Headers.TryGetValues("ETag", out var values) ? values.FirstOrDefault() : null;
 
+        // The endpoint keeps writing startup events, so a 200 carrying a *different* ETag only
+        // means the log moved on between the two requests, and says nothing about conditional
+        // GET support. Poll again with the ETag that response handed back, until either the log
+        // stops changing (304, or a 200 repeating the validator we sent, which is the real
+        // failure) or the attempts run out and the caller retries from a fresh read.
+        async Task<HttpResponseMessage> PollUntilTheLogGoesQuiet(string etag)
+        {
+            for (var attempt = 0; attempt < MaxPollAttempts; attempt++)
+            {
+                var response = await Poll(etag);
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    return response;
+                }
+
+                var newEtag = ReadEtag(response);
+
+                if (string.IsNullOrEmpty(newEtag) || newEtag == etag)
+                {
+                    return response;
+                }
+
+                etag = newEtag;
+            }
+
+            return null;
+        }
+
         Task<HttpResponseMessage> Poll(string ifNoneMatch)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, "/api/eventlogitems/");
@@ -103,6 +129,8 @@ namespace ServiceControl.AcceptanceTests.EventLogs
 
             return HttpClient.SendAsync(request);
         }
+
+        const int MaxPollAttempts = 5;
 
         public class StartingEndpoint : EndpointConfigurationBuilder
         {

--- a/src/ServiceControl.AcceptanceTests/EventLogs/When_the_event_log_is_polled_with_an_etag.cs
+++ b/src/ServiceControl.AcceptanceTests/EventLogs/When_the_event_log_is_polled_with_an_etag.cs
@@ -45,21 +45,25 @@ namespace ServiceControl.AcceptanceTests.EventLogs
                         return false;
                     }
 
-                    // Raw header: an unquoted value fails EntityTagHeaderValue parsing, and this test
-                    // has to observe that rather than throw on it.
-                    if (!first.Headers.TryGetValues("ETag", out var values))
+                    var currentEtag = ReadEtag(first);
+
+                    if (string.IsNullOrEmpty(currentEtag))
                     {
                         return false;
                     }
 
-                    etag = values.FirstOrDefault();
+                    var current = await Poll(currentEtag);
 
-                    if (string.IsNullOrEmpty(etag))
+                    // The endpoint keeps writing startup events, so a 200 here means either the
+                    // validator went stale between the two requests, or the server ignored
+                    // If-None-Match. Only the second is a failure, and the ETag tells them apart.
+                    if (current.StatusCode == HttpStatusCode.OK && ReadEtag(current) != currentEtag)
                     {
                         return false;
                     }
 
-                    currentEtagStatus = (await Poll(etag)).StatusCode;
+                    etag = currentEtag;
+                    currentEtagStatus = current.StatusCode;
 
                     var unknown = await Poll("\"not-an-etag-this-instance-ever-issued\"");
                     unknownEtagStatus = unknown.StatusCode;
@@ -86,6 +90,11 @@ namespace ServiceControl.AcceptanceTests.EventLogs
                     "a cache miss must carry the items, not an empty body with a 200");
             }
         }
+
+        // Raw header: an unquoted value fails EntityTagHeaderValue parsing, and this test
+        // has to observe that rather than throw on it.
+        static string ReadEtag(HttpResponseMessage response) =>
+            response.Headers.TryGetValues("ETag", out var values) ? values.FirstOrDefault() : null;
 
         Task<HttpResponseMessage> Poll(string ifNoneMatch)
         {


### PR DESCRIPTION
The test could fail if new events were written to the log between the initial request and the conditional poll, resulting in a 200 OK instead of a 304 Not Modified. The validation now accounts for this by checking if the ETag has changed when a 200 OK is received.