### PR TITLE
Disable RavenDB storage prefetching by default

### DIFF
--- a/src/ServiceControl.RavenDB/Dockerfile
+++ b/src/ServiceControl.RavenDB/Dockerfile
@@ -11,7 +11,8 @@ USER ravendb
 
 ENV RAVEN_License_Eula_Accepted=true \
     RAVEN_License_Path=/usr/lib/ravendb/servicecontrol-license.json \
-    RAVEN_Setup_Mode=None
+    RAVEN_Setup_Mode=None \
+    RAVEN_Storage_EnablePrefetching=false
 
 LABEL org.opencontainers.image.source=https://github.com/Particular/ServiceControl \
       org.opencontainers.image.authors="Particular Software" \

--- a/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
+++ b/src/ServiceControl.RavenDB/EmbeddedDatabase.cs
@@ -83,6 +83,9 @@ namespace ServiceControl.RavenDB
                     // HINT: If this is not set, then Raven will pick a default location relative to the server binaries
                     // See https://github.com/ravendb/ravendb/issues/15694
                     $"--Indexing.NuGetPackagesPath=\"{nugetPackagesPath}\"",
+                    // HINT: Storage.EnablePrefetching is server-wide only and defaults to true in RavenDB. ServiceControl
+                    // disables it by default. Set RAVEN_Storage_EnablePrefetching on the container image to change it there.
+                    "--Storage.EnablePrefetching=false",
                     ..optionalArgs
                 ],
                 DataDirectory = databaseConfiguration.DbPath,


### PR DESCRIPTION
During load testing we notices that RavenDB does a lot of read IO. This is caused due to prefetching. We tested with disabling prefetching and index rate remained pretty much identical, ingestion rate slightly improved but read IO was reduced over 5x.

Storage.EnablePrefetching is a server-wide-only RavenDB setting that defaults to true. ServiceControl now disables it by default:

- Embedded mode (Primary and Audit): --Storage.EnablePrefetching=false is passed via ServerOptions.CommandLineArgs
- Container image (servicecontrol-ravendb): RAVEN_Storage_EnablePrefetching=false is set as an image ENV, which users can still override