### PR TITLE
Make failingendpoint address non-nullable to match usage

### DIFF
--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260812000001_MakeFailingEndpointAddressNonNull.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260812000001_MakeFailingEndpointAddressNonNull.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ServiceControl.Persistence.EFCore.PostgreSql;
@@ -12,9 +13,11 @@ using ServiceControl.Persistence.EFCore.PostgreSql;
 namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
 {
     [DbContext(typeof(PostgreSqlServiceControlDbContext))]
-    partial class PostgreSqlServiceControlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260812000001_MakeFailingEndpointAddressNonNull")]
+    partial class MakeFailingEndpointAddressNonNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260812000001_MakeFailingEndpointAddressNonNull.cs
+++ b/src/ServiceControl.Persistence.EFCore.PostgreSql/Migrations/20260812000001_MakeFailingEndpointAddressNonNull.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ServiceControl.Persistence.EFCore.PostgreSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeFailingEndpointAddressNonNull : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // In practice no rows have a null failing_endpoint_address — ingestion throws if the
+            // FailedQ header is missing — but defaultValue ensures any strays are cleaned up
+            // before the column is made NOT NULL.
+            migrationBuilder.AlterColumn<string>(
+                name: "failing_endpoint_address",
+                table: "failed_messages",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(450)",
+                oldMaxLength: 450,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "failing_endpoint_address",
+                table: "failed_messages",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(450)",
+                oldMaxLength: 450);
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260812000000_MakeFailingEndpointAddressNonNull.Designer.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260812000000_MakeFailingEndpointAddressNonNull.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ServiceControl.Persistence.EFCore.SqlServer;
 
@@ -11,9 +12,11 @@ using ServiceControl.Persistence.EFCore.SqlServer;
 namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
 {
     [DbContext(typeof(SqlServerServiceControlDbContext))]
-    partial class SqlServerServiceControlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260812000000_MakeFailingEndpointAddressNonNull")]
+    partial class MakeFailingEndpointAddressNonNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260812000000_MakeFailingEndpointAddressNonNull.cs
+++ b/src/ServiceControl.Persistence.EFCore.SqlServer/Migrations/20260812000000_MakeFailingEndpointAddressNonNull.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ServiceControl.Persistence.EFCore.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeFailingEndpointAddressNonNull : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // In practice no rows have a null FailingEndpointAddress — ingestion throws if the
+            // FailedQ header is missing — but defaultValue ensures any strays are cleaned up
+            // before the column is made NOT NULL.
+            migrationBuilder.AlterColumn<string>(
+                name: "FailingEndpointAddress",
+                table: "FailedMessages",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)",
+                oldMaxLength: 450,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FailingEndpointAddress",
+                table: "FailedMessages",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)",
+                oldMaxLength: 450);
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/Entities/FailedMessageEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/FailedMessageEntity.cs
@@ -56,5 +56,5 @@ public class FailedMessageEntity
 
     public string? BodyContentType { get; set; }
 
-    public string FailingEndpointAddress { get; set; } = string.Empty;
+    public required string FailingEndpointAddress { get; set; }
 }

--- a/src/ServiceControl.Persistence.EFCore/Entities/FailedMessageEntity.cs
+++ b/src/ServiceControl.Persistence.EFCore/Entities/FailedMessageEntity.cs
@@ -56,5 +56,5 @@ public class FailedMessageEntity
 
     public string? BodyContentType { get; set; }
 
-    public string? FailingEndpointAddress { get; set; }
+    public string FailingEndpointAddress { get; set; } = string.Empty;
 }

--- a/src/ServiceControl.Persistence.EFCore/EntityConfigurations/FailedMessageConfiguration.cs
+++ b/src/ServiceControl.Persistence.EFCore/EntityConfigurations/FailedMessageConfiguration.cs
@@ -25,7 +25,7 @@ class FailedMessageConfiguration : IEntityTypeConfiguration<FailedMessageEntity>
         builder.Property(e => e.SendingEndpointHost).HasMaxLength(ColumnLengths.ShortTextLength);
         builder.Property(e => e.ReceivingEndpointName).HasMaxLength(ColumnLengths.ShortTextLength);
         builder.Property(e => e.ReceivingEndpointHost).HasMaxLength(ColumnLengths.ShortTextLength);
