### PR TITLE
Use Lucene search engine for new RavenDB databases and flag indexes still on Corax

### DIFF
--- a/src/ServiceControl.Audit.Persistence.RavenDB/CustomChecks/CheckRavenDBSearchEngine.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/CustomChecks/CheckRavenDBSearchEngine.cs
@@ -1,0 +1,22 @@
+namespace ServiceControl.Audit.Persistence.RavenDB.CustomChecks;
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus.CustomChecks;
+using ServiceControl.RavenDB;
+
+class CheckRavenDBSearchEngine(IRavenDocumentStoreProvider documentStoreProvider, DatabaseConfiguration databaseConfiguration) : CustomCheck("Audit Database Search Engine", "ServiceControl.Audit Health", TimeSpan.FromHours(1))
+{
+    public override async Task<CheckResult> PerformCheck(CancellationToken cancellationToken = default)
+    {
+        var documentStore = await documentStoreProvider.GetDocumentStore(cancellationToken);
+
+        var coraxIndexes = await StartupChecks.FindIndexesUsingCorax(documentStore, databaseConfiguration.Name, cancellationToken);
+
+        return coraxIndexes.Length == 0
+            ? CheckResult.Pass
+            : CheckResult.Failed(StartupChecks.CoraxIndexesMessage(coraxIndexes.Select(i => $"{databaseConfiguration.Name}/{i}")));
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
@@ -15,6 +15,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Indexes;
+using ServiceControl.RavenDB;
 using SagaAudit;
 
 class DatabaseSetup(DatabaseConfiguration configuration)
@@ -26,6 +27,8 @@ class DatabaseSetup(DatabaseConfiguration configuration)
         await UpdateDatabaseSettings(documentStore, configuration.Name, cancellationToken);
 
         await CreateIndexes(documentStore, configuration.EnableFullTextSearch, cancellationToken);
+
+        await StartupChecks.WarnIfIndexesUseCorax(documentStore, configuration.Name, cancellationToken);
 
         await LicenseStatusCheck.WaitForLicenseOrThrow(documentStore, cancellationToken);
         await ConfigureExpiration(documentStore, cancellationToken);

--- a/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/DatabaseSetup.cs
@@ -41,7 +41,9 @@ class DatabaseSetup(DatabaseConfiguration configuration)
             {
                 var databaseRecord = new DatabaseRecord(databaseName);
 
-                SetSearchEngineType(databaseRecord, SearchEngineType.Corax);
+                // New databases use Lucene: smaller indexes, lower memory usage and faster for our index definitions.
+                // Existing databases keep the engine they were created with, see UpdateDatabaseSettings.
+                SetSearchEngineType(databaseRecord, SearchEngineType.Lucene);
 
                 await documentStore.Maintenance.Server.SendAsync(new CreateDatabaseOperation(databaseRecord), cancellationToken);
             }
@@ -56,6 +58,9 @@ class DatabaseSetup(DatabaseConfiguration configuration)
     {
         var databaseRecord = await documentStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName), cancellationToken) ?? throw new InvalidOperationException($"Database '{databaseName}' does not exist.");
 
+        // Existing databases keep their configured search engine. Changing it would trigger a full rebuild of all
+        // indexes, which can take a long time and a lot of resources on large databases. Databases created before the
+        // search engine was pinned explicitly get Corax, which was the default at the time.
         if (!SetSearchEngineType(databaseRecord, SearchEngineType.Corax))
         {
             return;

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistence.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenPersistence.cs
@@ -22,6 +22,7 @@
                 endpointConfiguration.AddCustomCheck<CheckFreeDiskSpace>();
                 endpointConfiguration.AddCustomCheck<CheckMinimumStorageRequiredForIngestion>();
                 endpointConfiguration.AddCustomCheck<CheckRavenDBIndexLag>();
+                endpointConfiguration.AddCustomCheck<CheckRavenDBSearchEngine>();
             }
 
             services.AddSingleton<IAuditDataStore, RavenAuditDataStore>();

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/ApprovalFiles/CustomCheckTests.VerifyCustomChecks.approved.txt
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/ApprovalFiles/CustomCheckTests.VerifyCustomChecks.approved.txt
@@ -1,4 +1,5 @@
 ServiceControl.Audit Health: Audit Database Index Lag
+ServiceControl.Audit Health: Audit Database Search Engine
 ServiceControl.Audit Health: Audit Message Ingestion Process
 ServiceControl.Audit Health: RavenDB dirty memory
 Storage space: ServiceControl.Audit database

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents.Indexes;
+using ServiceControl.RavenDB;
 
 [TestFixture]
 class IndexSetupTests : PersistenceTestFixture
@@ -23,6 +24,26 @@ class IndexSetupTests : PersistenceTestFixture
             var indexStats = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexStatisticsOperation(DatabaseSetup.MessagesViewIndexWithFulltextSearchName));
             Assert.That(indexStats.SearchEngineType, Is.EqualTo(SearchEngineType.Lucene), $"{index.Name} is not using Lucene");
         }
