### PR TITLE
Scale out error ingestion for EF (1/3): ingestion owns its dispatcher

### DIFF
--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_error_forwarding_is_enabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_error_forwarding_is_enabled.cs
@@ -1,0 +1,79 @@
+namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.EndpointTemplates;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+
+    class When_error_forwarding_is_enabled : AcceptanceTest
+    {
+        [Test]
+        public async Task Should_forward_the_failed_message_to_the_error_log_queue()
+        {
+            SetSettings = settings =>
+            {
+                settings.ForwardErrorMessages = true;
+                settings.ErrorLogQueue = NServiceBus.AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Spy));
+            };
+
+            var context = await Define<MyContext>()
+                .WithEndpoint<Failing>(b => b
+                    .When(session => session.SendLocal(new ForwardedMessage()))
+                    .DoNotFailOnErrorMessages())
+                // The ingestor probes the forwarding address on startup with an empty message the
+                // spy cannot deserialize, so the spy has to tolerate its own failures.
+                .WithEndpoint<Spy>(b => b.DoNotFailOnErrorMessages())
+                .Done(c => c.ForwardedMessageId != null)
+                .Run();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(context.ForwardedMessageId, Is.EqualTo(context.FailedMessageId));
+                Assert.That(context.ForwardedWithFailureHeaders, Is.True);
+            }
+        }
+
+        public class Failing : EndpointConfigurationBuilder
+        {
+            public Failing() => EndpointSetup<DefaultServerWithoutAudit>(c => c.NoRetries());
+
+            [Handler]
+            public class ForwardedMessageHandler(MyContext testContext) : IHandleMessages<ForwardedMessage>
+            {
+                public Task Handle(ForwardedMessage message, IMessageHandlerContext context)
+                {
+                    testContext.FailedMessageId = context.MessageId;
+                    throw new Exception("Simulated exception");
+                }
+            }
+        }
+
+        public class Spy : EndpointConfigurationBuilder
+        {
+            public Spy() => EndpointSetup<DefaultServerWithoutAudit>(c => c.NoRetries());
+
+            [Handler]
+            public class ForwardedMessageHandler(MyContext testContext) : IHandleMessages<ForwardedMessage>
+            {
+                public Task Handle(ForwardedMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ForwardedWithFailureHeaders = context.MessageHeaders.ContainsKey("NServiceBus.ExceptionInfo.Message");
+                    testContext.ForwardedMessageId = context.MessageId;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public class MyContext : ScenarioContext
+        {
+            public string FailedMessageId { get; set; }
+            public string ForwardedMessageId { get; set; }
+            public bool ForwardedWithFailureHeaders { get; set; }
+        }
+    }
+
+    public class ForwardedMessage : ICommand;
+}

--- a/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestion.cs
@@ -142,8 +142,9 @@
                 );
 
                 messageReceiver = transportInfrastructure.Receivers[inputEndpoint];
+                messageDispatcher = transportInfrastructure.Dispatcher;
 
-                await auditIngestor.VerifyCanReachForwardingAddress(cancellationToken);
+                await auditIngestor.VerifyCanReachForwardingAddress(messageDispatcher, cancellationToken);
                 await messageReceiver.StartReceive(cancellationToken);
 
                 logger.LogInformation(LogMessages.StartedInfrastructure);
@@ -172,10 +173,7 @@
                 logger.LogInformation("Stopping infrastructure");
                 try
                 {
-                    if (messageReceiver != null)
-                    {
-                        await messageReceiver.StopReceive(cancellationToken);
-                    }
+                    await StopReceiving(cancellationToken);
                 }
                 finally
                 {
@@ -184,6 +182,7 @@
 
                 messageReceiver = null;
                 transportInfrastructure = null;
+                receiveStopped = false;
 
                 logger.LogInformation(LogMessages.StoppedInfrastructure);
             }
@@ -212,6 +211,33 @@
             {
                 startStopSemaphore.Release();
             }
