### PR TITLE
Add acceptance test guidelines and the first two scenarios written to them

### DIFF
--- a/docs/acceptance-test-review-plan.md
+++ b/docs/acceptance-test-review-plan.md
@@ -1,0 +1,283 @@
+# Primary instance acceptance test review
+
+A review of the primary instance's acceptance tests for assertion correctness, prioritised by what
+ServicePulse actually calls.
+
+## Why this is worth doing
+
+Two tests in this suite were recently found to be testing nothing at all. Both registered a test
+double with `AddSingleton<ConcreteType>()` while the code under test injects
+`IEnumerable<IEnrichImportedErrorMessages>`, so the double was never resolved and never ran. Both
+compiled, both passed, and both had passed for years.
+
+That is the shape of the problem: these failures are silent. A test that asserts nothing and a test
+that asserts something unfalsifiable both look identical to CI. The purpose of this review is to find
+the rest of them before the EF persistence work starts leaning on this suite as its safety net.
+
+## Scope
+
+In scope: the functional areas of `ServiceControl.AcceptanceTests`, being `Recoverability`,
+`Monitoring`, `EventLogs` and `WebApi`. That is 71 `When_*.cs` files.
+
+Out of scope: `Security/*` (25 files across ForwardedHeaders, OpenIdConnect, Cors and Https), which
+carries a different risk model and deserves its own pass. Also out of scope: the audit instance,
+monitoring instance, and multi-instance suites, except where they already cover a route the primary
+suite misses.
+
+Three artefacts anchor the work:
+
+- `src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.HttpApiRoutes.approved.txt` inventories 77
+  routes. It is **not** the whole primary-instance surface: the approval test behind it scans only
+  `typeof(Program).Assembly` and `typeof(MyRoutesController).Assembly`.
+- `src/Particular.LicensingComponent.UnitTests/ApprovalFiles/APIApprovals.HttpApiRoutes.approved.txt`
+  inventories the other 8, served under the `api/licensing` prefix, via a separate approval test
+  scanning `typeof(ThroughputCollector).Assembly`. Anything reasoning about "the API surface" has to
+  read both files or it will silently miss the throughput and licensing endpoints.
+- `src/composables/apiRoutes.ts` in ServicePulse maps each gated UI capability to the route behind
+  it and names the ServiceControl controller for each. It describes itself as the only place
+  coupling ServicePulse to ServiceControl's route surface.
+
+That makes 85 routes in total.
+
+## Defect patterns
+
+Each of these was found in the current suite. The value of naming them is that each becomes a
+repeatable check to run over all 71 files, rather than a one-off fix.
+
+### 1. Test double registered against the wrong service type (silent)
+
+The double is registered as its concrete type, so the collection the production code injects never
+contains it. The test still passes, having exercised none of the behaviour it names. Found twice:
+`CounterEnricher` in `When_errors_with_same_uniqueid_are_imported` and `FailOnceEnricher` in
+`When_single_message_fails_in_batch`. Both are fixed; the pattern is not.
+
+**Detect:** for every `AddSingleton<T>()` in a test, assert T is resolved by the component under
+test. A convention test over the test assembly can do this: resolve the host and assert each
+registered double appears in the collection its interface feeds.
+
+### 2. No assertion, failure surfaces only as a timeout (diagnostics)
+
+Seven of the 71 files contain no `Assert` at all. Five use the `Do("step", …)` sequence helper, which
+logs `Advancing from X to Y` on each transition, so a regression there is diagnosable from the
+console output. That is a deliberate and acceptable pattern. The remaining two gate on a single
+`Done` predicate and report a regression as a bare 90-second timeout with nothing to read.
+
+**Detect:** files matching `When_*.cs` with zero `Assert.` occurrences, minus those using the
+`Sequence` helper. Currently 2.
+
+### 3. Assertion restates the condition the scenario already waited on (unfalsifiable)
+
+`When_a_invalid_id_is_sent_to_retry` ends with `Assert.That(context.Done, Is.True)` after
+`.Done(ctx => ctx.Done)`. The assertion cannot fail: if the flag were false the scenario would have
+timed out first. The real subject of that test, that posting a retry for a non-existent id does not
+break subsequent batches, is never asserted, and the response of the invalid POST is never
+inspected.
+
+**Detect:** a mechanical grep found 8 candidates of the shape `Assert.That(context.Flag, Is.True)`.
+One is confirmed tautological; the rest need reading individually, because a flag set by a message
+handler and gated on something else is legitimate.
+
+### 4. Assertions coupled to one persister's internals (portability)
+
+Tests that assert RavenDB implementation details rather than the contract both persisters offer. The
+multi-attempt tests asserted Raven's ten-attempt trimming and its full attempt history, neither of
+which EF provides by design. These read as EF gaps when they are really over-specified tests, and
+they are the main reason the EF exclusion list looks longer than the real feature gap.
+
+**Detect:** the `<Compile Remove>` blocks in the two EF acceptance csprojs are the existing
+inventory. Each entry is either a real gap, a settled design difference, or an over-specified test,
+and the comments do not currently distinguish them.
+
+### 5. Setup computed but never asserted (rot)
+
+Fixtures, headers and constants that exist to support an assertion that was removed or never
+written: a `Counter` header recorded into a dictionary nothing reads, a
+`MaximalNumberOfStoredFailedAttempts` constant, a list of failure times trimmed to a window that is
+then discarded. Harmless on its own, but it makes tests read as though they cover more than they do,
+which is how the first two patterns survive review.
+
+**Detect:** per-file reading. Context properties with a setter and no read outside the scenario are
+the strongest signal.
+
+## The routes that need tests
+
+40 of the 85 routes are called by no acceptance test in any suite. This is the whole list, confirmed
+route by route against the two approved route lists and the test sources, and it is the work rather
+than a sample of it. Ticking every box here is what closes phase 4.
+
+The groups are sized to be one PR each and ordered by what breaks in ServicePulse if the route
+regresses. Each entry names the ServicePulse consumer where there is one, because that is what the
+test should assert: the contract the UI relies on, not a 200.
+
+### Nav-gating routes
+
+If one of these regresses, ServicePulse loses a whole section of its navigation and nothing in the
+suite notices.
+
+- [ ] `GET /api/heartbeats/stats`: gates the Heartbeats nav item (`viewHeartbeats`)
+- [ ] `GET /api/messages2`: gates the audit messages nav item (`viewAuditMessages`)
+- [ ] `GET /api/license`: gates the Licence nav item (`viewLicense`)
+
+`GET /api/licensing/report/available` gates the Throughput nav item and belongs to this tier too,
+but it is written with the rest of the licensing block below. `GET /api/connection` gates the
+Connections nav item and is covered in MultiInstance only, so it is a home decision rather than a
+new test.
+
+### Licensing and throughput
+
+All eight `api/licensing` routes, one PR. The largest single win: the throughput *domain logic*
+beneath them is the best-unit-tested area in the codebase, with a dedicated
+`Particular.LicensingComponent.UnitTests` project carrying report generation, masking, date handling
+and summary indicator tests plus approval files. None of it touches `LicensingController`, so the
+HTTP surface, its serialisation and its authorisation are untested end to end. Check first whether
+the acceptance test host even starts the licensing component, as that decides whether this is a new
+test file or a new test project.
+
+- [ ] `GET /api/licensing/report/available`: gates the Throughput nav item (`viewThroughput`)
+- [ ] `POST /api/licensing/settings/masks/update`: `manageThroughput`
+- [ ] `GET /api/licensing/settings/masks`: throughput masking settings
+- [ ] `GET /api/licensing/settings/test`: connection test on the throughput settings page
+- [ ] `GET /api/licensing/settings/info`: throughput settings summary
+- [ ] `GET /api/licensing/report/file`: downloads the throughput report
+- [ ] `GET /api/licensing/endpoints`: endpoint throughput list
+- [ ] `POST /api/licensing/endpoints/update`: saves per-endpoint user indicators
+
+### Notifications
+
+- [ ] `GET /api/notifications/email`: `viewNotifications`
+- [ ] `POST /api/notifications/email`: `manageNotifications`
+- [ ] `POST /api/notifications/email/test`: `testNotifications`
+- [ ] `POST /api/notifications/email/toggle`: the enable/disable switch
+
+### Actions ServicePulse offers on messages and groups
+
+- [ ] `PATCH/POST /api/errors/archive`: `deleteMessage`, the batch delete. `PATCH /api/errors/{id}/archive` is well covered, so the single-message route passing has been standing in for a batch route no test calls
+- [ ] `POST /api/recoverability/groups/{id}/errors/unarchive`: `restoreGroup`
+- [ ] `DELETE /api/customchecks/{id}`: `dismissCustomCheck`. Same shape as heartbeats: `GET /api/customchecks` is covered and the dismiss route beside it is not
+- [ ] `DELETE /api/recoverability/unacknowledgedgroups/{id}`: dismissing completed group operations
+
+### Endpoint settings
+
+- [ ] `PATCH /api/endpointssettings/{name}`: `manageEndpointSettings`
+- [ ] `GET /api/endpointssettings`: the settings list the PATCH edits
+
+### Failed message and group queries
+
+- [ ] `GET /api/errors/summary`: failed-message summary counts
+- [ ] `GET /api/recoverability/history`: retry history panel
+- [ ] `POST /api/recoverability/groups/{id}/comment`: group comments
+- [ ] `DELETE /api/recoverability/groups/{id}/comment`: group comments
+- [ ] `GET /api/recoverability/groups/id/{groupId}`: single group. The archive twin, `GET /api/archive/groups/id/{groupId}`, is covered
+- [ ] `HEAD /api/recoverability/groups/{id}/errors`: the count behind group paging
+- [ ] `GET /api/endpoints/{name}/errors`: failed messages filtered to one endpoint
+- [ ] `HEAD /api/errors`: the count behind failed-message paging
+
+### Retry and resolve routes
+
+- [ ] `POST /api/errors/queues/{queueAddress}/retry`: retry everything for a queue
+- [ ] `PATCH /api/pendingretries/queues/resolve`: resolve pending retries by queue
+- [ ] `PATCH /api/errors/{from}...{to}/unarchive`: unarchive by date range
+
+### Audit-backed message queries
+
+These need an audit instance, so decide whether MultiInstance is the right home before adding them
+to the primary suite.
+
+- [ ] `GET /api/messages/search`: the `?q=` form. The `/search/{keyword}` form is covered
+- [ ] `GET /api/endpoints/{endpoint}/messages/search`: the same, scoped to an endpoint
+- [ ] `GET /api/endpoints/{endpoint}/audit-count`: audit counts per endpoint
+
+### Configuration surface
+
+- [ ] `GET /api/configuration`: only `/api/configuration/remotes` is covered today
+- [ ] `GET /api/instance-info`: same action as `/api/configuration`, separate route
+- [ ] `GET /api/edit/config`: the edit-and-retry feature flag ServicePulse reads before offering edit
+- [ ] `GET /api/license/details`
+- [ ] `POST /api/license/detailsUpload`
+
+### Covered only in MultiInstance
+
+Not gaps, but not in the primary suite either. Decide deliberately whether MultiInstance is the
+right home before duplicating any of them.
+
+- [ ] `GET /api/connection`: gates the Connections nav item (`viewConnections`)
+- [ ] `GET /api/endpoints/known`: known endpoints list, covered by `When_endpoint_known_to_audit_instance`
+- [ ] `GET /api/conversations/{id}`: sequence diagram
+- [ ] `GET /api/sagas/{id}`: saga diagram
+- [ ] `GET /api/endpoints/{endpoint}/messages`
+- [ ] `GET /api/endpoints/{endpoint}/messages/search/{keyword}`
+
+Worth being precise about the heartbeats entry, because several others are the same shape. Heartbeat
+*ingestion* is well covered: six tests drive endpoints starting up, going quiet, and being marked
+monitored. What no test calls is `/api/heartbeats/stats`, the endpoint ServicePulse's heartbeats page
+actually reads. The plumbing is tested; the contract on top of it is not.
+
+## The work
+
+### Phase 1: confirm the gap list properly (done)
+
+The original table was grep-based, and a route reached through a helper, a constant or an
+interpolated base path would have been missed. The list above replaces it, built from both approved
+route lists rather than from greps and checked route by route against the primary and MultiInstance
+sources. Reading only the ServiceControl route list is what hid the licensing routes in the first
+place, so both were read.
+
+Two details mattered while confirming it. The approved lists carry the action-level template only,
+so they hold two rows both reading `GET /configuration`, one on `RootController` under `api` and one
+on `AuthenticationController` under `api/authentication`; the controller-level `[Route]` has to be
+folded in or the two merge. And the verb has to be tracked separately from the path, because
+ServicePulse gates `GET` and `POST` on `/api/notifications/email` as two different capabilities.
+
+Six entries changed as a result. `GET /api/endpoints/known` is not a gap: MultiInstance covers it.
+The other five were gaps the grep missed, and four of them gate a ServicePulse capability:
+`GET /api/license` and `GET /api/connection` gate nav items, and `DELETE /api/customchecks/{id}`,
+`PATCH/POST /api/errors/archive` and `POST /api/recoverability/groups/{id}/errors/unarchive` are
+actions the UI offers.
+
+No tooling came out of this phase, deliberately. A test that scans the suite's source to police its
+own coverage is a second thing to maintain and gets stale in its own way; the list above is the
+artefact, and new routes are a review-time concern.
+
+### Phase 2: make the silent-registration class impossible
+
+The highest-value item and the smallest. The failure mode is a test double that is registered but
+never resolved, and it is invisible in review, in CI, and in the test output. It should be caught by
+the harness, not by someone happening to read the file.
+
+- One PR: a convention test asserting every test-registered double is reachable through the
+  abstraction its collaborator injects.
+- Same PR: audit the other `CustomizeHostBuilder` registrations across the suite for the same
+  mistake.
+
+### Phase 3: sweep the 71 files, one area per PR
+
+Read for the five patterns above, area by area, so each PR stays reviewable and the diff maps to one
+owner's mental model. Fix what is cheap to fix in the same PR; raise anything that changes what a
+test means as its own change with the reasoning written down.
+
+- `Recoverability/MessageFailures`, 22 files, the densest area and the one the EF work touches most.
+- `Recoverability/*` root, `Groups`, `MessageRedirects`: the retry, group and redirect flows.
+- `Monitoring/*` and `EventLogs`: heartbeats, custom checks, endpoint monitoring.
+- `Recoverability/ExternalIntegration` and `Monitoring/ExternalIntegration`: hold until the EF
+  external-integration work lands, then review against both persisters at once.
+
+### Phase 4: work through the route list
+
+Straight down the list in "The routes that need tests", one PR per group, in the order the groups
+are given. The phase is done when every box is ticked.
+
+Each test asserts the contract its consumer relies on rather than just a 200: the shape ServicePulse
+reads, the status it branches on, the effect the action has on the next request. A test that only
+proves the route is routable would leave the same gap in a different form.
+
+## What this plan does not do
+
+It does not keep the route list current by machine. The list is a snapshot taken during phase 1, and
+a route added after that will not appear in it on its own. Catching those is a review-time concern:
+a new controller action arrives with the PR that adds it, which is where the test for it belongs.
+
+It does not review the `Security/*` tests, the audit instance, or the monitoring instance.
+
+It does not treat persister parity as a workstream in its own right. It appears only as one defect
+pattern, on the grounds that most of the current EF exclusions are over-specified tests rather than
+missing features, which is itself a claim worth confirming during phase 3.

