### PR TITLE
Implement RemoveEndpoints in SQL stores

### DIFF
--- a/src/ServiceControl.Persistence.EFCore/Implementation/LicensingDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/LicensingDataStore.cs
@@ -246,7 +246,21 @@ class LicensingDataStore(IServiceScopeFactory scopeFactory, TimeProvider timePro
         });
     }
 
-    public Task RemoveEndpoints(EndpointIdentifier[] endpointIds, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task RemoveEndpoints(EndpointIdentifier[] endpointIds, CancellationToken cancellationToken = default) =>
+        ExecuteWithDbContext(async (context, token) =>
+        {
+            foreach (var endpointsBySource in endpointIds.GroupBy(endpoint => endpoint.ThroughputSource))
+            {
+                var normalizedNames = endpointsBySource
+                    .Select(endpoint => Normalize(endpoint.Name))
+                    .Distinct()
+                    .ToList();
+
+                await context.LicensingEndpoints
+                    .Where(endpoint => endpoint.ThroughputSource == endpointsBySource.Key && normalizedNames.Contains(endpoint.NormalizedName))
+                    .ExecuteDeleteAsync(token);
+            }
+        }, cancellationToken);
 
     public Task UpdateUserIndicatorOnEndpoints(List<UpdateUserIndicator> userIndicatorUpdates, CancellationToken cancellationToken = default) =>
         ExecuteWithDbContext(async (context, token) =>

--- a/src/ServiceControl.Persistence.Tests/Throughput/EndpointsTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Throughput/EndpointsTests.cs
@@ -48,6 +48,30 @@ class EndpointsTests : PersistenceTestBase
     }
 
     [Test]
+    public async Task Should_remove_only_endpoints_matching_name_and_source()
+    {
+        var endpoint1Audit = new Endpoint("Endpoint1", ThroughputSource.Audit);
+        var endpoint1Broker = new Endpoint("Endpoint1", ThroughputSource.Broker);
+        var endpoint2Audit = new Endpoint("Endpoint2", ThroughputSource.Audit);
+        var endpoint3Monitoring = new Endpoint("Endpoint3", ThroughputSource.Monitoring);
+
+        await LicensingDataStore.SaveEndpoint(endpoint1Audit);
+        await LicensingDataStore.SaveEndpoint(endpoint1Broker);
+        await LicensingDataStore.SaveEndpoint(endpoint2Audit);
+        await LicensingDataStore.SaveEndpoint(endpoint3Monitoring);
+
+        await LicensingDataStore.RemoveEndpoints([endpoint1Audit.Id, endpoint3Monitoring.Id]);
+
+        var remainingEndpoints = await LicensingDataStore.GetAllEndpoints(true);
+
+        Assert.That(remainingEndpoints.Select(endpoint => endpoint.Id), Is.EquivalentTo(new[]
+        {
+            endpoint1Broker.Id,
+            endpoint2Audit.Id
+        }));
+    }
+
+    [Test]
     public async Task Should_update_endpoint_that_already_has_throughput_with_new_throughput()
     {
         // Arrange


### PR DESCRIPTION
This pull request implements the `RemoveEndpoints` method in the `LicensingDataStore` and adds a corresponding test to ensure correct removal behavior. The main focus is on enabling the removal of endpoints by both name and source, and verifying that only matching endpoints are deleted.

Key changes include:

### Licensing Endpoint Removal Implementation

* Implemented the `RemoveEndpoints` method in `LicensingDataStore`, allowing endpoints to be removed based on both their normalized name and throughput source. This ensures that only endpoints matching both criteria are deleted.

### Testing

* Added a new test, `Should_remove_only_endpoints_matching_name_and_source`, to verify that the removal logic only deletes endpoints with both matching name and source, leaving others intact.