+        }
+
+        async Task EnsureReceivingStopped(CancellationToken cancellationToken)
+        {
+            await startStopSemaphore.WaitAsync(cancellationToken);
+
+            try
+            {
+                await StopReceiving(cancellationToken);
+            }
+            finally
+            {
+                startStopSemaphore.Release();
+            }
+        }
+
+        // Stops the receiver on its own, leaving the infrastructure up. Idempotent because a
+        // shutdown stops receiving before draining and then tears down, so this runs twice.
+        async Task StopReceiving(CancellationToken cancellationToken)
+        {
+            if (messageReceiver == null || receiveStopped)
+            {
+                return;
+            }
+
+            await messageReceiver.StopReceive(cancellationToken);
+            receiveStopped = true;
         }
 
         async Task OnMessage(MessageContext messageContext, CancellationToken cancellationToken)
@@ -258,7 +284,7 @@
                             contexts.Add(context);
                         }
 
-                        await auditIngestor.Ingest(contexts, cancellationToken);
+                        await auditIngestor.Ingest(contexts, messageDispatcher, cancellationToken);
 
                         batchMetrics.Complete(contexts.Count);
                     }
@@ -300,28 +326,28 @@
         {
             try
             {
-                await watchdog.Stop(cancellationToken);
+                // Order matters. Receiving stops under the shutdown token rather than a cancelled
+                // one, so messages already being processed finish and their receives commit instead
+                // of being abandoned and redelivered after having been forwarded. Nothing new enters
+                // the channel after this, and the infrastructure stays up until the channel drains.
+                await EnsureReceivingStopped(cancellationToken);
                 channel.Writer.Complete();
                 await base.StopAsync(cancellationToken);
             }
             finally
             {
-                if (transportInfrastructure != null)
-                {
-                    try
-                    {
-                        await transportInfrastructure.Shutdown(cancellationToken);
-                    }
-                    catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested)
-                    {
-                        logger.LogInformation(e, "Shutdown cancelled");
-                    }
-                }
+                // Tears the infrastructure down, now that nothing is left to dispatch.
+                await watchdog.Stop(cancellationToken);
             }
         }
 
         TransportInfrastructure transportInfrastructure;
         IMessageReceiver messageReceiver;
+        bool receiveStopped;
+
+        // Left in place when the infrastructure is torn down. A shutdown drains before tearing down,
+        // so this is still usable there.
+        IMessageDispatcher messageDispatcher;
 
         readonly int MaxBatchSize;
         readonly SemaphoreSlim startStopSemaphore = new(1);

--- a/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditIngestor.cs
@@ -24,13 +24,11 @@
             EndpointInstanceMonitoring endpointInstanceMonitoring,
             IEnumerable<IEnrichImportedAuditMessages> auditEnrichers, // allows extending message enrichers with custom enrichers registered in the DI container
             IMessageSession messageSession,
-            Lazy<IMessageDispatcher> messageDispatcher,
             ITransportCustomization transportCustomization,
             ILogger<AuditIngestor> logger
         )
         {
             this.settings = settings;
-            this.messageDispatcher = messageDispatcher;
             this.logger = logger;
             var enrichers = new IEnrichImportedAuditMessages[] { new MessageTypeEnricher(), new EnrichWithTrackingIds(), new ProcessingStatisticsEnricher(), new DetectNewEndpointsFromAuditImportsEnricher(endpointInstanceMonitoring), new DetectSuccessfulRetriesEnricher(), new SagaRelationshipsEnricher() }.Concat(auditEnrichers).ToArray();
 
@@ -40,20 +38,19 @@
                 unitOfWorkFactory,
                 enrichers,
                 messageSession,
-                messageDispatcher,
                 logger
             );
         }
 
-        public async Task Ingest(List<MessageContext> contexts, CancellationToken cancellationToken = default)
+        public async Task Ingest(List<MessageContext> contexts, IMessageDispatcher dispatcher, CancellationToken cancellationToken = default)
         {
-            var stored = await auditPersister.Persist(contexts, cancellationToken);
+            var stored = await auditPersister.Persist(contexts, dispatcher, cancellationToken);
 
             try
             {
                 if (settings.ForwardAuditMessages)
                 {
-                    await Forward(stored, logQueueAddress, cancellationToken);
+                    await Forward(stored, logQueueAddress, dispatcher, cancellationToken);
                 }
 
                 foreach (var context in contexts)
@@ -74,7 +71,7 @@
             }
         }
 
