### PR TITLE
Scale out error ingestion for EF (2/3): --error-ingestion-only host

### DIFF
--- a/src/ServiceControl.AcceptanceTests.RavenDB/ServiceControl.AcceptanceTests.RavenDB.csproj
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/ServiceControl.AcceptanceTests.RavenDB.csproj
@@ -33,6 +33,9 @@
     <Compile Include="..\ServiceControl.Persistence.Tests.RavenDB\SharedEmbeddedServer.cs" />
     <Compile Include="..\ServiceControl.Persistence.Tests.RavenDB\StopSharedDatabase.cs" />
     <Compile Include="..\ServiceControl.UnitTests\NUnitParallelRunnerSettings.cs" />
+
+    <!-- Error ingestion only mode is supported on SQL Server and PostgreSQL storage only. -->
+    <Compile Remove="..\ServiceControl.AcceptanceTests\Recoverability\When_hosting_error_ingestion_only.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_hosting_error_ingestion_only.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_hosting_error_ingestion_only.cs
@@ -1,0 +1,267 @@
+namespace ServiceControl.AcceptanceTests.Recoverability
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Loader;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.TestHost;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
+    using NServiceBus;
+    using NServiceBus.Routing;
+    using NServiceBus.Transport;
+    using NUnit.Framework;
+    using Particular.ServiceControl.Hosting;
+    using ServiceBus.Management.Infrastructure.Settings;
+    using ServiceControl.ExternalIntegrations;
+    using ServiceControl.Hosting.Commands;
+    using ServiceControl.Infrastructure;
+    using ServiceControl.MessageFailures;
+    using ServiceControl.Operations;
+    using ServiceControl.Persistence.EFCore.DbContexts;
+    using ServiceControl.Persistence.EFCore.Entities;
+    using ServiceControl.Persistence.EFCore.Infrastructure;
+    using ServiceControl.Recoverability;
+    using ServiceControl.Transports;
+
+    class When_hosting_error_ingestion_only : AcceptanceTest
+    {
+        [Test]
+        public async Task Should_ingest_without_an_endpoint_and_without_the_single_owner_services()
+        {
+            var settings = await CreateSettings();
+
+            var host = ErrorIngestionOnlyCommand.BuildHost(settings);
+
+            try
+            {
+                var hostedServices = host.Services.GetServices<IHostedService>()
+                    .Select(hostedService => hostedService.GetType().Name)
+                    .ToArray();
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(host.Services.GetService<IMessageSession>(), Is.Null,
+                        "the host must not run an NServiceBus endpoint");
+                    Assert.That(host.Services.GetService<ErrorIngestor>(), Is.Not.Null);
+
+                    Assert.That(hostedServices, Is.EquivalentTo(ExpectedHostedServices),
+                        "the set of hosted services in the error ingestion only host changed. Every one of "
+                        + "these runs on every ingestion node, so decide whether that is safe before updating "
+                        + "this list. ReturnToSenderDequeuer would steal messages from a retry batch, "
+                        + "RetentionSweeper would duplicate the sweep, and EventDispatcherHostedService would "
+                        + "publish every integration event once per node.");
+                }
+            }
+            finally
+            {
+                await host.DisposeAsync();
+            }
+        }
+
+        static readonly string[] ExpectedHostedServices =
+        [
+            "GenericWebHostService",                // health endpoint only, no ServiceControl API
+            nameof(ErrorIngestion),                 // the reason this host exists
+            "HeartbeatMonitoringHostedService",     // warms the endpoint monitor, does not check heartbeats
+            "InternalCustomChecksHostedService",    // reports this node's ingestion health to the database
+            "MetricsReporterHostedService",
+            "ExternalIntegrationRequestsDataStore"  // its drain is inert here, nothing calls Subscribe
+        ];
+
+        [Test]
+        public void Should_refuse_to_start_against_unsupported_storage()
+        {
+            var settings = new Settings(TransportIntegration.TypeName, "RavenDB", CreateLoggingSettings(),
+                forwardErrorMessages: false, errorRetentionPeriod: TimeSpan.FromDays(10));
+
+            var exception = Assert.ThrowsAsync<Exception>(() =>
+                new ErrorIngestionOnlyCommand().Execute(new HostArguments([]), settings));
+
+            Assert.That(exception.Message, Does.Contain("SQL Server or PostgreSQL"));
+        }
+
+        [Test]
+        public async Task Should_ingest_a_failed_message_into_the_shared_database()
+        {
+            var settings = await CreateSettings();
+
+            // The schema and the queues are provisioned by a normal instance, never by an ingest only host.
+            await new SetupCommand().Execute(new HostArguments([]), settings);
+
+            var messageId = Guid.NewGuid().ToString();
+            var host = ErrorIngestionOnlyCommand.BuildHost(settings, builder => builder.WebHost.UseTestServer());
+
+            try
+            {
+                await host.StartAsync();
+
+                await DispatchFailedMessage(settings, messageId);
+
+                var failedMessage = await WaitForFailedMessage(host, messageId);
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(failedMessage.Status, Is.EqualTo(FailedMessageStatus.Unresolved));
+                    Assert.That(failedMessage.ExceptionType, Is.EqualTo("System.InvalidOperationException"));
+                    Assert.That(failedMessage.ExceptionMessage, Is.EqualTo("Simulated failure"));
+                    Assert.That(failedMessage.FailingEndpointAddress, Is.EqualTo("IngestOnly.Receiver@IngestOnlyHost"));
+
+                    Assert.That(failedMessage.SendingEndpointName, Is.EqualTo("IngestOnly.Sender"));
+                    Assert.That(failedMessage.SendingEndpointHost, Is.EqualTo("IngestOnlyHost"));
+                    Assert.That(failedMessage.SendingEndpointHostId, Is.Not.Null);
+                    Assert.That(failedMessage.ReceivingEndpointName, Is.EqualTo("IngestOnly.Receiver"));
+                    Assert.That(failedMessage.ReceivingEndpointHost, Is.EqualTo("IngestOnlyHost"));
+                    Assert.That(failedMessage.ReceivingEndpointHostId, Is.Not.Null);
+                }
+
+                await using var scope = host.Services.GetRequiredService<IServiceScopeFactory>().CreateAsyncScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
+
+                var groups = await dbContext.FailedMessageGroups.AsNoTracking()
+                    .Where(group => group.FailedMessageUniqueId == failedMessage.UniqueMessageId)
+                    .ToListAsync();
+                var knownEndpoints = await dbContext.KnownEndpoints.AsNoTracking().ToListAsync();
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(groups.Select(group => group.Type), Does.Contain("Endpoint Name"));
+                    Assert.That(groups.Select(group => group.Type), Does.Contain("Exception Type and Stack Trace"));
+                    Assert.That(knownEndpoints.Select(endpoint => endpoint.Name), Does.Contain("IngestOnly.Receiver"));
+                }
+
+                await WaitFor(host, async dbContext => await dbContext.EventLogItems.AsNoTracking()
+                        .AnyAsync(item => item.EventType == "MessageFailed" && item.Description == "Simulated failure"),
+                    "an event log entry for the failure");
+            }
+            finally
+            {
+                await host.StopAsync();
+                await host.DisposeAsync();
+            }
+        }
+
+        static async Task DispatchFailedMessage(Settings settings, string messageId)
+        {
+            var dispatchSettings = new TransportSettings
+            {
+                EndpointName = "IngestOnly.Dispatcher",
+                TransportType = settings.TransportType,
+                ConnectionString = settings.TransportConnectionString,
+                ErrorQueue = settings.ErrorQueue,
+                MaxConcurrency = 1,
+                AssemblyLoadContextResolver = settings.AssemblyLoadContextResolver
+            };
+
+            var customization = TransportFactory.Create(dispatchSettings);
+            var infrastructure = await customization.CreateTransportInfrastructure("IngestOnly.Dispatcher", dispatchSettings);
+
+            try
+            {
+                var headers = new Dictionary<string, string>
+                {
+                    [Headers.MessageId] = messageId,
+                    [Headers.EnclosedMessageTypes] = "IngestOnly.SomeCommand, IngestOnly, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    [Headers.ConversationId] = Guid.NewGuid().ToString(),
+                    [Headers.OriginatingEndpoint] = "IngestOnly.Sender",
+                    [Headers.OriginatingMachine] = "IngestOnlyHost",
+                    [Headers.OriginatingHostId] = Guid.NewGuid().ToString("N"),
+                    [Headers.ProcessingEndpoint] = "IngestOnly.Receiver",
+                    [Headers.HostDisplayName] = "IngestOnlyHost",
+                    [Headers.HostId] = Guid.NewGuid().ToString("N"),
+                    ["NServiceBus.FailedQ"] = "IngestOnly.Receiver@IngestOnlyHost",
+                    ["NServiceBus.TimeOfFailure"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow),
+                    ["NServiceBus.TimeSent"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow),
+                    ["NServiceBus.ExceptionInfo.ExceptionType"] = "System.InvalidOperationException",
+                    ["NServiceBus.ExceptionInfo.Message"] = "Simulated failure",
+                    ["NServiceBus.ExceptionInfo.Source"] = "IngestOnly",
+                    ["NServiceBus.ExceptionInfo.StackTrace"] = "   at IngestOnly.Receiver.Handle()"
+                };
+
+                var outgoing = new OutgoingMessage(messageId, headers, "{}"u8.ToArray());
+
+                await infrastructure.Dispatcher.Dispatch(
+                    new TransportOperations(new TransportOperation(outgoing, new UnicastAddressTag(settings.ErrorQueue))),
+                    new TransportTransaction());
+            }
+            finally
+            {
+                await infrastructure.Shutdown();
+            }
+        }
+
+        static async Task WaitFor(IHost host, Func<ServiceControlDbContext, Task<bool>> condition, string description)
+        {
+            var scopeFactory = host.Services.GetRequiredService<IServiceScopeFactory>();
+            var timeout = Stopwatch.StartNew();
+
+            while (timeout.Elapsed < TimeSpan.FromSeconds(60))
+            {
+                await using var scope = scopeFactory.CreateAsyncScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
+
+                if (await condition(dbContext))
+                {
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(200));
+            }
+
+            Assert.Fail($"Timed out waiting for {description}.");
+        }
+
+        static async Task<FailedMessageEntity> WaitForFailedMessage(IHost host, string messageId)
+        {
+            var scopeFactory = host.Services.GetRequiredService<IServiceScopeFactory>();
+            var timeout = Stopwatch.StartNew();
+
+            while (timeout.Elapsed < TimeSpan.FromSeconds(60))
+            {
+                await using var scope = scopeFactory.CreateAsyncScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<ServiceControlDbContext>();
+
+                var failedMessage = await dbContext.FailedMessages.AsNoTracking()
+                    .SingleOrDefaultAsync(message => message.MessageId == messageId);
+
+                if (failedMessage != null)
+                {
+                    return failedMessage;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(200));
+            }
+
+            Assert.Fail($"The failed message {messageId} was not ingested within the timeout.");
+            return null;
+        }
+
+        async Task<Settings> CreateSettings()
+        {
+            var settings = new Settings(TransportIntegration.TypeName, StorageConfiguration.PersistenceType,
+                CreateLoggingSettings(), forwardErrorMessages: false, errorRetentionPeriod: TimeSpan.FromDays(10))
+            {
+                InstanceName = $"IngestOnly.{Guid.NewGuid():n}",
+                TransportConnectionString = TransportIntegration.ConnectionString,
+                MaximumConcurrencyLevel = 2,
+                AssemblyLoadContextResolver = static _ => AssemblyLoadContext.Default
+            };
+
+            await StorageConfiguration.CustomizeSettings(settings);
+
+            return settings;
+        }
+
+        static LoggingSettings CreateLoggingSettings()
+        {
+            var logPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(logPath);
+            return new LoggingSettings(Settings.SettingsRootNamespace, defaultLevel: LogLevel.Debug, logPath: logPath);
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/Abstractions/BasePersistence.cs
+++ b/src/ServiceControl.Persistence.EFCore/Abstractions/BasePersistence.cs
@@ -33,7 +33,10 @@ public abstract class BasePersistence
         services.AddSingleton<IExternalIntegrationRequestsDataStore>(p => p.GetRequiredService<ExternalIntegrationRequestsDataStore>());
         services.AddHostedService(p => p.GetRequiredService<ExternalIntegrationRequestsDataStore>());
 
-        services.AddHostedService<RetentionSweeper>();
+        if (settings.RunRetentionSweep)
+        {
+            services.AddHostedService<RetentionSweeper>();
+        }
 
         services.AddSingleton<OperationsManager>();
         services.AddSingleton<IArchiveMessages, MessageArchiver>();

--- a/src/ServiceControl.Persistence/PersistenceSettings.cs
+++ b/src/ServiceControl.Persistence/PersistenceSettings.cs
@@ -11,6 +11,12 @@
         //HINT: This needs to be here so that ServerControl instance can add an instance specific metadata to tweak the DatabasePath value
         public string? DatabasePath { get; set; }
 
+        /// <summary>
+        /// Whether this host owns the background deletion of data past its retention period. Only one
+        /// host in a deployment should, so error ingestion only hosts turn it off.
+        /// </summary>
+        public bool RunRetentionSweep { get; set; } = true;
+
         public bool EnableFullTextSearchOnBodies { get; set; } = true;
 
         public TimeSpan? OverrideCustomCheckRepeatTime { get; set; }

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -68,6 +68,7 @@
   "ForwardErrorMessages": false,
   "IngestErrorMessages": true,
   "RunRetryProcessor": true,
+  "ErrorIngestionOnly": false,
   "AuditRetentionPeriod": null,
   "ErrorRetentionPeriod": "10.00:00:00",
   "EventsRetentionPeriod": "14.00:00:00",

--- a/src/ServiceControl/CustomChecks/CustomChecksComponent.cs
+++ b/src/ServiceControl/CustomChecks/CustomChecksComponent.cs
@@ -28,7 +28,11 @@
             hostBuilder.Services.AddEventLogMapping<CustomCheckDeletedDefinition>();
             hostBuilder.Services.AddEventLogMapping<CustomCheckFailedDefinition>();
             hostBuilder.Services.AddEventLogMapping<CustomCheckSucceededDefinition>();
-            hostBuilder.Services.AddPlatformConnectionProvider<CustomChecksPlatformConnectionDetailsProvider>();
+
+            if (!settings.ErrorIngestionOnly)
+            {
+                hostBuilder.Services.AddPlatformConnectionProvider<CustomChecksPlatformConnectionDetailsProvider>();
+            }
             hostBuilder.Services.AddSingleton<CustomCheckResultProcessor>();
         }
     }