--- a/docs/acceptance-test-review-plan.md
+++ b/docs/acceptance-test-review-plan.md
@@ -238,16 +238,32 @@ No tooling came out of this phase, deliberately. A test that scans the suite's s
 own coverage is a second thing to maintain and gets stale in its own way; the list above is the
 artefact, and new routes are a review-time concern.
 
-### Phase 2: make the silent-registration class impossible
+### Phase 2: the silent-registration class (done)
 
-The highest-value item and the smallest. The failure mode is a test double that is registered but
-never resolved, and it is invisible in review, in CI, and in the test output. It should be caught by
-the harness, not by someone happening to read the file.
+The whole suite registers services from a test in seven places, so the audit was exhaustive rather
+than a sample. Five were correct. Two were the known `IEnrichImportedErrorMessages` cases, already
+fixed. One was new:
 
-- One PR: a convention test asserting every test-registered double is reachable through the
-  abstraction its collaborator injects.
-- Same PR: audit the other `CustomizeHostBuilder` registrations across the suite for the same
-  mistake.
+`When_a_critical_error_is_triggered` registered `CriticalErrorCustomCheck` as its own concrete type,
+with a comment saying it overrode the production registration to shorten the check interval. It did
+not. The check is registered with `TryAddEnumerable` against `ICustomCheck` and consumed through
+`GetServices<ICustomCheck>()`, so the test's registration was never resolved and the check ran on
+its 60-second production interval. The test passed either way, about a minute slower than intended.
+It now removes the production registration explicitly and re-adds the check against `ICustomCheck`,
+and runs in six seconds.
+
+One registration is worth knowing about even though it is correct. `When_a_retry_fails_to_be_sent`
+substitutes a `FakeReturnToSender` by re-registering `ReturnToSender`, which works only because
+`CustomizeHostBuilder` runs after all production registration and `ReturnToSenderDequeuer` resolves
+a single instance rather than a collection. That is a real distinction, not a detail: the same move
+against a collection adds a second implementation and leaves the production one running.
+
+No harness check came out of this phase. The underlying fault is a test written so that it could
+pass without its own setup taking effect, and a convention test policing registrations would catch
+one shape of that while leaving the rest. The practice is written down instead, in
+[Writing acceptance tests](writing-acceptance-tests.md), which covers registering against the
+injected abstraction, replacing a production registration so that it fails loudly if production
+moves, and asserting on evidence the double actually ran.
 
 ### Phase 3: sweep the 71 files, one area per PR
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,6 +33,8 @@ Transport tests are done by executing the transport test suite for each transpor
 
 Run ServiceControl full version and use the HTTP API to validate results. LearningTransport is used for all tests.
 
