### PR TITLE
Enable nullable annotations in ServiceControl.Persistence

### DIFF
--- a/src/ServiceControl.AcceptanceTests/EventLogs/When_the_event_log_is_polled_with_an_etag.cs
+++ b/src/ServiceControl.AcceptanceTests/EventLogs/When_the_event_log_is_polled_with_an_etag.cs
@@ -36,7 +36,7 @@ namespace ServiceControl.AcceptanceTests.EventLogs
                         return false;
                     }
 
-                    var items = await first.Content.ReadFromJsonAsync<List<EventLogItem>>(SerializerOptions);
+                    var items = await first.Content.ReadFromJsonAsync<List<EventLogItemView>>(SerializerOptions);
 
                     // Keep polling until the endpoint's startup event has landed. An empty event
                     // log has a stable ETag of its own and would make the assertions meaningless.
@@ -65,7 +65,7 @@ namespace ServiceControl.AcceptanceTests.EventLogs
                     var unknown = await Poll("\"not-an-etag-this-instance-ever-issued\"");
                     unknownEtagStatus = unknown.StatusCode;
 
-                    var unknownBody = await unknown.Content.ReadFromJsonAsync<List<EventLogItem>>(SerializerOptions);
+                    var unknownBody = await unknown.Content.ReadFromJsonAsync<List<EventLogItemView>>(SerializerOptions);
                     unknownEtagReturnedItems = unknownBody is { Count: > 0 };
 
                     return true;

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_group_is_archived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_group_is_archived.cs
@@ -11,6 +11,7 @@
     using NUnit.Framework;
     using ServiceControl.Contracts;
     using ServiceControl.MessageFailures;
+    using ServiceControl.MessageFailures.Api;
 
     class When_a_group_is_archived : ExternalIntegrationAcceptanceTest
     {
@@ -39,7 +40,7 @@
                 .Do("WaitUntilGroupsContainsFailedMessages", async ctx =>
                 {
                     // Don't retry until the message has been added to a group
-                    var groups = await this.TryGetMany<FailedMessage.FailureGroup>("/api/recoverability/groups/");
+                    var groups = await this.TryGetMany<GroupOperation>("/api/recoverability/groups/");
                     if (!groups)
                     {
                         return false;
@@ -52,7 +53,7 @@
                     ctx => Task.FromResult(ctx.ExternalProcessorSubscribed))
                 .Do("WaitUntilGroupContainsBothMessages", async ctx =>
                 {
-                    var failedMessages = await this.TryGetMany<FailedMessage>($"/api/recoverability/groups/{ctx.GroupId}/errors");
+                    var failedMessages = await this.TryGetMany<FailedMessageView>($"/api/recoverability/groups/{ctx.GroupId}/errors");
                     return failedMessages && failedMessages.Items.Count == 1;
                 })
                 .Do("Archive", async ctx => { await this.Post<object>($"/api/recoverability/groups/{ctx.GroupId}/errors/archive"); })

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_archived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_archived.cs
@@ -11,6 +11,7 @@
     using NServiceBus.Settings;
     using NUnit.Framework;
     using ServiceControl.MessageFailures;
+    using ServiceControl.MessageFailures.Api;
     using TestSupport;
 
     class When_a_group_is_archived : AcceptanceTest
@@ -32,7 +33,7 @@
                     }
 
                     // Don't retry until the message has been added to a group
-                    var groups = await this.TryGetMany<FailedMessage.FailureGroup>("/api/recoverability/groups/");
+                    var groups = await this.TryGetMany<GroupOperation>("/api/recoverability/groups/");
                     if (!groups)
                     {
                         return false;
@@ -43,7 +44,7 @@
                 })
                 .Do("WaitUntilGroupContainsBothMessages", async ctx =>
                 {
-                    var failedMessages = await this.TryGetMany<FailedMessage>($"/api/recoverability/groups/{ctx.GroupId}/errors");
+                    var failedMessages = await this.TryGetMany<FailedMessageView>($"/api/recoverability/groups/{ctx.GroupId}/errors");
                     return failedMessages && failedMessages.Items.Count == 2;
                 })
                 .Do("Archive", async ctx => { await this.Post<object>($"/api/recoverability/groups/{ctx.GroupId}/errors/archive"); })
@@ -78,7 +79,7 @@
                     }
 
                     // Don't retry until the message has been added to a group
-                    var groups = await this.TryGetMany<FailedMessage.FailureGroup>("/api/recoverability/groups/");
+                    var groups = await this.TryGetMany<GroupOperation>("/api/recoverability/groups/");
                     if (!groups)
                     {
                         return false;
@@ -89,7 +90,7 @@
                 })
                 .Do("WaitUntilGroupContainsBothMessages", async ctx =>
                 {
-                    var failedMessages = await this.TryGetMany<FailedMessage>($"/api/recoverability/groups/{ctx.GroupId}/errors");
+                    var failedMessages = await this.TryGetMany<FailedMessageView>($"/api/recoverability/groups/{ctx.GroupId}/errors");
                     return failedMessages && failedMessages.Items.Count == 2;
                 })
                 .Do("Archive", async ctx => { await this.Post<object>($"/api/recoverability/groups/{ctx.GroupId}/errors/archive"); })
@@ -129,7 +130,7 @@
                     }
 
                     // Don't retry until the message has been added to a group
-                    var groups = await this.TryGetMany<FailedMessage.FailureGroup>("/api/recoverability/groups/");
+                    var groups = await this.TryGetMany<GroupOperation>("/api/recoverability/groups/");
                     if (!groups)
                     {
                         return false;
@@ -140,7 +141,7 @@
                 })
                 .Do("WaitUntilGroupContainsBothMessages", async ctx =>
                 {
-                    var failedMessages = await this.TryGetMany<FailedMessage>($"/api/recoverability/groups/{ctx.GroupId}/errors");
+                    var failedMessages = await this.TryGetMany<FailedMessageView>($"/api/recoverability/groups/{ctx.GroupId}/errors");
                     return failedMessages && failedMessages.Items.Count == 2;
                 })
                 .Do("Archive", async ctx => { await this.Post<object>($"/api/recoverability/groups/{ctx.GroupId}/errors/archive"); })
@@ -181,7 +182,7 @@
                     }
 
                     // Don't retry until the message has been added to a group
