### PR TITLE
Order the failed message status by the times the events happened

### DIFF
--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlFailedMessageIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/PostgreSqlFailedMessageIngestionSqlDialect.cs
@@ -63,6 +63,36 @@ class PostgreSqlFailedMessageIngestionSqlDialect : PostgreSqlDialect, IFailedMes
         }
     }
 
+    public async Task ResolveRetriedMessages(ServiceControlDbContext dbContext, IReadOnlyList<ConfirmedRetry> rows, DateTime now, CancellationToken cancellationToken = default)
+    {
+        const int resolved = (int)FailedMessageStatus.Resolved;
+
+        foreach (var chunk in rows.Chunk(MaxRowsPerStatement))
+        {
+            await Execute(
+                dbContext,
+                $"""
+                 UPDATE failed_messages SET
+                     status = {resolved},
+                     status_changed_at = @p0,
+                     last_modified = @p0
+                 FROM (VALUES
+                 {ConfirmedRetryRows(chunk.Length)}
+                 ) AS s (unique_message_id, succeeded_at)
+                 WHERE failed_messages.unique_message_id = s.unique_message_id
+                   AND failed_messages.last_attempted_at <= s.succeeded_at
+                 """,
+                [[now], .. chunk.Select(retry => new object?[] { retry.UniqueMessageId, retry.SucceededAt })],
+                cancellationToken);
+        }
+    }
+
+    // A bare VALUES list has no target column to take its types from, so the first row carries them.
+    static string ConfirmedRetryRows(int rowCount) =>
+        string.Join(",\n", Enumerable.Range(0, rowCount).Select(row => row == 0
+            ? "(@p1::uuid, @p2::timestamptz)"
+            : $"(@p{1 + (row * 2)}, @p{2 + (row * 2)})"));
+
     // The columns the newer attempt wins wholesale
     static readonly string[] PayloadColumns =
     [
@@ -96,6 +126,11 @@ class PostgreSqlFailedMessageIngestionSqlDialect : PostgreSqlDialect, IFailedMes
 
     static readonly string OnConflictUpdate = BuildOnConflictUpdate();
 
+    // Strictly newer, where the payload columns take the incoming attempt on a tie as well. A
+    // redelivery of the attempt already stored is not news, and must not undo a resolve or an
+    // archive that happened after it.
+    const string IsNewerAttempt = "excluded.last_attempted_at > failed_messages.last_attempted_at";
+
     static string BuildOnConflictUpdate()
     {
         const int unresolved = (int)FailedMessageStatus.Unresolved;
@@ -103,8 +138,8 @@ class PostgreSqlFailedMessageIngestionSqlDialect : PostgreSqlDialect, IFailedMes
         var sql = new StringBuilder(
             $"""
              ON CONFLICT (unique_message_id) DO UPDATE SET
-                 status = {unresolved},
-                 status_changed_at = CASE WHEN failed_messages.status <> {unresolved} THEN excluded.status_changed_at ELSE failed_messages.status_changed_at END,
+                 status = CASE WHEN {IsNewerAttempt} THEN {unresolved} ELSE failed_messages.status END,
+                 status_changed_at = CASE WHEN {IsNewerAttempt} AND failed_messages.status <> {unresolved} THEN excluded.status_changed_at ELSE failed_messages.status_changed_at END,
                  last_modified = excluded.last_modified,
                  number_of_processing_attempts = failed_messages.number_of_processing_attempts
                      + CASE WHEN excluded.last_attempted_at <> failed_messages.last_attempted_at THEN excluded.number_of_processing_attempts ELSE 0 END,

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerFailedMessageIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/SqlServerFailedMessageIngestionSqlDialect.cs
@@ -76,6 +76,35 @@ class SqlServerFailedMessageIngestionSqlDialect : SqlServerDialect, IFailedMessa
         }
     }
 
+    public async Task ResolveRetriedMessages(ServiceControlDbContext dbContext, IReadOnlyList<ConfirmedRetry> rows, DateTime now, CancellationToken cancellationToken = default)
+    {
+        const int resolved = (int)FailedMessageStatus.Resolved;
+
+        var maxRowsPerStatement = MaxRowsPerStatement(2);
+        foreach (var chunk in rows.Chunk(maxRowsPerStatement))
+        {
+            await Execute(
+                dbContext,
+                $"""
+                 UPDATE t SET
+                     [Status] = {resolved},
+                     [StatusChangedAt] = @p0,
+                     [LastModified] = @p0
+                 FROM [FailedMessages] AS t
+                 INNER JOIN (VALUES
+                 {ConfirmedRetryRows(chunk.Length)}
+                 ) AS s ([UniqueMessageId], [SucceededAt])
+                     ON t.[UniqueMessageId] = s.[UniqueMessageId]
+                 WHERE t.[LastAttemptedAt] <= s.[SucceededAt];
+                 """,
+                [[now], .. chunk.Select(retry => new object?[] { retry.UniqueMessageId, retry.SucceededAt })],
+                cancellationToken);
+        }
+    }
+
+    static string ConfirmedRetryRows(int rowCount) =>
+        string.Join(",\n", Enumerable.Range(0, rowCount).Select(row => $"(@p{1 + (row * 2)}, @p{2 + (row * 2)})"));
+
     // The columns the newer attempt wins wholesale
     static readonly string[] PayloadColumns =
     [
@@ -111,6 +140,11 @@ class SqlServerFailedMessageIngestionSqlDialect : SqlServerDialect, IFailedMessa
 
     static readonly string WhenMatchedUpdate = BuildWhenMatchedUpdate();
 
+    // Strictly newer, where the payload columns take the incoming attempt on a tie as well. A
+    // redelivery of the attempt already stored is not news, and must not undo a resolve or an
+    // archive that happened after it.
+    const string IsNewerAttempt = "s.[LastAttemptedAt] > t.[LastAttemptedAt]";
+
     static string BuildWhenMatchedUpdate()
     {
         const int unresolved = (int)FailedMessageStatus.Unresolved;
@@ -118,8 +152,8 @@ class SqlServerFailedMessageIngestionSqlDialect : SqlServerDialect, IFailedMessa
         var sql = new StringBuilder(
             $"""
              WHEN MATCHED THEN UPDATE SET
-                 [Status] = {unresolved},
-                 [StatusChangedAt] = CASE WHEN t.[Status] <> {unresolved} THEN s.[StatusChangedAt] ELSE t.[StatusChangedAt] END,
+                 [Status] = CASE WHEN {IsNewerAttempt} THEN {unresolved} ELSE t.[Status] END,
+                 [StatusChangedAt] = CASE WHEN {IsNewerAttempt} AND t.[Status] <> {unresolved} THEN s.[StatusChangedAt] ELSE t.[StatusChangedAt] END,
                  [LastModified] = s.[LastModified],
                  [NumberOfProcessingAttempts] = t.[NumberOfProcessingAttempts]
                      + CASE WHEN s.[LastAttemptedAt] <> t.[LastAttemptedAt] THEN s.[NumberOfProcessingAttempts] ELSE 0 END,

--- a/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/EFIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/EFIngestionUnitOfWork.cs
@@ -17,7 +17,7 @@ public class EFIngestionUnitOfWork : IIngestionUnitOfWork
     readonly ConcurrentQueue<RecordedFailedProcessingAttempt> failedProcessingAttempts = new();
     readonly ConcurrentQueue<Task> bodyWrites = new();
     readonly ConcurrentQueue<KnownEndpoint> knownEndpoints = new();
-    readonly ConcurrentQueue<Guid> confirmedRetries = new();
+    readonly ConcurrentQueue<ConfirmedRetry> confirmedRetries = new();
 
     public EFIngestionUnitOfWork(IAsyncDisposable scope, ServiceControlDbContext dbContext, IBodyStoragePersistence storagePersistence, EFPersisterSettings settings, IFailedMessageIngestionSqlDialect dialect, TimeProvider timeProvider)
     {
@@ -39,7 +39,7 @@ public class EFIngestionUnitOfWork : IIngestionUnitOfWork
 
     internal void Record(KnownEndpoint knownEndpoint) => knownEndpoints.Enqueue(knownEndpoint);
 
-    internal void RecordConfirmedRetry(Guid uniqueMessageId) => confirmedRetries.Enqueue(uniqueMessageId);
+    internal void RecordConfirmedRetry(ConfirmedRetry confirmedRetry) => confirmedRetries.Enqueue(confirmedRetry);
 
     public async Task Complete(CancellationToken cancellationToken = default)
     {

--- a/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/EFRecoverabilityIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/EFRecoverabilityIngestionUnitOfWork.cs
@@ -61,9 +61,9 @@ public class EFRecoverabilityIngestionUnitOfWork(EFIngestionUnitOfWork parentUni
         return Task.CompletedTask;
     }
 
-    public Task RecordSuccessfulRetry(string retriedMessageUniqueId, CancellationToken cancellationToken = default)
+    public Task RecordSuccessfulRetry(string retriedMessageUniqueId, DateTime succeededAt, CancellationToken cancellationToken = default)
     {
-        parentUnitOfWork.RecordConfirmedRetry(Guid.Parse(retriedMessageUniqueId));
+        parentUnitOfWork.RecordConfirmedRetry(new ConfirmedRetry(Guid.Parse(retriedMessageUniqueId), succeededAt));
 
         return Task.CompletedTask;
     }

--- a/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/FailedMessageBatchWriter.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/FailedMessageBatchWriter.cs
@@ -9,19 +9,19 @@ using ServiceControl.Persistence.EFCore.Infrastructure;
 // Writes one ingestion batch inside a single transaction. The statements providers genuinely
 // differ on (the upserts) come from the injected dialect; everything portable stays here as
 // set-based EF operations. Statement order matters: a message that fails and is retry-confirmed
-// in the same batch must end Resolved.
+// in the same batch must end Resolved, which the resolve running last is what gives it.
 class FailedMessageBatchWriter(ServiceControlDbContext dbContext, IFailedMessageIngestionSqlDialect dialect)
 {
     public async Task Write(
         IReadOnlyCollection<RecordedFailedProcessingAttempt> attempts,
         IReadOnlyCollection<KnownEndpoint> knownEndpoints,
-        IReadOnlyCollection<Guid> confirmedRetries,
+        IReadOnlyCollection<ConfirmedRetry> confirmedRetries,
         DateTime now,
         CancellationToken cancellationToken = default)
     {
         var (failedMessages, groups) = Fold(attempts, now);
         var endpoints = BuildEndpointRows(knownEndpoints);
-        var retries = confirmedRetries.Distinct().ToArray();
+        var retries = FoldRetries(confirmedRetries);
 
         if (failedMessages.Count == 0 && endpoints.Count == 0 && retries.Length == 0)
         {
@@ -110,6 +110,14 @@ class FailedMessageBatchWriter(ServiceControlDbContext dbContext, IFailedMessage
         return (messages, groups);
     }
 
+    // A message acknowledged more than once in one batch keeps the latest acknowledgement, so the
+    // guard the resolve applies is the one that lets the most attempts through.
+    static ConfirmedRetry[] FoldRetries(IReadOnlyCollection<ConfirmedRetry> confirmedRetries) =>
+        [.. confirmedRetries
+            .GroupBy(retry => retry.UniqueMessageId)
+            .Select(group => new ConfirmedRetry(group.Key, group.Max(retry => retry.SucceededAt)))
+            .OrderBy(retry => retry.UniqueMessageId)];
+
     static List<KnownEndpointEntity> BuildEndpointRows(IReadOnlyCollection<KnownEndpoint> knownEndpoints) =>
         [.. knownEndpoints
             .Select(knownEndpoint => new KnownEndpointEntity
@@ -174,17 +182,17 @@ class FailedMessageBatchWriter(ServiceControlDbContext dbContext, IFailedMessage
         ];
     }
 
-    async Task ResolveRetried(Guid[] retries, DateTime now, CancellationToken cancellationToken)
+    // The status only moves for messages whose newest stored attempt is not newer than the retry,
+    // which the dialect applies per row. The retry rows go regardless: the retry itself completed,
+    // so its claim is released whether or not the message has since failed again.
+    async Task ResolveRetried(ConfirmedRetry[] retries, DateTime now, CancellationToken cancellationToken)
     {
-        await dbContext.FailedMessages
-            .Where(failedMessage => retries.Contains(failedMessage.UniqueMessageId))
-            .ExecuteUpdateAsync(setters => setters
-                .SetProperty(failedMessage => failedMessage.Status, FailedMessageStatus.Resolved)
-                .SetProperty(failedMessage => failedMessage.StatusChangedAt, now)
-                .SetProperty(failedMessage => failedMessage.LastModified, now), cancellationToken);
+        await dialect.ResolveRetriedMessages(dbContext, retries, now, cancellationToken);
+
+        var messageIds = retries.Select(retry => retry.UniqueMessageId).ToArray();
 
         await dbContext.FailedMessageRetries
-            .Where(retry => retries.Contains(retry.UniqueMessageId))
+            .Where(retry => messageIds.Contains(retry.UniqueMessageId))
             .ExecuteDeleteAsync(cancellationToken);
     }
 }

--- a/src/ServiceControl.Persistence.EFCore/Infrastructure/ConfirmedRetry.cs
+++ b/src/ServiceControl.Persistence.EFCore/Infrastructure/ConfirmedRetry.cs
@@ -1,0 +1,7 @@
+namespace ServiceControl.Persistence.EFCore.Infrastructure;
+
+/// <summary>
+/// A retry acknowledgement, carrying the time the retry succeeded so that a message which failed
+/// again afterwards is not resolved by it.
+/// </summary>
+public readonly record struct ConfirmedRetry(Guid UniqueMessageId, DateTime SucceededAt);

--- a/src/ServiceControl.Persistence.EFCore/Infrastructure/IFailedMessageIngestionSqlDialect.cs
+++ b/src/ServiceControl.Persistence.EFCore/Infrastructure/IFailedMessageIngestionSqlDialect.cs
@@ -1,4 +1,4 @@
-namespace ServiceControl.Persistence.EFCore.Infrastructure;
+﻿namespace ServiceControl.Persistence.EFCore.Infrastructure;
 
 using ServiceControl.Persistence.EFCore.DbContexts;
 using ServiceControl.Persistence.EFCore.Entities;
@@ -28,4 +28,11 @@ public interface IFailedMessageIngestionSqlDialect
     /// Insert if absent, never update: existing endpoints keep their Monitored flag.
     /// </summary>
     Task InsertMissingKnownEndpoints(ServiceControlDbContext dbContext, IReadOnlyList<KnownEndpointEntity> rows, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// One row per message, distinct by UniqueMessageId. Marks each Resolved unless its stored
+    /// attempt is newer than the retry succeeded, which means the message failed again afterwards
+    /// and must stay Unresolved however the two batches interleave.
+    /// </summary>
+    Task ResolveRetriedMessages(ServiceControlDbContext dbContext, IReadOnlyList<ConfirmedRetry> rows, DateTime now, CancellationToken cancellationToken = default);
 }

--- a/src/ServiceControl.Persistence.RavenDB/ExpirationManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ExpirationManager.cs
@@ -39,14 +39,21 @@
             session.Advanced.GetMetadataFor(eventLogItem)[Constants.Documents.Metadata.Expires] = expiresAt;
         }
 
-        public void EnableExpiration(PatchRequest request)
+        public void EnableExpiration(PatchRequest request) => request.Script += "\n" + EnableExpirationScript(request);
+
+        // Registers the value and hands back the statement, for scripts that only expire the
+        // document down one branch and so cannot have it appended to the end.
+        public string EnableExpirationScript(PatchRequest request)
         {
             var expiredAt = DateTime.UtcNow + errorRetentionPeriod;
 
-            request.Script += "\nthis['@metadata']['@expires'] = args.Expires;";
             request.Values.Add("Expires", expiredAt);
+
+            return "this['@metadata']['@expires'] = args.Expires;";
         }
 
-        public void CancelExpiration(PatchRequest request) => request.Script += "delete this['@metadata']['@expires']";
+        public void CancelExpiration(PatchRequest request) => request.Script += CancelExpirationScript;
+
+        public const string CancelExpirationScript = "delete this['@metadata']['@expires'];";
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence.RavenDB/UnitOfWork/RavenRecoverabilityIngestionUnitOfWork.cs
@@ -68,20 +68,24 @@
             return Task.CompletedTask;
         }
 
-        public Task RecordSuccessfulRetry(string retriedMessageUniqueId, CancellationToken cancellationToken = default)
+        public Task RecordSuccessfulRetry(string retriedMessageUniqueId, DateTime succeededAt, CancellationToken cancellationToken = default)
         {
             var failedMessageDocumentId = FailedMessageIdGenerator.MakeDocumentId(retriedMessageUniqueId);
             var failedMessageRetryDocumentId = RetryDocumentDataStore.MakeFailedMessageRetriesDocumentId(retriedMessageUniqueId);
 
             var patchRequest = new PatchRequest
             {
-                Script = $@"this.{nameof(FailedMessage.Status)} = {(int)FailedMessageStatus.Resolved};"
+                Values = new Dictionary<string, object> { { "succeededAt", succeededAt } }
             };
 
-            expirationManager.EnableExpiration(patchRequest);
+            patchRequest.Script = $@"if({NewestStoredAttempt("<=", "args.succeededAt")}){{
+                                        this.{nameof(FailedMessage.Status)} = {(int)FailedMessageStatus.Resolved};
+                                        {expirationManager.EnableExpirationScript(patchRequest)}
+                                     }}";
 
             parentUnitOfWork.AddCommand(new PatchCommandData(failedMessageDocumentId, null, patchRequest));
 
+            // The retry itself did complete, so its claim is released either way.
             parentUnitOfWork.AddCommand(new DeleteCommandData(failedMessageRetryDocumentId, null));
             return Task.CompletedTask;
         }
@@ -91,14 +95,24 @@
         {
             var documentId = FailedMessageIdGenerator.MakeDocumentId(uniqueMessageId);
 
-            const string ProcessingAttempts = nameof(FailedMessage.ProcessingAttempts);
-            const string AttemptedAt = nameof(FailedMessage.ProcessingAttempt.AttemptedAt);
-
             //HINT: RavenDB 4.2 removed Lodash utility functions, but supports ECMAScript 5.1 and some 6.0 features like arrow functions and array primitive functions
             var existingDocPatch = new PatchRequest
             {
-                Script = $@"this.{nameof(FailedMessage.Status)} = args.status;
-                                this.{nameof(FailedMessage.FailureGroups)} = args.failureGroups;
+                // The status, the groups and the retention stamp describe the message as its newest
+                // attempt left it, so an attempt that is not the newest only joins the attempts
+                // array. Which attempt is newest has to be read before the incoming one is pushed.
+                //
+                // A message re-failing must not keep an @expires stamp set by an earlier
+                // resolve/archive/retry, otherwise it can be silently deleted while still
+                // Unresolved. A late older attempt must not strip the stamp off a message that is
+                // still resolved, which is why that runs down the same branch.
+                Script = $@"var isNewestAttempt = {NewestStoredAttempt("<", $"args.attempt.{AttemptedAt}")};
+
+                                if(isNewestAttempt){{
+                                    this.{nameof(FailedMessage.Status)} = args.status;
+                                    this.{nameof(FailedMessage.FailureGroups)} = args.failureGroups;
+                                    {ExpirationManager.CancelExpirationScript}
+                                }}
 
                                 var newAttempts = this.{nameof(FailedMessage.ProcessingAttempts)};
 
@@ -126,10 +140,6 @@
                         {"attempt", processingAttempt}
                     },
             };
-
-            // A message re-failing must not keep an @expires stamp set by an earlier
-            // resolve/archive/retry, otherwise it can be silently deleted while still Unresolved.
-            expirationManager.CancelExpiration(existingDocPatch);
 
             return new PatchCommandData(documentId, null, existingDocPatch,
                 patchIfMissing: new PatchRequest
@@ -166,6 +176,14 @@
 
         static string GetContentType(IReadOnlyDictionary<string, string> headers, string defaultContentType)
             => headers.GetValueOrDefault(Headers.ContentType, defaultContentType);
+
+        // Attempts are stored sorted ascending by AttemptedAt, so the last one is the newest. Both
+        // sides are RavenDB serialized dates, compared as strings exactly as the sort above does.
+        static string NewestStoredAttempt(string comparison, string time) =>
+            $"this.{ProcessingAttempts}.length === 0 || this.{ProcessingAttempts}[this.{ProcessingAttempts}.length - 1].{AttemptedAt} {comparison} {time}";
+
+        const string ProcessingAttempts = nameof(FailedMessage.ProcessingAttempts);
+        const string AttemptedAt = nameof(FailedMessage.ProcessingAttempt.AttemptedAt);
 
         static int MaxProcessingAttempts = 10;
         // large object heap starts above 85000 bytes and not above 85 KB!

--- a/src/ServiceControl.Persistence.Tests.InMemory/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.InMemory/PersistenceTestsContext.cs
@@ -13,6 +13,8 @@ public class PersistenceTestsContext : IPersistenceTestsContext
     public Task InsertFailedMessages(params FailedMessage[] messages) => throw new System.NotImplementedException();
     public void AdvanceClock(System.TimeSpan by) => throw new System.NotImplementedException();
 
+    public System.DateTime UtcNow => throw new System.NotImplementedException();
+
     public Task Setup(IHostApplicationBuilder hostBuilder)
     {
         hostBuilder.Services.AddLicensingInMemoryPersistence();

--- a/src/ServiceControl.Persistence.Tests.PostgreSql/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.PostgreSql/PersistenceTestsContext.cs
@@ -23,6 +23,8 @@ public partial class PersistenceTestsContext : IPersistenceTestsContext
 
     public void AdvanceClock(TimeSpan by) => FakeTime.Advance(by);
 
+    public DateTime UtcNow => FakeTime.GetUtcNow().UtcDateTime;
+
     public async Task Setup(IHostApplicationBuilder hostBuilder)
     {
         databaseName = $"sc_test_{Guid.NewGuid():n}";

--- a/src/ServiceControl.Persistence.Tests.RavenDB/Expiration/MessageExpiryTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/Expiration/MessageExpiryTests.cs
@@ -161,7 +161,7 @@
             // Successful retry stamps @expires on the FailedMessage document.
             await using (var uow = await IngestionUnitOfWorkFactory.StartNew())
             {
-                await uow.Recoverability.RecordSuccessfulRetry(uniqueMessageId);
+                await uow.Recoverability.RecordSuccessfulRetry(uniqueMessageId, attempt.AttemptedAt.AddMinutes(1));
 
                 await uow.Complete(TestContext.CurrentContext.CancellationToken);
             }
@@ -169,7 +169,7 @@
             await CompleteDatabaseOperation();
 
             // The same logical message fails again before the retention period elapses.
-            var (context2, attempt2) = CreateMessageContext(uniqueMessageId);
+            var (context2, attempt2) = CreateMessageContext(uniqueMessageId, attempt.AttemptedAt.AddMinutes(2));
 
             await using (var uow = await IngestionUnitOfWorkFactory.StartNew())
             {
@@ -211,7 +211,7 @@
 
             await using (var uow = await IngestionUnitOfWorkFactory.StartNew())
             {
-                await uow.Recoverability.RecordSuccessfulRetry(errors.Results.First().Id);
+                await uow.Recoverability.RecordSuccessfulRetry(errors.Results.First().Id, attempt.AttemptedAt.AddMinutes(1));
 
                 await uow.Complete(TestContext.CurrentContext.CancellationToken);
             }
@@ -219,7 +219,7 @@
             await WaitUntil(async () => (await GetAllMessages()).Results.Count == 0, "Retry confirmation should cause message removal.");
         }
 
-        static (MessageContext, FailedMessage.ProcessingAttempt) CreateMessageContext(string forceUniqueMessageId = null)
+        static (MessageContext, FailedMessage.ProcessingAttempt) CreateMessageContext(string forceUniqueMessageId = null, DateTime? attemptedAt = null)
         {
             var headers = new Dictionary<string, string>
             {
@@ -235,6 +235,11 @@
             }
 
             var attempt = FailedMessageBuilder.Minimal().ProcessingAttempts.First();
+
+            if (attemptedAt.HasValue)
+            {
+                attempt.AttemptedAt = attemptedAt.Value;
+            }
 
             var message = new MessageContext(Guid.NewGuid().ToString(), headers, ReadOnlyMemory<byte>.Empty, new TransportTransaction(), "receiveAddress", new ContextBag());
 

--- a/src/ServiceControl.Persistence.Tests.RavenDB/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/PersistenceTestsContext.cs
@@ -87,6 +87,8 @@ public class PersistenceTestsContext : IPersistenceTestsContext
     {
     }
 
+    public DateTime UtcNow => DateTime.UtcNow;
+
     public Task CompleteDatabaseOperation()
     {
         DocumentStore.WaitForIndexing();

--- a/src/ServiceControl.Persistence.Tests.RavenDB/Recoverability/RetryConfirmationOrderingTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/Recoverability/RetryConfirmationOrderingTests.cs
@@ -1,0 +1,79 @@
+namespace ServiceControl.Persistence.Tests.RavenDB.Recoverability;
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ServiceControl.MessageFailures;
+
+// A retry acknowledgement and a later failure of the same message reach storage in whatever order
+// their batches commit. Both orders are forced here rather than raced, so the assertion is about
+// the end state and not about which batch got there first.
+[TestFixture]
+class RetryConfirmationOrderingTests : RavenPersistenceTestBase
+{
+    [Test]
+    public async Task A_confirmation_arriving_after_a_later_attempt_leaves_the_message_unresolved()
+    {
+        var failure = new IngestedFailure();
+        var retrySucceededAt = failure.AttemptedAt.AddMinutes(1);
+
+        await Ingest(failure);
+        await Ingest(failure.NextAttempt(retrySucceededAt.AddMinutes(1)));
+        await ConfirmRetry(failure.UniqueMessageIdString, retrySucceededAt);
+
+        var message = await FailedMessageQueryStore.GetFailedMessage(failure.UniqueMessageIdString);
+
+        Assert.That(message.Status, Is.EqualTo(FailedMessageStatus.Unresolved), "the message failed again after the retry succeeded");
+    }
+
+    [Test]
+    public async Task A_later_attempt_arriving_after_a_confirmation_leaves_the_message_unresolved()
+    {
+        var failure = new IngestedFailure();
+        var retrySucceededAt = failure.AttemptedAt.AddMinutes(1);
+
+        await Ingest(failure);
+        await ConfirmRetry(failure.UniqueMessageIdString, retrySucceededAt);
+        await Ingest(failure.NextAttempt(retrySucceededAt.AddMinutes(1)));
+
+        var message = await FailedMessageQueryStore.GetFailedMessage(failure.UniqueMessageIdString);
+
+        Assert.That(message.Status, Is.EqualTo(FailedMessageStatus.Unresolved), "the message failed again after the retry succeeded");
+    }
+
+    [Test]
+    public async Task A_redelivered_attempt_arriving_after_a_confirmation_leaves_the_message_resolved()
+    {
+        var failure = new IngestedFailure();
+
+        await Ingest(failure);
+        await ConfirmRetry(failure.UniqueMessageIdString, failure.AttemptedAt.AddMinutes(1));
+        await Ingest(failure);
+
+        var message = await FailedMessageQueryStore.GetFailedMessage(failure.UniqueMessageIdString);
+
+        Assert.That(message.Status, Is.EqualTo(FailedMessageStatus.Resolved), "redelivering the attempt the retry was for is not a new failure");
+    }
+
+    async Task Ingest(IngestedFailure failure)
+    {
+        await using (var unitOfWork = await UnitOfWorkFactory.StartNew())
+        {
+            await unitOfWork.Recoverability.RecordFailedProcessingAttempt(failure.Context, failure.ProcessingAttempt, failure.Groups);
+            await unitOfWork.Complete(TestContext.CurrentContext.CancellationToken);
+        }
+
+        await CompleteDatabaseOperation();
+    }
+
+    async Task ConfirmRetry(string uniqueMessageId, DateTime succeededAt)
+    {
+        await using (var unitOfWork = await UnitOfWorkFactory.StartNew())
+        {
+            await unitOfWork.Recoverability.RecordSuccessfulRetry(uniqueMessageId, succeededAt);
+            await unitOfWork.Complete(TestContext.CurrentContext.CancellationToken);
+        }
+
+        await CompleteDatabaseOperation();
+    }
+}

--- a/src/ServiceControl.Persistence.Tests.SqlServer/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.SqlServer/PersistenceTestsContext.cs
@@ -22,6 +22,8 @@ public partial class PersistenceTestsContext : IPersistenceTestsContext
 
     public void AdvanceClock(TimeSpan by) => FakeTime.Advance(by);
 
+    public DateTime UtcNow => FakeTime.GetUtcNow().UtcDateTime;
+
     public async Task Setup(IHostApplicationBuilder hostBuilder)
     {
         databaseName = $"sc_test_{Guid.NewGuid():n}";

--- a/src/ServiceControl.Persistence.Tests/EFCore/EditFailedMessagesDataStoreRetentionTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/EditFailedMessagesDataStoreRetentionTests.cs
@@ -18,8 +18,6 @@ class EditFailedMessagesDataStoreRetentionTests : ErrorIngestionTestBase
 {
     IEditFailedMessagesDataStore EditStore => ServiceProvider.GetRequiredService<IEditFailedMessagesDataStore>();
 
-    DateTime Now => PersistenceTestsContext.FakeTime.GetUtcNow().UtcDateTime;
-
     [Test]
     public async Task TryBeginEdit_stamps_StatusChangedAt_and_LastModified()
     {

--- a/src/ServiceControl.Persistence.Tests/EFCore/ErrorIngestionConcurrencyTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/ErrorIngestionConcurrencyTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using ServiceControl.MessageFailures;
 using ServiceControl.Operations;
+using ServiceControl.Persistence.EFCore.Entities;
 
 class ErrorIngestionConcurrencyTests : ErrorIngestionTestBase
 {
@@ -81,6 +82,75 @@ class ErrorIngestionConcurrencyTests : ErrorIngestionTestBase
 
             Assert.That(groups.Select(group => group.GroupId), Is.EqualTo(new[] { newestGroupId }),
                 "only the newest attempt's groups may survive, regardless of commit order");
+        }
+    }
+
+    // A retry acknowledgement and a later failure of the same message reach storage in whatever
+    // order their batches commit, and with several ingestion hosts they need not even be on the
+    // same one. Both orders are forced here rather than raced, so the assertion is about the end
+    // state and not about which batch got there first.
+    [Test]
+    public async Task A_confirmation_arriving_after_a_later_attempt_leaves_the_message_unresolved()
+    {
+        var failure = new IngestedFailure();
+        var retrySucceededAt = failure.AttemptedAt.AddMinutes(1);
+
+        await Ingest(failure);
+        await Ingest(failure.NextAttempt(retrySucceededAt.AddMinutes(1)));
+        await ConfirmRetryAt(retrySucceededAt, failure.UniqueMessageIdString);
+
+        var row = await GetFailedMessage(failure.UniqueMessageId);
+
+        Assert.That(row.Status, Is.EqualTo(FailedMessageStatus.Unresolved), "the message failed again after the retry succeeded");
+    }
+
+    [Test]
+    public async Task A_later_attempt_arriving_after_a_confirmation_leaves_the_message_unresolved()
+    {
+        var failure = new IngestedFailure();
+        var retrySucceededAt = failure.AttemptedAt.AddMinutes(1);
+
+        await Ingest(failure);
+        await ConfirmRetryAt(retrySucceededAt, failure.UniqueMessageIdString);
+        await Ingest(failure.NextAttempt(retrySucceededAt.AddMinutes(1)));
+
+        var row = await GetFailedMessage(failure.UniqueMessageId);
+
+        Assert.That(row.Status, Is.EqualTo(FailedMessageStatus.Unresolved), "the message failed again after the retry succeeded");
+    }
+
+    [Test]
+    public async Task A_redelivered_attempt_arriving_after_a_confirmation_leaves_the_message_resolved()
+    {
+        var failure = new IngestedFailure();
+
+        await Ingest(failure);
+        await ConfirmRetryAt(failure.AttemptedAt.AddMinutes(1), failure.UniqueMessageIdString);
+        await Ingest(failure);
+
+        var row = await GetFailedMessage(failure.UniqueMessageId);
+
+        Assert.That(row.Status, Is.EqualTo(FailedMessageStatus.Resolved), "redelivering the attempt the retry was for is not a new failure");
+    }
+
+    [Test]
+    public async Task A_confirmation_releases_the_retry_claim_even_when_it_cannot_resolve()
+    {
+        var failure = new IngestedFailure();
+        var retrySucceededAt = failure.AttemptedAt.AddMinutes(1);
+
+        await Ingest(failure);
+        await Store(new FailedMessageRetryEntity { UniqueMessageId = failure.UniqueMessageId, RetryBatchId = Guid.NewGuid() });
+        await Ingest(failure.NextAttempt(retrySucceededAt.AddMinutes(1)));
+
+        await ConfirmRetryAt(retrySucceededAt, failure.UniqueMessageIdString);
+
+        var row = await GetFailedMessage(failure.UniqueMessageId);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(row.Status, Is.EqualTo(FailedMessageStatus.Unresolved));
+            Assert.That(await CountRetryRows(failure.UniqueMessageId), Is.Zero, "the retry itself completed, so its claim is released either way");
         }
     }
 

--- a/src/ServiceControl.Persistence.Tests/EFCore/ErrorIngestionTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/ErrorIngestionTests.cs
@@ -263,7 +263,7 @@ class ErrorIngestionTests : ErrorIngestionTestBase
         await InBatch(async unitOfWork =>
         {
             await unitOfWork.Recoverability.RecordFailedProcessingAttempt(failure.Context, failure.ProcessingAttempt, failure.Groups);
-            await unitOfWork.Recoverability.RecordSuccessfulRetry(failure.UniqueMessageIdString);
+            await unitOfWork.Recoverability.RecordSuccessfulRetry(failure.UniqueMessageIdString, Now);
         });
 
         var row = await GetFailedMessage(failure.UniqueMessageId);

--- a/src/ServiceControl.Persistence.Tests/EFCore/RetentionSweepTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/RetentionSweepTests.cs
@@ -15,8 +15,6 @@ class RetentionSweepTests : ErrorIngestionTestBase
     [SetUp]
     public void SetRetention() => EFSettings.ErrorRetentionPeriod = TimeSpan.FromDays(30);
 
-    DateTime Now => PersistenceTestsContext.FakeTime.GetUtcNow().UtcDateTime;
-
     [Test]
     public async Task Deletes_resolved_and_archived_rows_past_the_cutoff()
     {

--- a/src/ServiceControl.Persistence.Tests/IPersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests/IPersistenceTestsContext.cs
@@ -21,6 +21,11 @@ public interface IPersistenceTestsContext
     /// </summary>
     void AdvanceClock(TimeSpan by);
 
+    /// <summary>
+    /// Reads the same clock <see cref="AdvanceClock" /> moves
+    /// </summary>
+    DateTime UtcNow { get; }
+
     PersistenceSettings PersistenceSettings { get; }
 
     string GenerateFailedMessageRecordId(string messageId);

--- a/src/ServiceControl.Persistence.Tests/IngestionTestBase.cs
+++ b/src/ServiceControl.Persistence.Tests/IngestionTestBase.cs
@@ -28,12 +28,14 @@ abstract class IngestionTestBase : PersistenceTestBase
             }
         });
 
-    protected Task ConfirmRetry(params string[] uniqueMessageIds) =>
+    protected Task ConfirmRetry(params string[] uniqueMessageIds) => ConfirmRetryAt(Now, uniqueMessageIds);
+
+    protected Task ConfirmRetryAt(DateTime succeededAt, params string[] uniqueMessageIds) =>
         InBatch(async unitOfWork =>
         {
             foreach (var uniqueMessageId in uniqueMessageIds)
             {
-                await unitOfWork.Recoverability.RecordSuccessfulRetry(uniqueMessageId);
+                await unitOfWork.Recoverability.RecordSuccessfulRetry(uniqueMessageId, succeededAt);
             }
         });
 }

--- a/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
+++ b/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
@@ -85,6 +85,8 @@ public abstract class PersistenceTestBase
 
     protected void AdvanceClock(TimeSpan by) => PersistenceTestsContext.AdvanceClock(by);
 
+    protected DateTime Now => PersistenceTestsContext.UtcNow;
+
     protected static async Task WaitUntil(Func<Task<bool>> conditionChecker, string condition, TimeSpan timeout = default)
     {
         timeout = timeout == default ? TimeSpan.FromSeconds(10) : timeout;

--- a/src/ServiceControl.Persistence/UnitOfWork/IRecoverabilityIngestionUnitOfWork.cs
+++ b/src/ServiceControl.Persistence/UnitOfWork/IRecoverabilityIngestionUnitOfWork.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Persistence.UnitOfWork
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -12,6 +13,12 @@
             FailedMessage.ProcessingAttempt processingAttempt,
             List<FailedMessage.FailureGroup> groups, CancellationToken cancellationToken = default);
 
-        Task RecordSuccessfulRetry(string retriedMessageUniqueId, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Resolves the message the retry was for, unless an attempt made after
+        /// <paramref name="succeededAt" /> has already been recorded. That attempt means the message
+        /// failed again after the retry succeeded, and the two can reach storage in either order,
+        /// from separate batches or from separate ingestion instances.
+        /// </summary>
+        Task RecordSuccessfulRetry(string retriedMessageUniqueId, DateTime succeededAt, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ServiceControl/Operations/RetryConfirmationProcessor.cs
+++ b/src/ServiceControl/Operations/RetryConfirmationProcessor.cs
@@ -1,10 +1,12 @@
 ﻿namespace ServiceControl.Operations
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Contracts.MessageFailures;
     using Infrastructure.DomainEvents;
+    using NServiceBus;
     using NServiceBus.Transport;
     using ServiceControl.Persistence.UnitOfWork;
 
@@ -23,7 +25,7 @@
             foreach (var context in contexts)
             {
                 var retriedMessageUniqueId = context.Headers[RetryUniqueMessageIdHeader];
-                await unitOfWork.Recoverability.RecordSuccessfulRetry(retriedMessageUniqueId, cancellationToken);
+                await unitOfWork.Recoverability.RecordSuccessfulRetry(retriedMessageUniqueId, GetSucceededAt(context.Headers), cancellationToken);
             }
         }
 
@@ -34,6 +36,27 @@
                 FailedMessageId = messageContext.Headers[RetryUniqueMessageIdHeader],
             }, cancellationToken);
         }
+
+        // An acknowledgement that carries no readable time leaves nothing to order the confirmation
+        // against, so it is taken to be the most recent thing that happened to the message. That is
+        // how every confirmation was treated before the time was read at all.
+        static DateTime GetSucceededAt(Dictionary<string, string> headers)
+        {
+            if (headers.TryGetValue(SuccessfulRetryHeader, out var wireFormattedTime) && !string.IsNullOrWhiteSpace(wireFormattedTime))
+            {
+                try
+                {
+                    return DateTimeOffsetHelper.ToDateTimeOffset(wireFormattedTime).UtcDateTime;
+                }
+                catch (FormatException)
+                {
+                }
+            }
+
+            return NewerThanAnyAttempt;
+        }
+
+        static readonly DateTime NewerThanAnyAttempt = DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
 
         readonly IDomainEvents domainEvents;
     }


### PR DESCRIPTION
## The bug

Two unconditional writes to `FailedMessage.Status`:

- a retry acknowledgement sets it to `Resolved`
- an incoming processing attempt sets it to `Unresolved`

Neither looks at when the event it represents actually happened, so whichever
write lands last wins. Two symptoms:

1. A message that failed again after its retry succeeded can end up sitting at
   `Resolved`, so the failure is invisible.
2. A redelivered copy of an attempt pulls an already resolved or archived
   message back to `Unresolved`.

On RavenDB the second one also strips the message's `@expires` stamp, because
`CancelExpiration` runs down the same unconditional path, so the message
reappears in the failed message list and then never expires.

## This does not need scale-out, or even concurrency

Ingestion runs `TransportTransactionMode.ReceiveOnly`: the write commits, then
the receive is acknowledged. Any attempt can therefore arrive twice, which is
why the EF side already has `Redelivery_of_a_stored_attempt_is_not_a_new_attempt`.
Redelivery alone reaches symptom 2, on one host, with one writer.

Symptom 1 is queue ordering rather than writer count. The acknowledgement and
the later failure are two separate messages on the error queue being received at
`MaximumConcurrency`. A single writer preserves batch order, not event order.
When both land in the same batch it is worse: `ErrorIngestor.Ingest` runs the
error processor before the retry confirmation processor, so a confirmation and a
re-failure in one batch always end `Resolved` no matter what the timestamps say.

Verified by reverting the RavenDB guards in this branch and running the new
tests against them. Single writer, one process:

```
Failed A_confirmation_arriving_after_a_later_attempt_leaves_the_message_unresolved
  Expected: Unresolved   But was: Resolved
Failed A_redelivered_attempt_arriving_after_a_confirmation_leaves_the_message_resolved
  Expected: Resolved     But was: Unresolved
```

`--error-ingestion-only` widens the window, since several hosts drain one queue
and the two messages need not even be on the same host, but it did not create it
and it did not touch this code.

## How long

| | |
| --- | --- |
| `18bc698d6a6` (2023-09-29) | the unconditional `Status` write on RavenDB |
| `f9bc7c2b87b` (2026-07-23) | `CancelExpiration` joined it, on the same unconditional path |

The July change was right about the case it targeted, which is that a genuine
re-failure must not keep a stale expiry. It just inherited the 2023 bug and
made it worse: before it, a wrongly un-resolved message still expired away
eventually, and after it the message stays forever.

## The fix

The acknowledgement carries the time the retry succeeded, in the
`ServiceControl.Retry.Successful` header, so `RecordSuccessfulRetry` now takes
it. Both persisters compare it against the newest attempt they have stored:

- a confirmation resolves a message only if its newest stored attempt is **no
  newer than** the retry
- an attempt moves the status only if it is **strictly newer than** the newest
  stored attempt

Strict on one side and not the other is deliberate, and differs from the payload
columns, which take the incoming attempt on a tie. Refreshing the payload from a
redelivery of the attempt already stored changes nothing. Letting that same
redelivery flip the status undoes a resolve or an archive that came after it.