--- a/src/ServiceControl/ExternalIntegrations/ExternalIntegrationsComponent.cs
+++ b/src/ServiceControl/ExternalIntegrations/ExternalIntegrationsComponent.cs
@@ -16,8 +16,12 @@ namespace ServiceControl.ExternalIntegrations
 
             if (!settings.DisableExternalIntegrationsPublishing)
             {
-                services.AddHostedService<EventDispatcherHostedService>();
                 services.AddDomainEventHandler<IntegrationEventWriter>();
+
+                if (!settings.ErrorIngestionOnly)
+                {
+                    services.AddHostedService<EventDispatcherHostedService>();
+                }
             }
         }
     }

--- a/src/ServiceControl/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl/HostApplicationBuilderExtensions.cs
@@ -3,6 +3,7 @@ namespace Particular.ServiceControl
     using System;
     using System.Diagnostics;
     using System.Runtime.InteropServices;
+    using System.Threading.Tasks;
     using global::ServiceControl.CustomChecks;
     using global::ServiceControl.Hosting;
     using global::ServiceControl.Infrastructure;
@@ -22,6 +23,7 @@ namespace Particular.ServiceControl
     using Microsoft.Extensions.Logging;
     using NServiceBus;
     using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.Hosting;
     using NServiceBus.Transport;
     using Particular.LicensingComponent;
     using ServiceBus.Management.Infrastructure;