-        builder.Property(e => e.FailingEndpointAddress).HasMaxLength(ColumnLengths.ShortTextLength);
+        builder.Property(e => e.FailingEndpointAddress).IsRequired().HasMaxLength(ColumnLengths.ShortTextLength);
         builder.Property(e => e.BodyContentType).HasMaxLength(ColumnLengths.ShortTextLength);
 
         builder.Property(e => e.IsSystemMessage).IsRequired();

--- a/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageRetryDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageRetryDataStore.cs
@@ -28,8 +28,7 @@ public class FailedMessageRetryDataStore(IServiceScopeFactory scopeFactory)
                 .AsNoTracking()
                 .Where(m => m.Status == FailedMessageStatus.RetryIssued
                             && m.LastModified >= from && m.LastModified <= to
-                            && ((m.FailingEndpointAddress == null && normalizedQueueAddress == null)
-                                || (m.FailingEndpointAddress != null && m.FailingEndpointAddress.ToLower() == normalizedQueueAddress)))
+                            && m.FailingEndpointAddress.ToLower() == normalizedQueueAddress)
                 .Select(m => m.UniqueMessageId.ToString())
                 .ToListAsync(token);
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/RecordedFailedProcessingAttempt.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/UnitOfWork/RecordedFailedProcessingAttempt.cs
@@ -28,5 +28,5 @@ sealed class RecordedFailedProcessingAttempt
     public bool BodyStoredExternally { get; init; }
     public int BodySize { get; init; }
     public string? BodyContentType { get; init; }
-    public string? FailingEndpointAddress { get; set; }
+    public required string FailingEndpointAddress { get; set; }
 }

--- a/src/ServiceControl.Persistence.EFCore/Infrastructure/FailedMessageQueryFilters.cs
+++ b/src/ServiceControl.Persistence.EFCore/Infrastructure/FailedMessageQueryFilters.cs
@@ -93,7 +93,7 @@ static class FailedMessageQueryFilters
         var address = queueAddress.ToLowerInvariant();
 
         // The ToLower() here causes a full table scan!
-        return source.Where(message => message.FailingEndpointAddress != null && message.FailingEndpointAddress.ToLower() == address);
+        return source.Where(message => message.FailingEndpointAddress.ToLower() == address);
     }
 
     public static IQueryable<FailedMessageEntity> Sort(this IQueryable<FailedMessageEntity> source, SortInfo? sortInfo)

--- a/src/ServiceControl.Persistence.Tests.RavenDB/CompositeViews/FailedMessagesTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/CompositeViews/FailedMessagesTests.cs
@@ -28,7 +28,7 @@
                         {
                             AttemptedAt = DateTime.UtcNow,
                             MessageMetadata = [],
-                            FailureDetails = new FailureDetails()
+                            FailureDetails = new FailureDetails { AddressOfFailingEndpoint = "TestEndpoint" }
                         }
                     ]
                 };

--- a/src/ServiceControl.Persistence.Tests.RavenDB/FailedMessageBuilder.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/FailedMessageBuilder.cs
@@ -70,7 +70,7 @@
                                 ["DeliveryTime"]=TimeSpan.FromSeconds(5),
                                 ["IsSystemMessage"]=false,
                             },
-                            FailureDetails = new FailureDetails()
+                            FailureDetails = new FailureDetails { AddressOfFailingEndpoint = "TestEndpoint" }
                         }
                     }
             };

--- a/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
+++ b/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
@@ -285,7 +285,7 @@
                     {
                         AttemptedAt = DateTime.UtcNow,
                         MessageMetadata = [],
-                        FailureDetails = new FailureDetails(),
+                        FailureDetails = new FailureDetails { AddressOfFailingEndpoint = "TestEndpoint" },
                         Headers = []
                     }
                 ]
