### PR TITLE
Spike: shrink audit full-text search index

### DIFF
--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_processed_message_searched_by_conversationid.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_processed_message_searched_by_conversationid.cs
@@ -1,0 +1,59 @@
+﻿namespace ServiceControl.Audit.AcceptanceTests.Auditing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.EndpointTemplates;
+    using Audit.Auditing.MessagesView;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Customization;
+    using NServiceBus.Settings;
+    using NUnit.Framework;
+
+    class When_processed_message_searched_by_conversationid : AcceptanceTest
+    {
+        [Test]
+        public async Task Should_be_found() =>
+            await Define<MyContext>()
+                .WithEndpoint<Sender>(b => b.When((bus, c) => bus.Send(new MyMessage())))
+                .WithEndpoint<Receiver>()
+                .Done(async c => c.ConversationId != null && await this.TryGetMany<MessagesView>("/api/messages/search/" + c.ConversationId))
+                .Run();
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender() =>
+                EndpointSetup<DefaultServerWithoutAudit>(c =>
+                {
+                    var routing = c.ConfigureRouting();
+                    routing.RouteToEndpoint(typeof(MyMessage), typeof(Receiver));
+                });
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver() => EndpointSetup<DefaultServerWithAudit>();
+
+            [Handler]
+            public class MyMessageHandler(MyContext testContext, IReadOnlySettings settings)
+                : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.EndpointNameOfReceivingEndpoint = settings.EndpointName();
+                    testContext.ConversationId = context.MessageHeaders[Headers.ConversationId];
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public class MyMessage : ICommand;
+
+        public class MyContext : ScenarioContext
+        {
+            public string ConversationId { get; set; }
+
+            public string EndpointNameOfReceivingEndpoint { get; set; }
+        }
+    }
+}

--- a/src/ServiceControl.Audit.Persistence.RavenDB/Indexes/MessagesViewIndex.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/Indexes/MessagesViewIndex.cs
@@ -25,20 +25,31 @@ namespace ServiceControl.Audit.Persistence.RavenDB.Indexes
                     CriticalTime = (TimeSpan?)message.MessageMetadata["CriticalTime"],
                     ProcessingTime = (TimeSpan?)message.MessageMetadata["ProcessingTime"],
                     DeliveryTime = (TimeSpan?)message.MessageMetadata["DeliveryTime"],
-                    Query = message.MessageMetadata.Select(_ => _.Value.ToString()).Union(new[]
-                    {
-                        string.Join(" ", message.Headers.Select(x => x.Value))
-                    }).ToArray(),
+                    // Dates, durations, sizes and booleans only add tokens nobody searches for, so they are excluded.
+                    // Identifiers (message/conversation/correlation ids) are kept: /messages/search/{id} relies on them.
+                    Query = message.MessageMetadata
+                        .Where(m => m.Key != "TimeSent" && m.Key != "CriticalTime" && m.Key != "ProcessingTime"
+                                && m.Key != "DeliveryTime" && m.Key != "ContentLength" && m.Key != "BodyUrl"
+                                && m.Key != "IsSystemMessage" && m.Key != "IsRetried" && m.Key != "BodyNotStored"
+                                && m.Key != "OriginatesFromSaga")
+                        .Select(m => m.Value.ToString())
+                        .Concat(message.Headers
+                            .Where(h => h.Key != "NServiceBus.TimeSent" && h.Key != "NServiceBus.ProcessingStarted" && h.Key != "NServiceBus.ProcessingEnded"
+                                    && h.Key != "NServiceBus.DeliverAt" && h.Key != "NServiceBus.Timeout.Expire" && h.Key != "NServiceBus.Retries.Timestamp"
+                                    && h.Key != "NServiceBus.ExceptionInfo.TimeOfFailure" && h.Key != "NServiceBus.TimeOfFailure" && h.Key != "NServiceBus.NonDurableMessage"
+                                    && h.Key != "NServiceBus.TimeToBeReceived")
+                            .Select(h => h.Value))
+                        .Where(v => v != null && v.Length > 0)
+                        .Distinct()
+                        .ToArray(),
                     ConversationId = (string)message.MessageMetadata["ConversationId"]
                 };
 
             Index(x => x.Query, FieldIndexing.Search);
 
