### PR TITLE
Update dummy company name in licensing acceptance tests

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_broker_transport.cs
+++ b/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_broker_transport.cs
@@ -144,7 +144,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
             return JsonDocument.Parse(entry);
         }
 
-        const string SalesQueue = "Contoso/Sales";
+        const string SalesQueue = "Particular.Sales";
         const long BrokerThroughput = 42;
         const long MonitoringThroughput = 17;
 

--- a/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_non_broker_transport.cs
+++ b/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_non_broker_transport.cs
@@ -122,9 +122,9 @@ namespace ServiceControl.AcceptanceTests.Licensing
             return JsonDocument.Parse(entry);
         }
 
-        const string RedactedCustomer = "Contoso";
-        const string SalesEndpoint = "Contoso.Sales";
-        const string NotAnEndpoint = "Contoso.Website.Inbox";
+        const string RedactedCustomer = "Particular";
+        const string SalesEndpoint = "Particular.Sales";
+        const string NotAnEndpoint = "Particular.Website.Inbox";
         const long SalesThroughput = 42;
 
         class Context : ScenarioContext, ISequenceContext


### PR DESCRIPTION
Replace "Contoso" with "Particular" in endpoint and queue names used within the licensing usage report tests to align with internal naming conventions.