+For how to write one that fails when it should, see [Writing acceptance tests](writing-acceptance-tests.md).
+
 ### Windows prerequisite: register the event sources
 
 On Windows, every acceptance test fails on first run with:

--- a/docs/writing-acceptance-tests.md
+++ b/docs/writing-acceptance-tests.md
@@ -1,0 +1,122 @@
+# Writing acceptance tests
+
+## What these tests are for
+
+An acceptance test starts a full ServiceControl instance and drives it over the HTTP API, exactly as ServicePulse does. See [Testing](testing.md) for the suites and how to run them.
+
+This is what makes them different from the other suites. Component logic belongs in unit tests, and storage belongs in persistence tests. Both of those are faster and easier to debug. An acceptance test is worth its cost when it proves something a user can see: that a journey through ServicePulse still works, against a real instance and a real persister.
+
+So the question to start from is not "which endpoint am I testing" but "what is someone trying to do".
+
+### The transport is always LearningTransport
+
+Every acceptance test runs on LearningTransport, a file system transport with no broker behind it. A feature that asks the transport for something therefore takes a different branch here than it does in production. Throughput collection is the clearest case: RabbitMQ, Azure Service Bus, SQS, SQL Server and PostgreSQL each register an `IBrokerThroughputQuery`, while Learning and MSMQ do not, so code that reads throughput sees no broker unless the test provides one.
+
+So before writing a scenario, check whether the feature asks the transport for anything. If it does, choose which branch the test covers, register a fake if you want the other one, and put the branch in the test name rather than in a comment. A name such as `When_creating_a_usage_report_on_a_non_broker_transport` is visible in the test run and in the failure, where a comment is not, and it leaves room for the other branch beside it.
+
+## Start from the journey
+
+Write the test as the journey, and let it call every route the journey needs. "Create a usage report to send to Particular" is one test covering eight `api/licensing` routes, instead of eight tests covering one route each.
+
+There are two reasons for this. A test per route can show that each route answers. Only a journey can show that the id one call returns is accepted by the next call, and that is where the failures users notice come from. A journey is also cheaper to run, because starting ServiceControl takes most of the time. One scenario across eight routes costs about an eighth of eight tests across one route each.
+
+Drive it with the `Sequence` helper, with one `Do("step", …)` per thing the user does:
+
+```csharp
+await Define<Context>()
+    .WithEndpoint<MonitoringInstance>()
+    .Do("Wait for the throughput data to be recorded", async _ => …)
+    .Do("Correct the queue that is not an NServiceBus endpoint", async _ => …)
+    .Do("Redact the customer name in the queue names", async _ => …)
+    .Do("Download the report", async _ => …)
+    .Done(_ => true)
+    .Run();
+```
+
+Each step logs `Advancing from X to Y`. If the scenario stops making progress, the log names the step it stopped on, instead of the test failing with a timeout that tells you nothing. `When_creating_a_usage_report_on_a_non_broker_transport` is the worked example, and its name is doing the job described above: it says which branch it covers, so the broker one can sit beside it without either being mistaken for the other.
+
+Not everything is a journey. Edge cases, such as posting a retry for an id that does not exist, are separate focused tests next to the scenario, not extra steps inside it.
+
+## Arrange the data the way it really arrives
+
+Feed the system the way production does, rather than writing to the data store directly. The usage report scenario sends the same throughput message that a monitoring instance sends. The test therefore goes through the queue, the hosted service and the persistence before it asserts anything. Writing to the store directly would have skipped all three, and the test would still have passed.
+
+## Assert what the caller depends on
+
+A 200 and a non-empty body only show that the route is there, which is rarely the part that breaks. Assert what the caller needs: the shape ServicePulse reads, the status code it branches on, the effect the action has on the next request.
+
+The report scenario asserts that a name the user redacted does not appear in the downloaded file, and that a queue they marked as "not an endpoint" is still marked that way in the report. A user would be harmed if either broke, and a status code shows neither.
+
+## Expect the domain to have rules
+
+When a scenario hangs, it is often the system telling you a rule you did not know about. The report scenario first recorded throughput for today, and then waited until the 90 second timeout. The reason is that a usage report counts only complete days, and ignores a partial one on purpose.
+
+So when a step will not go green, read the code it is waiting on before you add longer timeouts or retries. Once you find the rule, write it in the test as a comment, because the next person will assume what you assumed.
+
+## Caveats
+
+One idea connects all of these: **a test must fail if the thing it sets up does not take effect.** Below are the ways that has gone wrong in this suite. Two of them went unnoticed for years.
+
+### The double that is registered but never used
+
+Register a double as the service type its collaborator asks for, never as its own concrete type.
+
+```csharp
+// Wrong: nothing resolves CounterEnricher, so the double never runs and the test still passes.
+builder.Services.AddSingleton<CounterEnricher>();
+
+// Right: the import pipeline injects IEnumerable<IEnrichImportedErrorMessages>.
+builder.Services.AddSingleton<IEnrichImportedErrorMessages, CounterEnricher>();
+```
+
+First check how the collaborator asks for its dependency, because the two shapes behave differently when a test adds to them:
+
+- **One instance**, such as `ReturnToSenderDequeuer` asking for a `ReturnToSender`. `CustomizeHostBuilder` runs after all production registration, so registering the same service type again replaces it with the double.
+- **A collection**, such as `IEnumerable<IEnrichImportedErrorMessages>` or `GetServices<ICustomCheck>()`. A later registration is *added to* the collection. The production implementation is still there, and still runs.
+
+### The registration that only says it replaces another
+
+In the collection case, find the production registration and remove it, instead of adding a second one. A comment saying that a registration replaces another one does not make it true:
+
+```csharp
+// Consumed through GetServices<ICustomCheck>(), so the shorter test interval only takes
+// effect if the production registration is replaced rather than added alongside it.
+var productionRegistration = builder.Services.Single(registration =>
+    registration.ServiceType == typeof(ICustomCheck) &&
+    registration.ImplementationType == typeof(CriticalErrorCustomCheck));
+
+builder.Services.Remove(productionRegistration);
+builder.Services.AddSingleton<ICustomCheck>(_ => new CriticalErrorCustomCheck(TimeSpan.FromSeconds(1)));
+```
+
+The `Single` call matters. If the production registration moves or changes, the test fails straight away and says so. Without it, the test would quietly go back to testing the production configuration.
+
+### The assertion that could not have failed
+
+```csharp
+await Define<Context>().Done(ctx => ctx.Done).Run();
+
+Assert.That(context.Done, Is.True); // The runner already waited for this. A false flag times out instead.
+```
+
+Assert the thing the test is named for. It is fine for a message handler to set a flag while the scenario waits for something else. Ask whether the assertion could fail while the scenario still finished.
+
+### The double whose effect is never checked
+
+Registering the double correctly is only half the job. If the assertion would also pass with the double absent, the test does not cover the double at all. Assert something only the double can produce: the counter it incremented, the failure it injected, the message it swallowed.
+
+### The assertion that only one persister can satisfy
+
+The suite runs against every persister. An assertion about how RavenDB happens to store or trim something says nothing about ServiceControl's behaviour. It also ends up on another persister's exclusion list, where it looks like a missing feature instead of a test that asks for too much. Assert what every persister has to do to be correct.
+
+### The setup that nothing reads
+
+Headers put into a dictionary nothing reads, constants nothing compares against, fixtures left behind after an assertion was deleted. Each one is harmless by itself. Together they make a test look like it covers more than it does, which is how everything above gets through review.
+
+## Before you open the PR
+
+**Make it fail on purpose.** Break the thing the test protects, run it, and read the message. If it still passes, or if it fails with something another person cannot act on, the test is not finished yet. This one run checks every caveat listed above.
+
+**Run it on a second persister.** A test that passes on Raven and is never run on SqlServer or PostgreSQL will be excluded later by someone who knows less about it than you do now.
+
+**Cover a new route in the PR that adds it.** Nothing in the suite notices an uncovered route.