-            // Not using typeof() to prevent dependency on Lucene.
-            // Unfortunately while "StandardAnalyzer" would probably be better and more future-proof here,
-            // we can't change this string without causing any existing audit database to completely rebuild this index.
-            // If this index *must* be changed for some other reason, the analyzer name should be changed at the same time.
-            Analyze(x => x.Query, "Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181");
+            // Any change to this index definition (map or analyzer) causes existing audit databases to rebuild the index on startup.
+            // The analyzer name deliberately does not use typeof() to prevent a dependency on Lucene.
+            Analyze(x => x.Query, "StandardAnalyzer");
         }
 
         public class SortAndFilterOptions

--- a/src/ServiceControl.Audit.Persistence.RavenDB/Indexes/MessagesViewIndex.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/Indexes/MessagesViewIndex.cs
@@ -26,15 +26,18 @@ namespace ServiceControl.Audit.Persistence.RavenDB.Indexes
                     ProcessingTime = (TimeSpan?)message.MessageMetadata["ProcessingTime"],
                     DeliveryTime = (TimeSpan?)message.MessageMetadata["DeliveryTime"],
                     // Dates, durations, sizes and booleans only add tokens nobody searches for, so they are excluded.
-                    // Identifiers (message/conversation/correlation ids) are kept: /messages/search/{id} relies on them.
+                    // Identifiers are excluded too: they are matched exactly on the MessageId/ConversationId fields instead.
                     Query = message.MessageMetadata
