### PR TITLE
Switch to standard OpenTelemetry environment variables for OTLP configuration

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -2,9 +2,9 @@
 
 Instances can be configured to emit telemetry to aid in performance testing or troubleshooting performance-related issues.
 
-Both the error and the audit instance report their ingestion the same way. Exporting is configured with the standard [OpenTelemetry environment variables](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options), not with instance settings, so the same variables that configure any other OpenTelemetry process apply here. Setting `OTEL_EXPORTER_OTLP_ENDPOINT` is enough to turn metrics on, and `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` overrides it for metrics alone. Both gRPC and HTTP endpoints are supported, and `OTEL_EXPORTER_OTLP_PROTOCOL` selects between them.
+Both the error and the audit instance report their ingestion the same way. Exporting is configured with the standard [OpenTelemetry environment variables](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options), not with instance settings, so the same variables that configure any other OpenTelemetry process apply here. Setting `OTEL_EXPORTER_OTLP_ENDPOINT` is enough to turn metrics on. Both gRPC and HTTP endpoints are supported, and `OTEL_EXPORTER_OTLP_PROTOCOL` selects between them.
 
-These variables have to be set in the instance's environment. They cannot be set in the instance's app.config, because the OpenTelemetry SDK reads them itself rather than going through the ServiceControl settings reader.
+The signal-specific variables, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` and its siblings, have no effect. The SDK only honours those under `UseOtlpExporter`, and instances use `AddOtlpExporter` so that OTLP applies to metrics without also being turned on for every other signal.
 
 Logs are exported separately. Add `Otlp` to the instance's `LoggingProviders` setting, which is what turns the OTLP log exporter on, and it then reads the same environment variables for its endpoint.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -2,17 +2,17 @@
 
 Instances can be configured to emit telemetry to aid in performance testing or troubleshooting performance-related issues.
 
-Both the error and the audit instance report their ingestion the same way. Set `OtlpEndpointUrl`
-in that instance's settings root to a valid [OTLP endpoint url](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options).
-Only GRPC endpoints are supported at this stage.
+Both the error and the audit instance report their ingestion the same way. Exporting is configured with the standard [OpenTelemetry environment variables](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options), not with instance settings, so the same variables that configure any other OpenTelemetry process apply here. Setting `OTEL_EXPORTER_OTLP_ENDPOINT` is enough to turn metrics on, and `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` overrides it for metrics alone. Both gRPC and HTTP endpoints are supported, and `OTEL_EXPORTER_OTLP_PROTOCOL` selects between them.
 
-The instruments differ only in their prefix and in the categories a message can fall into, so the
-same dashboard works for both with the prefix swapped. What the batches being measured actually are
-is covered in [ingestion-pipeline.md](ingestion-pipeline.md).
+These variables have to be set in the instance's environment. They cannot be set in the instance's app.config, because the OpenTelemetry SDK reads them itself rather than going through the ServiceControl settings reader.
+
+Logs are exported separately. Add `Otlp` to the instance's `LoggingProviders` setting, which is what turns the OTLP log exporter on, and it then reads the same environment variables for its endpoint.
+
+The instruments differ only in their prefix and in the categories a message can fall into, so the same dashboard works for both with the prefix swapped. What the batches being measured actually are is covered in [ingestion-pipeline.md](ingestion-pipeline.md).
 
 ## Error
 
-Meter `Particular.ServiceControl`, configured with `ServiceControl/OtlpEndpointUrl`.
+Meter `Particular.ServiceControl`.
 
 - `sc.error.ingestion.batch_duration_seconds` - Message batch processing duration in seconds
   - `result` - Whether the batch was written at its configured size: `full`, `partial` or `failed`
@@ -29,7 +29,7 @@ Meter `Particular.ServiceControl`, configured with `ServiceControl/OtlpEndpointU
 
 ## Audit
 
-Meter `Particular.ServiceControl.Audit`, configured with `ServiceControl.Audit/OtlpEndpointUrl`.
+Meter `Particular.ServiceControl.Audit`.
 
 - `sc.audit.ingestion.batch_duration_seconds` - Message batch processing duration in seconds
   - `result` - Whether the batch was written at its configured size: `full`, `partial` or `failed`