+    }
+
+    [Test]
+    public async Task Startup_check_should_not_report_corax_indexes_for_new_database()
+    {
+        var coraxIndexes = await StartupChecks.FindIndexesUsingCorax(configuration.DocumentStore, configuration.DocumentStore.Database, TestTimeoutCancellationToken);
+
+        Assert.That(coraxIndexes, Is.Empty);
+    }
+
+    [Test]
+    public async Task Startup_check_should_report_indexes_using_corax()
+    {
+        var index = new MessagesViewIndexWithFullTextSearch { Configuration = { ["Indexing.Static.SearchEngineType"] = SearchEngineType.Corax.ToString() } };
+
+        await UpdateIndex(index);
+
+        var coraxIndexes = await StartupChecks.FindIndexesUsingCorax(configuration.DocumentStore, configuration.DocumentStore.Database, TestTimeoutCancellationToken);
+
+        Assert.That(coraxIndexes, Is.EqualTo(new[] { index.IndexName }));
     }
 
     [Test]

--- a/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
+++ b/src/ServiceControl.Audit.Persistence.Tests.RavenDB/IndexSetupTests.cs
@@ -14,14 +14,14 @@ using Raven.Client.Exceptions.Documents.Indexes;
 class IndexSetupTests : PersistenceTestFixture
 {
     [Test]
-    public async Task Corax_should_be_the_default_search_engine_type()
+    public async Task Lucene_should_be_the_default_search_engine_type_for_new_databases()
     {
         var indexes = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexesOperation(0, int.MaxValue));
 
         foreach (var index in indexes)
         {
             var indexStats = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexStatisticsOperation(DatabaseSetup.MessagesViewIndexWithFulltextSearchName));
-            Assert.That(indexStats.SearchEngineType, Is.EqualTo(SearchEngineType.Corax), $"{index.Name} is not using Corax");
+            Assert.That(indexStats.SearchEngineType, Is.EqualTo(SearchEngineType.Lucene), $"{index.Name} is not using Lucene");
         }
     }
 
@@ -50,11 +50,11 @@ class IndexSetupTests : PersistenceTestFixture
     [Test]
     public async Task Indexes_should_be_reset_on_setup()
     {
-        var index = new MessagesViewIndexWithFullTextSearch { Configuration = { ["Indexing.Static.SearchEngineType"] = SearchEngineType.Lucene.ToString() } };
+        var index = new MessagesViewIndexWithFullTextSearch { Configuration = { ["Indexing.Static.SearchEngineType"] = SearchEngineType.Corax.ToString() } };
 
         var indexWithCustomConfigStats = await UpdateIndex(index);
 
-        Assert.That(indexWithCustomConfigStats.SearchEngineType, Is.EqualTo(SearchEngineType.Lucene));
+        Assert.That(indexWithCustomConfigStats.SearchEngineType, Is.EqualTo(SearchEngineType.Corax));
 
         await DatabaseSetup.CreateIndexes(configuration.DocumentStore, true, TestTimeoutCancellationToken);
 
@@ -62,7 +62,7 @@ class IndexSetupTests : PersistenceTestFixture
 
         var indexAfterResetStats = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
 
-        Assert.That(indexAfterResetStats.SearchEngineType, Is.EqualTo(SearchEngineType.Corax));
+        Assert.That(indexAfterResetStats.SearchEngineType, Is.EqualTo(SearchEngineType.Lucene));
     }
 
     [Test]
