### PR TITLE
Fix flaky IndexSetupTests on RavenDB

### DIFF
--- a/src/ServiceControl.AcceptanceTests.RavenDB/AcceptanceTestStorageConfiguration.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/AcceptanceTestStorageConfiguration.cs
@@ -8,6 +8,7 @@ using ServiceBus.Management.Infrastructure.Settings;
 using ServiceControl.AcceptanceTests.TestSupport;
 using ServiceControl.Persistence.Tests;
 using ServiceControl.RavenDB;
+using TestHelper;
 
 public class AcceptanceTestStorageConfiguration : IAcceptanceTestStorageConfiguration
 {

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/AcceptanceTestStorageConfiguration.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/AcceptanceTestStorageConfiguration.cs
@@ -8,6 +8,7 @@
     using ServiceControl.Audit.Persistence.RavenDB;
     using ServiceControl.Audit.Persistence.Tests;
     using ServiceControl.RavenDB;
+    using TestHelper;
 
     public class AcceptanceTestStorageConfiguration
     {

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
@@ -7,6 +7,7 @@ using Persistence.RavenDB;
 using Persistence.RavenDB.Indexes;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents.Indexes;
 
 [TestFixture]
@@ -109,8 +110,16 @@ class IndexSetupTests : PersistenceTestFixture
         return await WaitForIndexDefinitionUpdate(statsBefore);
     }
 
+    // How many consecutive RavenExceptions from the stats query below get tolerated before letting one propagate for real.
+    // RavenDB can throw a variety of transient errors for that race (seen so far: OperationCanceledException
+    // from the read transaction being cancelled, and ObjectDisposedException from the old engine's index persistence being torn down).
+    // A genuinely broken index should still fail the test.
+    const int MaxTransientRavenExceptionRetries = 2;
+
     async Task<IndexStats> WaitForIndexDefinitionUpdate(IndexStats oldStats)
     {
+        var transientFailures = 0;
+
         while (true)
         {
             try
@@ -126,6 +135,10 @@ class IndexSetupTests : PersistenceTestFixture
             catch (OperationCanceledException)
             {
                 // keep going since we can get this if we query right when the update happens
+            }
+            catch (RavenException) when (transientFailures < MaxTransientRavenExceptionRetries)
+            {
+                transientFailures++;
             }
 #pragma warning restore PS0020
 

--- a/src/ServiceControl.Persistence.Tests.RavenDB/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/PersistenceTestsContext.cs
@@ -15,6 +15,7 @@ using ServiceControl.MessageFailures;
 using ServiceControl.Persistence;
 using ServiceControl.Persistence.RavenDB;
 using ServiceControl.RavenDB;
+using TestHelper;
 
 public class PersistenceTestsContext : IPersistenceTestsContext
 {

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -13,7 +13,6 @@ namespace ServiceControl.RavenDB
     using Microsoft.Extensions.Logging;
     using Raven.Client.Documents;
     using Raven.Client.Documents.Conventions;
-    using Raven.Client.ServerWide.Operations;
     using Raven.Embedded;
     using ServiceControl.Infrastructure;
     using Sparrow.Logging;
@@ -178,15 +177,6 @@ namespace ServiceControl.RavenDB
 
             var store = await EmbeddedServer.Instance.GetDocumentStoreAsync(dbOptions, cancellationToken);
             return store;
-        }
-
-        public async Task DeleteDatabase(string dbName, CancellationToken cancellationToken = default)
-        {
-            using var store = await EmbeddedServer.Instance.GetDocumentStoreAsync(new DatabaseOptions(dbName)
-            {
-                SkipCreatingDatabase = true
-            }, cancellationToken);
-            await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(dbName, true), cancellationToken);
         }
 
         public async Task Stop(CancellationToken cancellationToken = default)

--- a/src/TestHelper/EmbeddedDatabaseExtensions.cs
+++ b/src/TestHelper/EmbeddedDatabaseExtensions.cs
@@ -1,0 +1,28 @@
+namespace TestHelper;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.ServerWide.Operations;
+using Raven.Embedded;
+using ServiceControl.RavenDB;
+
+public static class EmbeddedDatabaseExtensions
+{
+    public static async Task DeleteDatabase(this EmbeddedDatabase database, string dbName, CancellationToken cancellationToken = default)
+    {
+        using var store = await EmbeddedServer.Instance.GetDocumentStoreAsync(
+            new DatabaseOptions(dbName) { SkipCreatingDatabase = true },
+            cancellationToken);
+
+        // RavenDB's default confirmation wait (15s) is for its Raft commit log to catch up
+        // with this delete command's index. Under the volume this shared embedded server sees
+        // in a full test run (every test creates and deletes its own database against the same
+        // instance), that commit can occasionally land just past the default window even though
+        // the delete itself isn't failing - so give it more headroom explicitly rather than
+        // relying on RavenDB's default.
+        await store.Maintenance.Server.SendAsync(
+            new DeleteDatabasesOperation(dbName, hardDelete: true, timeToWaitForConfirmation: TimeSpan.FromSeconds(30)),
+            cancellationToken);
+    }
+}

--- a/src/TestHelper/TestHelper.csproj
+++ b/src/TestHelper/TestHelper.csproj
@@ -7,6 +7,11 @@
   <ItemGroup>
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="RavenDB.Embedded" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.RavenDB\ServiceControl.RavenDB.csproj" />
   </ItemGroup>
 
   <!-- Workaround to prevent VS test discovery error -->


### PR DESCRIPTION
`IndexSetupTests.Indexes_should_be_reset_on_setup` (and its sibling paths through `UpdateIndex`) has been failing intermittently on CI with an unhandled exception from `WaitForIndexDefinitionUpdate`.

The polling loop already tolerated a plain `OperationCanceledException`, with a comment noting "we can get this if we query right when the update happens", but that only covered the client-side cancellation shape. In practice, querying `GetIndexStatisticsOperation` right as RavenDB swaps an index's underlying storage engine during a reset can throw a variety of transient errors, not just that one:

- `OperationCanceledException` from the read transaction being cancelled as the reset starts
- `ObjectDisposedException` ("Index persistence for index '...' was already disposed"), from the old engine's index persistence (e.g. Lucene) being torn down once the reset takes over

Both surfaced in real CI failures as Raven.Client.Exceptions.RavenException. RavenDB reconstructs a generic wrapper client-side for server exceptions it doesn't specifically know how to rehydrate, so the original type/message ends up embedded in RavenException.Message rather than as a genuine .InnerException.

`WaitForIndexDefinitionUpdate` now tolerates up to `MaxTransientRavenExceptionRetries` (2) consecutive `RavenExceptions` of any kind before letting one propagate. 

A genuinely broken index (or a bug in the test itself) still fails fast with its real exception, rather than being silently retried for the rest of the test's 30s timeout budget.

Also moved RavenDB DeleteDatabase code into the TestHelper since it is only tests that are deleting databases.