-        Task Forward(IReadOnlyCollection<MessageContext> messageContexts, string forwardingAddress, CancellationToken cancellationToken)
+        Task Forward(IReadOnlyCollection<MessageContext> messageContexts, string forwardingAddress, IMessageDispatcher dispatcher, CancellationToken cancellationToken)
         {
             var transportOperations = new List<TransportOperation>(messageContexts.Count);
             MessageContext anyContext = null;
@@ -99,13 +96,13 @@
             }
 
             return anyContext != null
-                ? messageDispatcher.Value.Dispatch(
+                ? dispatcher.Dispatch(
                     new TransportOperations([.. transportOperations]),
                     anyContext.TransportTransaction, cancellationToken)
                 : Task.CompletedTask;
         }
 
-        public async Task VerifyCanReachForwardingAddress(CancellationToken cancellationToken = default)
+        public async Task VerifyCanReachForwardingAddress(IMessageDispatcher dispatcher, CancellationToken cancellationToken = default)
         {
             if (!settings.ForwardAuditMessages)
             {
@@ -122,7 +119,7 @@
                     )
                 );
 
-                await messageDispatcher.Value.Dispatch(transportOperations, new TransportTransaction(), cancellationToken);
+                await dispatcher.Dispatch(transportOperations, new TransportTransaction(), cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -136,7 +133,6 @@
 
         readonly AuditPersister auditPersister;
         readonly Settings settings;
-        readonly Lazy<IMessageDispatcher> messageDispatcher;
         readonly string logQueueAddress;
 
         readonly ILogger logger;

--- a/src/ServiceControl.Audit/Auditing/AuditPersister.cs
+++ b/src/ServiceControl.Audit/Auditing/AuditPersister.cs
@@ -19,10 +19,9 @@
     class AuditPersister(IAuditIngestionUnitOfWorkFactory unitOfWorkFactory,
         IEnrichImportedAuditMessages[] enrichers,
         IMessageSession messageSession,
-        Lazy<IMessageDispatcher> messageDispatcher,
         ILogger logger)
     {
-        public async Task<IReadOnlyList<MessageContext>> Persist(IReadOnlyList<MessageContext> contexts, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<MessageContext>> Persist(IReadOnlyList<MessageContext> contexts, IMessageDispatcher dispatcher, CancellationToken cancellationToken = default)
         {
             var storedContexts = new List<MessageContext>(contexts.Count);
             IAuditIngestionUnitOfWork unitOfWork = null;
@@ -33,7 +32,7 @@
                 var inserts = new List<Task>(contexts.Count);
                 foreach (var context in contexts)
                 {
-                    inserts.Add(ProcessMessage(context, cancellationToken));
+                    inserts.Add(ProcessMessage(context, dispatcher, cancellationToken));
                 }
 
                 await Task.WhenAll(inserts);
@@ -93,7 +92,7 @@
             return storedContexts;
         }
 
-        async Task ProcessMessage(MessageContext context, CancellationToken cancellationToken)
+        async Task ProcessMessage(MessageContext context, IMessageDispatcher dispatcher, CancellationToken cancellationToken)
         {
             if (context.Headers.TryGetValue(Headers.EnclosedMessageTypes, out var messageType)
                 && messageType == typeof(SagaUpdatedMessage).FullName)
@@ -102,7 +101,7 @@
             }
             else
             {
-                await ProcessAuditMessage(context, cancellationToken);
+                await ProcessAuditMessage(context, dispatcher, cancellationToken);
             }
         }
 
@@ -127,7 +126,7 @@
             }
         }
 