--- a/src/ServiceControl.AcceptanceTests.RavenDB/AcceptanceTestStorageConfiguration.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/AcceptanceTestStorageConfiguration.cs
@@ -23,7 +23,8 @@ public class AcceptanceTestStorageConfiguration : IAcceptanceTestStorageConfigur
         {
             ErrorRetentionPeriod = TimeSpan.FromDays(10),
             ConnectionString = databaseInstance.ServerUrl,
-            DatabaseName = databaseName
+            DatabaseName = databaseName,
+            ThroughputDatabaseName = $"{databaseName}-throughput"
         };
     }
 
@@ -35,6 +36,7 @@ public class AcceptanceTestStorageConfiguration : IAcceptanceTestStorageConfigur
         }
         using var _ = await UseDatabaseLifecycleLock(cancellationToken);
         await databaseInstance.DeleteDatabase(databaseName, cancellationToken);
+        await databaseInstance.DeleteDatabase($"{databaseName}-throughput", cancellationToken);
     }
 
     /// <summary>

--- a/src/ServiceControl.AcceptanceTests/Licensing/FakeBrokerThroughputQuery.cs
+++ b/src/ServiceControl.AcceptanceTests/Licensing/FakeBrokerThroughputQuery.cs
@@ -1,0 +1,75 @@
+namespace ServiceControl.AcceptanceTests.Licensing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using ServiceControl.Transports.BrokerThroughput;
+
+    class FakeBrokerThroughputQuery(params (string QueueName, long Throughput)[] queues) : IBrokerThroughputQuery
+    {
+        public Dictionary<string, string> Data { get; } = new() { ["Version"] = "1.2.3" };
+
+        public string MessageTransport => "FakeBroker";
+
+        public string ScopeType => null;
+
+        public KeyDescriptionPair[] Settings => [new KeyDescriptionPair(SettingKey, "Where the fake broker lives")];
+
+        public void Initialize(ReadOnlyDictionary<string, string> settings) { }
+
+        public bool HasInitialisationErrors(out string errorMessage)
+        {
+            errorMessage = string.Empty;
+            return false;
+        }
+
+        public Task<(bool Success, List<string> Errors, string Diagnostics)> TestConnection(CancellationToken cancellationToken = default) =>
+            Task.FromResult((true, new List<string>(), "Fake broker reachable"));
+
+        public async IAsyncEnumerable<IBrokerQueue> GetQueueNames([EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var (queueName, _) in queues)
+            {
+                yield return new FakeBrokerQueue(queueName, SanitizeEndpointName(queueName));
+            }
+
+            await Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<QueueThroughput> GetThroughputPerDay(IBrokerQueue brokerQueue, DateOnly startDate, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var (_, throughput) in queues.Where(queue => queue.QueueName == brokerQueue.QueueName))
+            {
+                // Yesterday, because a usage report only counts complete days.
+                yield return new QueueThroughput
+                {
+                    DateUTC = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)),
+                    TotalThroughput = throughput
+                };
+            }
+
+            await Task.CompletedTask;
+        }
+
+        public string SanitizeEndpointName(string endpointName) => endpointName.Replace('/', '.');
+
+        public string SanitizedEndpointNameCleanser(string endpointName) => endpointName;
+
+        public const string SettingKey = "FakeBroker/ConnectionString";
+
+        class FakeBrokerQueue(string queueName, string sanitizedName) : IBrokerQueue
+        {
+            public string QueueName { get; } = queueName;
+
+            public string SanitizedName { get; } = sanitizedName;
+
+            public string Scope => null;
+
+            public List<string> EndpointIndicators { get; } = [];
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_broker_transport.cs
+++ b/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_broker_transport.cs
@@ -1,0 +1,193 @@
+namespace ServiceControl.AcceptanceTests.Licensing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.EndpointTemplates;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Routing;
+    using NServiceBus.Transport;
+    using NUnit.Framework;
+    using Particular.LicensingComponent.BrokerThroughput;
+    using Particular.LicensingComponent.Contracts;
+    using Particular.LicensingComponent.MonitoringThroughput;
+    using Particular.LicensingComponent.Persistence;
+    using Particular.LicensingComponent.Shared;
+    using ServiceControl.Transports.BrokerThroughput;
+
+    // The same journey as When_creating_a_usage_report_on_a_non_broker_transport, on the branch every
+    // production install except MSMQ takes. 
+    class When_creating_a_usage_report_on_a_broker_transport : AcceptanceTest
+    {
+        [Test]
+        public async Task Should_report_what_the_broker_measured()
+        {
+            ReportGenerationState reportState = null;
+            ThroughputConnectionSettings connectionSettings = null;
+            ConnectionTestResults connectionTest = null;
+            List<EndpointThroughputSummary> endpoints = null;
+            JsonDocument report = null;
+
+            // AddLicensingComponent only starts the broker collector when a query is already
+            // registered, and it decides that while AddServiceControl runs.
+            CustomizeHostBuilderBeforeServiceControl = builder =>
+                builder.Services.AddSingleton<IBrokerThroughputQuery>(
+                    new FakeBrokerThroughputQuery((SalesQueue, BrokerThroughput)));
+
+            CustomizeHostBuilder = CollectFromTheBrokerImmediately;
+
+            await Define<Context>()
+                .WithEndpoint<MonitoringInstance>()
+                .Do("Wait for the broker throughput to be collected", async _ =>
+                {
+                    var available = await this.TryGet<ReportGenerationState>(
+                        "/api/licensing/report/available", state => state.ReportCanBeGenerated);
+
+                    reportState = available.Item;
+
+                    return available.HasResult;
+                })
+                .Do("Review where the numbers come from", async _ =>
+                {
+                    connectionSettings = await this.TryGet<ThroughputConnectionSettings>("/api/licensing/settings/info");
+                    connectionTest = await this.TryGet<ConnectionTestResults>("/api/licensing/settings/test");
+                })
+                .Do("List the endpoints reporting throughput", async _ =>
+                {
+                    // Monitoring reports the same endpoint the broker measured, so wait for both
+                    // before reading the list, otherwise the grouping below proves nothing.
+                    var summary = await this.TryGet<List<EndpointThroughputSummary>>(
+                        "/api/licensing/endpoints",
+                        items => items.Any(item => item.MaxDailyThroughput == BrokerThroughput));
+
+                    endpoints = summary.Item;
+
+                    return summary.HasResult;
+                })
+                .Do("Download the report", async _ =>
+                {
+                    var archive = await this.DownloadData("/api/licensing/report/file?spVersion=1.2.3");
+
+                    report = ReadReport(archive);
+                })
+                .Done(_ => true)
+                .Run();
+
+            var reportData = report.RootElement.GetProperty("ReportData");
+            var queues = reportData.GetProperty("Queues").EnumerateArray().ToArray();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(reportState.ReportCanBeGenerated, Is.True, reportState.Reason);
+
+                Assert.That(connectionTest.BrokerConnectionResult.ConnectionSuccessful, Is.True,
+                    $"The broker connection is only tested when a broker is configured: {connectionTest.BrokerConnectionResult.Diagnostics}");
+
+                Assert.That(connectionSettings.BrokerSettings.Select(setting => setting.Name),
+                    Has.Some.Contains(FakeBrokerThroughputQuery.SettingKey),
+                    "The settings page lists the broker's own settings so the user can fill them in");
+
+                Assert.That(reportData.GetProperty("ReportMethod").GetString(), Is.EqualTo("Broker"),
+                    "Particular reads the report method to know how the numbers were measured");
+
+                // The broker calls the queue Contoso/Sales and monitoring calls the endpoint the same
+                // thing, but the two only line up once the broker's sanitized name is applied to both.
+                // Without that they are two endpoints, and the customer's report counts them twice.
+                Assert.That(endpoints, Has.Exactly(1).Items,
+                    "The broker queue and the monitored endpoint are one endpoint, not two");
+
+                Assert.That(queues, Has.Length.EqualTo(1),
+                    "The report counts the endpoint once, not once per source");
+
+                var sales = queues.Single();
+
+                Assert.That(sales.GetProperty("QueueName").GetString(), Is.EqualTo(SalesQueue),
+                    "The report shows the name the user knows, not the sanitized one");
+
+                Assert.That(sales.GetProperty("DailyThroughputFromBroker").GetArrayLength(), Is.EqualTo(1),
+                    "Throughput measured at the broker has to be reported as coming from the broker");
+
+                Assert.That(sales.GetProperty("DailyThroughputFromMonitoring").GetArrayLength(), Is.EqualTo(1),
+                    "Throughput seen by monitoring has to be reported separately from the broker's");
+
+                Assert.That(sales.GetProperty("Throughput").GetInt64(), Is.EqualTo(BrokerThroughput),
+                    "The reported figure is the highest daily total across the sources");
+            }
+        }
+
+        // The collector waits 40 seconds before its first pass, which is longer than this scenario
+        // should take, and the delay is only reachable through the registration.
+        static void CollectFromTheBrokerImmediately(IHostApplicationBuilder builder)
+        {
+            var scheduled = builder.Services.Single(registration =>
+                registration.ServiceType == typeof(IHostedService) &&
+                registration.ImplementationType == typeof(BrokerThroughputCollectorHostedService));
+
+            builder.Services.Remove(scheduled);
+            builder.Services.AddHostedService(provider => new BrokerThroughputCollectorHostedService(
+                provider.GetRequiredService<ILogger<BrokerThroughputCollectorHostedService>>(),
+                provider.GetRequiredService<IBrokerThroughputQuery>(),
+                provider.GetRequiredService<ThroughputSettings>(),
+                provider.GetRequiredService<ILicensingDataStore>(),
+                provider.GetRequiredService<TimeProvider>())
+            {
+                DelayStart = TimeSpan.Zero
+            });
+        }
+
+        static JsonDocument ReadReport(byte[] archive)
+        {
+            using var zip = new ZipArchive(new MemoryStream(archive), ZipArchiveMode.Read);
+            using var entry = zip.Entries.Single().Open();
+
+            return JsonDocument.Parse(entry);
+        }
+
+        const string SalesQueue = "Contoso/Sales";
+        const long BrokerThroughput = 42;
+        const long MonitoringThroughput = 17;
+
+        class Context : ScenarioContext, ISequenceContext
+        {
+            public int Step { get; set; }
+        }
+
+        // Reports the same endpoint the broker measured, under the name monitoring knows it by.
+        class MonitoringInstance : EndpointConfigurationBuilder
+        {
+            public MonitoringInstance() =>
+                EndpointSetup<DefaultServerWithoutAudit>(c => c.EnableFeature<ReportThroughput>());
+
+            class ReportThroughput : DispatchRawMessages<Context>
+            {
+                protected override TransportOperations CreateMessage(Context context)
+                {
+                    var recorded = new RecordEndpointThroughputData
+                    {
+                        StartDateTime = DateTime.UtcNow.AddDays(-1).AddHours(-1),
+                        EndDateTime = DateTime.UtcNow.AddDays(-1),
+                        EndpointThroughputData =
+                        [
+                            new EndpointThroughputData { Name = SalesQueue, Throughput = MonitoringThroughput }
+                        ]
+                    };
+
+                    var body = JsonSerializer.SerializeToUtf8Bytes(recorded);
+                    var message = new OutgoingMessage(Guid.NewGuid().ToString(), [], body);
+
+                    return new TransportOperations(
+                        new TransportOperation(message, new UnicastAddressTag(ServiceControlSettings.ServiceControlThroughputDataQueue)));
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_non_broker_transport.cs
+++ b/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_non_broker_transport.cs
@@ -1,0 +1,171 @@
+namespace ServiceControl.AcceptanceTests.Licensing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.EndpointTemplates;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Routing;
+    using NServiceBus.Transport;
+    using NUnit.Framework;
+    using Particular.LicensingComponent.Contracts;
+    using Particular.LicensingComponent.MonitoringThroughput;
+    using Particular.LicensingComponent.Shared;
+
+    // The journey ServicePulse's throughput page walks a user through: see whether a report is
+    // possible, review where the numbers come from, correct what counts as an endpoint, redact the
+    // names that cannot leave the building, and download the report to send to Particular.
+    class When_creating_a_usage_report_on_a_non_broker_transport : AcceptanceTest
+    {
+        [Test]
+        public async Task Should_report_the_corrected_and_redacted_throughput()
+        {
+            ReportGenerationState reportState = null;
+            ThroughputConnectionSettings connectionSettings = null;
+            ConnectionTestResults connectionTest = null;
+            List<EndpointThroughputSummary> endpoints = null;
+            List<string> masks = null;
+            JsonDocument report = null;
+
+            await Define<Context>()
+                .WithEndpoint<MonitoringInstance>()
+                .Do("Wait for the throughput data to be recorded", async _ =>
+                {
+                    var available = await this.TryGet<ReportGenerationState>(
+                        "/api/licensing/report/available", state => state.ReportCanBeGenerated);
+
+                    reportState = available.Item;
+
+                    return available.HasResult;
+                })
+                .Do("Review where the numbers come from", async _ =>
+                {
+                    connectionSettings = await this.TryGet<ThroughputConnectionSettings>("/api/licensing/settings/info");
+                    connectionTest = await this.TryGet<ConnectionTestResults>("/api/licensing/settings/test");
+                })
+                .Do("List the endpoints reporting throughput", async _ =>
+                {
+                    var summary = await this.TryGet<List<EndpointThroughputSummary>>(
+                        "/api/licensing/endpoints",
+                        items => items.Any(item => item.Name == SalesEndpoint) && items.Any(item => item.Name == NotAnEndpoint));
+
+                    endpoints = summary.Item;
+
+                    return summary.HasResult;
+                })
+                .Do("Correct the queue that is not an NServiceBus endpoint", async _ =>
+                    await this.Post("/api/licensing/endpoints/update", new[]
+                    {
+                        new UpdateUserIndicator
+                        {
+                            Name = NotAnEndpoint,
+                            UserIndicator = nameof(UserIndicator.NotNServiceBusEndpoint)
+                        }
+                    }))
+                .Do("Redact the customer name in the queue names", async _ =>
+                {
+                    await this.Post("/api/licensing/settings/masks/update", new[] { RedactedCustomer });
+
+                    masks = await this.TryGet<List<string>>("/api/licensing/settings/masks", items => items.Contains(RedactedCustomer));
+
+                    return masks != null;
+                })
+                .Do("Download the report", async _ =>
+                {
+                    var archive = await this.DownloadData("/api/licensing/report/file?spVersion=1.2.3");
+
+                    report = ReadReport(archive);
+                })
+                .Done(_ => true)
+                .Run();
+
+            var queues = report.RootElement.GetProperty("ReportData").GetProperty("Queues").EnumerateArray().ToArray();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(reportState.ReportCanBeGenerated, Is.True, reportState.Reason);
+                Assert.That(reportState.Transport, Is.Not.Empty, "ServicePulse shows the transport on the throughput page");
+
+                Assert.That(connectionSettings, Is.Not.Null, "The settings page reads its content from settings/info");
+                Assert.That(connectionTest.MonitoringConnectionResult.ConnectionSuccessful, Is.True,
+                    $"Throughput arrived from monitoring, so the connection test should pass: {connectionTest.MonitoringConnectionResult.Diagnostics}");
+
+                Assert.That(endpoints.Single(endpoint => endpoint.Name == SalesEndpoint).MaxDailyThroughput, Is.EqualTo(SalesThroughput),
+                    "The endpoint list shows the throughput that was reported for the endpoint");
+
+                Assert.That(masks, Does.Contain(RedactedCustomer));
+
+                Assert.That(queues.Select(NameOf), Has.None.Contains(RedactedCustomer),
+                    "A redacted name must not reach the report that is sent to Particular");
+
+                Assert.That(queues.Select(NameOf).Any(name => name.Contains("Sales")), Is.True,
+                    "Only the redacted part of the name is masked, the rest is still identifiable");
+
+                Assert.That(UserIndicatorOf(queues.Single(queue => NameOf(queue).Contains("Website"))),
+                    Is.EqualTo(nameof(UserIndicator.NotNServiceBusEndpoint)),
+                    "The correction the user made in ServicePulse must survive into the report");
+            }
+        }
+
+        static string NameOf(JsonElement queue) => queue.GetProperty("QueueName").GetString();
+
+        static string UserIndicatorOf(JsonElement queue) => queue.GetProperty("UserIndicator").GetString();
+
+        static JsonDocument ReadReport(byte[] archive)
+        {
+            using var zip = new ZipArchive(new MemoryStream(archive), ZipArchiveMode.Read);
+            using var entry = zip.Entries.Single().Open();
+
+            return JsonDocument.Parse(entry);
+        }
+
+        const string RedactedCustomer = "Contoso";
+        const string SalesEndpoint = "Contoso.Sales";
+        const string NotAnEndpoint = "Contoso.Website.Inbox";
+        const long SalesThroughput = 42;
+
+        class Context : ScenarioContext, ISequenceContext
+        {
+            public int Step { get; set; }
+        }
+
+        // Stands in for the monitoring instance, which reports what it saw to the primary instance's
+        // throughput queue.
+        class MonitoringInstance : EndpointConfigurationBuilder
+        {
+            public MonitoringInstance() =>
+                EndpointSetup<DefaultServerWithoutAudit>(c => c.EnableFeature<ReportThroughput>());
+
+            class ReportThroughput : DispatchRawMessages<Context>
+            {
+                protected override TransportOperations CreateMessage(Context context)
+                {
+                    // Yesterday: a report only counts complete days, so throughput recorded for today
+                    // is deliberately not enough to generate one.
+                    var recorded = new RecordEndpointThroughputData
+                    {
+                        StartDateTime = DateTime.UtcNow.AddDays(-1).AddHours(-1),
+                        EndDateTime = DateTime.UtcNow.AddDays(-1),
+                        EndpointThroughputData =
+                        [
+                            new EndpointThroughputData { Name = SalesEndpoint, Throughput = SalesThroughput },
+                            new EndpointThroughputData { Name = NotAnEndpoint, Throughput = 7 }
+                        ]
+                    };
+
+                    var body = JsonSerializer.SerializeToUtf8Bytes(recorded);
+                    var message = new OutgoingMessage(Guid.NewGuid().ToString(), [], body);
+
+                    return new TransportOperations(
+                        new TransportOperation(message, new UnicastAddressTag(ServiceControlSettings.ServiceControlThroughputDataQueue)));
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/Monitoring/InternalCustomChecks/When_a_critical_error_is_triggered.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/InternalCustomChecks/When_a_critical_error_is_triggered.cs
@@ -7,7 +7,9 @@
     using Contracts.CustomChecks;
     using EventLog;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
     using NServiceBus.AcceptanceTesting;
+    using NServiceBus.CustomChecks;
     using NUnit.Framework;
     using ServiceControl.Operations;
 
@@ -20,7 +22,13 @@
         {
             CustomizeHostBuilder = builder =>
             {
-                builder.Services.AddTransient(_ => new CriticalErrorCustomCheck(TimeSpan.FromSeconds(1))); // Overrides existing registration to have an increased test interval
+                // Replace the production registration of the critical error custom check with a test version that has a shorter interval to trigger the critical error faster.
+                var productionRegistration = builder.Services.Single(registration =>
+                    registration.ServiceType == typeof(ICustomCheck) &&
+                    registration.ImplementationType == typeof(CriticalErrorCustomCheck));
+
+                builder.Services.Remove(productionRegistration);
+                builder.Services.AddSingleton<ICustomCheck>(_ => new CriticalErrorCustomCheck(TimeSpan.FromSeconds(1)));
             };
 
             SetSettings = settings =>

--- a/src/ServiceControl.AcceptanceTests/TestSupport/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/AcceptanceTest.cs
@@ -32,6 +32,7 @@ namespace ServiceControl.AcceptanceTests
             SetSettings = _ => { };
             CustomConfiguration = _ => { };
             CustomizeHostBuilder = _ => { };
+            CustomizeHostBuilderBeforeServiceControl = _ => { };
 
             var logfilesPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "logs");
             Directory.CreateDirectory(logfilesPath);
@@ -53,7 +54,8 @@ namespace ServiceControl.AcceptanceTests
                 StorageConfiguration,
                 s => SetSettings(s),
                 s => CustomConfiguration(s),
-                hb => CustomizeHostBuilder(hb)
+                hb => CustomizeHostBuilder(hb),
+                hb => CustomizeHostBuilderBeforeServiceControl(hb)
                 );
         }
 
@@ -93,6 +95,14 @@ namespace ServiceControl.AcceptanceTests
         protected Action<EndpointConfiguration> CustomConfiguration = _ => { };
         protected Action<Settings> SetSettings = _ => { };
         protected Action<IHostApplicationBuilder> CustomizeHostBuilder = _ => { };
+
+        /// <summary>
+        /// Runs before AddServiceControl, for the few registrations ServiceControl's own registration
+        /// reacts to, such as a transport's IBrokerThroughputQuery. Prefer CustomizeHostBuilder for
+        /// everything else: registering last is what lets a test substitute a service.
+        /// </summary>
+        protected Action<IHostApplicationBuilder> CustomizeHostBuilderBeforeServiceControl = _ => { };
+
         protected ITransportIntegration TransportIntegration;
         protected IAcceptanceTestStorageConfiguration StorageConfiguration;
 

--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentBehavior.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentBehavior.cs
@@ -13,11 +13,12 @@ namespace ServiceControl.AcceptanceTests.TestSupport
 
     class ServiceControlComponentBehavior : IComponentBehavior, IAcceptanceTestInfrastructureProvider
     {
-        public ServiceControlComponentBehavior(ITransportIntegration transportToUse, IAcceptanceTestStorageConfiguration persistenceToUse, Action<Settings> setSettings, Action<EndpointConfiguration> customConfiguration, Action<IHostApplicationBuilder> hostBuilderCustomization)
+        public ServiceControlComponentBehavior(ITransportIntegration transportToUse, IAcceptanceTestStorageConfiguration persistenceToUse, Action<Settings> setSettings, Action<EndpointConfiguration> customConfiguration, Action<IHostApplicationBuilder> hostBuilderCustomization, Action<IHostApplicationBuilder> hostBuilderCustomizationBeforeServiceControl)
         {
             this.customConfiguration = customConfiguration;
             this.persistenceToUse = persistenceToUse;
             this.hostBuilderCustomization = hostBuilderCustomization;
+            this.hostBuilderCustomizationBeforeServiceControl = hostBuilderCustomizationBeforeServiceControl;
             this.setSettings = setSettings;
             transportIntegration = transportToUse;
         }
@@ -29,7 +30,7 @@ namespace ServiceControl.AcceptanceTests.TestSupport
 
         public async Task<ComponentRunner> CreateRunner(RunDescriptor run)
         {
-            runner = new ServiceControlComponentRunner(transportIntegration, persistenceToUse, setSettings, customConfiguration, hostBuilderCustomization);
+            runner = new ServiceControlComponentRunner(transportIntegration, persistenceToUse, setSettings, customConfiguration, hostBuilderCustomization, hostBuilderCustomizationBeforeServiceControl);
             await runner.Initialize(run);
             return runner;
         }
@@ -39,6 +40,7 @@ namespace ServiceControl.AcceptanceTests.TestSupport
         readonly Action<Settings> setSettings;
         readonly Action<EndpointConfiguration> customConfiguration;
         readonly Action<IHostApplicationBuilder> hostBuilderCustomization;
+        readonly Action<IHostApplicationBuilder> hostBuilderCustomizationBeforeServiceControl;
         ServiceControlComponentRunner runner;
     }
 }

--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -25,19 +25,19 @@
     using NServiceBus.AcceptanceTesting.Support;
     using Particular.ServiceControl;
     using Particular.ServiceControl.Hosting;
-    using Persistence.Tests;
     using ServiceBus.Management.Infrastructure.Settings;
     using ServiceControl.Infrastructure;
     using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
     public class ServiceControlComponentRunner : ComponentRunner, IAcceptanceTestInfrastructureProvider
     {
-        public ServiceControlComponentRunner(ITransportIntegration transportToUse, IAcceptanceTestStorageConfiguration persistenceToUse, Action<Settings> setSettings, Action<EndpointConfiguration> customConfiguration, Action<IHostApplicationBuilder> hostBuilderCustomization)
+        public ServiceControlComponentRunner(ITransportIntegration transportToUse, IAcceptanceTestStorageConfiguration persistenceToUse, Action<Settings> setSettings, Action<EndpointConfiguration> customConfiguration, Action<IHostApplicationBuilder> hostBuilderCustomization, Action<IHostApplicationBuilder> hostBuilderCustomizationBeforeServiceControl)
         {
             this.transportToUse = transportToUse;
             this.persistenceToUse = persistenceToUse;
             this.customConfiguration = customConfiguration;
             this.hostBuilderCustomization = hostBuilderCustomization;
+            this.hostBuilderCustomizationBeforeServiceControl = hostBuilderCustomizationBeforeServiceControl;
             this.setSettings = setSettings;
         }
 
@@ -129,6 +129,9 @@
                 });
 
                 hostBuilder.Services.AddScenarioContext(context);
+
+                hostBuilderCustomizationBeforeServiceControl(hostBuilder);
+
                 hostBuilder.AddServiceControlAuthentication(settings.OpenIdConnectSettings);
                 hostBuilder.AddServiceControlAuthorization(settings.OpenIdConnectSettings);
                 hostBuilder.AddServiceControl(settings, configuration);
@@ -170,6 +173,7 @@
         readonly Action<Settings> setSettings;
         readonly Action<EndpointConfiguration> customConfiguration;
         readonly Action<IHostApplicationBuilder> hostBuilderCustomization;
+        readonly Action<IHostApplicationBuilder> hostBuilderCustomizationBeforeServiceControl;
         readonly string instanceName = Settings.DEFAULT_INSTANCE_NAME;
     }
 }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -107,7 +107,8 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.TestSupport
                     }
 
                     primaryHostBuilderCustomization(primaryHostBuilder);