--- a/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Audit.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   "LoggingSettings": {
     "LogLevel": "Information",
     "LogPath": "C:\\Logs"
@@ -47,7 +47,6 @@
   "ApiUrl": "http://localhost:8888/api",
   "Port": 8888,
   "PrintMetrics": false,
-  "OtlpEndpointUrl": null,
   "Hostname": "localhost",
   "VirtualDirectory": "",
   "TransportType": "LearningTransport",

--- a/src/ServiceControl.Audit/App.config
+++ b/src/ServiceControl.Audit/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 NOTE: Any settings in this file are not kept as part of packaging ServiceControl for a release.
 These settings are only here so that we can debug ServiceControl while developing it.
@@ -22,9 +22,11 @@ These settings are only here so that we can debug ServiceControl while developin
     <add key="ServiceControl.Audit/PersistenceType" value="InMemory" />
     <!--<add key="ServiceControl.Audit/PersistenceType" value="RavenDB" />-->
 
-	<!-- options are any comma separated combination of NLog,Seq,Otlp -->
-	<add key="ServiceControl.Audit/LoggingProviders" value="NLog,Seq"/>
-	<add key="ServiceControl.Audit/SeqAddress" value="http://localhost:5341"/>
+    <!-- options are any comma separated combination of NLog,Seq,Otlp -->
+    <add key="ServiceControl.Audit/LoggingProviders" value="NLog,Seq"/>
+    <add key="ServiceControl.Audit/SeqAddress" value="http://localhost:5341"/>
+
+    <!-- OTLP logs and metrics are configured with the standard OpenTelemetry environment variables, e.g. OTEL_EXPORTER_OTLP_ENDPOINT -->
 
     <!-- Authentication Settings (JWT with OpenID Connect) -->
     <!-- Uncomment and configure to enable authentication -->

--- a/src/ServiceControl.Audit/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Audit/HostApplicationBuilderExtensions.cs
@@ -1,4 +1,4 @@
-namespace ServiceControl.Audit;
+﻿namespace ServiceControl.Audit;
 
 using System;
 using System.Diagnostics;
@@ -97,31 +97,30 @@ static class HostApplicationBuilderExtensions
     {
         builder.Services.AddSingleton<IngestionMetrics>();
 
-        if (!string.IsNullOrEmpty(settings.OtlpEndpointUrl))
+        var otlpEndpoint = OtlpEndpoint.MetricsEndpointFromEnvironment();
+
+        if (otlpEndpoint is null)
         {
-            if (!Uri.TryCreate(settings.OtlpEndpointUrl, UriKind.Absolute, out var otelMetricsUri))
-            {
-                throw new UriFormatException($"Invalid OtlpEndpointUrl: {settings.OtlpEndpointUrl}");
-            }
-
-            builder.Services.AddOpenTelemetry()
-                .ConfigureResource(b => b.AddService(
-                    serviceName: settings.InstanceName,
-                    serviceVersion: InstanceVersion,
-                    autoGenerateServiceInstanceId: true))
-                .WithMetrics(b =>
-                {
-                    b.AddIngestionMetrics();
-                    b.AddOtlpExporter(e => e.Endpoint = otelMetricsUri);
-                    if (Debugger.IsAttached)
-                    {
-                        b.AddConsoleExporter();
-                    }
-                });
-
-            var logger = LoggerUtil.CreateStaticLogger(typeof(HostApplicationBuilderExtensions), settings.LoggingSettings.LogLevel);
-            logger.LogInformation("OpenTelemetry metrics exporter enabled: {OtlpEndpointUrl}", settings.OtlpEndpointUrl);
+            return;
         }
+
+        builder.Services.AddOpenTelemetry()
+            .ConfigureResource(b => b.AddService(
+                serviceName: settings.InstanceName,
+                serviceVersion: InstanceVersion,
+                autoGenerateServiceInstanceId: true))
+            .WithMetrics(b =>
+            {
+                b.AddIngestionMetrics();
+                b.AddOtlpExporter();
+                if (Debugger.IsAttached)
+                {
+                    b.AddConsoleExporter();
+                }
+            });
+
+        var logger = LoggerUtil.CreateStaticLogger(typeof(HostApplicationBuilderExtensions), settings.LoggingSettings.LogLevel);
+        logger.LogInformation("OpenTelemetry metrics exporter enabled: {OtlpEndpoint}", otlpEndpoint);
     }
 
     static void RecordStartup(Settings settings, EndpointConfiguration endpointConfiguration, IPersistenceConfiguration persistenceConfiguration)

--- a/src/ServiceControl.Audit/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Audit/HostApplicationBuilderExtensions.cs
@@ -97,7 +97,7 @@ static class HostApplicationBuilderExtensions
     {
         builder.Services.AddSingleton<IngestionMetrics>();
 
-        var otlpEndpoint = OtlpEndpoint.MetricsEndpointFromEnvironment();
+        var otlpEndpoint = OtlpEndpoint.Read(builder.Configuration);
 
         if (otlpEndpoint is null)
         {

--- a/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl.Audit/Infrastructure/Settings/Settings.cs
@@ -148,7 +148,6 @@
         public int Port { get; set; }
 
         public bool PrintMetrics => SettingsReader.Read<bool>(SettingsRootNamespace, "PrintMetrics");
-        public string OtlpEndpointUrl { get; set; } = SettingsReader.Read<string>(SettingsRootNamespace, nameof(OtlpEndpointUrl));
         public string Hostname { get; private set; }
         public string VirtualDirectory => SettingsReader.Read(SettingsRootNamespace, "VirtualDirectory", string.Empty);
 

--- a/src/ServiceControl.Infrastructure/OtlpEndpoint.cs
+++ b/src/ServiceControl.Infrastructure/OtlpEndpoint.cs
@@ -1,0 +1,15 @@
+namespace ServiceControl.Infrastructure;
+
+using System;
+
+public static class OtlpEndpoint
+{
+    public static string MetricsEndpointFromEnvironment() =>
+        Read("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") ?? Read("OTEL_EXPORTER_OTLP_ENDPOINT");
+
+    static string Read(string variable)
+    {
+        var value = Environment.GetEnvironmentVariable(variable);
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+}

--- a/src/ServiceControl.Infrastructure/OtlpEndpoint.cs
+++ b/src/ServiceControl.Infrastructure/OtlpEndpoint.cs
@@ -1,15 +1,28 @@
 namespace ServiceControl.Infrastructure;
 
 using System;
+using Microsoft.Extensions.Configuration;
 
 public static class OtlpEndpoint
 {
-    public static string MetricsEndpointFromEnvironment() =>
-        Read("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") ?? Read("OTEL_EXPORTER_OTLP_ENDPOINT");
+    // This is the default environment variable name used by the OpenTelemetry .NET SDK to configure the OTLP exporter endpoint
+    // as specified in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md.
+    const string EndpointKey = "OTEL_EXPORTER_OTLP_ENDPOINT";
 
-    static string Read(string variable)
+    public static Uri Read(IConfiguration configuration)
     {
-        var value = Environment.GetEnvironmentVariable(variable);
-        return string.IsNullOrWhiteSpace(value) ? null : value;
+        var configuredEndpoint = configuration[EndpointKey];
+
+        if (string.IsNullOrWhiteSpace(configuredEndpoint))
+        {
+            return null;
+        }
+
+        if (!Uri.TryCreate(configuredEndpoint, UriKind.Absolute, out var endpoint))
+        {
+            throw new UriFormatException($"Invalid {EndpointKey}: {configuredEndpoint}");
+        }
+
+        return endpoint;
     }
 }

--- a/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.Monitoring.UnitTests/ApprovalFiles/SettingsTests.PlatformSampleSettings.approved.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   "LoggingSettings": {
     "LogLevel": "Information",
     "LogPath": "C:\\Logs"

--- a/src/ServiceControl.Monitoring/App.config
+++ b/src/ServiceControl.Monitoring/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 NOTE: Any settings in this file are not kept as part of packaging ServiceControl for a release.
 These settings are only here so that we can debug ServiceControl while developing it.
@@ -19,9 +19,11 @@ These settings are only here so that we can debug ServiceControl while developin
     <!--<add key="Monitoring/TransportType" value="RabbitMQ.QuorumConventionalRouting" />-->
     <!--<add key="Monitoring/TransportType" value="SQLServer" />-->
 
-	<!-- options are any comma separated combination of NLog,Seq,Otlp -->
-	<add key="Monitoring/LoggingProviders" value="NLog,Seq"/>
-	<add key="Monitoring/SeqAddress" value="http://localhost:5341"/>
+    <!-- options are any comma separated combination of NLog,Seq,Otlp -->
+    <add key="Monitoring/LoggingProviders" value="NLog,Seq"/>
+    <add key="Monitoring/SeqAddress" value="http://localhost:5341"/>
+	
+    <!-- OTLP logs and metrics are configured with the standard OpenTelemetry environment variables, e.g. OTEL_EXPORTER_OTLP_ENDPOINT -->
 	  
     <!-- Authentication Settings (JWT with OpenID Connect) -->
     <!-- Uncomment and configure to enable authentication -->

--- a/src/ServiceControl.Monitoring/Settings.cs
+++ b/src/ServiceControl.Monitoring/Settings.cs
@@ -1,4 +1,4 @@
-namespace ServiceControl.Monitoring
+﻿namespace ServiceControl.Monitoring
 {
     using System;
     using System.Collections.Generic;

--- a/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
+++ b/src/ServiceControl.UnitTests/ApprovalFiles/APIApprovals.PlatformSampleSettings.approved.txt
@@ -1,4 +1,4 @@
-{
+﻿{
   "LoggingSettings": {
     "LogLevel": "Information",
     "LogPath": "C:\\Logs"
@@ -59,7 +59,6 @@
   "Port": 8888,
   "PersisterSpecificSettings": null,
   "PrintMetrics": false,
-  "OtlpEndpointUrl": null,
   "Hostname": "localhost",
   "VirtualDirectory": "",
   "HeartbeatGracePeriod": "00:00:40",

--- a/src/ServiceControl/App.config
+++ b/src/ServiceControl/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 NOTE: Any settings in this file are not kept as part of packaging ServiceControl for a release.
 These settings are only here so that we can debug ServiceControl while developing it.
@@ -28,6 +28,8 @@ These settings are only here so that we can debug ServiceControl while developin
     <!-- options are any comma separated combination of NLog,Seq,Otlp -->
     <add key="ServiceControl/LoggingProviders" value="NLog,Seq"/>
     <add key="ServiceControl/SeqAddress" value="http://localhost:5341"/>
+    
+    <!-- OTLP logs and metrics are configured with the standard OpenTelemetry environment variables, e.g. OTEL_EXPORTER_OTLP_ENDPOINT -->
 
     <!-- Authentication Settings (JWT with OpenID Connect) -->
     <!-- Uncomment and configure to enable authentication -->

--- a/src/ServiceControl/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl/HostApplicationBuilderExtensions.cs
@@ -152,7 +152,7 @@
         {
             hostBuilder.Services.AddSingleton<IngestionMetrics>();
 
-            var otlpEndpoint = OtlpEndpoint.MetricsEndpointFromEnvironment();
+            var otlpEndpoint = OtlpEndpoint.Read(hostBuilder.Configuration);
 
             if (otlpEndpoint is null)
             {

--- a/src/ServiceControl/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl/HostApplicationBuilderExtensions.cs
@@ -152,14 +152,11 @@
         {
             hostBuilder.Services.AddSingleton<IngestionMetrics>();
 
-            if (string.IsNullOrEmpty(settings.OtlpEndpointUrl))
+            var otlpEndpoint = OtlpEndpoint.MetricsEndpointFromEnvironment();
+
+            if (otlpEndpoint is null)
             {
                 return;
-            }
-
-            if (!Uri.TryCreate(settings.OtlpEndpointUrl, UriKind.Absolute, out var otlpEndpoint))
-            {
-                throw new UriFormatException($"Invalid OtlpEndpointUrl: {settings.OtlpEndpointUrl}");
             }
 
             hostBuilder.Services.AddOpenTelemetry()
@@ -170,7 +167,7 @@
                 .WithMetrics(metrics =>
                 {
                     metrics.AddIngestionMetrics();
-                    metrics.AddOtlpExporter(exporter => exporter.Endpoint = otlpEndpoint);
+                    metrics.AddOtlpExporter();
 
                     if (Debugger.IsAttached)
                     {
@@ -179,7 +176,7 @@
                 });
 
             LoggerUtil.CreateStaticLogger(typeof(HostApplicationBuilderExtensions), settings.LoggingSettings.LogLevel)
-                .LogInformation("OpenTelemetry metrics exporter enabled: {OtlpEndpointUrl}", settings.OtlpEndpointUrl);
+                .LogInformation("OpenTelemetry metrics exporter enabled: {OtlpEndpoint}", otlpEndpoint);
         }
 
         static void RecordStartup(Settings settings, EndpointConfiguration endpointConfiguration)

--- a/src/ServiceControl/Infrastructure/Settings/Settings.cs
+++ b/src/ServiceControl/Infrastructure/Settings/Settings.cs
@@ -178,7 +178,6 @@
 
         public bool PrintMetrics => SettingsReader.Read<bool>(SettingsRootNamespace, "PrintMetrics");
 
-        public string OtlpEndpointUrl { get; set; } = SettingsReader.Read<string>(SettingsRootNamespace, nameof(OtlpEndpointUrl));
         public string Hostname { get; private set; }
         public string VirtualDirectory => SettingsReader.Read(SettingsRootNamespace, "VirtualDirectory", string.Empty);
 


### PR DESCRIPTION
Removes the custom OtlpEndpointUrl setting in favor of standard environment variables such as OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_METRICS_ENDPOINT. This ensures compatibility with native OpenTelemetry SDK configuration, supports both gRPC and HTTP protocols, and simplifies instance configuration.


This came from https://github.com/Particular/ServiceControl/pull/5816#discussion_r3840896578