@@ -398,7 +398,7 @@
                     {
                         AttemptedAt = DateTime.UtcNow,
                         MessageMetadata = [],
-                        FailureDetails = new FailureDetails(),
+                        FailureDetails = new FailureDetails { AddressOfFailingEndpoint = "TestEndpoint" },
                         Headers = []
                     }
                 ]

--- a/src/ServiceControl.Persistence/FailedMessage.cs
+++ b/src/ServiceControl.Persistence/FailedMessage.cs
@@ -31,7 +31,7 @@
             }
 
             public Dictionary<string, object> MessageMetadata { get; set; }
-            public FailureDetails FailureDetails { get; set; } = new();
+            public FailureDetails FailureDetails { get; set; } = new() { AddressOfFailingEndpoint = string.Empty };
             public DateTime AttemptedAt { get; set; }
             public string? MessageId { get; set; }
             public string? Body { get; set; }

--- a/src/ServiceControl.Persistence/FailureDetails.cs
+++ b/src/ServiceControl.Persistence/FailureDetails.cs
@@ -9,7 +9,7 @@ namespace ServiceControl.Contracts.Operations
             TimeOfFailure = DateTime.UtcNow;
         }
 
-        public string? AddressOfFailingEndpoint { get; set; }
+        public string AddressOfFailingEndpoint { get; set; } = string.Empty;
 
         public DateTime TimeOfFailure { get; set; }
 

--- a/src/ServiceControl.Persistence/FailureDetails.cs
+++ b/src/ServiceControl.Persistence/FailureDetails.cs
@@ -9,7 +9,7 @@ namespace ServiceControl.Contracts.Operations
             TimeOfFailure = DateTime.UtcNow;
         }
 
-        public string AddressOfFailingEndpoint { get; set; } = string.Empty;
+        public required string AddressOfFailingEndpoint { get; set; }
 
         public DateTime TimeOfFailure { get; set; }
 

--- a/src/ServiceControl.Persistence/StagingMessage.cs
+++ b/src/ServiceControl.Persistence/StagingMessage.cs
@@ -13,7 +13,7 @@ namespace ServiceControl.Persistence
         string Id,
         string UniqueMessageId,
         string AttemptMessageId,
-        string? FailingEndpointAddress,
+        string FailingEndpointAddress,
         Dictionary<string, string> Headers,
         int StageAttempts);
 }