-                        .Where(m => m.Key != "TimeSent" && m.Key != "CriticalTime" && m.Key != "ProcessingTime"
+                        .Where(m => m.Key != "MessageId" && m.Key != "ConversationId" && m.Key != "RelatedToId"
+                                && m.Key != "TimeSent" && m.Key != "CriticalTime" && m.Key != "ProcessingTime"
                                 && m.Key != "DeliveryTime" && m.Key != "ContentLength" && m.Key != "BodyUrl"
                                 && m.Key != "IsSystemMessage" && m.Key != "IsRetried" && m.Key != "BodyNotStored"
                                 && m.Key != "OriginatesFromSaga")
                         .Select(m => m.Value.ToString())
                         .Concat(message.Headers
-                            .Where(h => h.Key != "NServiceBus.TimeSent" && h.Key != "NServiceBus.ProcessingStarted" && h.Key != "NServiceBus.ProcessingEnded"
+                            .Where(h => h.Key != "NServiceBus.MessageId" && h.Key != "NServiceBus.ConversationId"
+                                    && h.Key != "NServiceBus.CorrelationId" && h.Key != "NServiceBus.RelatedTo"
+                                    && h.Key != "NServiceBus.TimeSent" && h.Key != "NServiceBus.ProcessingStarted" && h.Key != "NServiceBus.ProcessingEnded"
                                     && h.Key != "NServiceBus.DeliverAt" && h.Key != "NServiceBus.Timeout.Expire" && h.Key != "NServiceBus.Retries.Timestamp"
                                     && h.Key != "NServiceBus.ExceptionInfo.TimeOfFailure" && h.Key != "NServiceBus.TimeOfFailure" && h.Key != "NServiceBus.NonDurableMessage"
                                     && h.Key != "NServiceBus.TimeToBeReceived")

--- a/src/ServiceControl.Audit.Persistence.RavenDB/Indexes/MessagesViewIndexWithFullTextSearch.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/Indexes/MessagesViewIndexWithFullTextSearch.cs
@@ -25,21 +25,32 @@ namespace ServiceControl.Audit.Persistence.RavenDB.Indexes
                     CriticalTime = (TimeSpan?)message.MessageMetadata["CriticalTime"],
                     ProcessingTime = (TimeSpan?)message.MessageMetadata["ProcessingTime"],
                     DeliveryTime = (TimeSpan?)message.MessageMetadata["DeliveryTime"],
-                    Query = message.MessageMetadata.Select(_ => _.Value.ToString()).Union(new[]
-                    {
-                        string.Join(" ", message.Headers.Select(x => x.Value)),
-                        LoadAttachment(message, "body").GetContentAsString()
-                    }).ToArray(),
+                    // Dates, durations, sizes and booleans only add tokens nobody searches for, so they are excluded.
+                    // Identifiers (message/conversation/correlation ids) are kept: /messages/search/{id} relies on them.
+                    Query = message.MessageMetadata
+                        .Where(m => m.Key != "TimeSent" && m.Key != "CriticalTime" && m.Key != "ProcessingTime"
+                                && m.Key != "DeliveryTime" && m.Key != "ContentLength" && m.Key != "BodyUrl"
+                                && m.Key != "IsSystemMessage" && m.Key != "IsRetried" && m.Key != "BodyNotStored"
+                                && m.Key != "OriginatesFromSaga")
+                        .Select(m => m.Value.ToString())
+                        .Concat(message.Headers
+                            .Where(h => h.Key != "NServiceBus.TimeSent" && h.Key != "NServiceBus.ProcessingStarted" && h.Key != "NServiceBus.ProcessingEnded"
+                                    && h.Key != "NServiceBus.DeliverAt" && h.Key != "NServiceBus.Timeout.Expire" && h.Key != "NServiceBus.Retries.Timestamp"
+                                    && h.Key != "NServiceBus.ExceptionInfo.TimeOfFailure" && h.Key != "NServiceBus.TimeOfFailure" && h.Key != "NServiceBus.NonDurableMessage"
+                                    && h.Key != "NServiceBus.TimeToBeReceived")
+                            .Select(h => h.Value))
+                        .Where(v => v != null && v.Length > 0)
+                        .Distinct()
+                        .Concat(new[] { LoadAttachment(message, "body").GetContentAsString() })
+                        .ToArray(),
                     ConversationId = (string)message.MessageMetadata["ConversationId"]
                 };
 
             Index(x => x.Query, FieldIndexing.Search);
 
-            // Not using typeof() to prevent dependency on Lucene.
-            // Unfortunately while "StandardAnalyzer" would probably be better and more future-proof here,
-            // we can't change this string without causing any existing audit database to completely rebuild this index.
-            // If this index *must* be changed for some other reason, the analyzer name should be changed at the same time.
-            Analyze(x => x.Query, "Lucene.Net.Analysis.Standard.StandardAnalyzer, Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181");
+            // Any change to this index definition (map or analyzer) causes existing audit databases to rebuild the index on startup.
+            // The analyzer name deliberately does not use typeof() to prevent a dependency on Lucene.
+            Analyze(x => x.Query, "StandardAnalyzer");
         }
     }
 }

--- a/src/ServiceControl.Audit.Persistence.RavenDB/Indexes/MessagesViewIndexWithFullTextSearch.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/Indexes/MessagesViewIndexWithFullTextSearch.cs
@@ -26,15 +26,18 @@ namespace ServiceControl.Audit.Persistence.RavenDB.Indexes
                     ProcessingTime = (TimeSpan?)message.MessageMetadata["ProcessingTime"],
                     DeliveryTime = (TimeSpan?)message.MessageMetadata["DeliveryTime"],
                     // Dates, durations, sizes and booleans only add tokens nobody searches for, so they are excluded.
-                    // Identifiers (message/conversation/correlation ids) are kept: /messages/search/{id} relies on them.
+                    // Identifiers are excluded too: they are matched exactly on the MessageId/ConversationId fields instead.
                     Query = message.MessageMetadata