-        async Task ProcessAuditMessage(MessageContext context, CancellationToken cancellationToken)
+        async Task ProcessAuditMessage(MessageContext context, IMessageDispatcher dispatcher, CancellationToken cancellationToken)
         {
             if (!context.Headers.TryGetValue(Headers.MessageId, out var messageId))
             {
@@ -160,7 +159,7 @@
                     await messageSession.Send(commandToEmit, cancellationToken);
                 }
 
-                await messageDispatcher.Value.Dispatch(new TransportOperations(messagesToEmit.ToArray()),
+                await dispatcher.Dispatch(new TransportOperations(messagesToEmit.ToArray()),
                     new TransportTransaction(), cancellationToken); //Do not hook into the incoming transaction
 
                 logger.LogDebug("{CommandsToEmitCount} commands and {MessagesToEmitCount} control messages emitted", commandsToEmit.Count, messagesToEmit.Count);

--- a/src/ServiceControl.Audit/Auditing/ImportFailedAudits.cs
+++ b/src/ServiceControl.Audit/Auditing/ImportFailedAudits.cs
@@ -14,18 +14,20 @@ namespace ServiceControl.Audit.Auditing
         public ImportFailedAudits(
             IFailedAuditStorage failedAuditStore,
             AuditIngestor auditIngestor,
+            Lazy<IMessageDispatcher> messageDispatcher,
             Settings settings,
             ILogger<ImportFailedAudits> logger)
         {
             this.settings = settings;
             this.failedAuditStore = failedAuditStore;
             this.auditIngestor = auditIngestor;
+            this.messageDispatcher = messageDispatcher;
             this.logger = logger;
         }
 
         public async Task Run(CancellationToken cancellationToken = default)
         {
-            await auditIngestor.VerifyCanReachForwardingAddress(cancellationToken);
+            await auditIngestor.VerifyCanReachForwardingAddress(messageDispatcher.Value, cancellationToken);
 
             var succeeded = 0;
             var failed = 0;
@@ -47,7 +49,7 @@ namespace ServiceControl.Audit.Auditing
                             var taskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                             messageContext.SetTaskCompletionSource(taskCompletionSource);
 
-                            await auditIngestor.Ingest([messageContext], cancellationToken);
+                            await auditIngestor.Ingest([messageContext], messageDispatcher.Value, cancellationToken);
 
                             await taskCompletionSource.Task;
 
@@ -78,6 +80,7 @@ namespace ServiceControl.Audit.Auditing
 
         readonly IFailedAuditStorage failedAuditStore;
         readonly AuditIngestor auditIngestor;
+        readonly Lazy<IMessageDispatcher> messageDispatcher;
         readonly Settings settings;
         readonly ILogger<ImportFailedAudits> logger;
 

--- a/src/ServiceControl/Operations/ErrorIngestion.cs
+++ b/src/ServiceControl/Operations/ErrorIngestion.cs
@@ -97,7 +97,7 @@
                         batchSizeMeter.Mark(contexts.Count);
                         using (batchDurationMeter.Measure())
                         {
-                            await ingestor.Ingest(contexts, cancellationToken);
+                            await ingestor.Ingest(contexts, messageDispatcher, cancellationToken);
                         }
                     }
                     catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested)
@@ -138,23 +138,17 @@
         {
             try
             {
-                await watchdog.Stop(cancellationToken);
+                // Order matters. Receiving stops first so nothing new enters the channel, but the
+                // infrastructure is left running while the channel drains, because those batches
+                // still forward through its dispatcher and Shutdown disposes it.
+                await EnsureReceivingStopped(cancellationToken);
                 channel.Writer.Complete();
                 await base.StopAsync(cancellationToken);
             }
             finally
             {
-                if (transportInfrastructure != null)
-                {
-                    try
-                    {
-                        await transportInfrastructure.Shutdown(cancellationToken);
-                    }
-                    catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested)
-                    {
-                        logger.LogInformation(e, "Shutdown cancelled");
-                    }
-                }
+                // Tears the infrastructure down, now that nothing is left to dispatch.
+                await watchdog.Stop(cancellationToken);
             }
         }
 
@@ -226,10 +220,11 @@
                 );
 
                 messageReceiver = transportInfrastructure.Receivers[errorQueue];
+                messageDispatcher = transportInfrastructure.Dispatcher;
 
                 if (settings.ForwardErrorMessages)
                 {
-                    await ingestor.VerifyCanReachForwardingAddress(cancellationToken);
+                    await ingestor.VerifyCanReachForwardingAddress(messageDispatcher, cancellationToken);
                 }
 
                 await messageReceiver.StartReceive(cancellationToken);
@@ -258,10 +253,7 @@
                 logger.LogInformation("Stopping infrastructure");
                 try
                 {
-                    if (messageReceiver != null)
-                    {
-                        await messageReceiver.StopReceive(cancellationToken);
-                    }
+                    await StopReceiving(cancellationToken);
                 }
                 finally
                 {
@@ -270,6 +262,7 @@
 
                 messageReceiver = null;
                 transportInfrastructure = null;
+                receiveStopped = false;
 
                 logger.LogInformation(LogMessages.StoppedInfrastructure);
             }
@@ -327,11 +320,43 @@
             }
         }
 