@@ -70,13 +70,13 @@ class IndexSetupTests : PersistenceTestFixture
     {
         var index = new MessagesViewIndexWithFullTextSearch
         {
-            Configuration = { ["Indexing.Static.SearchEngineType"] = SearchEngineType.Lucene.ToString() },
+            Configuration = { ["Indexing.Static.SearchEngineType"] = SearchEngineType.Corax.ToString() },
             LockMode = IndexLockMode.LockedIgnore
         };
 
         var indexStatsBefore = await UpdateIndex(index);
 
-        Assert.That(indexStatsBefore.SearchEngineType, Is.EqualTo(SearchEngineType.Lucene));
+        Assert.That(indexStatsBefore.SearchEngineType, Is.EqualTo(SearchEngineType.Corax));
 
         await DatabaseSetup.CreateIndexes(configuration.DocumentStore, true, TestTimeoutCancellationToken);
 
@@ -84,7 +84,7 @@ class IndexSetupTests : PersistenceTestFixture
         await Task.Delay(1000);
 
         var indexStatsAfter = await configuration.DocumentStore.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
-        Assert.That(indexStatsAfter.SearchEngineType, Is.EqualTo(SearchEngineType.Lucene));
+        Assert.That(indexStatsAfter.SearchEngineType, Is.EqualTo(SearchEngineType.Corax));
     }
 
     [Test]
@@ -92,7 +92,7 @@ class IndexSetupTests : PersistenceTestFixture
     {
         var index = new MessagesViewIndexWithFullTextSearch
         {
-            Configuration = { ["Indexing.Static.SearchEngineType"] = SearchEngineType.Lucene.ToString() },
+            Configuration = { ["Indexing.Static.SearchEngineType"] = SearchEngineType.Corax.ToString() },
             LockMode = IndexLockMode.LockedError
         };
 

--- a/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckRavenDBSearchEngine.cs
+++ b/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckRavenDBSearchEngine.cs
@@ -1,0 +1,30 @@
+namespace ServiceControl.Persistence.RavenDB.CustomChecks;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus.CustomChecks;
+using ServiceControl.RavenDB;
+
+class CheckRavenDBSearchEngine(IRavenDocumentStoreProvider documentStoreProvider, RavenPersisterSettings settings) : CustomCheck("Error Database Search Engine", "ServiceControl Health", TimeSpan.FromHours(1))
+{
+    public override async Task<CheckResult> PerformCheck(CancellationToken cancellationToken = default)
+    {
+        var documentStore = await documentStoreProvider.GetDocumentStore(cancellationToken);
+
+        var coraxIndexes = new List<string>();
+
+        foreach (var databaseName in new[] { settings.DatabaseName, settings.ThroughputDatabaseName })
+        {
+            foreach (var indexName in await StartupChecks.FindIndexesUsingCorax(documentStore, databaseName, cancellationToken))
+            {
+                coraxIndexes.Add($"{databaseName}/{indexName}");
+            }
+        }
+
+        return coraxIndexes.Count == 0
+            ? CheckResult.Pass
+            : CheckResult.Failed(StartupChecks.CoraxIndexesMessage(coraxIndexes));
+    }
+}

--- a/src/ServiceControl.Persistence.RavenDB/DatabaseSetup.cs
+++ b/src/ServiceControl.Persistence.RavenDB/DatabaseSetup.cs
@@ -10,6 +10,7 @@ namespace ServiceControl.Persistence.RavenDB
     using Raven.Client.ServerWide;
     using Raven.Client.ServerWide.Operations;
     using Raven.Client.ServerWide.Operations.Configuration;
+    using ServiceControl.RavenDB;
 
     class DatabaseSetup(RavenPersisterSettings settings, IDocumentStore documentStore)
     {
@@ -22,6 +23,9 @@ namespace ServiceControl.Persistence.RavenDB
             await UpdateDatabaseSettings(settings.ThroughputDatabaseName, cancellationToken);
 
             await IndexCreation.CreateIndexesAsync(typeof(DatabaseSetup).Assembly, documentStore, null, null, cancellationToken);
+
+            await StartupChecks.WarnIfIndexesUseCorax(documentStore, settings.DatabaseName, cancellationToken);
+            await StartupChecks.WarnIfIndexesUseCorax(documentStore, settings.ThroughputDatabaseName, cancellationToken);
 
             await LicenseStatusCheck.WaitForLicenseOrThrow(documentStore, cancellationToken);
             await ConfigureExpiration(settings, cancellationToken);

--- a/src/ServiceControl.Persistence.RavenDB/DatabaseSetup.cs
+++ b/src/ServiceControl.Persistence.RavenDB/DatabaseSetup.cs
@@ -36,8 +36,11 @@ namespace ServiceControl.Persistence.RavenDB
                 try
                 {
                     var databaseRecord = new DatabaseRecord(databaseName);
-                    databaseRecord.Settings.Add("Indexing.Auto.SearchEngineType", "Corax");
-                    databaseRecord.Settings.Add("Indexing.Static.SearchEngineType", "Corax");
+
+                    // New databases use Lucene: smaller indexes, lower memory usage and faster for our index definitions.
+                    // Existing databases keep the engine they were created with, see UpdateDatabaseSettings.
+                    databaseRecord.Settings.Add("Indexing.Auto.SearchEngineType", "Lucene");
+                    databaseRecord.Settings.Add("Indexing.Static.SearchEngineType", "Lucene");
 
                     await documentStore.Maintenance.Server.SendAsync(new CreateDatabaseOperation(databaseRecord), cancellationToken);
                 }
@@ -57,6 +60,9 @@ namespace ServiceControl.Persistence.RavenDB
                 throw new InvalidOperationException($"Database '{databaseName}' does not exist.");
             }
 
+            // Existing databases keep their configured search engine. Changing it would trigger a full rebuild of all
+            // indexes, which can take a long time and a lot of resources on large databases. Databases created before the
+            // search engine was pinned explicitly get Corax, which was the default at the time.
             var updated = false;
 
             updated |= dbRecord.Settings.TryAdd("Indexing.Auto.SearchEngineType", "Corax");

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
@@ -46,6 +46,7 @@ class RavenPersistence(RavenPersisterSettings settings) : IPersistence
         services.AddCustomCheck<CheckFreeDiskSpace>();
         services.AddCustomCheck<CheckMinimumStorageRequiredForIngestion>();
         services.AddCustomCheck<CheckDirtyMemory>();
+        services.AddCustomCheck<CheckRavenDBSearchEngine>();
 
         services.AddSingleton<MemoryInformationRetriever>();
         services.AddSingleton<OperationsManager>();

--- a/src/ServiceControl.Persistence.Tests.RavenDB/ApprovalFiles/CustomCheckTests.VerifyCustomChecks.approved.txt
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/ApprovalFiles/CustomCheckTests.VerifyCustomChecks.approved.txt
@@ -1,5 +1,6 @@
 ServiceControl Health: Error Database Index Errors
 ServiceControl Health: Error Database Index Lag
+ServiceControl Health: Error Database Search Engine
 ServiceControl Health: Message Ingestion Process
 ServiceControl Health: RavenDB dirty memory
 Storage space: ServiceControl database

--- a/src/ServiceControl.RavenDB/StartupChecks.cs
+++ b/src/ServiceControl.RavenDB/StartupChecks.cs
@@ -20,7 +20,7 @@
 
             if (coraxIndexes.Length > 0)
             {
-                Logger.LogWarning("Database '{DatabaseName}' has {Count} index(es) using the Corax search engine: {Indexes}. Lucene indexes are smaller, use less memory and perform better for ServiceControl workloads. Consider switching these indexes to Lucene, note that this will trigger a full rebuild of the index.", databaseName, coraxIndexes.Length, string.Join(", ", coraxIndexes));
+                Logger.LogWarning("Database '{DatabaseName}' has {Count} index(es) using the Corax search engine: {Indexes}. Lucene indexes are smaller, use less memory and perform better for ServiceControl workloads. Consider switching these indexes to Lucene. Note that switching triggers a full rebuild of the index: on very large databases this can take days depending on the available compute, and while the rebuild is running ingestion and indexing rates can be degraded. Plan the switch accordingly.", databaseName, coraxIndexes.Length, string.Join(", ", coraxIndexes));
             }
         }
 

