### PR TITLE
Remove references to TotalThroughput in usage report

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageVersion Include="Particular.Approvals" Version="2.0.1" />
-    <PackageVersion Include="Particular.LicensingComponent.Report" Version="1.2.0" />
+    <PackageVersion Include="Particular.LicensingComponent.Report" Version="1.3.0" />
     <PackageVersion Include="Particular.Licensing.Sources" Version="7.4.0" />
     <PackageVersion Include="Particular.Obsoletes" Version="1.1.0" />
     <PackageVersion Include="Particular.ServicePulse.Core" Version="2.10.2" />

--- a/src/Particular.LicensingComponent.UnitTests/ApprovalFiles/ThroughputCollector_Report_Throughput_Tests.Should_generate_correct_report.approved.txt
+++ b/src/Particular.LicensingComponent.UnitTests/ApprovalFiles/ThroughputCollector_Report_Throughput_Tests.Should_generate_correct_report.approved.txt
@@ -146,7 +146,6 @@
         "DailyThroughputFromMonitoring": []
       }
     ],
-    "TotalThroughput": 249,
     "TotalQueues": 5,
     "IgnoredQueues": [],
     "EnvironmentInformation": {

--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
@@ -144,11 +144,6 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
             Assert.That(report.ReportData.Queues.First(w => w.QueueName == "Endpoint1").Throughput, Is.EqualTo(55), $"Incorrect Throughput recorded for Endpoint1");
             Assert.That(report.ReportData.Queues.First(w => w.QueueName == "Endpoint2").Throughput, Is.EqualTo(65), $"Incorrect Throughput recorded for Endpoint2");
             Assert.That(report.ReportData.Queues.First(w => w.QueueName == "Endpoint3").Throughput, Is.EqualTo(75), $"Incorrect Throughput recorded for Endpoint3");
-        }
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(195), $"Incorrect TotalThroughput recorded");
             Assert.That(report.ReportData.TotalQueues, Is.EqualTo(3), $"Incorrect TotalQueues recorded");
         }
     }
@@ -182,11 +177,6 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
             Assert.That(report.ReportData.Queues.First(w => w.QueueName == "Endpoint1").Throughput, Is.EqualTo(65), $"Incorrect Throughput recorded for Endpoint1");
             Assert.That(report.ReportData.Queues.First(w => w.QueueName == "Endpoint2").Throughput, Is.EqualTo(65), $"Incorrect Throughput recorded for Endpoint2");
             Assert.That(report.ReportData.Queues.First(w => w.QueueName == "Endpoint3").Throughput, Is.EqualTo(57), $"Incorrect Throughput recorded for Endpoint3");
-        }
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(187), $"Incorrect TotalThroughput recorded");
             Assert.That(report.ReportData.TotalQueues, Is.EqualTo(3), $"Incorrect TotalQueues recorded");
         }
     }
@@ -206,8 +196,6 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
         using (Assert.EnterMultipleScope())
         {
             Assert.That(report.ReportData.Queues[0].Throughput, Is.EqualTo(0), $"Incorrect Throughput recorded for {report.ReportData.Queues[0].QueueName}");
-
-            Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(0), $"Incorrect TotalThroughput recorded");
             Assert.That(report.ReportData.TotalQueues, Is.EqualTo(1), $"Incorrect TotalQueues recorded");
         }
     }
@@ -253,7 +241,6 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
             //even though the names are different, we should have matched on the sanitized name and hence displayed max throughput from the 2 endpoints
             Assert.That(report.ReportData.Queues[0].Throughput, Is.EqualTo(75), $"Incorrect Throughput recorded for Endpoint1");
 
-            Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(75), $"Incorrect TotalThroughput recorded");
             Assert.That(report.ReportData.TotalQueues, Is.EqualTo(1), $"Incorrect TotalQueues recorded");
         }
     }
@@ -278,12 +265,7 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
         // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.Queues.Count, Is.EqualTo(1));
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(75), $"Incorrect TotalThroughput recorded");
-            Assert.That(report.ReportData.TotalQueues, Is.EqualTo(1), $"Incorrect TotalQueues recorded");
-        }
+        Assert.That(report.ReportData.TotalQueues, Is.EqualTo(1), $"Incorrect TotalQueues recorded");
     }
 
     [TestCase(ThroughputSource.Audit)]

--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_Report_Throughput_Tests.cs
@@ -302,7 +302,6 @@ class ThroughputCollector_Report_Throughput_Tests : ThroughputCollectorTestFixtu
             Assert.That(dailyThroughput, Has.All.Matches<DailyThroughput>(
                 throughput => throughput.DateUTC <= DateOnly.FromDateTime(reportEndDate)));
             Assert.That(queue.Throughput, Is.EqualTo(55));
-            Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(55));
         }
     }
 

--- a/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_SanitizedNameGrouping_Tests.cs
+++ b/src/Particular.LicensingComponent.UnitTests/ThroughputCollector/ThroughputCollector_SanitizedNameGrouping_Tests.cs
@@ -69,8 +69,6 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
         // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.Queues.Count, Is.EqualTo(1));
-        //should see 1 endpoint with both throughputs, and return 60 as the maximum one
-        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(60));
         Assert.That(report.ReportData.Queues.FirstOrDefault(f => f.QueueName == "Endpoint1").DailyThroughputFromAudit.Sum(s => s.MessageCount), Is.EqualTo(60));
         Assert.That(report.ReportData.Queues.FirstOrDefault(f => f.QueueName == "Endpoint1").DailyThroughputFromBroker.Sum(s => s.MessageCount), Is.EqualTo(50));
     }
@@ -122,8 +120,6 @@ class ThroughputCollector_SanitizedNameGrouping_Tests : ThroughputCollectorTestF
         // Assert
         Assert.That(report, Is.Not.Null);
         Assert.That(report.ReportData.Queues.Count, Is.EqualTo(2));
-        //two different endpoints hence total throughput is a sum of both of them
-        Assert.That(report.ReportData.TotalThroughput, Is.EqualTo(110));
     }
 
     class BrokerThroughputQuery_WithLowerCaseSanitizedNameCleanse : IBrokerThroughputQuery

--- a/src/Particular.LicensingComponent/ThroughputCollector.cs
+++ b/src/Particular.LicensingComponent/ThroughputCollector.cs
@@ -166,7 +166,6 @@ public class ThroughputCollector(ILicensingDataStore dataStore, ThroughputSettin
             IgnoredQueues = [.. ignoredQueueNames],
             Queues = [.. queueThroughputs],
             TotalQueues = queueThroughputs.Count,
-            TotalThroughput = queueThroughputs.Sum(q => q.Throughput ?? 0),
             EnvironmentInformation = new EnvironmentInformation { AuditServicesData = new AuditServicesData(auditServiceMetadata.Versions, auditServiceMetadata.Transports), EnvironmentData = brokerMetaData.Data }
         };
 


### PR DESCRIPTION
Related to https://github.com/Particular/Particular.LicensingComponent.Report/pull/132

> The way Total Throughput is currently calculated by the platform and the endpoint throughput counter is incorrect, and is not used. The internal tools that process usage reports ignore this field and calculate the total throughput correctly. To avoid confusion, this field is being removed.

Closes https://github.com/Particular/ServiceControl/issues/5592