+        async Task EnsureReceivingStopped(CancellationToken cancellationToken)
+        {
+            await startStopSemaphore.WaitAsync(cancellationToken);
+
+            try
+            {
+                await StopReceiving(cancellationToken);
+            }
+            finally
+            {
+                startStopSemaphore.Release();
+            }
+        }
+
+        // Stops the receiver on its own, leaving the infrastructure up. Idempotent because a
+        // shutdown stops receiving before draining and then tears down, so this runs twice.
+        async Task StopReceiving(CancellationToken cancellationToken)
+        {
+            if (messageReceiver == null || receiveStopped)
+            {
+                return;
+            }
+
+            await messageReceiver.StopReceive(cancellationToken);
+            receiveStopped = true;
+        }
+
         SemaphoreSlim startStopSemaphore = new(1);
         string errorQueue;
         ErrorIngestionFaultPolicy errorHandlingPolicy;
         TransportInfrastructure transportInfrastructure;
         IMessageReceiver messageReceiver;
+        bool receiveStopped;
+
+        // Left in place when the infrastructure is torn down. A shutdown drains before tearing down,
+        // so this is still usable there
+        IMessageDispatcher messageDispatcher;
 
         readonly Settings settings;
         readonly ITransportCustomization transportCustomization;

--- a/src/ServiceControl/Operations/ErrorIngestor.cs
+++ b/src/ServiceControl/Operations/ErrorIngestor.cs
@@ -26,13 +26,11 @@
             IEnumerable<IFailedMessageEnricher> failedMessageEnrichers,
             IDomainEvents domainEvents,
             IIngestionUnitOfWorkFactory unitOfWorkFactory,
-            Lazy<IMessageDispatcher> messageDispatcher,
             ITransportCustomization transportCustomization,
             Settings settings,
             ILogger<ErrorIngestor> logger)
         {
             this.unitOfWorkFactory = unitOfWorkFactory;
-            this.messageDispatcher = messageDispatcher;
             this.settings = settings;
             this.logger = logger;
             bulkInsertDurationMeter = metrics.GetMeter("Error ingestion - bulk insert duration", FrequencyInMilliseconds);
@@ -51,7 +49,7 @@
             logQueueAddress = new UnicastAddressTag(transportCustomization.ToTransportQualifiedQueueName(this.settings.ErrorLogQueue));
         }
 
-        public async Task Ingest(List<MessageContext> contexts, CancellationToken cancellationToken = default)
+        public async Task Ingest(List<MessageContext> contexts, IMessageDispatcher dispatcher, CancellationToken cancellationToken = default)
         {
             var failedMessages = new List<MessageContext>(contexts.Count);
             var retriedMessages = new List<MessageContext>(contexts.Count);
@@ -89,7 +87,7 @@
                 {
                     logger.LogDebug("Forwarding {FailedMessageCount} messages", storedFailed.Count);
 
-                    await Forward(storedFailed, cancellationToken);
+                    await Forward(storedFailed, dispatcher, cancellationToken);
 
                     logger.LogDebug("Forwarded messages");
                 }
@@ -149,7 +147,7 @@
             }
         }
 
-        Task Forward(IReadOnlyCollection<MessageContext> messageContexts, CancellationToken cancellationToken)
+        Task Forward(IReadOnlyCollection<MessageContext> messageContexts, IMessageDispatcher dispatcher, CancellationToken cancellationToken)
         {
             var transportOperations = new TransportOperation[messageContexts.Count]; //We could allocate based on the actual number of ProcessedMessages but this should be OK
             var index = 0;
@@ -170,13 +168,13 @@
             }
 
             return anyContext != null
-                ? messageDispatcher.Value.Dispatch(
+                ? dispatcher.Dispatch(
                     new TransportOperations(transportOperations),
                     anyContext.TransportTransaction, cancellationToken)
                 : Task.CompletedTask;
         }
 
-        public async Task VerifyCanReachForwardingAddress(CancellationToken cancellationToken = default)
+        public async Task VerifyCanReachForwardingAddress(IMessageDispatcher dispatcher, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -188,7 +186,7 @@
                     )
                 );
 