-                });
+                },
+                _ => { });
             typeof(ScenarioContext).GetProperty("CurrentEndpoint", BindingFlags.Static | BindingFlags.NonPublic)?.SetValue(run.ScenarioContext, PrimaryInstanceSettings.DEFAULT_INSTANCE_NAME);
             await primaryInstanceComponentRunner.Initialize(run);
 


### PR DESCRIPTION
Two tests in this suite were recently found to be testing nothing: a double registered against its concrete type, never resolved, passing for years. This writes down how to avoid that, and adds two tests in the shape it argues for.

## Guidelines

`docs/writing-acceptance-tests.md`, linked from `docs/testing.md`.

## The two scenarios

`When_creating_a_usage_report_on_a_non_broker_transport` and `..._on_a_broker_transport`, which
between them cover all eight `api/licensing` routes. Those had no acceptance coverage in any
suite. Two tests rather than one because LearningTransport registers no `IBrokerThroughputQuery`,
so each branch needs its own, and the names say which is which.

## Worth a closer look

Three changes that are neither docs nor new tests:

- **Throughput data is now isolated per test.** `ThroughputDatabaseName` defaults to a fixed name
  and the Raven acceptance storage config set only `DatabaseName`, so every acceptance test was
  sharing one throughput database. The EF suites were unaffected. This is the highest risk change
  here, since it touches every Raven acceptance test.
- **`When_a_critical_error_is_triggered` was not overriding the registration its comment claimed
  it did.** The check ran on its 60 second production interval and the test passed anyway, about
  a minute slower than intended. Now 6 seconds instead of 65.
- **New `CustomizeHostBuilderBeforeServiceControl` hook**, for the narrow case of registrations
  that `AddServiceControl` reacts to. The MultiInstance runner is updated for the new parameter.

## Plan

`docs/acceptance-test-review-plan.md` carries the review this came from, including the confirmed
list of routes with no acceptance test. 40 of 85 had none; this closes 8, leaving 32.