--- a/src/ServiceControl.RavenDB/StartupChecks.cs
+++ b/src/ServiceControl.RavenDB/StartupChecks.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.RavenDB
 {
+    using System.Collections.Generic;
     using System.Reflection;
     using System.Threading;
     using Microsoft.Extensions.Logging;
@@ -20,9 +21,15 @@
 
             if (coraxIndexes.Length > 0)
             {
-                Logger.LogWarning("Database '{DatabaseName}' has {Count} index(es) using the Corax search engine: {Indexes}. Lucene indexes are smaller, use less memory and perform better for ServiceControl workloads. Consider switching these indexes to Lucene. Note that switching triggers a full rebuild of the index: on very large databases this can take days depending on the available compute, and while the rebuild is running ingestion and indexing rates can be degraded. Plan the switch accordingly.", databaseName, coraxIndexes.Length, string.Join(", ", coraxIndexes));
+                Logger.LogWarning(CoraxIndexesMessage(coraxIndexes.Select(i => $"{databaseName}/{i}")));
             }
         }
+
+        public static string CoraxIndexesMessage(IEnumerable<string> indexes) =>
+            $"The following RavenDB index(es) use the Corax search engine: {string.Join(", ", indexes)}. " +
+            "Lucene indexes are smaller, use less memory and perform better for ServiceControl workloads, and are the default for new databases. " +
+            "Consider switching these indexes to Lucene. Note that switching triggers a full rebuild of the index: on very large databases this can take days depending on the available compute, " +
+            "and while the rebuild is running ingestion and indexing rates can be degraded. Plan the switch accordingly.";
 
         public static async Task<string[]> FindIndexesUsingCorax(IDocumentStore store, string databaseName, CancellationToken cancellationToken = default)
         {

--- a/src/ServiceControl.RavenDB/StartupChecks.cs
+++ b/src/ServiceControl.RavenDB/StartupChecks.cs
@@ -2,11 +2,38 @@
 {
     using System.Reflection;
     using System.Threading;
+    using Microsoft.Extensions.Logging;
     using Raven.Client.Documents;
+    using Raven.Client.Documents.Indexes;
+    using Raven.Client.Documents.Operations.Indexes;
     using Raven.Client.ServerWide.Operations;
+    using ServiceControl.Infrastructure;
 
     public static class StartupChecks
     {
+        public static async Task WarnIfIndexesUseCorax(IDocumentStore store, string databaseName, CancellationToken cancellationToken = default)
+        {
+            // New databases are created with Lucene, existing databases keep whatever search engine they were created
+            // with as switching would trigger a full rebuild of all indexes. Let the operator know so they can plan the
+            // transition to Lucene themselves.
+            var coraxIndexes = await FindIndexesUsingCorax(store, databaseName, cancellationToken);
+
+            if (coraxIndexes.Length > 0)
+            {
+                Logger.LogWarning("Database '{DatabaseName}' has {Count} index(es) using the Corax search engine: {Indexes}. Lucene indexes are smaller, use less memory and perform better for ServiceControl workloads. Consider switching these indexes to Lucene, note that this will trigger a full rebuild of the index.", databaseName, coraxIndexes.Length, string.Join(", ", coraxIndexes));
+            }
+        }
+
+        public static async Task<string[]> FindIndexesUsingCorax(IDocumentStore store, string databaseName, CancellationToken cancellationToken = default)
+        {
+            var indexStats = await store.Maintenance.ForDatabase(databaseName).SendAsync(new GetIndexesStatisticsOperation(), cancellationToken);
+
+            return indexStats
+                .Where(i => i.SearchEngineType == SearchEngineType.Corax)
+                .Select(i => i.Name)
+                .ToArray();
+        }
+
         public static async Task EnsureServerVersion(IDocumentStore store, CancellationToken cancellationToken = default)
         {
             // RavenDB compatibility policy is that the major/minor version of the server must be
@@ -31,5 +58,7 @@
                 throw new Exception($"ServiceControl expects RavenDB Server version {clientProductVersion} or higher, but the server is using {serverProductVersion}.");
             }
         }
+
+        static readonly ILogger Logger = LoggerUtil.CreateStaticLogger(typeof(StartupChecks));
     }
 }