-                await messageDispatcher.Value.Dispatch(transportOperations, new TransportTransaction(), cancellationToken);
+                await dispatcher.Dispatch(transportOperations, new TransportTransaction(), cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -204,7 +202,6 @@
         readonly Meter bulkInsertDurationMeter;
         readonly Settings settings;
         readonly ErrorProcessor errorProcessor;
-        readonly Lazy<IMessageDispatcher> messageDispatcher;
         readonly RetryConfirmationProcessor retryConfirmationProcessor;
         readonly UnicastAddressTag logQueueAddress;
 

--- a/src/ServiceControl/Operations/ImportFailedErrors.cs
+++ b/src/ServiceControl/Operations/ImportFailedErrors.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Operations
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
@@ -10,13 +11,14 @@
     public class ImportFailedErrors(
         IFailedErrorImportDataStore store,
         ErrorIngestor errorIngestor,
+        Lazy<IMessageDispatcher> messageDispatcher,
         Settings settings)
     {
         public async Task Run(CancellationToken cancellationToken = default)
         {
             if (settings.ForwardErrorMessages)
             {
-                await errorIngestor.VerifyCanReachForwardingAddress(cancellationToken);
+                await errorIngestor.VerifyCanReachForwardingAddress(messageDispatcher.Value, cancellationToken);
             }
 
             await store.ProcessFailedErrorImports(async (transportMessage, token) =>
@@ -32,7 +34,7 @@
                 var taskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 messageContext.SetTaskCompletionSource(taskCompletionSource);
 
-                await errorIngestor.Ingest([messageContext], token);
+                await errorIngestor.Ingest([messageContext], messageDispatcher.Value, token);
                 await taskCompletionSource.Task;
             }, cancellationToken);
         }


### PR DESCRIPTION
Part 1 of 3 introducing scale-out of error ingestion for EF persistence, where several
processes drain the error queue into one shared database.

This part contains no scale-out feature. It is groundwork plus a bug fix, and stands on
its own.

## Ingestion takes its dispatcher as an argument

`ErrorIngestor` and `AuditIngestor` held a `Lazy<IMessageDispatcher>`. That is a
constructor dependency which cannot be satisfied at construction time: the dispatcher is
registered by `AddNServiceBusEndpoint` behind a factory that dereferences the transport
seam, so resolving it before the endpoint's hosted service starts throws a bare
`NullReferenceException`. The `Lazy` wrapper, and the comment apologising for registration
order next to it, were the tell.

It is not a constructor dependency, it is a call-time collaborator. The ingestors do not
own a transport: they take message contexts, persist them, announce them and forward them.
The dispatcher belongs to whoever received the batch.

So `Ingest` and `VerifyCanReachForwardingAddress` now take an `IMessageDispatcher`, and
`ErrorIngestion` / `AuditIngestion` pass the one from the `TransportInfrastructure` they
already create. `ImportFailedErrors` and `ImportFailedAudits` take the `Lazy` that the
ingestors used to hold, so their behaviour is unchanged.

Three things fall out: `Forward` passing `anyContext.TransportTransaction` now visibly
belongs with the dispatcher it is handed to rather than one from a different
infrastructure, the start-order hazard leaves the ingestion path, and the ingestors become
testable with a fake dispatcher and no container.

`AuditPersister` threads the dispatcher through as well. It is hand constructed inside
`AuditIngestor`'s constructor, so leaving it holding a `Lazy` would have the file arguing
with itself. Its `IMessageSession` is untouched: saga audit commands genuinely need the
endpoint.

## Shutdown ordering, which was duplicating forwarded messages

`StopAsync` tore the transport infrastructure down before draining the channel. Worse,
`EnsureStopped` stops the receiver with `new CancellationToken(canceled: true)` ("stop
receivers ASAP"), which fires the registration in `OnMessage` that cancels every in-flight
`TaskCompletionSource`. Those messages were abandoned and redelivered on the next start,
*after* the drain had already forwarded them. With `ForwardErrorMessages` on, every
graceful shutdown with a non-empty channel put duplicates in the error log queue.

The order is now: stop receiving under the shutdown token, complete the writer, drain, then
tear down. Stopping under the real token means `StopReceive` waits for in-flight messages
while the loop is still running and the infrastructure is still up, so they ingest, forward
once, and their receives actually commit.

This is what the (previously dead) `finally` block in `StopAsync` was always shaped for.
`Watchdog` is untouched; the split is local to each ingestion class.