-                        .Where(m => m.Key != "TimeSent" && m.Key != "CriticalTime" && m.Key != "ProcessingTime"
+                        .Where(m => m.Key != "MessageId" && m.Key != "ConversationId" && m.Key != "RelatedToId"
+                                && m.Key != "TimeSent" && m.Key != "CriticalTime" && m.Key != "ProcessingTime"
                                 && m.Key != "DeliveryTime" && m.Key != "ContentLength" && m.Key != "BodyUrl"
                                 && m.Key != "IsSystemMessage" && m.Key != "IsRetried" && m.Key != "BodyNotStored"
                                 && m.Key != "OriginatesFromSaga")
                         .Select(m => m.Value.ToString())
                         .Concat(message.Headers
-                            .Where(h => h.Key != "NServiceBus.TimeSent" && h.Key != "NServiceBus.ProcessingStarted" && h.Key != "NServiceBus.ProcessingEnded"
+                            .Where(h => h.Key != "NServiceBus.MessageId" && h.Key != "NServiceBus.ConversationId"
+                                    && h.Key != "NServiceBus.CorrelationId" && h.Key != "NServiceBus.RelatedTo"
+                                    && h.Key != "NServiceBus.TimeSent" && h.Key != "NServiceBus.ProcessingStarted" && h.Key != "NServiceBus.ProcessingEnded"
                                     && h.Key != "NServiceBus.DeliverAt" && h.Key != "NServiceBus.Timeout.Expire" && h.Key != "NServiceBus.Retries.Timestamp"
                                     && h.Key != "NServiceBus.ExceptionInfo.TimeOfFailure" && h.Key != "NServiceBus.TimeOfFailure" && h.Key != "NServiceBus.NonDurableMessage"
                                     && h.Key != "NServiceBus.TimeToBeReceived")

--- a/src/ServiceControl.Audit.Persistence.RavenDB/RavenAuditDataStore.cs
+++ b/src/ServiceControl.Audit.Persistence.RavenDB/RavenAuditDataStore.cs
@@ -9,6 +9,8 @@
     using Extensions;
     using Indexes;
     using Raven.Client.Documents;
+    using Raven.Client.Documents.Linq;
+    using Raven.Client.Documents.Session;
     using ServiceControl.Audit.Auditing;
     using ServiceControl.Audit.Infrastructure;
     using ServiceControl.SagaAudit;
@@ -46,9 +48,8 @@
         public async Task<QueryResult<IList<MessagesView>>> QueryMessages(string searchParam, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken = default)
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
-            var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
+            var results = await SearchMessages(session, searchParam)
                 .Statistics(out var stats)
-                .Search(x => x.Query, searchParam)
                 .FilterBySentTimeRange(timeSentRange)
                 .Sort(sortInfo)
                 .Paging(pagingInfo)
@@ -61,9 +62,8 @@
         public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpointAndKeyword(string endpoint, string keyword, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken = default)
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
-            var results = await session.Query<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
+            var results = await SearchMessages(session, keyword)
                 .Statistics(out var stats)
-                .Search(x => x.Query, keyword)
                 .Where(m => m.ReceivingEndpointName == endpoint)
                 .FilterBySentTimeRange(timeSentRange)
                 .Sort(sortInfo)
@@ -73,6 +73,18 @@
 
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
+
+        // Identifiers are not part of the full-text Query field; they are matched exactly on their own fields.
+        // Built as a DocumentQuery because the LINQ provider does not parenthesize an OR group, so subsequent Where
+        // clauses would bind to the last OR term only.
+        IRavenQueryable<MessagesViewIndex.SortAndFilterOptions> SearchMessages(IAsyncDocumentSession session, string searchParam) =>
+            session.Advanced.AsyncDocumentQuery<MessagesViewIndex.SortAndFilterOptions>(GetIndexName(isFullTextSearchEnabled))
+                .OpenSubclause()
+                .Search(x => x.Query, searchParam)
+                .OrElse().WhereEquals(x => x.MessageId, searchParam)
+                .OrElse().WhereEquals(x => x.ConversationId, searchParam)
+                .CloseSubclause()
+                .ToQueryable();
 
         public async Task<QueryResult<IList<MessagesView>>> QueryMessagesByReceivingEndpoint(bool includeSystemMessages, string endpointName, PagingInfo pagingInfo, SortInfo sortInfo, DateTimeRange timeSentRange, CancellationToken cancellationToken = default)
         {

--- a/src/ServiceControl.Persistence.RavenDB/ErrorMessagesDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ErrorMessagesDataStore.cs
@@ -92,9 +92,8 @@
             )
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
-            var query = session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
+            var query = SearchMessages(session, searchKeyword)
                 .Statistics(out var stats)
-                .Search(x => x.Query, searchKeyword)
                 .Where(m => m.ReceivingEndpointName == endpointName)
                 .FilterBySentTimeRange(timeSentRange)
                 .Sort(sortInfo)
@@ -106,6 +105,18 @@
 
             return new QueryResult<IList<MessagesView>>(results, stats.ToQueryStatsInfo());
         }
+
+        // Identifiers are not part of the full-text Query field; they are matched exactly on their own fields.
+        // Built as a DocumentQuery because the LINQ provider does not parenthesize an OR group, so subsequent Where
+        // clauses would bind to the last OR term only.
+        static IRavenQueryable<MessagesViewIndex.SortAndFilterOptions> SearchMessages(IAsyncDocumentSession session, string searchParam) =>
+            session.Advanced.AsyncDocumentQuery<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
+                .OpenSubclause()
+                .Search(x => x.Query, searchParam)
+                .OrElse().WhereEquals(x => x.MessageId, searchParam)
+                .OrElse().WhereEquals(x => x.ConversationId, searchParam)
+                .CloseSubclause()
+                .ToQueryable();
 
         public async Task<QueryResult<IList<MessagesView>>> GetAllMessagesByConversation(
             string conversationId,
@@ -138,9 +149,8 @@
             )
         {
             using var session = await sessionProvider.OpenSession(cancellationToken: cancellationToken);
-            var query = session.Query<MessagesViewIndex.SortAndFilterOptions, MessagesViewIndex>()
+            var query = SearchMessages(session, searchTerms)
                 .Statistics(out var stats)
-                .Search(x => x.Query, searchTerms)
                 .FilterBySentTimeRange(timeSentRange)
                 .Sort(sortInfo)
                 .Paging(pagingInfo)

--- a/src/ServiceControl.Persistence.RavenDB/Indexes/MessagesViewIndex.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Indexes/MessagesViewIndex.cs
@@ -32,7 +32,25 @@ namespace ServiceControl.Persistence
                     CriticalTime = (TimeSpan?)last.MessageMetadata["CriticalTime"],
                     ProcessingTime = (TimeSpan?)last.MessageMetadata["ProcessingTime"],
                     DeliveryTime = (TimeSpan?)last.MessageMetadata["DeliveryTime"],
-                    Query = last.MessageMetadata.Select(_ => _.Value.ToString()).Union(new[] { string.Join(" ", last.Headers.Select(x => x.Value)) }).ToArray(),
+                    // Dates, durations, sizes and booleans only add tokens nobody searches for, so they are excluded.
+                    // Identifiers are excluded too: they are matched exactly on the MessageId/ConversationId fields instead.
+                    Query = last.MessageMetadata
+                        .Where(m => m.Key != "MessageId" && m.Key != "ConversationId" && m.Key != "RelatedToId"
+                                && m.Key != "TimeSent" && m.Key != "CriticalTime" && m.Key != "ProcessingTime"
+                                && m.Key != "DeliveryTime" && m.Key != "ContentLength" && m.Key != "BodyUrl"
+                                && m.Key != "IsSystemMessage")
+                        .Select(m => m.Value.ToString())
+                        .Concat(last.Headers
+                            .Where(h => h.Key != "NServiceBus.MessageId" && h.Key != "NServiceBus.ConversationId"
+                                    && h.Key != "NServiceBus.CorrelationId" && h.Key != "NServiceBus.RelatedTo"
+                                    && h.Key != "NServiceBus.TimeSent" && h.Key != "NServiceBus.ProcessingStarted" && h.Key != "NServiceBus.ProcessingEnded"
+                                    && h.Key != "NServiceBus.DeliverAt" && h.Key != "NServiceBus.Timeout.Expire" && h.Key != "NServiceBus.Retries.Timestamp"
+                                    && h.Key != "NServiceBus.ExceptionInfo.TimeOfFailure" && h.Key != "NServiceBus.TimeOfFailure" && h.Key != "NServiceBus.NonDurableMessage"
+                                    && h.Key != "NServiceBus.TimeToBeReceived")
+                            .Select(h => h.Value))
+                        .Where(v => v != null && v.Length > 0)
+                        .Distinct()
+                        .ToArray(),
                     ConversationId = (string)last.MessageMetadata["ConversationId"]
                 };
 


### PR DESCRIPTION
## Spike: shrink the audit `MessagesView` full-text index

Draft/spike — measuring on a real audit database before deciding whether to ship.

### Problem

The `Query` search field of both `MessagesViewIndex` and `MessagesViewIndexWithFullTextSearch` indexes *every* metadata value and *every* header value. A large share of those are timestamps, durations, sizes, booleans and identifiers. Nobody searches for a timestamp or a `ProcessingTime`, and because each of those values is unique per message they never share dictionary terms across documents, so they inflate the term dictionary far more than the shared tokens (endpoint names, message types, host names) do.

### Changes

1. **Exclude temporal, numeric and boolean values from `Query`** — metadata `TimeSent`, `CriticalTime`, `ProcessingTime`, `DeliveryTime`, `ContentLength`, `BodyUrl`, `IsSystemMessage`, `IsRetried`, `BodyNotStored`, `OriginatesFromSaga` and headers `TimeSent`, `ProcessingStarted`, `ProcessingEnded`, `DeliverAt`, `Timeout.Expire`, `Retries.Timestamp`, `ExceptionInfo.TimeOfFailure`, `TimeOfFailure`, `NonDurableMessage`, `TimeToBeReceived`. Header values are indexed individually rather than as one joined string; null/empty values dropped; `Distinct()` removes metadata/header duplicates.
2. **Match identifiers exactly instead of via full-text** — `/messages/search/{keyword}` now ORs `MessageId = keyword` and `ConversationId = keyword` with the full-text search, and ids (plus their `NServiceBus.MessageId/ConversationId/CorrelationId/RelatedTo` header copies) are dropped from `Query`. The OR group is built with the DocumentQuery API because the LINQ provider does not parenthesize `Search(..., SearchOptions.Or)`, which would bind the endpoint/time-range filters to the last OR term only (verified by inspecting the generated RQL).
3. Analyzer referenced by its short name `StandardAnalyzer`, as the old comment suggested doing whenever the index has to rebuild anyway.
4. New acceptance test `When_processed_message_searched_by_conversationid`.

### Estimated effect

Representative `OrderPlaced` audit message (21 headers, no body), StandardAnalyzer-style tokenization:

| | before | after |
|---|---|---|
| tokens / message | 83 | 35 |
| distinct terms / message | 42 | 22 |
| per-message-unique terms | 18 | 0 |

Real numbers to be measured on an existing audit database (side-by-side trial indexes filtered on `ProcessedAt`, old vs new `Query` projection over the same document set).

### Behaviour changes / open questions

- Any deployment picking this up rebuilds both `MessagesView` indexes on startup (unavoidable for any map change).
- `CorrelationId` and `RelatedTo` are no longer searchable (no exact-match field). Correlation id usually equals message id. Acceptable?
- The EF/SQL persisters still index ids and timestamps as free text — same pattern, follow-up candidate.

### Primary instance

The error `MessagesViewIndex` and `ErrorMessagesDataStore` get the same treatment (third commit): identical `Query` exclusions (minus audit-only metadata keys), exact-match OR on `MessageId`/`ConversationId`, headers indexed individually with `Distinct()`. Exception details (`NServiceBus.ExceptionInfo.ExceptionType/Message/StackTrace`) and `MsgFullText` remain searchable; only `ExceptionInfo.TimeOfFailure` is dropped. This index also rebuilds on deployment.

### Verification

- `ServiceControl.Audit.Persistence.Tests.RavenDB` 41/41; `ServiceControl.Persistence.Tests.RavenDB` 326/326
- `ServiceControl.Audit.AcceptanceTests.RavenDB` and `ServiceControl.Audit.AcceptanceTests` search tests 5/5 each; `ServiceControl.AcceptanceTests.RavenDB` search/queried tests 8/8

