### PR TITLE
Register FailOnceEnricher using its interface in batch import test

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_single_message_fails_in_batch.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_single_message_fails_in_batch.cs
@@ -24,7 +24,7 @@
         public async Task Should_import_all_messages()
         {
             //Make sure the error import attempt fails
-            CustomizeHostBuilder = builder => builder.Services.AddSingleton<FailOnceEnricher>();
+            CustomizeHostBuilder = builder => builder.Services.AddSingleton<IEnrichImportedErrorMessages, FailOnceEnricher>();
 
             var maximumConcurrencyLevel = 5;
 


### PR DESCRIPTION
By registering the enricher using IEnrichImportedErrorMessages, the system under test can correctly resolve and use the test implementation to trigger the expected failure.

This is part of a review of the AcceptanceTests to enable them for RF.
This issue is a bug.