--- a/src/ServiceControl.UnitTests/ExternalIntegrations/MessageFailedConverterTests.cs
+++ b/src/ServiceControl.UnitTests/ExternalIntegrations/MessageFailedConverterTests.cs
@@ -156,6 +156,7 @@
                         {
                             FailureDetails = new FailureDetails
                             {
+                                AddressOfFailingEndpoint = "TestEndpoint",
                                 Exception = new ExceptionDetails()
                             },
                             MessageMetadata = messageMetadata

--- a/src/ServiceControl.UnitTests/Recoverability/ExceptionTypeAndStackTraceFailureClassifierTest.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/ExceptionTypeAndStackTraceFailureClassifierTest.cs
@@ -133,6 +133,7 @@ at NServiceBus.SagaPersistenceBehavior.Invoke(IInvokeHandlerContext context, Fun
         {
             var failure = new FailureDetails
             {
+                AddressOfFailingEndpoint = "TestEndpoint",
                 Exception = new ExceptionDetails
                 {
                     StackTrace = stackTrace,
@@ -146,6 +147,7 @@ at NServiceBus.SagaPersistenceBehavior.Invoke(IInvokeHandlerContext context, Fun
         {
             var failure = new FailureDetails
             {
+                AddressOfFailingEndpoint = "TestEndpoint",
                 Exception = new ExceptionDetails
                 {
                     StackTrace = "Stack trace",

--- a/src/ServiceControl/Operations/FailedMessageFactory.cs
+++ b/src/ServiceControl/Operations/FailedMessageFactory.cs
@@ -30,17 +30,19 @@
 
         public FailureDetails ParseFailureDetails(IReadOnlyDictionary<string, string> headers)
         {
-            var result = new FailureDetails();
-
-            DictionaryExtensions.CheckIfKeyExists("NServiceBus.TimeOfFailure", headers, s => result.TimeOfFailure = DateTimeOffsetHelper.ToDateTimeOffset(s).UtcDateTime);
-
-            result.Exception = GetException(headers);
-
             if (!headers.ContainsKey(FaultsHeaderKeys.FailedQ))
             {
                 throw new Exception($"Missing '{FaultsHeaderKeys.FailedQ}' header. Message is poison message or incorrectly send to (error) queue.");
             }
-            result.AddressOfFailingEndpoint = headers[FaultsHeaderKeys.FailedQ];
+
+            var result = new FailureDetails
+            {
+                AddressOfFailingEndpoint = headers[FaultsHeaderKeys.FailedQ]
+            };
+
+            DictionaryExtensions.CheckIfKeyExists("NServiceBus.TimeOfFailure", headers, s => result.TimeOfFailure = DateTimeOffsetHelper.ToDateTimeOffset(s).UtcDateTime);
+
+            result.Exception = GetException(headers);
 
             return result;
         }


### PR DESCRIPTION
 ### Problem                                                                                                                                                                           
                                                                                                                                                                                       
 `FailingEndpointAddress` (EF entity) and `AddressOfFailingEndpoint`  were marked `string?`, but the ingestion path (`FailedMessageFactory.ParseFailureDetails`)        
 already guarantees a non-null value — it throws if the NServiceBus.FailedQ header is missing. The nullable annotation was propagated from the mutable FailureDetails DTO rather than  
 reflecting actual usage, leading to a nullable column, a dedicated NullableEndpointAddress migration, and defensive != null guards scattered across the EF query layer.               
                                                                                                                                                                                       
 ### Changes                                                                                                                                                                           
                                                                                                                                                                                       
 Made the types non-nullable with required:                                                                                                                                            
 - `FailureDetails.AddressOfFailingEndpoint` → `required string` (was `string?`)                                                                                                             
 - `FailedMessageEntity.FailingEndpointAddress` → required string (was `string?`)                                                                                                          
 - `RecordedFailedProcessingAttempt.FailingEndpointAddress` → `required string` (was `string?`)                                                                                              
 - `StagingMessage.FailingEndpointAddress` → `string` record parameter (was `string?`)                                                                                                       
                                                                                                                                                                                       
 Refactored `FailedMessageFactory.ParseFailureDetails` to check the FailedQ header before constructing, using an object initializer to satisfy required.                                 
                                                                                                                                                                                       
 Updated `FailedMessage.ProcessingAttempt.FailureDetails` default from `= new()` to `= new() { AddressOfFailingEndpoint = string.Empty }` so placeholder attempts satisfy the required       
 member.                                                                                                                                                                               
                                                                                                                                                                                       
 Removed defensive null checks that existed only because of the nullable:                                                                                                              
 - `FailedMessageQueryFilters.FilterByQueueAddress` — dropped `FailingEndpointAddress != null &&` guard                                                                                    
 - `FailedMessageRetryDataStore.GetRetryPendingMessages` — replaced two-branch null match with simple comparison                                                                         
                                                                                                                                                                                       
 Added EF migration MakeFailingEndpointAddressNonNull (SQL Server + PostgreSQL) to make the column NOT NULL with defaultValue: "" to safely handle any stray nulls. Updated model      
 snapshots and designer files.                                                                                                                                                         
                                                                                                                                                                                       
 Fixed 5 test files that constructed `FailureDetails` without setting `AddressOfFailingEndpoint`.                                                                                          
                                                                                                                                                                                       
 ### What's not affected                                                                                                                                                               
                                                                                                                                                                                       
 - RavenDB — stores the domain document directly (no flattened column), no schema migration needed. Indexes and transformers read the now-non-nullable property without changes.       
 - API/view models (FailedMessageView.QueueAddress, QueueAddress.PhysicalAddress) remain string? — non-nullable → nullable assignment is fine. 