### PR DESCRIPTION
## Summary

Load testing showed that Lucene indexes are smaller, use less RAM and are faster than Corax for the index definitions ServiceControl uses. This PR moves **new** databases to Lucene while leaving existing databases untouched, and makes it visible to operators when their indexes are still on Corax.

Switching an existing database is deliberately **not** done automatically: changing the search engine triggers a full rebuild of all indexes, which on very large databases can take days depending on available compute and degrades ingestion/indexing rates while it runs. Migration remains an operator decision (docs guidance to follow).

> [!NOTE]
> The default RavenDB full-text search engine changes from Corax to Lucene to resolve performance and stability issues on large database instances. Existing indexes are not automatically updated, as an index rebuild can take significant time and can severely impact compute and storage utilization while it runs. For more information, see the [6.19 to 6.20 upgrade guide](https://docs.particular.net/servicecontrol/upgrades/6.19to6.20).

## Changes

- **New databases are created with `Indexing.Static/Auto.SearchEngineType=Lucene`** (Primary main + throughput databases, Audit). `UpdateDatabaseSettings` is unchanged, so existing databases keep whatever engine they currently have configured.
- **Startup WARN** listing any index still using Corax (`StartupChecks.WarnIfIndexesUseCorax`, shared by both persisters).
- **Custom check** `Error Database Search Engine` / `Audit Database Search Engine` surfacing the same information in ServicePulse (hourly).
- Tests: default engine for a fresh database is Lucene; per-index override is still reset on setup; Corax detection is covered; custom check approval files updated.