-                    var groups = await this.TryGetMany<FailedMessage.FailureGroup>("/api/recoverability/groups/");
+                    var groups = await this.TryGetMany<GroupOperation>("/api/recoverability/groups/");
                     if (!groups)
                     {
                         return false;

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_message_groups_are_sorted_by_a_web_api_call.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_message_groups_are_sorted_by_a_web_api_call.cs
@@ -50,8 +50,8 @@ namespace ServiceControl.AcceptanceTests.Recoverability.Groups
                 .WithEndpoint<Receiver>()
                 .Done(async c =>
                 {
-                    var result = await this.TryGetMany<FailedMessage.FailureGroup>("/api/recoverability/groups");
-                    List<FailedMessage.FailureGroup> groups = result;
+                    var result = await this.TryGetMany<GroupOperation>("/api/recoverability/groups");
+                    List<GroupOperation> groups = result;
                     if (!result)
                     {
                         return false;

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_messages_have_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_messages_have_failed.cs
@@ -19,9 +19,9 @@
         [Test]
         public async Task Should_be_grouped()
         {
-            List<FailureGroupView> defaultGroups = null;
-            List<FailureGroupView> exceptionTypeAndStackTraceGroups = null;
-            List<FailureGroupView> messageTypeGroups = null;
+            List<GroupOperation> defaultGroups = null;
+            List<GroupOperation> exceptionTypeAndStackTraceGroups = null;
+            List<GroupOperation> messageTypeGroups = null;
 
             FailedMessage failedMessageA = null;
             FailedMessage failedMessageB = null;
@@ -39,7 +39,7 @@
                         return false;
                     }
 
-                    var defaultGroupsResult = await this.TryGetMany<FailureGroupView>("/api/recoverability/groups/");
+                    var defaultGroupsResult = await this.TryGetMany<GroupOperation>("/api/recoverability/groups/");
                     defaultGroups = defaultGroupsResult;
                     if (!defaultGroupsResult)
                     {
@@ -51,8 +51,8 @@
                         return false;
                     }
 
-                    messageTypeGroups = await this.TryGetMany<FailureGroupView>("/api/recoverability/groups/Message%20Type");
-                    exceptionTypeAndStackTraceGroups = await this.TryGetMany<FailureGroupView>("/api/recoverability/groups/Exception%20Type%20and%20Stack%20Trace");
+                    messageTypeGroups = await this.TryGetMany<GroupOperation>("/api/recoverability/groups/Message%20Type");
+                    exceptionTypeAndStackTraceGroups = await this.TryGetMany<GroupOperation>("/api/recoverability/groups/Exception%20Type%20and%20Stack%20Trace");
 
                     var failedMessageAResult = await this.TryGet<FailedMessage>($"/api/errors/{c.UniqueMessageIdA}", msg => msg.FailureGroups.Any());
                     failedMessageA = failedMessageAResult;

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_two_similar_messages_have_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_two_similar_messages_have_failed.cs
@@ -19,8 +19,8 @@
         [Test]
         public async Task They_should_be_grouped_together()
         {
-            List<FailureGroupView> exceptionTypeAndStackTraceGroups = null;
-            List<FailureGroupView> messageTypeGroups = null;
+            List<GroupOperation> exceptionTypeAndStackTraceGroups = null;
+            List<GroupOperation> messageTypeGroups = null;
             FailedMessage firstFailure = null;
             FailedMessage secondFailure = null;
 
@@ -38,7 +38,7 @@
                         return false;
                     }
 
-                    var result = await this.TryGetMany<FailureGroupView>("/api/recoverability/groups/");
+                    var result = await this.TryGetMany<GroupOperation>("/api/recoverability/groups/");
                     exceptionTypeAndStackTraceGroups = result;
                     if (!result)
                     {
@@ -50,7 +50,7 @@
                         return false;
                     }
 
-                    messageTypeGroups = await this.TryGetMany<FailureGroupView>("/api/recoverability/groups/Message%20Type");
+                    messageTypeGroups = await this.TryGetMany<GroupOperation>("/api/recoverability/groups/Message%20Type");
 
                     var firstFailureResult = await this.TryGet<FailedMessage>($"/api/errors/{c.FirstMessageId}");
                     firstFailure = firstFailureResult;

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_resolved_by_queue_and_timeframe.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_resolved_by_queue_and_timeframe.cs
@@ -12,6 +12,7 @@
     using NServiceBus.Settings;
     using NUnit.Framework;
     using ServiceControl.MessageFailures;
+    using ServiceControl.MessageFailures.Api;
 
     class When_a_pending_retry_is_resolved_by_queue_and_timeframe : AcceptanceTest
     {
@@ -36,7 +37,7 @@
                 })
                 .Do("WaitForStaleIndex", async ctx =>
                 {
-                    return await this.TryGet<FailedMessage[]>("/api/errors",
+                    return await this.TryGet<FailedMessageView[]>("/api/errors",
                         allErrors => allErrors.Any(fm => fm.Id == ctx.UniqueMessageId));
                 })
                 .Do("ResolvePending", async ctx =>

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_retried_by_queue_and_timeframe.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_retried_by_queue_and_timeframe.cs
@@ -12,6 +12,7 @@
     using NServiceBus.Settings;
     using NUnit.Framework;
     using ServiceControl.MessageFailures;
+    using ServiceControl.MessageFailures.Api;
 
     class When_a_pending_retry_is_retried_by_queue_and_timeframe : AcceptanceTest
     {
@@ -32,7 +33,7 @@
                 })
                 .Do("WaitForIndex", async ctx =>
                 {
-                    return await this.TryGet<FailedMessage[]>("/api/errors",
+                    return await this.TryGet<FailedMessageView[]>("/api/errors",
                         allErrors => allErrors.Any(fm => fm.Id == ctx.UniqueMessageId));
                 })
                 .Do("RetryPending", async ctx =>

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_retry_fails_to_be_sent.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_retry_fails_to_be_sent.cs
@@ -27,7 +27,7 @@
         [CancelAfter(180_000)]
         public async Task SubsequentBatchesShouldBeProcessed(CancellationToken cancellationToken = default)
         {
-            FailedMessage decomissionedFailure = null, successfullyRetried = null;
+            FailedMessageView decomissionedFailure = null, successfullyRetried = null;
 
             CustomizeHostBuilder = hostBuilder =>
             {
@@ -56,9 +56,9 @@
                         return false;
                     }
 
-                    var decomissionedFailureResult = await this.TryGetSingle<FailedMessage>("/api/errors/", m => m.Id == ctx.DecommissionedEndpointUniqueMessageId && m.Status == FailedMessageStatus.Unresolved);
+                    var decomissionedFailureResult = await this.TryGetSingle<FailedMessageView>("/api/errors/", m => m.Id == ctx.DecommissionedEndpointUniqueMessageId && m.Status == FailedMessageStatus.Unresolved);
                     decomissionedFailure = decomissionedFailureResult;
-                    var successfullyRetriedResult = await this.TryGetSingle<FailedMessage>("/api/errors/", m => m.Id == ctx.MessageThatWillFailUniqueMessageId && m.Status == FailedMessageStatus.Resolved);
+                    var successfullyRetriedResult = await this.TryGetSingle<FailedMessageView>("/api/errors/", m => m.Id == ctx.MessageThatWillFailUniqueMessageId && m.Status == FailedMessageStatus.Resolved);
                     successfullyRetried = successfullyRetriedResult;
                     return decomissionedFailureResult && successfullyRetriedResult;
                 })

--- a/src/ServiceControl.Persistence.EFCore/Implementation/BodyStorage/BodyStorage.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/BodyStorage/BodyStorage.cs
@@ -60,7 +60,7 @@ public class BodyStorage(IServiceScopeFactory scopeFactory, IBodyStoragePersiste
 
             return MessageBodyResult.Available(new MessageBodyStreamContent(
                 new MemoryStream(bytes, writable: false),
-                row.BodyContentType,
+                row.BodyContentType ?? "text/plain",
                 bytes.Length,
                 uniqueMessageId));
         }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/EventLogDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/EventLogDataStore.cs
@@ -13,7 +13,7 @@ public class EventLogDataStore(IServiceScopeFactory scopeFactory) : DataStoreBas
         {
             dbContext.EventLogItems.Add(new EventLogItemEntity
             {
-                Description = logItem.Description,
+                Description = logItem.Description ?? "",
                 Severity = logItem.Severity,
                 RaisedAt = logItem.RaisedAt,
                 RelatedTo = logItem.RelatedTo ?? [],

--- a/src/ServiceControl.Persistence.EFCore/Implementation/EventLogDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/EventLogDataStore.cs
@@ -13,7 +13,7 @@ public class EventLogDataStore(IServiceScopeFactory scopeFactory) : DataStoreBas
         {
             dbContext.EventLogItems.Add(new EventLogItemEntity
             {
-                Description = logItem.Description ?? "",
+                Description = logItem.Description ?? string.Empty,
                 Severity = logItem.Severity,
                 RaisedAt = logItem.RaisedAt,
                 RelatedTo = logItem.RelatedTo ?? [],

--- a/src/ServiceControl.Persistence.EFCore/Implementation/FailedErrorImportDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/FailedErrorImportDataStore.cs
@@ -54,7 +54,7 @@ public class FailedErrorImportDataStore(
                 HeadersJson = headersJson,
                 Body = storedBody,
                 BodyStoredExternally = storeExternally,
-                ExceptionInfo = failure.ExceptionInfo ?? ""
+                ExceptionInfo = failure.ExceptionInfo ?? string.Empty
             }, (entity) =>
             {
                 entity.FailedAt = failedAt;
@@ -62,7 +62,7 @@ public class FailedErrorImportDataStore(
                 entity.HeadersJson = headersJson;
                 entity.Body = storedBody;
                 entity.BodyStoredExternally = storeExternally;
-                entity.ExceptionInfo = failure.ExceptionInfo ?? "";
+                entity.ExceptionInfo = failure.ExceptionInfo ?? string.Empty;
             }, token);
         }, cancellationToken);
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/FailedErrorImportDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/FailedErrorImportDataStore.cs
@@ -32,7 +32,7 @@ public class FailedErrorImportDataStore(
     public Task StoreFailedErrorImport(FailedErrorImport failure, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(async (dbContext, token) =>
         {
-            var uniqueMessageId = FailedErrorImport.DeriveKey(failure.Message.Headers, failure.Message.Id);
+            var uniqueMessageId = FailedErrorImport.DeriveKey(failure.Message!.Headers, failure.Message.Id);
             var body = failure.Message.Body ?? [];
             var storeExternally = body.Length > bodyStorageSettings.MaxBodySizeToStore;
 
@@ -54,7 +54,7 @@ public class FailedErrorImportDataStore(
                 HeadersJson = headersJson,
                 Body = storedBody,
                 BodyStoredExternally = storeExternally,
-                ExceptionInfo = failure.ExceptionInfo
+                ExceptionInfo = failure.ExceptionInfo ?? ""
             }, (entity) =>
             {
                 entity.FailedAt = failedAt;
@@ -62,7 +62,7 @@ public class FailedErrorImportDataStore(
                 entity.HeadersJson = headersJson;
                 entity.Body = storedBody;
                 entity.BodyStoredExternally = storeExternally;
-                entity.ExceptionInfo = failure.ExceptionInfo;
+                entity.ExceptionInfo = failure.ExceptionInfo ?? "";
             }, token);
         }, cancellationToken);
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageViewMapper.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageViewMapper.cs
@@ -127,22 +127,22 @@ static class FailedMessageViewMapper
         };
 
     public static EndpointDetails? ToSendingEndpoint(this FailedMessageEntity entity) =>
-        entity.SendingEndpointName == null && entity.SendingEndpointHost == null
+        entity.SendingEndpointName == null
             ? null
             : new EndpointDetails
             {
-                Name = entity.SendingEndpointName ?? "",
-                Host = entity.SendingEndpointHost ?? "",
+                Name = entity.SendingEndpointName,
+                Host = entity.SendingEndpointHost ?? string.Empty,
                 HostId = entity.SendingEndpointHostId ?? Guid.Empty
             };
 
     public static EndpointDetails? ToReceivingEndpoint(this FailedMessageEntity entity) =>
-        entity.ReceivingEndpointName == null && entity.ReceivingEndpointHost == null
+        entity.ReceivingEndpointName == null
             ? null
             : new EndpointDetails
             {
-                Name = entity.ReceivingEndpointName ?? "",
-                Host = entity.ReceivingEndpointHost ?? "",
+                Name = entity.ReceivingEndpointName,
+                Host = entity.ReceivingEndpointHost ?? string.Empty,
                 HostId = entity.ReceivingEndpointHostId ?? Guid.Empty
             };
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageViewMapper.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageViewMapper.cs
@@ -127,22 +127,22 @@ static class FailedMessageViewMapper
         };
 
     public static EndpointDetails? ToSendingEndpoint(this FailedMessageEntity entity) =>
-        entity.SendingEndpointName == null
+        entity.SendingEndpointName == null && entity.SendingEndpointHost == null
             ? null
             : new EndpointDetails
             {
-                Name = entity.SendingEndpointName,
-                Host = entity.SendingEndpointHost,
+                Name = entity.SendingEndpointName ?? "",
+                Host = entity.SendingEndpointHost ?? "",
                 HostId = entity.SendingEndpointHostId ?? Guid.Empty
             };
 
     public static EndpointDetails? ToReceivingEndpoint(this FailedMessageEntity entity) =>
-        entity.ReceivingEndpointName == null
+        entity.ReceivingEndpointName == null && entity.ReceivingEndpointHost == null
             ? null
             : new EndpointDetails
             {
-                Name = entity.ReceivingEndpointName,
-                Host = entity.ReceivingEndpointHost,
+                Name = entity.ReceivingEndpointName ?? "",
+                Host = entity.ReceivingEndpointHost ?? "",
                 HostId = entity.ReceivingEndpointHostId ?? Guid.Empty
             };
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/GroupsDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/GroupsDataStore.cs
@@ -12,7 +12,7 @@ using ServiceControl.Recoverability;
 
 public class GroupsDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IGroupsDataStore
 {
-    public Task<IList<FailureGroupView>> GetUnresolvedGroupsByClassifier(string classifier, string classifierFilter, CancellationToken cancellationToken = default) =>
+    public Task<IList<FailureGroupView>> GetUnresolvedGroupsByClassifier(string classifier, string? classifierFilter, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(async (dbContext, token) =>
         {
             var groups = ByClassifier(dbContext, classifier);
@@ -33,16 +33,16 @@ public class GroupsDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(
         ExecuteWithDbContext((dbContext, token) => MostRecent(
             ByClassifier(dbContext, classifier).AggregateGroups(WithStatus(dbContext, FailedMessageStatus.Archived)), token), cancellationToken);
 
-    public Task<QueryResult<FailureGroupView>> GetUnresolvedGroup(string groupId, string status, string modified, CancellationToken cancellationToken = default) =>
+    public Task<QueryResult<FailureGroupView>> GetUnresolvedGroup(string groupId, string? status, string? modified, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext((dbContext, token) => SingleGroup(dbContext, groupId, FailedMessageStatus.Unresolved, status, modified, token), cancellationToken);
 
-    public Task<QueryResult<FailureGroupView>> GetArchivedGroup(string groupId, string status, string modified, CancellationToken cancellationToken = default) =>
+    public Task<QueryResult<FailureGroupView>> GetArchivedGroup(string groupId, string? status, string? modified, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext((dbContext, token) => SingleGroup(dbContext, groupId, FailedMessageStatus.Archived, status, modified, token), cancellationToken);
 
-    public Task<QueryResult<IList<FailedMessageView>>> GetGroupErrors(string groupId, string status, string modified, SortInfo sortInfo, PagingInfo pagingInfo, CancellationToken cancellationToken = default) =>
+    public Task<QueryResult<IList<FailedMessageView>>> GetGroupErrors(string groupId, string? status, string? modified, SortInfo sortInfo, PagingInfo pagingInfo, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext((dbContext, token) => InGroup(dbContext, groupId, status, modified).ToPagedResult(pagingInfo, sortInfo, token), cancellationToken);
 
-    public Task<QueryStatsInfo> GetGroupErrorsCount(string groupId, string status, string modified, CancellationToken cancellationToken = default) =>
+    public Task<QueryStatsInfo> GetGroupErrorsCount(string groupId, string? status, string? modified, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext((dbContext, token) => InGroup(dbContext, groupId, status, modified).ToQueryStatsInfo(token), cancellationToken);
 
     public Task EditComment(string groupId, string comment, CancellationToken cancellationToken = default) =>
@@ -73,7 +73,7 @@ public class GroupsDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(
             .AsNoTracking()
             .Where(group => group.Type == classifier);
 
-    static async Task<QueryResult<FailureGroupView>> SingleGroup(ServiceControlDbContext dbContext, string groupId, FailedMessageStatus baseline, string status, string modified, CancellationToken cancellationToken)
+    static async Task<QueryResult<FailureGroupView>> SingleGroup(ServiceControlDbContext dbContext, string groupId, FailedMessageStatus baseline, string? status, string? modified, CancellationToken cancellationToken)
     {
         var groups = await dbContext.FailedMessageGroups
             .AsNoTracking()
@@ -91,7 +91,7 @@ public class GroupsDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(
             .AsNoTracking()
             .Where(message => message.Status == status);
 
-    static IQueryable<FailedMessageEntity> InGroup(ServiceControlDbContext dbContext, string groupId, string status, string modified) =>
+    static IQueryable<FailedMessageEntity> InGroup(ServiceControlDbContext dbContext, string groupId, string? status, string? modified) =>
         dbContext.FailedMessages
             .AsNoTracking()
             .Where(message => dbContext.FailedMessageGroups.Any(group => group.GroupId == groupId && group.FailedMessageUniqueId == message.UniqueMessageId))

--- a/src/ServiceControl.Persistence.EFCore/Implementation/RetryBatchStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/RetryBatchStore.cs
@@ -11,7 +11,7 @@ using ServiceControl.Persistence.Infrastructure;
 public class RetryBatchStore(IServiceScopeFactory scopeFactory, IRetryBatchSqlDialect dialect) : DataStoreBase(scopeFactory), IRetryBatchStore
 {
     public Task<string> CreateBatch(string retrySessionId, string requestId, RetryType retryType,
-        string[] failedMessageRetryIds, string originator, DateTime startTime, DateTime? last = null,
+        string[] failedMessageRetryIds, string? originator, DateTime startTime, DateTime? last = null,
         string? batchName = null, string? classifier = null,
         string? initiatedById = null, string? initiatedByName = null, string? operationId = null,
         CancellationToken cancellationToken = default) =>

--- a/src/ServiceControl.Persistence.EFCore/Implementation/RetryHistoryDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/RetryHistoryDataStore.cs
@@ -51,7 +51,7 @@ public class RetryHistoryDataStore(IServiceScopeFactory scopeFactory) : DataStor
         }, cancellationToken);
 
     public Task RecordRetryOperationCompleted(string requestId, RetryType retryType, DateTime startTime, DateTime completionTime,
-        string originator, string classifier, bool messageFailed, int numberOfMessagesProcessed, DateTime lastProcessed, int retryHistoryDepth,
+        string? originator, string? classifier, bool messageFailed, int numberOfMessagesProcessed, DateTime lastProcessed, int retryHistoryDepth,
         CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(async (dbContext, token) =>
         {
@@ -101,7 +101,7 @@ public class RetryHistoryDataStore(IServiceScopeFactory scopeFactory) : DataStor
         retryType is not RetryType.SingleMessage and not RetryType.MultipleMessages;
 
     static async Task RecordUnacknowledged(ServiceControlDbContext dbContext, string requestId, RetryType retryType,
-        DateTime startTime, DateTime completionTime, string originator, string classifier, bool messageFailed,
+        DateTime startTime, DateTime completionTime, string? originator, string? classifier, bool messageFailed,
         int numberOfMessagesProcessed, DateTime lastProcessed, CancellationToken cancellationToken)
     {
         var unacknowledged = await dbContext.UnacknowledgedRetryOperations

--- a/src/ServiceControl.Persistence.RavenDB/EndpointDetailsParser.cs
+++ b/src/ServiceControl.Persistence.RavenDB/EndpointDetailsParser.cs
@@ -10,7 +10,7 @@ namespace ServiceControl
     {
         public static EndpointDetails SendingEndpoint(IReadOnlyDictionary<string, string> headers)
         {
-            var endpointDetails = new EndpointDetails();
+            var endpointDetails = new EndpointDetails() { Name = "", Host = "" };
 
             DictionaryExtensions.CheckIfKeyExists(Headers.OriginatingEndpoint, headers, s => endpointDetails.Name = s);
             DictionaryExtensions.CheckIfKeyExists("NServiceBus.OriginatingMachine", headers, s => endpointDetails.Host = s);
@@ -37,7 +37,7 @@ namespace ServiceControl
 
         public static EndpointDetails ReceivingEndpoint(IReadOnlyDictionary<string, string> headers)
         {
-            var endpoint = new EndpointDetails();
+            var endpoint = new EndpointDetails() { Name = "", Host = "" };
 
             if (headers.TryGetValue(Headers.HostId, out var hostIdHeader))
             {

--- a/src/ServiceControl.Persistence.Tests.RavenDB/CompositeViews/MessagesViewTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/CompositeViews/MessagesViewTests.cs
@@ -213,6 +213,7 @@
                 session.Store(new FailedMessage
                 {
                     Id = "1",
+                    UniqueMessageId = Guid.NewGuid().ToString(),
                     ProcessingAttempts =
                     [
                         new FailedMessage.ProcessingAttempt
@@ -255,6 +256,7 @@
                 session.Store(new FailedMessage
                 {
                     Id = "1",
+                    UniqueMessageId = Guid.NewGuid().ToString(),
                     ProcessingAttempts =
                     [
                         new FailedMessage.ProcessingAttempt

--- a/src/ServiceControl.Persistence.Tests.RavenDB/FailedMessageBuilder.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/FailedMessageBuilder.cs
@@ -15,6 +15,7 @@
             var message = new FailedMessage
             {
                 Id = "1",
+                UniqueMessageId = Guid.NewGuid().ToString(),
                 ProcessingAttempts =
                 [
                     new FailedMessage.ProcessingAttempt

--- a/src/ServiceControl.Persistence.Tests/EFCore/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/PersistenceTestsContext.cs
@@ -51,7 +51,7 @@ public partial class PersistenceTestsContext
             var contentType = attempt.Headers.GetValueOrDefault(Headers.ContentType, "text/plain");
             db.FailedMessages.Add(new FailedMessageEntity
             {
-                UniqueMessageId = Guid.Parse(failedMessage.UniqueMessageId!),
+                UniqueMessageId = Guid.Parse(failedMessage.UniqueMessageId),
                 FirstTimeOfFailure = ordered.Min(pa => pa.FailureDetails.TimeOfFailure),
                 LastTimeOfFailure = ordered.Max(pa => pa.FailureDetails.TimeOfFailure),
                 LastAttemptedAt = attempt.AttemptedAt,

--- a/src/ServiceControl.Persistence.Tests/EFCore/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/PersistenceTestsContext.cs
@@ -4,7 +4,6 @@ namespace ServiceControl.Persistence.Tests;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using EFCore.DbContexts;
@@ -52,7 +51,7 @@ public partial class PersistenceTestsContext
             var contentType = attempt.Headers.GetValueOrDefault(Headers.ContentType, "text/plain");
             db.FailedMessages.Add(new FailedMessageEntity
             {
-                UniqueMessageId = Guid.Parse(failedMessage.UniqueMessageId),
+                UniqueMessageId = Guid.Parse(failedMessage.UniqueMessageId!),
                 FirstTimeOfFailure = ordered.Min(pa => pa.FailureDetails.TimeOfFailure),
                 LastTimeOfFailure = ordered.Max(pa => pa.FailureDetails.TimeOfFailure),
                 LastAttemptedAt = attempt.AttemptedAt,

--- a/src/ServiceControl.Persistence.Tests/IngestedFailure.cs
+++ b/src/ServiceControl.Persistence.Tests/IngestedFailure.cs
@@ -153,6 +153,7 @@ class IngestedFailure
         // stores the document under it while the relational persisters ignore it.
         return new FailedMessage
         {
+            Id = Guid.NewGuid().ToString(),
             UniqueMessageId = UniqueMessageIdString,
             Status = status,
             ProcessingAttempts = attempts,

--- a/src/ServiceControl.Persistence.Tests/MessageRedirects/MessageRedirectsDataStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/MessageRedirects/MessageRedirectsDataStoreTests.cs
@@ -96,7 +96,7 @@ class MessageRedirectsDataStoreTests : PersistenceTestBase
         await Add("Sales", "Sales.New");
         await Add("Shipping", "Shipping.New");
 
-        await MessageRedirectsDataStore.RemoveRedirect(new MessageRedirect { FromPhysicalAddress = "Sales" });
+        await MessageRedirectsDataStore.RemoveRedirect(new MessageRedirect { FromPhysicalAddress = "Sales", ToPhysicalAddress = "Sales.New" });
 
         var redirects = await MessageRedirectsDataStore.GetRedirects();
 
@@ -112,7 +112,7 @@ class MessageRedirectsDataStoreTests : PersistenceTestBase
     {
         await Add("Sales", "Sales.New");
 
-        await MessageRedirectsDataStore.RemoveRedirect(new MessageRedirect { FromPhysicalAddress = "Unknown" });
+        await MessageRedirectsDataStore.RemoveRedirect(new MessageRedirect { FromPhysicalAddress = "Unknown", ToPhysicalAddress = "Sales" });
 
         Assert.That(await MessageRedirectsDataStore.GetRedirects(), Has.Count.EqualTo(1));
     }

--- a/src/ServiceControl.Persistence.Tests/Recoverability/RetryConfirmationProcessorTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/RetryConfirmationProcessorTests.cs
@@ -1,4 +1,4 @@
-namespace ServiceControl.Persistence.Tests.Recoverability
+﻿namespace ServiceControl.Persistence.Tests.Recoverability
 {
     using System;
     using System.Collections.Generic;
@@ -23,6 +23,7 @@ namespace ServiceControl.Persistence.Tests.Recoverability
                 new FailedMessage
                 {
                     Id = MessageId,
+                    UniqueMessageId = Guid.NewGuid().ToString(),
                     Status = FailedMessageStatus.Unresolved
                 }
             );

--- a/src/ServiceControl.Persistence/CustomCheck.cs
+++ b/src/ServiceControl.Persistence/CustomCheck.cs
@@ -6,12 +6,12 @@
 
     public class CustomCheck
     {
-        public string Id { get; set; }
-        public string CustomCheckId { get; set; }
-        public string Category { get; set; }
+        public string? Id { get; set; }
+        public string? CustomCheckId { get; set; }
+        public string? Category { get; set; }
         public Status Status { get; set; }
         public DateTime ReportedAt { get; set; }
-        public string FailureReason { get; set; }
-        public EndpointDetails OriginatingEndpoint { get; set; }
+        public string? FailureReason { get; set; }
+        public EndpointDetails? OriginatingEndpoint { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/CustomCheckDetail.cs
+++ b/src/ServiceControl.Persistence/CustomCheckDetail.cs
@@ -17,13 +17,13 @@ namespace ServiceControl.Contracts.CustomChecks
             ReportedAt = DateTime.UtcNow;
         }
 
-        public EndpointDetails OriginatingEndpoint { get; set; }
-        public string CustomCheckId { get; set; }
+        public required EndpointDetails OriginatingEndpoint { get; set; }
+        public required string CustomCheckId { get; set; }
         public DateTime ReportedAt { get; set; }
-        public string Category { get; set; }
+        public required string Category { get; set; }
         public bool HasFailed { get; set; }
-        public string FailureReason { get; set; }
+        public string? FailureReason { get; set; }
 
-        public Guid GetDeterministicId() => DeterministicGuid.MakeId(OriginatingEndpoint.Name, OriginatingEndpoint.HostId.ToString(), CustomCheckId);
+        public Guid GetDeterministicId() => DeterministicGuid.MakeId(OriginatingEndpoint.Name ?? "", OriginatingEndpoint.HostId.ToString(), CustomCheckId);
     }
 }

--- a/src/ServiceControl.Persistence/EmailNotifications.cs
+++ b/src/ServiceControl.Persistence/EmailNotifications.cs
@@ -4,18 +4,18 @@
     {
         public bool Enabled { get; set; }
 
-        public string SmtpServer { get; set; }
+        public string? SmtpServer { get; set; }
 
         public int? SmtpPort { get; set; }
 
-        public string AuthenticationAccount { get; set; }
+        public string? AuthenticationAccount { get; set; }
 
-        public string AuthenticationPassword { get; set; }
+        public string? AuthenticationPassword { get; set; }
 
         public bool EnableTLS { get; set; }
 
-        public string To { get; set; }
+        public string? To { get; set; }
 
-        public string From { get; set; }
+        public string? From { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/EndpointDetails.cs
+++ b/src/ServiceControl.Persistence/EndpointDetails.cs
@@ -5,12 +5,12 @@ namespace ServiceControl.Operations
 
     public class EndpointDetails
     {
-        public string Name { get; set; }
+        public required string Name { get; set; }
 
         public Guid HostId { get; set; }
 
-        public string Host { get; set; }
+        public required string Host { get; set; }
 
-        public Guid GetDeterministicId() => DeterministicGuid.MakeId(Name, HostId.ToString());
+        public Guid GetDeterministicId() => DeterministicGuid.MakeId(Name ?? "", HostId.ToString());
     }
 }

--- a/src/ServiceControl.Persistence/EndpointInstanceId.cs
+++ b/src/ServiceControl.Persistence/EndpointInstanceId.cs
@@ -15,7 +15,7 @@ namespace ServiceControl.Persistence
 
         public Guid UniqueId { get; }
 
-        public bool Equals(EndpointInstanceId other)
+        public bool Equals(EndpointInstanceId? other)
         {
             if (other is null)
             {
@@ -30,7 +30,7 @@ namespace ServiceControl.Persistence
             return string.Equals(LogicalName, other.LogicalName) && string.Equals(HostName, other.HostName) && HostGuid.Equals(other.HostGuid);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as EndpointInstanceId);
         }

--- a/src/ServiceControl.Persistence/EndpointSettings.cs
+++ b/src/ServiceControl.Persistence/EndpointSettings.cs
@@ -2,6 +2,6 @@
 
 public class EndpointSettings
 {
-    public string Name { get; set; }
+    public required string Name { get; set; }
     public bool TrackInstances { get; set; }
 }

--- a/src/ServiceControl.Persistence/EndpointsView.cs
+++ b/src/ServiceControl.Persistence/EndpointsView.cs
@@ -5,11 +5,11 @@ namespace ServiceControl.Persistence
     public class EndpointsView
     {
         public Guid Id { get; set; }
-        public string Name { get; set; }
-        public string HostDisplayName { get; set; }
+        public required string Name { get; set; }
+        public string? HostDisplayName { get; set; }
         public bool Monitored { get; set; }
         public bool MonitorHeartbeat { get; set; }
-        public HeartbeatInformation HeartbeatInformation { get; set; }
+        public HeartbeatInformation? HeartbeatInformation { get; set; }
         public bool IsSendingHeartbeats { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/EventLog/EventLogItem.cs
+++ b/src/ServiceControl.Persistence/EventLog/EventLogItem.cs
@@ -9,14 +9,14 @@
     /// </summary>
     public class EventLogItem
     {
-        public string Description { get; set; }
+        public string? Description { get; set; }
         public Severity Severity { get; set; }
         public DateTime RaisedAt { get; set; }
         /// <summary>
         /// This could be the Id of a related document, such as the FailedMessage event, which will have more information regarding this alert.
         /// </summary>
-        public List<string> RelatedTo { get; set; }
-        public string Category { get; set; }
-        public string EventType { get; set; }
+        public List<string> RelatedTo { get; set; } = [];
+        public required string Category { get; set; }
+        public required string EventType { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/EventLog/EventLogItem.cs
+++ b/src/ServiceControl.Persistence/EventLog/EventLogItem.cs
@@ -15,7 +15,7 @@
         /// <summary>
         /// This could be the Id of a related document, such as the FailedMessage event, which will have more information regarding this alert.
         /// </summary>
-        public List<string> RelatedTo { get; set; } = [];
+        public List<string>? RelatedTo { get; set; }
         public required string Category { get; set; }
         public required string EventType { get; set; }
     }

--- a/src/ServiceControl.Persistence/EventLog/EventLogItemView.cs
+++ b/src/ServiceControl.Persistence/EventLog/EventLogItemView.cs
@@ -11,12 +11,12 @@ namespace ServiceControl.EventLog
         /// <summary>
         /// Assigned by whichever persister stored the item, and opaque.
         /// </summary>
-        public string Id { get; set; }
-        public string Description { get; set; }
+        public required string Id { get; set; }
+        public required string Description { get; set; }
         public Severity Severity { get; set; }
         public DateTime RaisedAt { get; set; }
-        public List<string> RelatedTo { get; set; }
-        public string Category { get; set; }
-        public string EventType { get; set; }
+        public List<string> RelatedTo { get; set; } = [];
+        public required string Category { get; set; }
+        public required string EventType { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/ExceptionDetails.cs
+++ b/src/ServiceControl.Persistence/ExceptionDetails.cs
@@ -2,9 +2,9 @@ namespace ServiceControl.Contracts.Operations
 {
     public class ExceptionDetails
     {
-        public string ExceptionType { get; set; }
-        public string Message { get; set; }
-        public string Source { get; set; }
-        public string StackTrace { get; set; }
+        public string? ExceptionType { get; set; }
+        public string? Message { get; set; }
+        public string? Source { get; set; }
+        public string? StackTrace { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/ExternalIntegrations/ExternalIntegrationDispatchRequest.cs
+++ b/src/ServiceControl.Persistence/ExternalIntegrations/ExternalIntegrationDispatchRequest.cs
@@ -2,7 +2,7 @@ namespace ServiceControl.ExternalIntegrations
 {
     public class ExternalIntegrationDispatchRequest
     {
-        public required string Id { get; set; }
+        public string? Id { get; set; }
         public required object DispatchContext;
     }
 }

--- a/src/ServiceControl.Persistence/ExternalIntegrations/ExternalIntegrationDispatchRequest.cs
+++ b/src/ServiceControl.Persistence/ExternalIntegrations/ExternalIntegrationDispatchRequest.cs
@@ -2,7 +2,7 @@ namespace ServiceControl.ExternalIntegrations
 {
     public class ExternalIntegrationDispatchRequest
     {
-        public string? Id { get; set; }
+        public required string Id { get; set; }
         public required object DispatchContext;
     }
 }

--- a/src/ServiceControl.Persistence/ExternalIntegrations/ExternalIntegrationDispatchRequest.cs
+++ b/src/ServiceControl.Persistence/ExternalIntegrations/ExternalIntegrationDispatchRequest.cs
@@ -2,7 +2,7 @@ namespace ServiceControl.ExternalIntegrations
 {
     public class ExternalIntegrationDispatchRequest
     {
-        public string Id { get; set; }
-        public object DispatchContext;
+        public string? Id { get; set; }
+        public required object DispatchContext;
     }
 }

--- a/src/ServiceControl.Persistence/FailedErrorImport.cs
+++ b/src/ServiceControl.Persistence/FailedErrorImport.cs
@@ -6,9 +6,9 @@ namespace ServiceControl.Operations
 
     public class FailedErrorImport
     {
-        public string Id { get; set; }
-        public FailedTransportMessage Message { get; set; }
-        public string ExceptionInfo { get; set; }
+        public required string Id { get; set; }
+        public FailedTransportMessage? Message { get; set; }
+        public string? ExceptionInfo { get; set; }
 
         public static Guid DeriveKey(IReadOnlyDictionary<string, string> headers, string nativeMessageId)
         {

--- a/src/ServiceControl.Persistence/FailedMessage.cs
+++ b/src/ServiceControl.Persistence/FailedMessage.cs
@@ -8,16 +8,21 @@
     {
         public FailedMessage()
         {
+            // these ID fields *should* be marked as required
+            // but there seem to be some wire usages of this type for 
+            // deserialisation that omit the UniqueMessageId on output
+            Id = string.Empty;
+            UniqueMessageId = string.Empty;
             ProcessingAttempts = [];
             FailureGroups = [];
         }
 
-        public string? Id { get; set; }
+        public required string Id { get; set; }
+        public string UniqueMessageId { get; set; }
 
         public List<ProcessingAttempt> ProcessingAttempts { get; set; }
         public List<FailureGroup> FailureGroups { get; set; }
 
-        public required string UniqueMessageId { get; set; }
 
         public FailedMessageStatus Status { get; set; }
 

--- a/src/ServiceControl.Persistence/FailedMessage.cs
+++ b/src/ServiceControl.Persistence/FailedMessage.cs
@@ -12,12 +12,12 @@
             FailureGroups = [];
         }
 
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         public List<ProcessingAttempt> ProcessingAttempts { get; set; }
         public List<FailureGroup> FailureGroups { get; set; }
 
-        public string UniqueMessageId { get; set; }
+        public required string UniqueMessageId { get; set; }
 
         public FailedMessageStatus Status { get; set; }
 
@@ -31,25 +31,25 @@
             }
 
             public Dictionary<string, object> MessageMetadata { get; set; }
-            public FailureDetails FailureDetails { get; set; }
+            public FailureDetails FailureDetails { get; set; } = new();
             public DateTime AttemptedAt { get; set; }
-            public string MessageId { get; set; }
-            public string Body { get; set; }
+            public string? MessageId { get; set; }
+            public string? Body { get; set; }
             public Dictionary<string, string> Headers { get; set; }
         }
 
         public class FailureGroup
         {
-            public string Id { get; set; }
-            public string Title { get; set; }
-            public string Type { get; set; }
+            public required string Id { get; set; }
+            public string? Title { get; set; }
+            public string? Type { get; set; }
         }
     }
 
     public class GroupComment
     {
-        public string Id { get; set; }
-        public string Comment { get; set; }
+        public required string Id { get; set; }
+        public string? Comment { get; set; }
     }
 
     public enum FailedMessageStatus

--- a/src/ServiceControl.Persistence/FailedMessage.cs
+++ b/src/ServiceControl.Persistence/FailedMessage.cs
@@ -8,17 +8,12 @@
     {
         public FailedMessage()
         {
-            // these ID fields *should* be marked as required
-            // but there seem to be some wire usages of this type for 
-            // deserialisation that omit the UniqueMessageId on output
-            Id = string.Empty;
-            UniqueMessageId = string.Empty;
             ProcessingAttempts = [];
             FailureGroups = [];
         }
 
-        public required string Id { get; set; }
-        public string UniqueMessageId { get; set; }
+        public string? Id { get; set; }
+        public required string UniqueMessageId { get; set; }
 
         public List<ProcessingAttempt> ProcessingAttempts { get; set; }
         public List<FailureGroup> FailureGroups { get; set; }

--- a/src/ServiceControl.Persistence/FailedMessageView.cs
+++ b/src/ServiceControl.Persistence/FailedMessageView.cs
@@ -6,20 +6,20 @@
 
     public class FailedMessageView
     {
-        public string Id { get; set; }
-        public string MessageType { get; set; }
+        public required string Id { get; set; }
+        public string? MessageType { get; set; }
         public DateTime? TimeSent { get; set; }
         public bool IsSystemMessage { get; set; }
-        public ExceptionDetails Exception { get; set; }
-        public string MessageId { get; set; }
+        public required ExceptionDetails Exception { get; set; }
+        public string? MessageId { get; set; }
         public int NumberOfProcessingAttempts { get; set; }
         public FailedMessageStatus Status { get; set; }
-        public EndpointDetails SendingEndpoint { get; set; }
-        public EndpointDetails ReceivingEndpoint { get; set; }
-        public string QueueAddress { get; set; }
+        public EndpointDetails? SendingEndpoint { get; set; }
+        public EndpointDetails? ReceivingEndpoint { get; set; }
+        public string? QueueAddress { get; set; }
         public DateTime TimeOfFailure { get; set; }
         public DateTime LastModified { get; set; }
         public bool Edited { get; set; }
-        public string EditOf { get; set; }
+        public string? EditOf { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/FailedTransportMessage.cs
+++ b/src/ServiceControl.Persistence/FailedTransportMessage.cs
@@ -4,8 +4,8 @@
 
     public class FailedTransportMessage
     {
-        public string Id { get; set; }
-        public Dictionary<string, string> Headers { get; set; }
-        public byte[] Body { get; set; }
+        public required string Id { get; set; }
+        public required Dictionary<string, string> Headers { get; set; }
+        public required byte[] Body { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/FailureDetails.cs
+++ b/src/ServiceControl.Persistence/FailureDetails.cs
@@ -9,10 +9,10 @@ namespace ServiceControl.Contracts.Operations
             TimeOfFailure = DateTime.UtcNow;
         }
 
-        public string AddressOfFailingEndpoint { get; set; }
+        public string? AddressOfFailingEndpoint { get; set; }
 
         public DateTime TimeOfFailure { get; set; }
 
-        public ExceptionDetails Exception { get; set; }
+        public ExceptionDetails? Exception { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/FailureGroupMessageView.cs
+++ b/src/ServiceControl.Persistence/FailureGroupMessageView.cs
@@ -5,12 +5,12 @@ namespace ServiceControl.Recoverability
 
     public class FailureGroupMessageView : IHaveStatus
     {
-        public string Id { get; set; }
-        public string FailureGroupId { get; set; }
-        public string FailureGroupName { get; set; }
-        public string MessageId { get; set; }
+        public required string Id { get; set; }
+        public required string FailureGroupId { get; set; }
+        public required string FailureGroupName { get; set; }
+        public required string MessageId { get; set; }
         public DateTime TimeSent { get; set; }
-        public string MessageType { get; set; }
+        public required string MessageType { get; set; }
         public DateTime TimeOfFailure { get; set; }
         public long LastModified { get; set; }
         public FailedMessageStatus Status { get; set; }

--- a/src/ServiceControl.Persistence/FailureGroupView.cs
+++ b/src/ServiceControl.Persistence/FailureGroupView.cs
@@ -4,11 +4,11 @@ namespace ServiceControl.Recoverability
 
     public class FailureGroupView
     {
-        public string Id { get; set; }
-        public string Title { get; set; }
-        public string Type { get; set; }
+        public required string Id { get; set; }
+        public required string Title { get; set; }
+        public required string Type { get; set; }
         public int Count { get; set; }
-        public string Comment { get; set; }
+        public string? Comment { get; set; }
         public DateTime First { get; set; }
         public DateTime Last { get; set; }
     }

--- a/src/ServiceControl.Persistence/ForwardingRetryBatch.cs
+++ b/src/ServiceControl.Persistence/ForwardingRetryBatch.cs
@@ -3,5 +3,5 @@ namespace ServiceControl.Persistence
     /// <summary>
     /// The batch currently being forwarded.
     /// </summary>
-    public record ForwardingRetryBatch(string RequestId, RetryType RetryType, string Originator, string Classifier);
+    public record ForwardingRetryBatch(string RequestId, RetryType RetryType, string? Originator, string? Classifier);
 }

--- a/src/ServiceControl.Persistence/GroupOperation.cs
+++ b/src/ServiceControl.Persistence/GroupOperation.cs
@@ -2,15 +2,15 @@ using System;
 
 public class GroupOperation
 {
-    public string Id { get; set; }
-    public string Title { get; set; }
-    public string Type { get; set; }
+    public string? Id { get; set; }
+    public string? Title { get; set; }
+    public string? Type { get; set; }
     public int Count { get; set; }
     public int? OperationMessagesCompletedCount { get; set; }
-    public string Comment { get; set; }
+    public string? Comment { get; set; }
     public DateTime? First { get; set; }
     public DateTime? Last { get; set; }
-    public string OperationStatus { get; set; }
+    public string? OperationStatus { get; set; }
     public bool? OperationFailed { get; set; }
     public double OperationProgress { get; set; }
     public int? OperationRemainingCount { get; set; }

--- a/src/ServiceControl.Persistence/History/HistoricRetryOperation.cs
+++ b/src/ServiceControl.Persistence/History/HistoricRetryOperation.cs
@@ -5,11 +5,11 @@
 
     public class HistoricRetryOperation
     {
-        public string RequestId { get; set; }
+        public required string RequestId { get; set; }
         public RetryType RetryType { get; set; }
         public DateTime StartTime { get; set; }
         public DateTime CompletionTime { get; set; }
-        public string Originator { get; set; }
+        public string? Originator { get; set; }
         public bool Failed { get; set; }
         public int NumberOfMessagesProcessed { get; set; }
     }

--- a/src/ServiceControl.Persistence/History/UnacknowledgedRetryOperation.cs
+++ b/src/ServiceControl.Persistence/History/UnacknowledgedRetryOperation.cs
@@ -5,13 +5,13 @@
 
     public class UnacknowledgedRetryOperation
     {
-        public string RequestId { get; set; }
+        public required string RequestId { get; set; }
         public RetryType RetryType { get; set; }
         public DateTime StartTime { get; set; }
         public DateTime CompletionTime { get; set; }
         public DateTime Last { get; set; }
-        public string Originator { get; set; }
-        public string Classifier { get; set; }
+        public string? Originator { get; set; }
+        public string? Classifier { get; set; }
         public bool Failed { get; set; }
         public int NumberOfMessagesProcessed { get; set; }
     }

--- a/src/ServiceControl.Persistence/IBodyStorage.cs
+++ b/src/ServiceControl.Persistence/IBodyStorage.cs
@@ -20,7 +20,7 @@
 
     public sealed class MessageBodyResult
     {
-        MessageBodyResult(MessageBodyState state, MessageBodyStreamContent content = null)
+        MessageBodyResult(MessageBodyState state, MessageBodyStreamContent? content = null)
         {
             State = state;
             ContentValue = content;
@@ -28,9 +28,9 @@
 
         public MessageBodyState State { get; }
 
-        public MessageBodyStreamContent Content => State == MessageBodyState.Available
+        public MessageBodyStreamContent Content => State == MessageBodyState.Available && ContentValue is not null
             ? ContentValue
-            : throw new InvalidOperationException($"Body content is not available when the state is {State}.");
+            : throw new InvalidOperationException($"Body content is not available when the state is {State} or content is null.");
 
         public static MessageBodyResult NotFound() => new(MessageBodyState.NotFound);
 
@@ -44,7 +44,7 @@
             return new MessageBodyResult(MessageBodyState.Available, content);
         }
 
-        MessageBodyStreamContent ContentValue { get; }
+        MessageBodyStreamContent? ContentValue { get; }
     }
 
     public sealed record MessageBodyStreamContent(Stream Stream, string ContentType, int BodySize, string Etag);

--- a/src/ServiceControl.Persistence/ICustomChecksDataStore.cs
+++ b/src/ServiceControl.Persistence/ICustomChecksDataStore.cs
@@ -11,7 +11,7 @@ namespace ServiceControl.Persistence
     {
         Task<CheckStateChange> UpdateCustomCheckStatus(CustomCheckDetail detail, CancellationToken cancellationToken = default);
 
-        Task<QueryResult<IList<CustomCheck>>> GetStats(PagingInfo paging, string status = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<CustomCheck>>> GetStats(PagingInfo paging, string? status = null, CancellationToken cancellationToken = default);
         Task DeleteCustomCheck(Guid id, CancellationToken cancellationToken = default);
         Task<int> GetNumberOfFailedChecks(CancellationToken cancellationToken = default);
     }

--- a/src/ServiceControl.Persistence/IEventLogDataStore.cs
+++ b/src/ServiceControl.Persistence/IEventLogDataStore.cs
@@ -41,6 +41,6 @@
         /// one is added, since nothing else tells a client its cached page is now wrong.
         /// </returns>
         Task<QueryResult<IList<EventLogItemView>>> GetEventLogItems(
-            PagingInfo pagingInfo, string knownVersion = null, CancellationToken cancellationToken = default);
+            PagingInfo pagingInfo, string? knownVersion = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Persistence/IGroupsDataStore.cs
+++ b/src/ServiceControl.Persistence/IGroupsDataStore.cs
@@ -9,13 +9,13 @@ namespace ServiceControl.Persistence
 
     public interface IGroupsDataStore
     {
-        Task<IList<FailureGroupView>> GetUnresolvedGroupsByClassifier(string classifier, string classifierFilter, CancellationToken cancellationToken = default);
+        Task<IList<FailureGroupView>> GetUnresolvedGroupsByClassifier(string classifier, string? classifierFilter, CancellationToken cancellationToken = default);
         Task<IList<FailureGroupView>> GetArchivedGroupsByClassifier(string classifier, CancellationToken cancellationToken = default);
 
-        Task<QueryResult<FailureGroupView>> GetUnresolvedGroup(string groupId, string status, string modified, CancellationToken cancellationToken = default);
-        Task<QueryResult<FailureGroupView>> GetArchivedGroup(string groupId, string status, string modified, CancellationToken cancellationToken = default);
-        Task<QueryResult<IList<FailedMessageView>>> GetGroupErrors(string groupId, string status, string modified, SortInfo sortInfo, PagingInfo pagingInfo, CancellationToken cancellationToken = default);
-        Task<QueryStatsInfo> GetGroupErrorsCount(string groupId, string status, string modified, CancellationToken cancellationToken = default);
+        Task<QueryResult<FailureGroupView>> GetUnresolvedGroup(string groupId, string? status, string? modified, CancellationToken cancellationToken = default);
+        Task<QueryResult<FailureGroupView>> GetArchivedGroup(string groupId, string? status, string? modified, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<FailedMessageView>>> GetGroupErrors(string groupId, string? status, string? modified, SortInfo sortInfo, PagingInfo pagingInfo, CancellationToken cancellationToken = default);
+        Task<QueryStatsInfo> GetGroupErrorsCount(string groupId, string? status, string? modified, CancellationToken cancellationToken = default);
 
         Task EditComment(string groupId, string comment, CancellationToken cancellationToken = default);
         Task DeleteComment(string groupId, CancellationToken cancellationToken = default);

--- a/src/ServiceControl.Persistence/IMessagesViewDataStore.cs
+++ b/src/ServiceControl.Persistence/IMessagesViewDataStore.cs
@@ -9,10 +9,10 @@ namespace ServiceControl.Persistence
 
     public interface IMessagesViewDataStore
     {
-        Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
-        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessages(PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange? timeSentRange = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForEndpoint(string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, DateTimeRange? timeSentRange = null, CancellationToken cancellationToken = default);
         Task<QueryResult<IList<MessagesView>>> GetAllMessagesByConversation(string conversationId, PagingInfo pagingInfo, SortInfo sortInfo, bool includeSystemMessages, CancellationToken cancellationToken = default);
-        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
-        Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> GetAllMessagesForSearch(string searchTerms, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange? timeSentRange = null, CancellationToken cancellationToken = default);
+        Task<QueryResult<IList<MessagesView>>> SearchEndpointMessages(string endpointName, string searchKeyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange? timeSentRange = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Persistence/IRetryBatchStore.cs
+++ b/src/ServiceControl.Persistence/IRetryBatchStore.cs
@@ -10,9 +10,9 @@ namespace ServiceControl.Persistence
     public interface IRetryBatchStore
     {
         Task<string> CreateBatch(string retrySessionId, string requestId, RetryType retryType,
-            string[] failedMessageRetryIds, string originator, DateTime startTime, DateTime? last = null,
-            string batchName = null, string classifier = null,
-            string initiatedById = null, string initiatedByName = null, string operationId = null,
+            string[] failedMessageRetryIds, string? originator, DateTime startTime, DateTime? last = null,
+            string? batchName = null, string? classifier = null,
+            string? initiatedById = null, string? initiatedByName = null, string? operationId = null,
             CancellationToken cancellationToken = default);
 
         Task AssignMessagesToBatch(string batchId, string[] messageIds, CancellationToken cancellationToken = default);
@@ -22,7 +22,7 @@ namespace ServiceControl.Persistence
         Task<QueryResult<IList<RetryBatch>>> GetOrphanedBatches(string retrySessionId, CancellationToken cancellationToken = default);
         Task<IList<RetryBatchGroup>> GetAvailableBatchGroups(CancellationToken cancellationToken = default);
 
-        Task<ForwardingRetryBatch> GetCurrentForwardingBatch(CancellationToken cancellationToken = default);
+        Task<ForwardingRetryBatch?> GetCurrentForwardingBatch(CancellationToken cancellationToken = default);
 
         Task ForEachUnresolvedMessage(Func<string, DateTime, CancellationToken, Task> callback, CancellationToken cancellationToken = default);
         Task ForEachUnresolvedMessageForEndpoint(string endpoint, Func<string, DateTime, CancellationToken, Task> callback, CancellationToken cancellationToken = default);

--- a/src/ServiceControl.Persistence/IRetryHistoryDataStore.cs
+++ b/src/ServiceControl.Persistence/IRetryHistoryDataStore.cs
@@ -9,7 +9,7 @@
     {
         Task<RetryHistory> GetRetryHistory(CancellationToken cancellationToken = default);
         Task RecordRetryOperationCompleted(string requestId, RetryType retryType, DateTime startTime, DateTime completionTime,
-            string originator, string classifier, bool messageFailed, int numberOfMessagesProcessed, DateTime lastProcessed, int retryHistoryDepth,
+            string? originator, string? classifier, bool messageFailed, int numberOfMessagesProcessed, DateTime lastProcessed, int retryHistoryDepth,
             CancellationToken cancellationToken = default);
         Task<bool> AcknowledgeRetryGroup(string groupId, CancellationToken cancellationToken = default);
     }

--- a/src/ServiceControl.Persistence/Infrastructure/DateTimeRange.cs
+++ b/src/ServiceControl.Persistence/Infrastructure/DateTimeRange.cs
@@ -8,7 +8,7 @@ public class DateTimeRange
     public DateTime? From { get; }
     public DateTime? To { get; }
 
-    public DateTimeRange(string from = null, string to = null)
+    public DateTimeRange(string? from = null, string? to = null)
     {
         if (from != null)
         {

--- a/src/ServiceControl.Persistence/Infrastructure/DeterministicGuid.cs
+++ b/src/ServiceControl.Persistence/Infrastructure/DeterministicGuid.cs
@@ -6,20 +6,11 @@
 
     public static class DeterministicGuid
     {
-        public static Guid MakeId(string data)
-        {
-            return DeterministicGuidBuilder(data);
-        }
+        public static Guid MakeId(string data) => DeterministicGuidBuilder(data);
 
-        public static Guid MakeId(string data1, string data2)
-        {
-            return DeterministicGuidBuilder($"{data1}{data2}");
-        }
+        public static Guid MakeId(string data1, string data2) => DeterministicGuidBuilder($"{data1}{data2}");
 
-        public static Guid MakeId(string data1, string data2, string data3)
-        {
-            return DeterministicGuidBuilder($"{data1}{data2}{data3}");
-        }
+        public static Guid MakeId(string data1, string data2, string data3) => DeterministicGuidBuilder($"{data1}{data2}{data3}");
 
         static Guid DeterministicGuidBuilder(string input)
         {

--- a/src/ServiceControl.Persistence/Infrastructure/QueryResult.cs
+++ b/src/ServiceControl.Persistence/Infrastructure/QueryResult.cs
@@ -2,12 +2,12 @@ namespace ServiceControl.Persistence.Infrastructure
 {
     using System.Threading.Tasks;
 
-    public class QueryResult<TOut>(TOut results, QueryStatsInfo queryStatsInfo)
+    public class QueryResult<TOut>(TOut? results, QueryStatsInfo queryStatsInfo)
         where TOut : class
     {
-        public TOut Results { get; } = results;
+        public TOut? Results { get; } = results;
 
-        public string InstanceId { get; set; }
+        public string? InstanceId { get; set; }
 
         public QueryStatsInfo QueryStats { get; } = queryStatsInfo;
 

--- a/src/ServiceControl.Persistence/Infrastructure/SortInfo.cs
+++ b/src/ServiceControl.Persistence/Infrastructure/SortInfo.cs
@@ -5,7 +5,7 @@
     using System.Diagnostics;
 
     [DebuggerDisplay("{Sort} {Direction}")]
-    public class SortInfo(string sort = null, string direction = null)
+    public class SortInfo(string? sort = null, string? direction = null)
     {
         public string Direction { get; } = string.IsNullOrWhiteSpace(direction) ? "desc" : direction;
         public string Sort { get; } = string.IsNullOrWhiteSpace(sort) ? "time_sent" : sort;

--- a/src/ServiceControl.Persistence/Infrastructure/TransportMessageExtensions.cs
+++ b/src/ServiceControl.Persistence/Infrastructure/TransportMessageExtensions.cs
@@ -7,7 +7,7 @@
 
     public static class HeaderExtensions
     {
-        public static string ProcessingEndpointName(this IReadOnlyDictionary<string, string> headers)
+        public static string? ProcessingEndpointName(this IReadOnlyDictionary<string, string> headers)
         {
             if (headers.TryGetValue(Headers.ProcessingEndpoint, out var endpoint))
             {
@@ -40,7 +40,7 @@
         {
             return headers.TryGetValue("ServiceControl.Retry.UniqueMessageId", out var existingUniqueMessageId)
                 ? existingUniqueMessageId
-                : DeterministicGuid.MakeId(headers.MessageId(), headers.ProcessingEndpointName()).ToString();
+                : DeterministicGuid.MakeId(headers.MessageId() ?? "", headers.ProcessingEndpointName() ?? "").ToString();
         }
 
         public static string ProcessingId(this IReadOnlyDictionary<string, string> headers)
@@ -58,13 +58,13 @@
         }
 
         // NOTE: Duplicated from TransportMessage
-        public static string MessageId(this IReadOnlyDictionary<string, string> headers)
+        public static string? MessageId(this IReadOnlyDictionary<string, string> headers)
         {
             return headers.TryGetValue(Headers.MessageId, out var str) ? str : default;
         }
 
         // NOTE: Duplicated from TransportMessage
-        public static string CorrelationId(this IReadOnlyDictionary<string, string> headers)
+        public static string? CorrelationId(this IReadOnlyDictionary<string, string> headers)
         {
             return headers.TryGetValue(Headers.CorrelationId, out var correlationId) ? correlationId : null;
         }
@@ -102,17 +102,17 @@
 
             return true;
         }
-        static string ReplyToAddress(this IReadOnlyDictionary<string, string> headers) => headers.GetValueOrDefault(Headers.ReplyToAddress);
+        static string? ReplyToAddress(this IReadOnlyDictionary<string, string> headers) => headers.GetValueOrDefault(Headers.ReplyToAddress);
 
-        static string ProcessingStarted(this IReadOnlyDictionary<string, string> headers) => headers.GetValueOrDefault(Headers.ProcessingStarted);
+        static string? ProcessingStarted(this IReadOnlyDictionary<string, string> headers) => headers.GetValueOrDefault(Headers.ProcessingStarted);
 
-        static string ExtractQueue(string address)
+        static string? ExtractQueue(string? address)
         {
             var atIndex = address?.IndexOf("@", StringComparison.InvariantCulture);
 
-            if (atIndex.HasValue && atIndex.Value > -1)
+            if (atIndex is > -1)
             {
-                return address.Substring(0, atIndex.Value);
+                return address![..atIndex.Value];
             }
 
             return address;

--- a/src/ServiceControl.Persistence/KnownEndpoint.cs
+++ b/src/ServiceControl.Persistence/KnownEndpoint.cs
@@ -4,8 +4,8 @@
 
     public class KnownEndpoint
     {
-        public string HostDisplayName { get; set; }
+        public string? HostDisplayName { get; set; }
         public bool Monitored { get; set; }
-        public EndpointDetails EndpointDetails { get; set; }
+        public required EndpointDetails EndpointDetails { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/KnownEndpointsView.cs
+++ b/src/ServiceControl.Persistence/KnownEndpointsView.cs
@@ -6,7 +6,7 @@
     public class KnownEndpointsView
     {
         public Guid Id { get; set; }
-        public EndpointDetails EndpointDetails { get; set; }
-        public string HostDisplayName { get; set; }
+        public required EndpointDetails EndpointDetails { get; set; }
+        public string? HostDisplayName { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/MessageRedirects/MessageRedirect.cs
+++ b/src/ServiceControl.Persistence/MessageRedirects/MessageRedirect.cs
@@ -1,4 +1,4 @@
-namespace ServiceControl.Persistence.MessageRedirects
+﻿namespace ServiceControl.Persistence.MessageRedirects
 {
     using System;
     using System.Collections.Concurrent;
@@ -8,8 +8,8 @@ namespace ServiceControl.Persistence.MessageRedirects
     {
         public Guid MessageRedirectId => idCache.GetOrAdd(FromPhysicalAddress, DeterministicGuid.MakeId);
 
-        public string FromPhysicalAddress { get; set; }
-        public string ToPhysicalAddress { get; set; }
+        public required string FromPhysicalAddress { get; set; }
+        public required string ToPhysicalAddress { get; set; }
         public DateTime LastModified { get; set; }
         static ConcurrentDictionary<string, Guid> idCache = new ConcurrentDictionary<string, Guid>();
     }

--- a/src/ServiceControl.Persistence/MessageRedirects/MessageRedirectExtensions.cs
+++ b/src/ServiceControl.Persistence/MessageRedirects/MessageRedirectExtensions.cs
@@ -6,10 +6,10 @@ namespace ServiceControl.Persistence.MessageRedirects
 
     public static class MessageRedirectExtensions
     {
-        public static MessageRedirect FindByAddress(this IEnumerable<MessageRedirect> redirects, string fromPhysicalAddress) =>
+        public static MessageRedirect? FindByAddress(this IEnumerable<MessageRedirect> redirects, string fromPhysicalAddress) =>
             redirects.SingleOrDefault(redirect => redirect.FromPhysicalAddress == fromPhysicalAddress);
 
-        public static MessageRedirect FindById(this IEnumerable<MessageRedirect> redirects, Guid messageRedirectId) =>
+        public static MessageRedirect? FindById(this IEnumerable<MessageRedirect> redirects, Guid messageRedirectId) =>
             redirects.SingleOrDefault(redirect => redirect.MessageRedirectId == messageRedirectId);
     }
 }

--- a/src/ServiceControl.Persistence/MessagesView.cs
+++ b/src/ServiceControl.Persistence/MessagesView.cs
@@ -9,25 +9,25 @@ namespace ServiceControl.CompositeViews.Messages
 
     public class MessagesView
     {
-        public string Id { get; set; }
-        public string MessageId { get; set; }
-        public string MessageType { get; set; }
-        public EndpointDetails SendingEndpoint { get; set; }
-        public EndpointDetails ReceivingEndpoint { get; set; }
+        public string? Id { get; set; }
+        public string? MessageId { get; set; }
+        public string? MessageType { get; set; }
+        public EndpointDetails? SendingEndpoint { get; set; }
+        public EndpointDetails? ReceivingEndpoint { get; set; }
         public DateTime? TimeSent { get; set; }
         public DateTime ProcessedAt { get; set; }
         public TimeSpan CriticalTime { get; set; }
         public TimeSpan ProcessingTime { get; set; }
         public TimeSpan DeliveryTime { get; set; }
         public bool IsSystemMessage { get; set; }
-        public string ConversationId { get; set; }
-        public IEnumerable<KeyValuePair<string, object>> Headers { get; set; }
+        public string? ConversationId { get; set; }
+        public IEnumerable<KeyValuePair<string, object>> Headers { get; set; } = [];
         public MessageStatus Status { get; set; }
         public MessageIntent MessageIntent { get; set; }
-        public string BodyUrl { get; set; }
+        public string? BodyUrl { get; set; }
         public int BodySize { get; set; }
-        public List<SagaInfo> InvokedSagas { get; set; }
-        public SagaInfo OriginatesFromSaga { get; set; }
-        public string InstanceId { get; set; }
+        public List<SagaInfo>? InvokedSagas { get; set; }
+        public SagaInfo? OriginatesFromSaga { get; set; }
+        public string? InstanceId { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/PersistenceManifest.cs
+++ b/src/ServiceControl.Persistence/PersistenceManifest.cs
@@ -10,17 +10,17 @@
 
     public class PersistenceManifest
     {
-        public string Location { get; set; }
+        public string? Location { get; set; }
 
-        public string Name { get; set; }
+        public required string Name { get; set; }
 
-        public string DisplayName { get; set; }
+        public required string DisplayName { get; set; }
 
-        public string Description { get; set; }
+        public required string Description { get; set; }
 
-        public string AssemblyName { get; set; }
+        public required string AssemblyName { get; set; }
 
-        public string TypeName { get; set; }
+        public required string TypeName { get; set; }
 
         public bool IsSupported { get; set; } = true;
 
@@ -61,10 +61,7 @@
             {
                 foreach (var manifestFile in Directory.EnumerateFiles(assemblyDirectory, "persistence.manifest", SearchOption.AllDirectories))
                 {
-                    var manifest = JsonSerializer.Deserialize<PersistenceManifest>(File.ReadAllText(manifestFile));
-                    manifest.Location = Path.GetDirectoryName(manifestFile);
-
-                    PersistenceManifests.Add(manifest);
+                    PersistenceManifests.Add(DeserializeManifest(manifestFile));
                 }
             }
             catch (Exception ex)
@@ -76,10 +73,7 @@
             {
                 foreach (var manifestFile in DevelopmentPersistenceLocations.ManifestFiles)
                 {
-                    var manifest = JsonSerializer.Deserialize<PersistenceManifest>(File.ReadAllText(manifestFile));
-                    manifest.Location = Path.GetDirectoryName(manifestFile);
-
-                    PersistenceManifests.Add(manifest);
+                    PersistenceManifests.Add(DeserializeManifest(manifestFile));
                 }
             }
             catch (Exception ex)
@@ -90,13 +84,23 @@
             PersistenceManifests.ForEach(m => logger.LogInformation("Found persistence manifest for {ManifestDisplayName}", m.DisplayName));
         }
 
+        static PersistenceManifest DeserializeManifest(string manifestFile)
+        {
+            var manifest = JsonSerializer.Deserialize<PersistenceManifest>(File.ReadAllText(manifestFile))
+                ?? throw new InvalidDataException($"The persistence manifest '{manifestFile}' is empty or invalid.");
+            manifest.Location = Path.GetDirectoryName(manifestFile)
+                ?? throw new InvalidDataException($"The persistence manifest '{manifestFile}' has no containing directory.");
+            return manifest;
+        }
+
         static string GetAssemblyDirectory()
         {
             var assemblyLocation = typeof(PersistenceManifestLibrary).Assembly.Location;
-            return Path.GetDirectoryName(assemblyLocation);
+            return Path.GetDirectoryName(assemblyLocation)
+                ?? throw new InvalidOperationException("The persistence assembly has no containing directory.");
         }
 
-        public static PersistenceManifest Find(string persistenceType)
+        public static PersistenceManifest? Find(string persistenceType)
         {
             if (persistenceType == null)
             {

--- a/src/ServiceControl.Persistence/PersistenceSettings.cs
+++ b/src/ServiceControl.Persistence/PersistenceSettings.cs
@@ -9,7 +9,7 @@
     {
         public bool MaintenanceMode { get; set; }
         //HINT: This needs to be here so that ServerControl instance can add an instance specific metadata to tweak the DatabasePath value
-        public string DatabasePath { get; set; }
+        public string? DatabasePath { get; set; }
 
         public bool EnableFullTextSearchOnBodies { get; set; } = true;
 

--- a/src/ServiceControl.Persistence/ProcessedMessage.cs
+++ b/src/ServiceControl.Persistence/ProcessedMessage.cs
@@ -24,9 +24,9 @@
                 DateTimeOffsetHelper.ToDateTimeOffset(processedAt).UtcDateTime : DateTime.UtcNow; // best guess
         }
 
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
-        public string UniqueMessageId { get; set; }
+        public string? UniqueMessageId { get; set; }
 
         public Dictionary<string, object> MessageMetadata { get; set; }
 

--- a/src/ServiceControl.Persistence/QueueAddress.cs
+++ b/src/ServiceControl.Persistence/QueueAddress.cs
@@ -2,7 +2,7 @@
 {
     public class QueueAddress
     {
-        public string PhysicalAddress { get; set; }
+        public string? PhysicalAddress { get; set; }
         public int FailedMessageCount { get; set; }
     }
 }

--- a/src/ServiceControl.Persistence/Recoverability/Archiving/IArchiveMessages.cs
+++ b/src/ServiceControl.Persistence/Recoverability/Archiving/IArchiveMessages.cs
@@ -11,8 +11,8 @@
     /// </summary>
     public interface IArchiveMessages
     {
-        Task ArchiveAllInGroup(string groupId, AuditUser? initiatedBy = null, string operationId = null, CancellationToken cancellationToken = default);
-        Task UnarchiveAllInGroup(string groupId, AuditUser? initiatedBy = null, string operationId = null, CancellationToken cancellationToken = default);
+        Task ArchiveAllInGroup(string groupId, AuditUser? initiatedBy = null, string? operationId = null, CancellationToken cancellationToken = default);
+        Task UnarchiveAllInGroup(string groupId, AuditUser? initiatedBy = null, string? operationId = null, CancellationToken cancellationToken = default);
 
         bool IsOperationInProgressFor(string groupId, ArchiveType archiveType);
 

--- a/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryArchive.cs
+++ b/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryArchive.cs
@@ -22,7 +22,7 @@
         public DateTime? Last { get; set; }
         public DateTime Started { get; set; }
         public ArchiveState ArchiveState { get; set; }
-        public string GroupName { get; set; }
+        public string? GroupName { get; set; }
         public string RequestId { get; set; }
         public ArchiveType ArchiveType { get; set; }
 

--- a/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryUnarchive.cs
+++ b/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryUnarchive.cs
@@ -22,7 +22,7 @@
         public DateTime? Last { get; set; }
         public DateTime Started { get; set; }
         public ArchiveState ArchiveState { get; set; }
-        public string GroupName { get; set; }
+        public string? GroupName { get; set; }
         public string RequestId { get; set; }
         public ArchiveType ArchiveType { get; set; }
 

--- a/src/ServiceControl.Persistence/Recoverability/Archiving/OperationsManager.cs
+++ b/src/ServiceControl.Persistence/Recoverability/Archiving/OperationsManager.cs
@@ -6,14 +6,16 @@ namespace ServiceControl.Recoverability
     {
         public bool IsOperationInProgressFor(string requestId, ArchiveType archiveType)
         {
-            var isUnarchiveOpration = UnarchiveOperations.TryGetValue(InMemoryUnarchive.MakeId(requestId, archiveType),
+            var isUnarchiveOperation = UnarchiveOperations.TryGetValue(InMemoryUnarchive.MakeId(requestId, archiveType),
                 out var unarchiveSummary);
-            if (!ArchiveOperations.TryGetValue(InMemoryArchive.MakeId(requestId, archiveType), out var archiveSummary) && !isUnarchiveOpration)
+            if (!ArchiveOperations.TryGetValue(InMemoryArchive.MakeId(requestId, archiveType), out var archiveSummary) && !isUnarchiveOperation)
             {
                 return false;
             }
 
-            return archiveSummary?.ArchiveState != ArchiveState.ArchiveCompleted && isUnarchiveOpration && unarchiveSummary.ArchiveState != ArchiveState.ArchiveCompleted;
+            return archiveSummary?.ArchiveState != ArchiveState.ArchiveCompleted
+                   && isUnarchiveOperation
+                   && unarchiveSummary?.ArchiveState != ArchiveState.ArchiveCompleted;
         }
 
         public Dictionary<string, InMemoryUnarchive> UnarchiveOperations { get; } = [];

--- a/src/ServiceControl.Persistence/Recoverability/ClassifiableMessageDetails.cs
+++ b/src/ServiceControl.Persistence/Recoverability/ClassifiableMessageDetails.cs
@@ -8,7 +8,7 @@ namespace ServiceControl.Recoverability
     public struct ClassifiableMessageDetails
     {
         public ProcessingAttempt ProcessingAttempt { get; }
-        public FailureDetails Details { get; }
+        public FailureDetails? Details { get; }
         public string MessageType { get; }
 
         public ClassifiableMessageDetails(FailedMessage message)

--- a/src/ServiceControl.Persistence/RetryBatch.cs
+++ b/src/ServiceControl.Persistence/RetryBatch.cs
@@ -4,14 +4,14 @@ namespace ServiceControl.Persistence
 
     public class RetryBatch
     {
-        public string Id { get; init; }
-        public string Context { get; init; }
-        public string StagingId { get; init; }
-        public string Originator { get; init; }
-        public string Classifier { get; init; }
+        public required string Id { get; init; }
+        public string? Context { get; init; }
+        public string? StagingId { get; init; }
+        public string? Originator { get; init; }
+        public string? Classifier { get; init; }
         public DateTime StartTime { get; init; }
         public DateTime? Last { get; init; }
-        public string RequestId { get; init; }
+        public string? RequestId { get; init; }
         public int InitialBatchSize { get; init; }
         public RetryType RetryType { get; init; }
         public RetryBatchStatus Status { get; init; }
@@ -29,12 +29,12 @@ namespace ServiceControl.Persistence
         /// correlated to the API's operation entry by <see cref="OperationId"/>. Null only for legacy
         /// in-flight commands sent without the headers.
         /// </summary>
-        public string InitiatedById { get; init; }
+        public string? InitiatedById { get; init; }
 
         /// <inheritdoc cref="InitiatedById"/>
-        public string InitiatedByName { get; init; }
+        public string? InitiatedByName { get; init; }
 
         /// <inheritdoc cref="InitiatedById"/>
-        public string OperationId { get; init; }
+        public string? OperationId { get; init; }
     }
 }

--- a/src/ServiceControl.Persistence/RetryBatchGroup.cs
+++ b/src/ServiceControl.Persistence/RetryBatchGroup.cs
@@ -4,7 +4,7 @@ namespace ServiceControl.Persistence
 
     public class RetryBatchGroup
     {
-        public string RequestId { get; set; }
+        public required string RequestId { get; set; }
 
         public RetryType RetryType { get; set; }
 
@@ -14,9 +14,9 @@ namespace ServiceControl.Persistence
 
         public int InitialBatchSize { get; set; }
 
-        public string Originator { get; set; }
+        public string? Originator { get; set; }
 
-        public string Classifier { get; set; }
+        public string? Classifier { get; set; }
 
         public DateTime StartTime { get; set; }
 

--- a/src/ServiceControl.Persistence/ServiceControl.Persistence.csproj
+++ b/src/ServiceControl.Persistence/ServiceControl.Persistence.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Persistence/UnitOfWork/FallbackIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence/UnitOfWork/FallbackIngestionUnitOfWork.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Persistence.UnitOfWork
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -8,15 +9,19 @@
     // recoverability and monitoring. It can focus on one at a time.
     class FallbackIngestionUnitOfWork : IngestionUnitOfWorkBase
     {
-        IIngestionUnitOfWork primary;
-        IIngestionUnitOfWork fallback;
+        readonly IIngestionUnitOfWork primary;
+        readonly IIngestionUnitOfWork fallback;
 
         public FallbackIngestionUnitOfWork(IIngestionUnitOfWork primary, IIngestionUnitOfWork fallback)
         {
-            this.primary = primary;
-            this.fallback = fallback;
-            Monitoring = primary.Monitoring ?? fallback.Monitoring;
-            Recoverability = primary.Recoverability ?? fallback.Recoverability;
+            this.primary = primary ?? throw new ArgumentNullException(nameof(primary));
+            this.fallback = fallback ?? throw new ArgumentNullException(nameof(fallback));
+            Monitoring = primary.Monitoring
+                         ?? fallback.Monitoring
+                         ?? throw new InvalidOperationException("Fallback unit of work must implement Monitoring");
+            Recoverability = primary.Recoverability
+                             ?? fallback.Recoverability
+                             ?? throw new InvalidOperationException("Fallback unit of work must implement Recoverability");
         }
 
         public override Task Complete(CancellationToken cancellationToken = default)
@@ -27,15 +32,8 @@
 
         protected override async ValueTask DisposeAsyncCore()
         {
-            if (primary != null)
-            {
-                await primary.DisposeAsync();
-            }
-
-            if (fallback != null)
-            {
-                await fallback.DisposeAsync();
-            }
+            await primary.DisposeAsync();
+            await fallback.DisposeAsync();
         }
     }
 }

--- a/src/ServiceControl.Persistence/UnitOfWork/IIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence/UnitOfWork/IIngestionUnitOfWork.cs
@@ -6,8 +6,8 @@
 
     public interface IIngestionUnitOfWork : IAsyncDisposable
     {
-        IMonitoringIngestionUnitOfWork Monitoring { get; }
-        IRecoverabilityIngestionUnitOfWork Recoverability { get; }
+        IMonitoringIngestionUnitOfWork? Monitoring { get; }
+        IRecoverabilityIngestionUnitOfWork? Recoverability { get; }
         Task Complete(CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl.Persistence/UnitOfWork/IngestionUnitOfWorkBase.cs
+++ b/src/ServiceControl.Persistence/UnitOfWork/IngestionUnitOfWorkBase.cs
@@ -17,8 +17,8 @@ namespace ServiceControl.Persistence.UnitOfWork
             GC.SuppressFinalize(this);
         }
 
-        public IMonitoringIngestionUnitOfWork Monitoring { get; protected set; }
-        public IRecoverabilityIngestionUnitOfWork Recoverability { get; protected set; }
+        public IMonitoringIngestionUnitOfWork? Monitoring { get; protected set; }
+        public IRecoverabilityIngestionUnitOfWork? Recoverability { get; protected set; }
         public virtual Task Complete(CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/src/ServiceControl.UnitTests/ExternalIntegrations/MessageFailedConverterTests.cs
+++ b/src/ServiceControl.UnitTests/ExternalIntegrations/MessageFailedConverterTests.cs
@@ -134,12 +134,13 @@
             {
                 return new FailedMessage
                 {
+                    UniqueMessageId = Guid.NewGuid().ToString(),
                     ProcessingAttempts = processingAttempts.Select(x =>
                     {
                         var messageMetadata = new Dictionary<string, object>
                         {
-                            {"SendingEndpoint", new EndpointDetails()},
-                            {"ReceivingEndpoint", new EndpointDetails()}
+                            {"SendingEndpoint", new EndpointDetails {  Name = "Sales",  Host = "sales-server" }},
+                            {"ReceivingEndpoint", new EndpointDetails() {  Name = "Shipping",  Host = "shipping-server" }},
                         };
                         if (messageType != null)
                         {

--- a/src/ServiceControl.UnitTests/MessageFailures/ArchiveScopeAuditTests.cs
+++ b/src/ServiceControl.UnitTests/MessageFailures/ArchiveScopeAuditTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 namespace ServiceControl.UnitTests.MessageFailures;
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus.Testing;
@@ -50,7 +51,7 @@ public class ArchiveScopeAuditTests
     public async Task Archived_message_is_audited_with_the_scope_of_the_originating_operation()
     {
         var audit = new RecordingMessageActionAuditLog();
-        var store = new AsyncRangeAndQueueAuditTests.StubErrorMessageDataStore { ErrorByResult = new FailedMessage { Status = FailedMessageStatus.Unresolved } };
+        var store = new AsyncRangeAndQueueAuditTests.StubErrorMessageDataStore { ErrorByResult = new FailedMessage { UniqueMessageId = Guid.NewGuid().ToString(), Status = FailedMessageStatus.Unresolved } };
         var handler = new ArchiveMessageHandler(store, store, new FakeDomainEvents(), audit);
 
         var context = new TestableMessageHandlerContext

--- a/src/ServiceControl.UnitTests/MessageFailures/AsyncRangeAndQueueAuditTests.cs
+++ b/src/ServiceControl.UnitTests/MessageFailures/AsyncRangeAndQueueAuditTests.cs
@@ -84,7 +84,7 @@ public class AsyncRangeAndQueueAuditTests
     public async Task ArchiveMessage_audits_the_archived_message()
     {
         var audit = new RecordingMessageActionAuditLog();
-        var store = new StubErrorMessageDataStore { ErrorByResult = new FailedMessage { Status = FailedMessageStatus.Unresolved } };
+        var store = new StubErrorMessageDataStore { ErrorByResult = new FailedMessage { UniqueMessageId = Guid.NewGuid().ToString(), Status = FailedMessageStatus.Unresolved } };
         var handler = new ArchiveMessageHandler(store, store, new FakeDomainEvents(), audit);
 
         var context = new TestableMessageHandlerContext { MessageHeaders = StampedHeaders("op-a") };
@@ -104,7 +104,7 @@ public class AsyncRangeAndQueueAuditTests
     public async Task ArchiveMessage_already_archived_is_not_audited()
     {
         var audit = new RecordingMessageActionAuditLog();
-        var store = new StubErrorMessageDataStore { ErrorByResult = new FailedMessage { Status = FailedMessageStatus.Archived } };
+        var store = new StubErrorMessageDataStore { ErrorByResult = new FailedMessage { UniqueMessageId = Guid.NewGuid().ToString(), Status = FailedMessageStatus.Archived } };
         var handler = new ArchiveMessageHandler(store, store, new FakeDomainEvents(), audit);
 
         var context = new TestableMessageHandlerContext { MessageHeaders = StampedHeaders("op-a") };
@@ -157,7 +157,10 @@ public class AsyncRangeAndQueueAuditTests
         public string[] RetryPendingMessagesResult { get; set; } = [];
         public string[] UnArchiveByRangeResult { get; set; } = [];
         public string[] UnArchiveMessagesResult { get; set; } = [];
-        public FailedMessage ErrorByResult { get; set; } = new();
+        public FailedMessage ErrorByResult { get; set; } = new()
+        {
+            UniqueMessageId = Guid.NewGuid().ToString(),
+        };
 
         public Task<string[]> GetRetryPendingMessages(DateTime from, DateTime to, string queueAddress, CancellationToken cancellationToken = default) => Task.FromResult(RetryPendingMessagesResult);
         public Task RemoveFailedMessageRetry(string uniqueMessageId, CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/src/ServiceControl.UnitTests/MessageFailures/EditFailedMessagesControllerAuditTests.cs
+++ b/src/ServiceControl.UnitTests/MessageFailures/EditFailedMessagesControllerAuditTests.cs
@@ -34,7 +34,7 @@ public class EditFailedMessagesControllerAuditTests
     public async Task Edit_emits_single_operation()
     {
         var audit = new RecordingMessageActionAuditLog();
-        var store = new StubErrorMessageDataStore { ErrorByResult = new FailedMessage { ProcessingAttempts = { new FailedMessage.ProcessingAttempt() } } };
+        var store = new StubErrorMessageDataStore { ErrorByResult = new FailedMessage { UniqueMessageId = Guid.NewGuid().ToString(), ProcessingAttempts = { new FailedMessage.ProcessingAttempt() } } };
 
         await Create(store, audit).Edit("msg-1", ValidEdit());
 

--- a/src/ServiceControl.UnitTests/Monitoring/HeartbeatEndpointSettingsSyncHostedServiceTests.cs
+++ b/src/ServiceControl.UnitTests/Monitoring/HeartbeatEndpointSettingsSyncHostedServiceTests.cs
@@ -148,7 +148,7 @@ public class HeartbeatEndpointSettingsSyncHostedServiceTests
         Guid instanceB = DeterministicGuid.MakeId(endpointName1, "B");
         Guid instanceC = DeterministicGuid.MakeId(endpointName1, "C");
         var mockMonitoringDataStore = new MockMonitoringDataStore(
-            [new KnownEndpoint { EndpointDetails = new EndpointDetails { Name = endpointName1 } }]);
+            [new KnownEndpoint { EndpointDetails = new EndpointDetails { Name = endpointName1, Host = endpointName1 } }]);
         var mockEndpointInstanceMonitoring = new MockEndpointInstanceMonitoring([
             new EndpointsView { IsSendingHeartbeats = false, Name = endpointName1, Id = instanceA },
             new EndpointsView { IsSendingHeartbeats = false, Name = endpointName1, Id = instanceB },
@@ -189,7 +189,7 @@ public class HeartbeatEndpointSettingsSyncHostedServiceTests
         const string endpointName1 = "Sales";
         Guid instanceA = DeterministicGuid.MakeId(endpointName1, "A");
         var mockMonitoringDataStore = new MockMonitoringDataStore(
-            [new KnownEndpoint { EndpointDetails = new EndpointDetails { Name = endpointName1 } }]);
+            [new KnownEndpoint { EndpointDetails = new EndpointDetails { Name = endpointName1, Host = endpointName1 } }]);
         var mockEndpointInstanceMonitoring = new MockEndpointInstanceMonitoring([
             new EndpointsView { IsSendingHeartbeats = false, Name = endpointName1, Id = instanceA },
             new EndpointsView

--- a/src/ServiceControl/ExternalIntegrations/IntegrationEventWriter.cs
+++ b/src/ServiceControl/ExternalIntegrations/IntegrationEventWriter.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.ExternalIntegrations
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;

--- a/src/ServiceControl/Operations/EndpointDetailsParser.cs
+++ b/src/ServiceControl/Operations/EndpointDetailsParser.cs
@@ -13,7 +13,7 @@ namespace ServiceControl.Contracts.Operations
         {
             var endpointDetails = new EndpointDetails()
             {
-                Name = headers.GetValueOrDefault(Headers.OriginatingHostId, string.Empty),
+                Name = headers.GetValueOrDefault(Headers.OriginatingEndpoint, string.Empty),
                 Host = headers.GetValueOrDefault(Headers.OriginatingMachine, string.Empty),
                 HostId = Guid.TryParse(headers.GetValueOrDefault(Headers.OriginatingHostId, string.Empty), out var g) ? g : Guid.Empty
             };

--- a/src/ServiceControl/Operations/EndpointDetailsParser.cs
+++ b/src/ServiceControl/Operations/EndpointDetailsParser.cs
@@ -11,7 +11,7 @@ namespace ServiceControl.Contracts.Operations
     {
         public static EndpointDetails SendingEndpoint(IReadOnlyDictionary<string, string> headers)
         {
-            var endpointDetails = new EndpointDetails();
+            var endpointDetails = new EndpointDetails() { Name = "", Host = "" };
 
             DictionaryExtensions.CheckIfKeyExists(Headers.OriginatingEndpoint, headers, s => endpointDetails.Name = s);
             DictionaryExtensions.CheckIfKeyExists(Headers.OriginatingMachine, headers, s => endpointDetails.Host = s);
@@ -38,7 +38,7 @@ namespace ServiceControl.Contracts.Operations
 
         public static EndpointDetails ReceivingEndpoint(IReadOnlyDictionary<string, string> headers)
         {
-            var endpoint = new EndpointDetails();
+            var endpoint = new EndpointDetails() { Name = "", Host = "" };
 
             if (headers.TryGetValue(Headers.HostId, out var hostIdHeader))
             {

--- a/src/ServiceControl/Operations/EndpointDetailsParser.cs
+++ b/src/ServiceControl/Operations/EndpointDetailsParser.cs
@@ -11,11 +11,12 @@ namespace ServiceControl.Contracts.Operations
     {
         public static EndpointDetails SendingEndpoint(IReadOnlyDictionary<string, string> headers)
         {
-            var endpointDetails = new EndpointDetails() { Name = "", Host = "" };
-
-            DictionaryExtensions.CheckIfKeyExists(Headers.OriginatingEndpoint, headers, s => endpointDetails.Name = s);
-            DictionaryExtensions.CheckIfKeyExists(Headers.OriginatingMachine, headers, s => endpointDetails.Host = s);
-            DictionaryExtensions.CheckIfKeyExists(Headers.OriginatingHostId, headers, s => endpointDetails.HostId = Guid.Parse(s));
+            var endpointDetails = new EndpointDetails()
+            {
+                Name = headers.GetValueOrDefault(Headers.OriginatingHostId, string.Empty),
+                Host = headers.GetValueOrDefault(Headers.OriginatingMachine, string.Empty),
+                HostId = Guid.TryParse(headers.GetValueOrDefault(Headers.OriginatingHostId, string.Empty), out var g) ? g : Guid.Empty
+            };
 
             if (!string.IsNullOrEmpty(endpointDetails.Name) && !string.IsNullOrEmpty(endpointDetails.Host))
             {
@@ -38,23 +39,13 @@ namespace ServiceControl.Contracts.Operations
 
         public static EndpointDetails ReceivingEndpoint(IReadOnlyDictionary<string, string> headers)
         {
-            var endpoint = new EndpointDetails() { Name = "", Host = "" };
-
-            if (headers.TryGetValue(Headers.HostId, out var hostIdHeader))
+            var endpoint = new EndpointDetails()
             {
-                endpoint.HostId = Guid.Parse(hostIdHeader);
-            }
-
-            if (headers.TryGetValue(Headers.HostDisplayName, out var hostDisplayNameHeader))
-            {
-                endpoint.Host = hostDisplayNameHeader;
-            }
-            else
-            {
-                DictionaryExtensions.CheckIfKeyExists(Headers.ProcessingMachine, headers, s => endpoint.Host = s);
-            }
-
-            DictionaryExtensions.CheckIfKeyExists(Headers.ProcessingEndpoint, headers, s => endpoint.Name = s);
+                Name = headers.GetValueOrDefault(Headers.ProcessingEndpoint, string.Empty),
+                Host = headers.GetValueOrDefault(Headers.HostDisplayName, null)
+                       ?? headers.GetValueOrDefault(Headers.ProcessingMachine, string.Empty),
+                HostId = Guid.TryParse(headers.GetValueOrDefault(Headers.HostId, string.Empty), out var g) ? g : Guid.Empty
+            };
 
             if (!string.IsNullOrEmpty(endpoint.Name) && !string.IsNullOrEmpty(endpoint.Host))
             {


### PR DESCRIPTION
This PR enables nullable annotations in ServiceControl.Persistence

The change is strives to avoid any functional code changes to above the persistence seam where possible by codifying the existing usage into the annotations based upon object creation or consumption patterns.