@@ -32,7 +34,10 @@ namespace Particular.ServiceControl
     {
         public static void AddServiceControl(this IHostApplicationBuilder hostBuilder, Settings settings, EndpointConfiguration configuration, params ReadOnlySpan<ServiceControlComponent> components)
         {
-            ArgumentNullException.ThrowIfNull(configuration);
+            if (!settings.ErrorIngestionOnly)
+            {
+                ArgumentNullException.ThrowIfNull(configuration);
+            }
 
             RecordStartup(settings, configuration);
 
@@ -85,14 +90,34 @@ namespace Particular.ServiceControl
             // directly and to make things more complex of course the order of registration still matters ;)
             services.AddSingleton(provider => new Lazy<IMessageDispatcher>(provider.GetRequiredService<IMessageDispatcher>));
 
-            services.AddLicenseCheck();
             services.AddPersistence(settings);
             services.AddMetrics(settings.PrintMetrics);
 
-            NServiceBusFactory.Configure(settings, transportCustomization, transportSettings, configuration);
-            hostBuilder.Services.AddNServiceBusEndpoint(configuration);
+            if (settings.ErrorIngestionOnly)
+            {
+                // Ingestion receives through its own transport infrastructure and forwards through
+                // that same infrastructure's dispatcher, so the endpoint is not hosted at all.
+                var machineName = NServiceBus.Support.RuntimeEnvironment.MachineName;
+                services.AddSingleton(new HostInformation(
+                    DeterministicGuid.MakeId(machineName, settings.InstanceName),
+                    machineName));
+                services.AddSingleton(provider => new CriticalError((context, _) =>
+                {
+                    provider.GetRequiredService<ILogger<CriticalError>>().LogCritical(context.Exception, "{CriticalError}", context.Error);
+                    provider.GetRequiredService<IHostApplicationLifetime>().StopApplication();
+                    return Task.CompletedTask;
+                }));
+            }
+            else
+            {
+                services.AddLicenseCheck();
 
-            hostBuilder.AddEmailNotifications();
+                NServiceBusFactory.Configure(settings, transportCustomization, transportSettings, configuration);
+                hostBuilder.Services.AddNServiceBusEndpoint(configuration);
+
+                hostBuilder.AddEmailNotifications();
+            }
+
             hostBuilder.AddAsyncTimer();
 
             if (!settings.DisableHealthChecks)
@@ -125,6 +150,7 @@ ServiceControl Version:             {version}
 Audit Retention Period (optional):  {settings.AuditRetentionPeriod}
 Error Retention Period:             {settings.ErrorRetentionPeriod}
 Ingest Error Messages:              {settings.IngestErrorMessages}
+Error Ingestion Only:               {settings.ErrorIngestionOnly}
 Forwarding Error Messages:          {settings.ForwardErrorMessages}
 ServiceControl Logging Level:       {settings.LoggingSettings.LogLevel}
 Selected Transport Customization:   {settings.TransportType}
@@ -133,7 +159,9 @@ Integrated ServicePulse:            {(settings.EnableIntegratedServicePulse ? "E
 
             var logger = LoggerUtil.CreateStaticLogger(typeof(HostApplicationBuilderExtensions), settings.LoggingSettings.LogLevel);
             logger.LogInformation(startupMessage);
-            endpointConfiguration.GetSettings().AddStartupDiagnosticsSection("Startup", new
+
+            // There is no endpoint to hang diagnostics off in error ingestion only mode.
+            endpointConfiguration?.GetSettings().AddStartupDiagnosticsSection("Startup", new
             {
                 Settings = settings,
             });

--- a/src/ServiceControl/Hosting/Commands/ErrorIngestionOnlyCommand.cs
+++ b/src/ServiceControl/Hosting/Commands/ErrorIngestionOnlyCommand.cs
@@ -1,0 +1,72 @@
+namespace ServiceControl.Hosting.Commands
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Builder;
+    using NServiceBus;
+    using Particular.ServiceControl;
+    using Particular.ServiceControl.Hosting;
+    using ServiceBus.Management.Infrastructure.Settings;
+    using ServiceControl.EventLog;
+    using ServiceControl.ExternalIntegrations;
+    using ServiceControl.Monitoring;
+    using ServiceControl.Persistence;
+    using ServiceControl.Recoverability;
+
+    /// <summary>
+    /// Runs a host that does nothing but drain the error queue into the shared database, so several
+    /// processes can ingest against one database. Everything a deployment may only run once, the
+    /// retry pipeline, the retention sweep, integration event dispatch and heartbeat monitoring,
+    /// stays with the primary instance.
+    /// </summary>
+    class ErrorIngestionOnlyCommand : AbstractCommand
+    {
+        static readonly string[] SupportedStorageNames = ["SQLServer", "PostgreSQL"];
+
+        public override async Task Execute(HostArguments args, Settings settings, CancellationToken cancellationToken = default)
+        {
+            EnsureStorageCanScaleOut(settings);
+
+            var app = BuildHost(settings);
+
+            await app.RunAsync(settings.RootUrl);
+        }
+
+        internal static WebApplication BuildHost(Settings settings, Action<WebApplicationBuilder> customize = null)
+        {
+            settings.ErrorIngestionOnly = true;
+            settings.IngestErrorMessages = true;
+            settings.RunRetryProcessor = false;
+
+            var hostBuilder = WebApplication.CreateBuilder();
+
+            hostBuilder.AddServiceControl(settings, configuration: null, Components);
+
+            customize?.Invoke(hostBuilder);
+
+            return hostBuilder.Build();
+        }
+
+        static void EnsureStorageCanScaleOut(Settings settings)
+        {
+            var manifest = PersistenceManifestLibrary.Find(settings.PersistenceType);
+
+            if (manifest == null || !SupportedStorageNames.Contains(manifest.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                throw new Exception(
+                    $"--error-ingestion-only requires SQL Server or PostgreSQL storage, but this instance is configured to use '{settings.PersistenceType}'. Scaling out error ingestion is not supported for this storage type.");
+            }
+        }
+
+        static ServiceControlComponent[] Components =>
+        [
+            new EventLogComponent(),
+            new ExternalIntegrationsComponent(),
+            new RecoverabilityComponent(),
+            new HeartbeatMonitoringComponent(),
+            new CustomChecks.CustomChecksComponent()
+        ];
+    }
+}

--- a/src/ServiceControl/Hosting/Help.txt
+++ b/src/ServiceControl/Hosting/Help.txt
@@ -10,6 +10,18 @@ The REST API, message importers and the background document expiry are all disab
 
 This mode is only supported when run interactively.
 
+ERROR INGESTION ONLY
+
+   ServiceControl.exe --error-ingestion-only
+
+Runs a host that only drains the error queue into the configured database, so several processes can
+share the ingestion load. Requires SQL Server or PostgreSQL storage, and requires that the database
+has already been provisioned by a normal instance. Exactly one normal instance must still be running:
+it owns the retry pipeline, the retention sweep, integration event dispatch and heartbeat monitoring.
+
+Message bodies must be stored somewhere every host can read, so this mode should not be combined with
+file system body storage unless the path is a shared mount.
+
 SERVICE INSTALL AND UNINSTALL AND CONFIGURATION OPTIONS
 
 As of Service Control 1.7 the command line  uninstall and install switches have been removed.

--- a/src/ServiceControl/Hosting/HostArguments.cs
+++ b/src/ServiceControl/Hosting/HostArguments.cs
@@ -53,6 +53,15 @@ namespace Particular.ServiceControl.Hosting
                 }
             };
 
+            var errorIngestionOnlyOptions = new OptionSet
+            {
+                {
+                    "error-ingestion-only",
+                    "Run only error ingestion, for scaling out ingestion across several processes",
+                    s => Command = typeof(ErrorIngestionOnlyCommand)
+                }
+            };
+
             try
             {
                 externalInstallerOptions.Parse(args);
@@ -72,6 +81,13 @@ namespace Particular.ServiceControl.Hosting
                 reimportFailedErrorsOptions.Parse(args);
 
                 if (Command == typeof(ImportFailedErrorsCommand))
+                {
+                    return;
+                }
+
+                errorIngestionOnlyOptions.Parse(args);
+
+                if (Command == typeof(ErrorIngestionOnlyCommand))
                 {
                     return;
                 }

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -201,6 +201,9 @@ namespace ServiceBus.Management.Infrastructure.Settings
         public bool IngestErrorMessages { get; set; } = true;
         public bool RunRetryProcessor { get; set; } = true;
 
+        // Set by the --error-ingestion-only command, never read from configuration.
+        public bool ErrorIngestionOnly { get; set; }
+
         public TimeSpan? AuditRetentionPeriod { get; set; }
 
         public TimeSpan ErrorRetentionPeriod { get; }

--- a/src/ServiceControl/Monitoring/HeartbeatMonitoringComponent.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatMonitoringComponent.cs
@@ -30,7 +30,11 @@
         public override void Configure(Settings settings, ITransportCustomization transportCustomization, IHostApplicationBuilder hostBuilder)
         {
             hostBuilder.Services.AddHostedService<HeartbeatMonitoringHostedService>();
-            hostBuilder.Services.AddHostedService<HeartbeatEndpointSettingsSyncHostedService>();
+
+            if (!settings.ErrorIngestionOnly)
+            {
+                hostBuilder.Services.AddHostedService<HeartbeatEndpointSettingsSyncHostedService>();
+            }
 
             hostBuilder.Services.AddSingleton<IEndpointInstanceMonitoring, EndpointInstanceMonitoring>();
             hostBuilder.Services.AddSingleton<MassTransitConnectorHeartbeatStatus>();
@@ -48,7 +52,10 @@
 
             hostBuilder.Services.AddErrorMessageEnricher<DetectNewEndpointsFromErrorImportsEnricher>();
 
-            hostBuilder.Services.AddPlatformConnectionProvider<HeartbeatsPlatformConnectionDetailsProvider>();
+            if (!settings.ErrorIngestionOnly)
+            {
+                hostBuilder.Services.AddPlatformConnectionProvider<HeartbeatsPlatformConnectionDetailsProvider>();
+            }
         }
     }
 }

--- a/src/ServiceControl/Monitoring/HeartbeatMonitoringHostedService.cs
+++ b/src/ServiceControl/Monitoring/HeartbeatMonitoringHostedService.cs
@@ -17,15 +17,25 @@
             this.persistence = persistence;
             this.scheduler = scheduler;
             this.logger = logger;
+            this.settings = settings;
             gracePeriod = settings.HeartbeatGracePeriod;
         }
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {
             await persistence.WarmupMonitoringFromPersistence(monitor, cancellationToken);
+
+            // An ingestion only host receives no heartbeats, so it has nothing to check and would
+            // only report every endpoint as dead. It still warms the monitor, because the error
+            // enricher asks it whether an endpoint is new before recording it.
+            if (settings.ErrorIngestionOnly)
+            {
+                return;
+            }
+
             timer = scheduler.Schedule(CheckEndpoints, TimeSpan.Zero, TimeSpan.FromSeconds(5), e => logger.LogError(e, "Exception occurred when monitoring endpoint instances"));
         }
 
-        public Task StopAsync(CancellationToken cancellationToken = default) => timer.Stop(cancellationToken);
+        public Task StopAsync(CancellationToken cancellationToken = default) => timer?.Stop(cancellationToken) ?? Task.CompletedTask;
 
         async Task<TimerJobExecutionResult> CheckEndpoints(CancellationToken cancellationToken)
         {
@@ -42,6 +52,7 @@
         IAsyncTimer scheduler;
         TimerJob timer;
         TimeSpan gracePeriod;
+        readonly Settings settings;
 
         readonly ILogger<HeartbeatMonitoringHostedService> logger;
     }

--- a/src/ServiceControl/Persistence/PersistenceFactory.cs
+++ b/src/ServiceControl/Persistence/PersistenceFactory.cs
@@ -13,6 +13,7 @@ namespace ServiceControl.Persistence
             //HINT: This is false when executed from acceptance tests
             settings.PersisterSpecificSettings ??= persistenceConfiguration.CreateSettings(Settings.SettingsRootNamespace);
             settings.PersisterSpecificSettings.MaintenanceMode = maintenanceMode;
+            settings.PersisterSpecificSettings.RunRetentionSweep = !settings.ErrorIngestionOnly;
 
             var persistence = persistenceConfiguration.Create(settings.PersisterSpecificSettings);
             return persistence;

--- a/src/ServiceControl/Recoverability/RecoverabilityComponent.cs
+++ b/src/ServiceControl/Recoverability/RecoverabilityComponent.cs
@@ -79,7 +79,11 @@
             services.AddSingleton<ReturnToSender>();
             services.AddSingleton<ErrorQueueNameCache>();
             services.AddSingleton<ReturnToSenderDequeuer>();
-            services.AddHostedService(provider => provider.GetRequiredService<ReturnToSenderDequeuer>());
+
+            if (!settings.ErrorIngestionOnly)
+            {
+                services.AddHostedService(provider => provider.GetRequiredService<ReturnToSenderDequeuer>());
+            }
 
             //Error importer
             services.AddSingleton<ImportFailedErrors>();


### PR DESCRIPTION
Part 2 of 3 introducing scale-out of error ingestion for EF persistence. Depends on #<PR 1>.

Adds `--error-ingestion-only`, which runs a host that does nothing but drain the error
queue into the shared database. Several of these can run alongside one normal instance.
SQL Server and PostgreSQL only; the command refuses to start on any other storage.

## Why this works at all

Ingestion never uses the NServiceBus endpoint. `ErrorIngestion` builds its own
`TransportInfrastructure` and receiver through the low-level transport API, which is why
competing consumers come for free, and after part 1 it forwards through that same
infrastructure's dispatcher. Everything else the ingestion path does after the receive is a
database write: event log, integration dispatch requests, retry claim cleanup, known
endpoints, failed import records.

The batch writer was already built for concurrent writers (`INSERT ... ON CONFLICT` /
`MERGE WITH (HOLDLOCK)`, newer-wins guards, ordering by `UniqueMessageId` for consistent
lock order), and `ErrorIngestionConcurrencyTests` already covers it.

## No NServiceBus endpoint

The endpoint is not hosted. Its only remaining role would have been as a registration
source for other code in the process, so the host supplies the two things that actually
needed it: `HostInformation` (derived from the machine name, so each node reports its own
custom check row) and `CriticalError` (logs and stops the application).

A send-only endpoint looks like the safer option but is worse. `SendOnly()` drops
`ReceiveAddresses` anyway, which the EF `SubscriptionStorage` registered in
`BasePersistence` needs, and with the endpoint running the subscription feature activates
on any transport without native pub/sub (SQL Server, PostgreSQL, ASQ, MSMQ) and resolves a
store it cannot construct. Dropping the endpoint avoids that entirely.

## What is switched off, and why

| Component | Reason |
| --- | --- |
| `EventDispatcherHostedService` | The drain selects, publishes, then deletes with no row claim, so a second dispatcher publishes every integration event twice. Correctness, not tidiness. |
| `ReturnToSenderDequeuer` | A second staging queue receiver would steal messages from a retry batch. Gated on the mode flag rather than `RunRetryProcessor`, because it is the only writer of `ErrorQueueNameCache.ResolvedErrorAddress`, which `EditHandler` reads. |
| `RetentionSweeper` | Only one host should sweep. New `PersistenceSettings.RunRetentionSweep`. |
| `HeartbeatEndpointSettingsSyncHostedService`, heartbeat checking | A node that receives no heartbeats would report every endpoint dead. The monitor is still warmed from persistence, because the error enricher asks it whether an endpoint is new. |
| `AddEmailNotifications`, `AddLicenseCheck` | `CustomChecksMailNotification` needs `IMessageSession`, and nothing here reads `ActiveLicense`. |
| Two platform connection providers | They take `ReceiveAddresses`. Nothing resolves them today, but leaving them registered is a trap. |

`IntegrationEventWriter` is deliberately kept: it performs the database *write*, and the
normal instance picks the rows up on its polling interval. Without it the event is lost,
not deferred.

## Component list

`EventLog`, `ExternalIntegrations`, `Recoverability`, `HeartbeatMonitoring`, `CustomChecks`.
Not `Hosting` (claims the instance queue) or `Licensing` (would count throughput once per
node).

Four of those five are required, and the reason is worth stating: which node ingests a
given message is arbitrary, so if nodes behave differently then whether a failure produces
an event log entry becomes a coin flip per message. That is worse than either consistent
choice.

## Testing

`When_hosting_error_ingestion_only`, run on SQL Server and PostgreSQL:

- resolves every hosted service (the real proof the container composes without an endpoint)
  and asserts the **exact set**, so adding one anywhere forces a deliberate decision about
  whether it is safe to run on every node
- asserts `IMessageSession` is absent
- end to end: dispatches a raw failed message and asserts the row, the denormalized endpoint
  columns, the failure groups, the known endpoint row and the event log entry
- refuses to start against RavenDB storage

The end-to-end assertions were verified by removal: dropping `HeartbeatMonitoringComponent`
or `EventLogComponent` still builds, starts and ingests, and only the derived data goes
missing. Both now fail loudly.

## Known gaps

Message bodies must be readable by every host. This mode should not be combined with file
system body storage unless the path is a shared mount. Documented in `Help.txt`, not yet
enforced or warned about at startup.
