### PR TITLE
Simplify and clarify Platform Install experience on ServiceControl Management

### DIFF
--- a/src/ServiceControl.Config.Tests/ServiceControlAddScreenLoadedTests.cs
+++ b/src/ServiceControl.Config.Tests/ServiceControlAddScreenLoadedTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.ComponentModel;
+    using System.Linq;
     using NUnit.Framework;
     using ServiceControlInstaller.Engine.Configuration.ServiceControl;
     using UI.InstanceAdd;
@@ -275,6 +276,87 @@
             {
                 Assert.That(viewModel.AuditEnableFullTextSearchOnBodiesOptions, Is.Not.Empty);
                 Assert.That(viewModel.AuditEnableFullTextSearchOnBodies.Value, Is.EqualTo(true));
+            }
+        }
+
+        [Test]
+        public void Instance_sections_are_expanded_by_default()
+        {
+            var viewModel = new ServiceControlAddViewModel();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.IsServiceControlExpanded, Is.True);
+                Assert.That(viewModel.IsServiceControlAuditExpanded, Is.True);
+            }
+        }
+
+        [Test]
+        public void Integrated_ServicePulse_is_enabled_by_default()
+        {
+            var viewModel = new ServiceControlAddViewModel();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(viewModel.ErrorEnableIntegratedServicePulseOptions, Is.Not.Empty);
+                Assert.That(viewModel.ErrorEnableIntegratedServicePulse.Value, Is.True);
+            }
+        }
+
+        [Test]
+        public void Integrated_ServicePulse_can_be_disabled()
+        {
+            var viewModel = new ServiceControlAddViewModel();
+
+            var offOption = viewModel.ErrorEnableIntegratedServicePulseOptions.First(o => !o.Value);
+            viewModel.ServiceControl.EnableIntegratedServicePulse = offOption;
+
+            Assert.That(viewModel.ErrorEnableIntegratedServicePulse.Value, Is.False);
+        }
+
+        [Test]
+        public void Audit_only_configuration_has_no_validation_errors_for_error_fields()
+        {
+            var viewModel = new ServiceControlAddViewModel(() => [])
+            {
+                InstallErrorInstance = false,
+                InstallAuditInstance = true,
+                SubmitAttempted = true
+            };
+
+            var notifyErrorInfo = (INotifyDataErrorInfo)viewModel;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.ErrorInstanceName)), Is.Empty);
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.ErrorHostName)), Is.Empty);
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.ErrorPortNumber)), Is.Empty);
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.ErrorDestinationPath)), Is.Empty);
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.ErrorLogPath)), Is.Empty);
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.ErrorDatabasePath)), Is.Empty);
+            }
+        }
+
+        [Test]
+        public void Error_only_configuration_has_no_validation_errors_for_audit_fields()
+        {
+            var viewModel = new ServiceControlAddViewModel(() => [])
+            {
+                InstallErrorInstance = true,
+                InstallAuditInstance = false,
+                SubmitAttempted = true
+            };
+
+            var notifyErrorInfo = (INotifyDataErrorInfo)viewModel;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.AuditInstanceName)), Is.Empty);
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.AuditHostName)), Is.Empty);
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.AuditPortNumber)), Is.Empty);
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.AuditDestinationPath)), Is.Empty);
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.AuditLogPath)), Is.Empty);
+                Assert.That(notifyErrorInfo.GetErrors(nameof(viewModel.AuditDatabasePath)), Is.Empty);
             }
         }
     }

--- a/src/ServiceControl.Config.Tests/SetupModeTests.cs
+++ b/src/ServiceControl.Config.Tests/SetupModeTests.cs
@@ -4,7 +4,7 @@ namespace ServiceControl.Config.Tests
     using UI.Shell;
 
     [TestFixture]
-    public class SetupModeTests
+    class SetupModeTests
     {
         [TestCase(SetupMode.ErrorHandling, true, false, false)]
         [TestCase(SetupMode.ErrorAndAudit, true, true, false)]

--- a/src/ServiceControl.Config.Tests/SetupModeTests.cs
+++ b/src/ServiceControl.Config.Tests/SetupModeTests.cs
@@ -1,0 +1,51 @@
+namespace ServiceControl.Config.Tests
+{
+    using NUnit.Framework;
+    using UI.Shell;
+
+    [TestFixture]
+    public class SetupModeTests
+    {
+        [TestCase(SetupMode.ErrorHandling, true, false, false)]
+        [TestCase(SetupMode.ErrorAndAudit, true, true, false)]
+        [TestCase(SetupMode.AuditOnly, false, true, false)]
+        [TestCase(SetupMode.MonitoringOnly, false, false, true)]
+        public void Scenario_selects_the_instances_to_install(SetupMode mode, bool serviceControl, bool audit, bool monitoring)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(mode.InstallsServiceControl(), Is.EqualTo(serviceControl));
+                Assert.That(mode.InstallsAudit(), Is.EqualTo(audit));
+                Assert.That(mode.InstallsMonitoring(), Is.EqualTo(monitoring));
+            }
+        }
+
+        [TestCase(SetupMode.ErrorHandling)]
+        [TestCase(SetupMode.ErrorAndAudit)]
+        [TestCase(SetupMode.AuditOnly)]
+        [TestCase(SetupMode.MonitoringOnly)]
+        public void Every_scenario_installs_at_least_one_instance(SetupMode mode)
+        {
+            // The Next button is always enabled, so no scenario may resolve to nothing.
+            Assert.That(mode.InstallsServiceControl() || mode.InstallsAudit() || mode.InstallsMonitoring(), Is.True);
+        }
+
+        [TestCase(SetupMode.ErrorHandling)]
+        [TestCase(SetupMode.ErrorAndAudit)]
+        public void Integrated_ServicePulse_follows_the_choice_when_an_error_instance_is_installed(SetupMode mode)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(mode.InstallsServicePulse(wanted: true), Is.True);
+                Assert.That(mode.InstallsServicePulse(wanted: false), Is.False);
+            }
+        }
+
+        [TestCase(SetupMode.AuditOnly)]
+        [TestCase(SetupMode.MonitoringOnly)]
+        public void Integrated_ServicePulse_is_never_installed_without_an_error_instance(SetupMode mode)
+        {
+            Assert.That(mode.InstallsServicePulse(wanted: true), Is.False);
+        }
+    }
+}

--- a/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
@@ -1,6 +1,8 @@
-﻿namespace ServiceControl.Config.Commands
+namespace ServiceControl.Config.Commands
 {
     using System;
+    using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Framework;
     using Framework.Commands;
@@ -25,6 +27,32 @@
 
             var instanceViewModel = addInstance();
             await windowManager.ShowInnerDialog(instanceViewModel);
+        }
+
+        public async Task ExecuteWithOptions(bool installError, bool installAudit, bool installServicePulse, CancellationToken cancellationToken = default)
+        {
+            if (!await commandChecks.CanAddInstance(true, cancellationToken))
+            {
+                return;
+            }
+
+            var instanceViewModel = addInstance();
+            instanceViewModel.InstallErrorInstance = installError;
+            instanceViewModel.InstallAuditInstance = installAudit;
+
+            if (installError)
+            {
+                var spOption = installServicePulse
+                    ? instanceViewModel.ServiceControl.EnableIntegratedServicePulseOptions.FirstOrDefault(o => o.Value)
+                    : instanceViewModel.ServiceControl.EnableIntegratedServicePulseOptions.FirstOrDefault(o => !o.Value);
+
+                if (spOption != null)
+                {
+                    instanceViewModel.ServiceControl.EnableIntegratedServicePulse = spOption;
+                }
+            }
+
+            await windowManager.ShowInnerDialog(instanceViewModel, cancellationToken: cancellationToken);
         }
 
         readonly Func<ServiceControlAddViewModel> addInstance;

--- a/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
@@ -36,13 +36,9 @@ namespace ServiceControl.Config.Commands
 
             if (installError)
             {
-                var spOption = instanceViewModel.ServiceControl.EnableIntegratedServicePulseOptions
-                    .FirstOrDefault(o => o.Value == installServicePulse);
-
-                if (spOption != null)
-                {
-                    instanceViewModel.ServiceControl.EnableIntegratedServicePulse = spOption;
-                }
+                // The options list always carries both an On and an Off entry.
+                instanceViewModel.ServiceControl.EnableIntegratedServicePulse = instanceViewModel.ServiceControl
+                    .EnableIntegratedServicePulseOptions.First(o => o.Value == installServicePulse);
             }
 
             await windowManager.ShowInnerDialog(instanceViewModel, cancellationToken: cancellationToken);

--- a/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
@@ -20,13 +20,7 @@ namespace ServiceControl.Config.Commands
 
         public override async Task ExecuteAsync(object obj)
         {
-            if (!await commandChecks.CanAddInstance(true))
-            {
-                return;
-            }
-
-            var instanceViewModel = addInstance();
-            await windowManager.ShowInnerDialog(instanceViewModel);
+            await ExecuteWithOptions(installError: true, installAudit: true, installServicePulse: true);
         }
 
         public async Task ExecuteWithOptions(bool installError, bool installAudit, bool installServicePulse, CancellationToken cancellationToken = default)

--- a/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
+++ b/src/ServiceControl.Config/Commands/AddServiceControlInstanceCommand.cs
@@ -36,9 +36,8 @@ namespace ServiceControl.Config.Commands
 
             if (installError)
             {
-                var spOption = installServicePulse
-                    ? instanceViewModel.ServiceControl.EnableIntegratedServicePulseOptions.FirstOrDefault(o => o.Value)
-                    : instanceViewModel.ServiceControl.EnableIntegratedServicePulseOptions.FirstOrDefault(o => !o.Value);
+                var spOption = instanceViewModel.ServiceControl.EnableIntegratedServicePulseOptions
+                    .FirstOrDefault(o => o.Value == installServicePulse);
 
                 if (spOption != null)
                 {

--- a/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
+++ b/src/ServiceControl.Config/UI/AdvancedOptions/ServiceControlAdvancedView.xaml
@@ -46,7 +46,7 @@
                            Visibility="{Binding InMaintenanceMode, Converter={StaticResource boolToVisInverted}}"
                            Margin="0,0,0,20"
                 >
-                Enter database maintenance mode to access to RavenDB Management Studio.  While in this mode all message processing is disabled and the REST API is unavailable. This will prevent ServicePulse and ServiceInsight connecting to this instance.
+                Enter database maintenance mode to access to RavenDB Management Studio.  While in this mode all message processing is disabled and the REST API is unavailable. This will prevent ServicePulse connecting to this instance.
                 </TextBlock>
 
                 <TextBlock FontSize="12px"
@@ -54,7 +54,7 @@
                            Visibility="{Binding InMaintenanceMode, Converter={StaticResource boolToVis}}"
                            Margin="0,0,0,20"
                 >
-                This instance is in database maintenance mode. All message processing is disabled and the REST API is unavailable.<LineBreak />ServicePulse and ServiceInsight cannot connect to this instance while it is in maintenance mode.<LineBreak />Launch <Hyperlink Command="{Binding OpenUrl}" CommandParameter="{Binding RavenDbStudioUrl}">
+                This instance is in database maintenance mode. All message processing is disabled and the REST API is unavailable.<LineBreak />ServicePulse cannot connect to this instance while it is in maintenance mode.<LineBreak />Launch <Hyperlink Command="{Binding OpenUrl}" CommandParameter="{Binding RavenDbStudioUrl}">
                         RavenDB Management Studio
                         <Hyperlink.ContextMenu>
                             <ContextMenu>

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddView.xaml
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddView.xaml
@@ -73,34 +73,14 @@
                                                   Converter={StaticResource boolToVis}}" />
                 </StackPanel>
 
-                <TextBlock Padding="0, 0, 0, 10" Visibility="{Binding OneInstanceTypeSelected, Converter={StaticResource boolToVisInverted}}"
-                            FontSize="13px"
-                            Foreground="{StaticResource ErrorBrush}"
-                            Text="Must select either an audit or an error instance." />
-
-                <StackPanel>
-                    <!-- Horizontal layout: CheckBox + Expander side by side -->
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-
-                        <CheckBox Grid.Column="0" 
-                                  Padding="0, 0, 0, 0" 
-                                  IsChecked="{Binding InstallErrorInstance}"
-                                  VerticalAlignment="Top"
-                                  Margin="0,8,8,5"/>
-
-                        <Expander Grid.Column="1" 
-                                  Header="ServiceControl" 
-                                  IsExpanded="{Binding IsServiceControlExpanded}" 
-                                  IsEnabled="{Binding InstallErrorInstance}"
-                                  Margin="0,5,0,5"
-                                  MouseDown="Button_MouseDown" 
-                                  PreviewMouseDown="Button_MouseDown" 
-                                  PreviewMouseLeftButtonDown="Button_MouseDown">
-                            <StackPanel Margin="60,0,60,0" Visibility="{Binding InstallErrorInstance, Converter={StaticResource boolToVis}}">
+                <StackPanel Visibility="{Binding InstallErrorInstance, Converter={StaticResource boolToVis}}">
+                    <Expander Header="ServiceControl"
+                              IsExpanded="{Binding IsServiceControlExpanded}"
+                              Margin="0,5,0,5"
+                              MouseDown="Button_MouseDown"
+                              PreviewMouseDown="Button_MouseDown"
+                              PreviewMouseLeftButtonDown="Button_MouseDown">
+                            <StackPanel Margin="60,0,60,0">
                                 <Border Margin="0,40,0,20"
                                 BorderBrush="{StaticResource Gray70Brush}"
                                 BorderThickness="0,0,0,1">
@@ -261,34 +241,17 @@
                                                ItemsSource="{Binding ErrorEnableIntegratedServicePulseOptions}"
                                                SelectedValue="{Binding ErrorEnableIntegratedServicePulse}" />
                             </StackPanel>
-                        </Expander>
-                    </Grid>
+                    </Expander>
                 </StackPanel>
 
-                <StackPanel>
-                    <!-- Horizontal layout: CheckBox + Expander side by side -->
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-
-                        <CheckBox Grid.Column="0" 
-                                  Padding="0, 0, 0, 0" 
-                                  IsChecked="{Binding InstallAuditInstance}" 
-                                  IsThreeState="False"
-                                  VerticalAlignment="Top"
-                                  Margin="0,8,8,5"/>
-
-                        <Expander Grid.Column="1" 
-                                  Header="ServiceControl Audit" 
-                                  IsExpanded="{Binding IsServiceControlAuditExpanded}" 
-                                  IsEnabled="{Binding InstallAuditInstance}"
-                                  Margin="0,5,0,5"
-                                  MouseDown="Button_MouseDown" 
-                                  PreviewMouseDown="Button_MouseDown" 
-                                  PreviewMouseLeftButtonDown="Button_MouseDown">
-                            <StackPanel Margin="60,0,60,0" Visibility="{Binding InstallAuditInstance, Converter={StaticResource boolToVis}}">
+                <StackPanel Visibility="{Binding InstallAuditInstance, Converter={StaticResource boolToVis}}">
+                    <Expander Header="ServiceControl Audit"
+                              IsExpanded="{Binding IsServiceControlAuditExpanded}"
+                              Margin="0,5,0,5"
+                              MouseDown="Button_MouseDown"
+                              PreviewMouseDown="Button_MouseDown"
+                              PreviewMouseLeftButtonDown="Button_MouseDown">
+                            <StackPanel Margin="60,0,60,0">
                                 <Border Margin="0,40,0,20"
                                 BorderBrush="{StaticResource Gray70Brush}"
                                 BorderThickness="0,0,0,1">
@@ -458,8 +421,7 @@
                                                ItemsSource="{Binding AuditEnableFullTextSearchOnBodiesOptions}"
                                                SelectedValue="{Binding AuditEnableFullTextSearchOnBodies}" />
                             </StackPanel>
-                        </Expander>
-                    </Grid>
+                    </Expander>
                 </StackPanel>
             </StackPanel>
         </sie:SharedServiceControlEditorView.SharedContent>

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlAddViewModel.cs
@@ -396,9 +396,9 @@ namespace ServiceControl.Config.UI.InstanceAdd
 
         public TimeSpanUnits AuditRetentionUnits => ServiceControlAudit.AuditRetentionUnits;
 
-        public bool IsServiceControlExpanded { get; set; }
+        public bool IsServiceControlExpanded { get; set; } = true;
 
-        public bool IsServiceControlAuditExpanded { get; set; }
+        public bool IsServiceControlAuditExpanded { get; set; } = true;
 
         public double AuditRetention
         {

--- a/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlEditorViewModel.cs
+++ b/src/ServiceControl.Config/UI/InstanceAdd/ServiceControlEditorViewModel.cs
@@ -36,8 +36,6 @@ public class ServiceControlEditorViewModel : RxProgressScreen
         // Needs to exist in base class for Fody to call it so it can be executed in superclass
     }
 
-    public bool OneInstanceTypeSelected => InstallErrorInstance || InstallAuditInstance;
-
     public string TransportWarning => SelectedTransport?.Help;
 
     public string ConnectionString { get; set; }

--- a/src/ServiceControl.Config/UI/NoInstances/NoInstancesView.xaml
+++ b/src/ServiceControl.Config/UI/NoInstances/NoInstancesView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="ServiceControl.Config.UI.NoInstances.NoInstancesView"
+<UserControl x:Class="ServiceControl.Config.UI.NoInstances.NoInstancesView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -7,26 +7,11 @@
              d:DesignWidth="600"
              mc:Ignorable="d">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-
         <TextBlock Margin="10"
                    HorizontalAlignment="Center"
-                   VerticalAlignment="Bottom"
+                   VerticalAlignment="Center"
                    FontSize="20"
                    Foreground="{StaticResource Gray60Brush}"
                    Text="No service instances installed" />
-
-        <Button Grid.Row="1"
-                Margin="10"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Top"
-                Command="{Binding AddInstance}"
-                Content="Add new instance"
-                Style="{StaticResource HiliteButton}"
-                Visibility="{Binding ShowMonitoringInstances,
-                             Converter={StaticResource boolToVisInverted}}" />
     </Grid>
 </UserControl>

--- a/src/ServiceControl.Config/UI/NoInstances/NoInstancesViewModel.cs
+++ b/src/ServiceControl.Config/UI/NoInstances/NoInstancesViewModel.cs
@@ -1,21 +1,12 @@
-﻿namespace ServiceControl.Config.UI.NoInstances
+namespace ServiceControl.Config.UI.NoInstances
 {
-    using System.Windows.Input;
-    using Commands;
     using Framework.Rx;
 
     class NoInstancesViewModel : RxScreen
     {
-        public NoInstancesViewModel(AddServiceControlInstanceCommand addInstance)
+        public NoInstancesViewModel()
         {
             DisplayName = "DEPLOYED INSTANCES";
-
-            AddInstance = addInstance;
         }
-
-        public ICommand AddInstance { get; }
-
-        [FeatureToggle(Feature.MonitoringInstances)]
-        public bool ShowMonitoringInstances { get; set; }
     }
 }

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml
@@ -150,7 +150,7 @@
                     <StackPanel Grid.Column="1" Margin="10,0,0,0">
                         <TextBlock Style="{StaticResource ComponentLabel}" Text="ServiceControl Instance" />
                         <TextBlock Style="{StaticResource ComponentDescription}"
-                                   Text="Collects failed messages for retry and management" />
+                                   Text="Ability to retry failed / dead lettered messages" />
                     </StackPanel>
                 </Grid>
 
@@ -162,16 +162,9 @@
                           Checked="ServicePulse_Changed"
                           Unchecked="ServicePulse_Changed">
                     <StackPanel Margin="5,0,0,0">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Style="{StaticResource ComponentLabel}" Text="Integrated ServicePulse" />
-                            <TextBlock FontSize="12"
-                                       Foreground="{StaticResource Gray50Brush}"
-                                       FontStyle="Italic"
-                                       Margin="6,0,0,0"
-                                       Text="(requires ServiceControl Instance)" />
-                        </StackPanel>
+                        <TextBlock Style="{StaticResource ComponentLabel}" Text="Integrated ServicePulse" />
                         <TextBlock Style="{StaticResource ComponentDescription}"
-                                   Text="Built-in web UI hosted by the Error instance for managing failed messages" />
+                                   Text="Built-in web UI hosted by the Error instance" />
                     </StackPanel>
                 </CheckBox>
 
@@ -197,7 +190,7 @@
                     <StackPanel Grid.Column="1" Margin="10,0,0,0">
                         <TextBlock Style="{StaticResource ComponentLabel}" Text="Monitoring Instance" />
                         <TextBlock Style="{StaticResource ComponentDescription}"
-                                   Text="Collects monitoring data from endpoints running the NServiceBus.Metrics.ServiceControl plugin" />
+                                   Text="Collects monitoring data from endpoints for visualization with ServicePulse" />
                     </StackPanel>
                 </Grid>
 

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml
@@ -6,7 +6,7 @@
              mc:Ignorable="d"
              d:DesignHeight="500" d:DesignWidth="600">
     <UserControl.Resources>
-        <Style x:Key="PresetButton" TargetType="RadioButton">
+        <Style x:Key="ModeButton" TargetType="RadioButton">
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="RadioButton">
@@ -34,9 +34,36 @@
                 </Setter.Value>
             </Setter>
         </Style>
+        <Style x:Key="ModeLabel" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="TextAlignment" Value="Center" />
+        </Style>
+        <Style x:Key="ModeSubLabel" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="10" />
+            <Setter Property="Foreground" Value="{StaticResource Gray60Brush}" />
+            <Setter Property="TextAlignment" Value="Center" />
+            <Setter Property="Margin" Value="0,2,0,0" />
+        </Style>
+        <!-- Legible against both the unselected (Gray10) and selected (DarkTheme) tab backgrounds -->
+        <Style x:Key="ModeSubLabelHighlight" TargetType="TextBlock" BasedOn="{StaticResource ModeSubLabel}">
+            <Setter Property="Foreground" Value="{StaticResource WhiteBrush}" />
+            <Setter Property="Opacity" Value="0.85" />
+        </Style>
+        <!-- Installed components are outcomes, not controls, so they are ticks rather than
+             check boxes: the only box on the screen is the only thing worth clicking. -->
+        <Style x:Key="CheckGlyph" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource LightThemeBrush}" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Width" Value="16" />
+            <Setter Property="TextAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="Margin" Value="0,1,0,0" />
+        </Style>
         <Style x:Key="ComponentCheckBox" TargetType="CheckBox">
             <Setter Property="Foreground" Value="White" />
-            <Setter Property="Margin" Value="0,8" />
             <Setter Property="Cursor" Value="Hand" />
         </Style>
         <Style x:Key="ComponentLabel" TargetType="TextBlock">
@@ -53,173 +80,149 @@
     </UserControl.Resources>
 
     <Grid Background="Black" MinWidth="500">
-        <Grid Margin="20">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+        <StackPanel Margin="20">
 
             <!-- Header -->
-            <TextBlock Grid.Row="0"
-                       FontSize="15"
+            <TextBlock FontSize="15"
                        FontWeight="SemiBold"
                        Foreground="White"
                        Margin="0,0,0,15"
                        Text="Choose a setup scenario" />
 
-            <!-- Preset Buttons -->
-            <UniformGrid Grid.Row="1" Columns="3" Margin="0,0,0,15">
-                <RadioButton x:Name="PresetMinimal"
-                             GroupName="Preset"
-                             Style="{StaticResource PresetButton}"
-                             Checked="Preset_Checked">
-                    <TextBlock FontSize="12" FontWeight="SemiBold" Foreground="White"
-                               Text="Minimal Setup" TextAlignment="Center" />
+            <!-- Scenario selection. These are mutually exclusive, so they are the only
+                 thing driving what gets installed. -->
+            <UniformGrid Columns="4" Margin="0,0,0,20">
+                <RadioButton x:Name="ModeErrorHandling"
+                             GroupName="SetupMode"
+                             Style="{StaticResource ModeButton}"
+                             Checked="Mode_Checked">
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource ModeLabel}" Text="Error handling" />
+                        <TextBlock Style="{StaticResource ModeSubLabel}" Text="Failed messages" />
+                    </StackPanel>
                 </RadioButton>
-                <RadioButton x:Name="PresetFull"
-                             GroupName="Preset"
+                <RadioButton x:Name="ModeErrorAndAudit"
+                             GroupName="SetupMode"
                              IsChecked="True"
-                             Style="{StaticResource PresetButton}"
-                             Checked="Preset_Checked">
-                    <TextBlock FontSize="12" FontWeight="SemiBold" Foreground="White"
-                               Text="Full Setup" TextAlignment="Center" />
+                             Style="{StaticResource ModeButton}"
+                             Checked="Mode_Checked">
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource ModeLabel}" Text="Error + Audit" />
+                        <TextBlock Style="{StaticResource ModeSubLabelHighlight}" Text="Failed and audit messages" />
+                    </StackPanel>
                 </RadioButton>
-                <RadioButton x:Name="PresetAuditOnly"
-                             GroupName="Preset"
-                             Style="{StaticResource PresetButton}"
-                             Checked="Preset_Checked">
-                    <TextBlock FontSize="12" FontWeight="SemiBold" Foreground="White"
-                               Text="Audit Only" TextAlignment="Center" />
+                <RadioButton x:Name="ModeAuditOnly"
+                             GroupName="SetupMode"
+                             Style="{StaticResource ModeButton}"
+                             Checked="Mode_Checked">
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource ModeLabel}" Text="Audit only" />
+                        <TextBlock Style="{StaticResource ModeSubLabel}" Text="Add to existing Error instance" />
+                    </StackPanel>
+                </RadioButton>
+                <RadioButton x:Name="ModeMonitoringOnly"
+                             GroupName="SetupMode"
+                             Style="{StaticResource ModeButton}"
+                             Checked="Mode_Checked">
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource ModeLabel}" Text="Monitoring only" />
+                        <TextBlock Style="{StaticResource ModeSubLabel}" Text="Add to existing Error instance" />
+                    </StackPanel>
                 </RadioButton>
             </UniformGrid>
 
-            <!-- "This will install:" label -->
-            <TextBlock Grid.Row="2"
-                       FontSize="13"
+            <TextBlock FontSize="13"
                        FontWeight="SemiBold"
                        Foreground="{StaticResource Gray70Brush}"
                        Margin="0,0,0,5"
                        Text="This will install:" />
 
-            <!-- ServiceControl Instance checkbox -->
-            <CheckBox x:Name="CbServiceControl"
-                      Grid.Row="3"
-                      Style="{StaticResource ComponentCheckBox}"
-                      IsChecked="True"
-                      Checked="ComponentCheckBox_Changed"
-                      Unchecked="ComponentCheckBox_Changed">
-                <StackPanel Margin="5,0,0,0">
-                    <TextBlock Style="{StaticResource ComponentLabel}" Text="ServiceControl Instance" />
-                    <TextBlock Style="{StaticResource ComponentDescription}"
-                               Text="Collects failed messages for retry and management" />
-                </StackPanel>
-            </CheckBox>
+            <!-- MinHeight keeps the popup from resizing as scenarios with different
+                 numbers of components are selected. -->
+            <StackPanel MinHeight="150">
 
-            <!-- Integrated ServicePulse checkbox -->
-            <CheckBox x:Name="CbServicePulse"
-                      Grid.Row="4"
-                      Style="{StaticResource ComponentCheckBox}"
-                      IsChecked="True"
-                      Checked="ComponentCheckBox_Changed"
-                      Unchecked="ComponentCheckBox_Changed">
-                <StackPanel Margin="5,0,0,0">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Style="{StaticResource ComponentLabel}" Text="Integrated ServicePulse" />
-                        <TextBlock FontSize="12"
-                                   Foreground="{StaticResource Gray50Brush}"
-                                   FontStyle="Italic"
-                                   Margin="6,0,0,0"
-                                   Text="(requires ServiceControl Instance)" />
+                <Grid x:Name="ServiceControlRow" Margin="0,8,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Style="{StaticResource CheckGlyph}" Text="&#x2713;" />
+                    <StackPanel Grid.Column="1" Margin="10,0,0,0">
+                        <TextBlock Style="{StaticResource ComponentLabel}" Text="ServiceControl Instance" />
+                        <TextBlock Style="{StaticResource ComponentDescription}"
+                                   Text="Collects failed messages for retry and management" />
                     </StackPanel>
-                    <TextBlock Style="{StaticResource ComponentDescription}"
-                               Text="Built-in web UI hosted by the error instance for managing failed messages" />
-                </StackPanel>
-            </CheckBox>
+                </Grid>
 
-            <!-- ServiceControl Audit Instance checkbox -->
-            <CheckBox x:Name="CbAudit"
-                      Grid.Row="5"
-                      Style="{StaticResource ComponentCheckBox}"
-                      IsChecked="True"
-                      Checked="ComponentCheckBox_Changed"
-                      Unchecked="ComponentCheckBox_Changed">
-                <StackPanel Margin="5,0,0,0">
-                    <TextBlock Style="{StaticResource ComponentLabel}" Text="ServiceControl Audit Instance" />
-                    <TextBlock Style="{StaticResource ComponentDescription}"
-                               Text="Collects audited messages for visualization with ServiceInsight" />
-                </StackPanel>
-            </CheckBox>
+                <!-- Nested under the instance that hosts it, and the one genuine choice here -->
+                <CheckBox x:Name="CbServicePulse"
+                          Style="{StaticResource ComponentCheckBox}"
+                          Margin="26,8,0,0"
+                          IsChecked="True"
+                          Checked="ServicePulse_Changed"
+                          Unchecked="ServicePulse_Changed">
+                    <StackPanel Margin="5,0,0,0">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Style="{StaticResource ComponentLabel}" Text="Integrated ServicePulse" />
+                            <TextBlock FontSize="12"
+                                       Foreground="{StaticResource Gray50Brush}"
+                                       FontStyle="Italic"
+                                       Margin="6,0,0,0"
+                                       Text="(requires ServiceControl Instance)" />
+                        </StackPanel>
+                        <TextBlock Style="{StaticResource ComponentDescription}"
+                                   Text="Built-in web UI hosted by the Error instance for managing failed messages" />
+                    </StackPanel>
+                </CheckBox>
 
-            <!-- Separator: "Or install separately" -->
-            <Grid Grid.Row="6" Margin="0,15,0,8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <Rectangle Grid.Column="0" Height="1" Fill="{StaticResource Gray20Brush}" VerticalAlignment="Center" />
-                <TextBlock Grid.Column="1"
-                           FontSize="11"
-                           Foreground="{StaticResource Gray50Brush}"
-                           FontWeight="SemiBold"
-                           Margin="10,0"
-                           Text="OR INSTALL SEPARATELY" />
-                <Rectangle Grid.Column="2" Height="1" Fill="{StaticResource Gray20Brush}" VerticalAlignment="Center" />
-            </Grid>
+                <Grid x:Name="AuditRow" Margin="0,8,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Style="{StaticResource CheckGlyph}" Text="&#x2713;" />
+                    <StackPanel Grid.Column="1" Margin="10,0,0,0">
+                        <TextBlock Style="{StaticResource ComponentLabel}" Text="ServiceControl Audit Instance" />
+                        <TextBlock Style="{StaticResource ComponentDescription}"
+                                   Text="Collects audited messages from endpoints for visualization with ServicePulse" />
+                    </StackPanel>
+                </Grid>
 
-            <!-- Monitoring checkbox -->
-            <CheckBox x:Name="CbMonitoring"
-                      Grid.Row="7"
-                      Style="{StaticResource ComponentCheckBox}"
-                      Checked="MonitoringCheckBox_Checked"
-                      Unchecked="MonitoringCheckBox_Unchecked">
-                <StackPanel Margin="5,0,0,0">
-                    <TextBlock Style="{StaticResource ComponentLabel}" Text="Monitoring Instance" />
-                    <TextBlock Style="{StaticResource ComponentDescription}"
-                               Text="Collects monitoring data from endpoints running the NServiceBus.Metrics.ServiceControl plugin" />
-                </StackPanel>
-            </CheckBox>
+                <Grid x:Name="MonitoringRow" Margin="0,8,0,0" Visibility="Collapsed">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Style="{StaticResource CheckGlyph}" Text="&#x2713;" />
+                    <StackPanel Grid.Column="1" Margin="10,0,0,0">
+                        <TextBlock Style="{StaticResource ComponentLabel}" Text="Monitoring Instance" />
+                        <TextBlock Style="{StaticResource ComponentDescription}"
+                                   Text="Collects monitoring data from endpoints running the NServiceBus.Metrics.ServiceControl plugin" />
+                    </StackPanel>
+                </Grid>
 
-            <!-- Monitoring info box (hidden by default) -->
-            <Border x:Name="MonitoringInfoBox"
-                    Grid.Row="8"
-                    Background="#0d2818"
-                    BorderBrush="{StaticResource SuccessBrush}"
-                    BorderThickness="1"
-                    CornerRadius="2"
-                    Padding="12"
-                    Margin="0,4,0,0"
-                    Visibility="Collapsed">
-                <TextBlock FontSize="12"
-                           Foreground="{StaticResource Gray90Brush}"
-                           TextWrapping="Wrap"
-                           Text="Monitoring instances are installed separately and cannot be combined with Error or Audit instances in the same setup. Selecting this option will start a dedicated monitoring instance installation." />
-            </Border>
+            </StackPanel>
 
-            <!-- Next / Cancel buttons -->
-            <StackPanel Grid.Row="9"
-                        Orientation="Horizontal"
+            <TextBlock FontSize="11"
+                       FontStyle="Italic"
+                       Foreground="{StaticResource Gray50Brush}"
+                       TextWrapping="Wrap"
+                       Margin="0,14,0,0"
+                       Text="Pick a scenario above to change what gets installed." />
+
+            <StackPanel Orientation="Horizontal"
                         HorizontalAlignment="Right"
                         Margin="0,15,0,5">
                 <Button Content="Cancel"
                         Style="{StaticResource BasicButton}"
                         Padding="30,8"
                         Click="Cancel_Click" />
-                <Button x:Name="NextButton"
-                        Content="Next"
+                <Button Content="Next"
                         Style="{StaticResource HiliteButton}"
                         Padding="30,8"
                         Margin="10,0,0,0"
                         Click="Next_Click" />
             </StackPanel>
-        </Grid>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml
@@ -1,161 +1,226 @@
-﻿<UserControl x:Class="ServiceControl.Config.UI.Shell.NewInstanceOverlay"
+<UserControl x:Class="ServiceControl.Config.UI.Shell.NewInstanceOverlay"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              mc:Ignorable="d"
-             d:DesignHeight="300" d:DesignWidth="600">
-    <Grid Margin="0" Background="Black">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*" />
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="2*" />
-        </Grid.ColumnDefinitions>
+             d:DesignHeight="500" d:DesignWidth="600">
+    <UserControl.Resources>
+        <Style x:Key="PresetButton" TargetType="RadioButton">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="RadioButton">
+                        <Border x:Name="border"
+                                Background="{StaticResource Gray10Brush}"
+                                BorderBrush="{StaticResource Gray20Brush}"
+                                BorderThickness="1"
+                                Padding="10,8"
+                                Cursor="Hand"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="{StaticResource Gray20Brush}" />
+                            </Trigger>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="{StaticResource DarkThemeBrush}" />
+                                <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource ThemeBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style x:Key="ComponentCheckBox" TargetType="CheckBox">
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="Margin" Value="0,8" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style x:Key="ComponentLabel" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+        <Style x:Key="ComponentDescription" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="Foreground" Value="{StaticResource Gray60Brush}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="Margin" Value="0,2,0,0" />
+        </Style>
+    </UserControl.Resources>
 
-        <Grid Grid.Column="0" Margin="20">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="14" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+    <Grid Background="Black" MinWidth="500">
+        <Grid Margin="20">
             <Grid.RowDefinitions>
-                <RowDefinition Height="40" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <Border Margin="-5,5,0,5" Height="40" Grid.Row="0" Grid.ColumnSpan="2">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="30" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
+            <!-- Header -->
+            <TextBlock Grid.Row="0"
+                       FontSize="15"
+                       FontWeight="SemiBold"
+                       Foreground="White"
+                       Margin="0,0,0,15"
+                       Text="Choose a setup scenario" />
 
-                    <ContentControl Grid.Column="0"
-                                    Width="16"
-                                    Height="16"
-                                    SnapsToDevicePixels="True"
-                                    Template="{StaticResource NewControlInstanceIcon}" />
+            <!-- Preset Buttons -->
+            <UniformGrid Grid.Row="1" Columns="3" Margin="0,0,0,15">
+                <RadioButton x:Name="PresetMinimal"
+                             GroupName="Preset"
+                             Style="{StaticResource PresetButton}"
+                             Checked="Preset_Checked">
+                    <TextBlock FontSize="12" FontWeight="SemiBold" Foreground="White"
+                               Text="Minimal Setup" TextAlignment="Center" />
+                </RadioButton>
+                <RadioButton x:Name="PresetFull"
+                             GroupName="Preset"
+                             IsChecked="True"
+                             Style="{StaticResource PresetButton}"
+                             Checked="Preset_Checked">
+                    <TextBlock FontSize="12" FontWeight="SemiBold" Foreground="White"
+                               Text="Full Setup" TextAlignment="Center" />
+                </RadioButton>
+                <RadioButton x:Name="PresetAuditOnly"
+                             GroupName="Preset"
+                             Style="{StaticResource PresetButton}"
+                             Checked="Preset_Checked">
+                    <TextBlock FontSize="12" FontWeight="SemiBold" Foreground="White"
+                               Text="Audit Only" TextAlignment="Center" />
+                </RadioButton>
+            </UniformGrid>
 
-                    <TextBlock Grid.Column="1"
-                               Margin="10"
-                               FontSize="13"
-                               FontWeight="SemiBold"
-                               VerticalAlignment="Center">
-                        <Hyperlink Command="{Binding AddInstance}"  Style="{StaticResource UnderlinedLink}">Add ServiceControl and Audit Instances...</Hyperlink>
-                    </TextBlock>
+            <!-- "This will install:" label -->
+            <TextBlock Grid.Row="2"
+                       FontSize="13"
+                       FontWeight="SemiBold"
+                       Foreground="{StaticResource Gray70Brush}"
+                       Margin="0,0,0,5"
+                       Text="This will install:" />
 
-                </Grid>
+            <!-- ServiceControl Instance checkbox -->
+            <CheckBox x:Name="CbServiceControl"
+                      Grid.Row="3"
+                      Style="{StaticResource ComponentCheckBox}"
+                      IsChecked="True"
+                      Checked="ServiceControlCheckBox_Changed"
+                      Unchecked="ServiceControlCheckBox_Changed">
+                <StackPanel Margin="5,0,0,0">
+                    <TextBlock Style="{StaticResource ComponentLabel}" Text="ServiceControl Instance" />
+                    <TextBlock Style="{StaticResource ComponentDescription}"
+                               Text="Collects failed messages for retry and management" />
+                </StackPanel>
+            </CheckBox>
+
+            <!-- Integrated ServicePulse checkbox -->
+            <CheckBox x:Name="CbServicePulse"
+                      Grid.Row="4"
+                      Style="{StaticResource ComponentCheckBox}"
+                      IsChecked="True"
+                      Checked="ComponentCheckBox_Changed"
+                      Unchecked="ComponentCheckBox_Changed">
+                <StackPanel Margin="5,0,0,0">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="LblServicePulse" Style="{StaticResource ComponentLabel}" Text="Integrated ServicePulse" />
+                        <TextBlock FontSize="12"
+                                   Foreground="{StaticResource Gray50Brush}"
+                                   FontStyle="Italic"
+                                   Margin="6,0,0,0"
+                                   Text="(requires ServiceControl Instance)" />
+                    </StackPanel>
+                    <TextBlock Style="{StaticResource ComponentDescription}"
+                               Text="Built-in web UI hosted by the error instance for managing failed messages" />
+                </StackPanel>
+            </CheckBox>
+
+            <!-- ServiceControl Audit Instance checkbox -->
+            <CheckBox x:Name="CbAudit"
+                      Grid.Row="5"
+                      Style="{StaticResource ComponentCheckBox}"
+                      IsChecked="True"
+                      Checked="ComponentCheckBox_Changed"
+                      Unchecked="ComponentCheckBox_Changed">
+                <StackPanel Margin="5,0,0,0">
+                    <TextBlock Style="{StaticResource ComponentLabel}" Text="ServiceControl Audit Instance" />
+                    <TextBlock Style="{StaticResource ComponentDescription}"
+                               Text="Collects audited messages for visualization with ServiceInsight" />
+                </StackPanel>
+            </CheckBox>
+
+            <!-- Separator: "Or install separately" -->
+            <Grid Grid.Row="6" Margin="0,15,0,8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Rectangle Grid.Column="0" Height="1" Fill="{StaticResource Gray20Brush}" VerticalAlignment="Center" />
+                <TextBlock Grid.Column="1"
+                           FontSize="11"
+                           Foreground="{StaticResource Gray50Brush}"
+                           FontWeight="SemiBold"
+                           Margin="10,0"
+                           Text="OR INSTALL SEPARATELY" />
+                <Rectangle Grid.Column="2" Height="1" Fill="{StaticResource Gray20Brush}" VerticalAlignment="Center" />
+            </Grid>
+
+            <!-- Monitoring checkbox -->
+            <CheckBox x:Name="CbMonitoring"
+                      Grid.Row="7"
+                      Style="{StaticResource ComponentCheckBox}"
+                      Checked="MonitoringCheckBox_Checked"
+                      Unchecked="MonitoringCheckBox_Unchecked">
+                <StackPanel Margin="5,0,0,0">
+                    <TextBlock Style="{StaticResource ComponentLabel}" Text="Monitoring Instance" />
+                    <TextBlock Style="{StaticResource ComponentDescription}"
+                               Text="Collects monitoring data from endpoints running the NServiceBus.Metrics.ServiceControl plugin" />
+                </StackPanel>
+            </CheckBox>
+
+            <!-- Monitoring info box (hidden by default) -->
+            <Border x:Name="MonitoringInfoBox"
+                    Grid.Row="8"
+                    Background="#0d2818"
+                    BorderBrush="{StaticResource SuccessBrush}"
+                    BorderThickness="1"
+                    CornerRadius="2"
+                    Padding="12"
+                    Margin="0,4,0,0"
+                    Visibility="Collapsed">
+                <TextBlock FontSize="12"
+                           Foreground="{StaticResource Gray90Brush}"
+                           TextWrapping="Wrap"
+                           Text="Monitoring instances are installed separately and cannot be combined with Error or Audit instances in the same setup. Selecting this option will start a dedicated monitoring instance installation." />
             </Border>
 
-            <TextBlock Grid.Column="0" Grid.Row="1"
-                       Margin="1,10,0,0"
-                       HorizontalAlignment="Left"
-                       VerticalAlignment="Top"
-                       Text="•"
-                       Foreground="{StaticResource Gray90Brush}" />
-
-            <TextBlock Grid.Column="0" Grid.Row="2"
-                       Margin="1,10,0,0"
-                       HorizontalAlignment="Left"
-                       VerticalAlignment="Top"
-                       Text="•"
-                       Foreground="{StaticResource Gray90Brush}" />
-
-            <TextBlock Grid.Column="1" Grid.Row="1"
-                       FontSize="13"
-                       Foreground="{StaticResource Gray90Brush}"
-                       Margin="0,10,10,10"
-                       Text="Collects Audited messages for visualization with ServiceInsight"
-                       TextWrapping="Wrap" />
-
-            <TextBlock Grid.Column="1" Grid.Row="2"
-                    FontSize="13"
-                    Foreground="{StaticResource Gray90Brush}"
-                    Margin="0,10,10,10"
-                    Text="Collects Failed messages to be retried with ServicePulse or ServiceInsight"
-                    TextWrapping="Wrap" />
+            <!-- Next / Cancel buttons -->
+            <StackPanel Grid.Row="10"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Margin="0,15,0,5">
+                <Button Content="Cancel"
+                        Style="{StaticResource BasicButton}"
+                        Padding="30,8"
+                        Click="Cancel_Click" />
+                <Button x:Name="NextButton"
+                        Content="Next"
+                        Style="{StaticResource HiliteButton}"
+                        Padding="30,8"
+                        Margin="10,0,0,0"
+                        Click="Next_Click" />
+            </StackPanel>
         </Grid>
-
-        <Rectangle Grid.Column="1"
-                   Width="1"
-                   Fill="{StaticResource Gray20Brush}"
-                   Margin="10"
-                   />
-
-        <Grid Grid.Column="2" Margin="20">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="14" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="40" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-
-            <Border Margin="-5,0,5,0" Height="40" Grid.ColumnSpan="2" Grid.Row="0">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="30" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-
-                    <ContentControl Grid.Column="0"
-                                    Width="16"
-                                    Height="16"
-                                    SnapsToDevicePixels="True"
-                                    Template="{StaticResource NewMonitoringInstanceIcon}" />
-
-                    <TextBlock Grid.Column="1"
-                               Margin="10"
-                               FontSize="13"
-                               FontWeight="SemiBold"
-                               VerticalAlignment="Center">
-                        <Hyperlink Command="{Binding AddMonitoringInstance}" Style="{StaticResource UnderlinedLink}">Add monitoring instance...</Hyperlink>
-                    </TextBlock>
-
-                </Grid>
-            </Border>
-
-            <TextBlock Grid.Column="0" Grid.Row="1"
-                       Margin="1,10,0,10"
-                       HorizontalAlignment="Left"
-                       VerticalAlignment="Top"
-                       Text="•"
-                       Foreground="{StaticResource Gray90Brush}" />
-
-            <TextBlock Grid.Column="1" Grid.Row="1"
-                       Foreground="{StaticResource Gray90Brush}"
-                       FontSize="13"
-                       Margin="0,10,10,10"
-                       Text="Collects Monitoring data from endpoints running the NServiceBus.Metrics.ServiceControl plugin"
-                       TextWrapping="Wrap" />
-
-            <ContentControl Grid.Column="0"
-                            Grid.Row="2"
-                            Margin="0,5,3,0"
-                            VerticalContentAlignment="Center" VerticalAlignment="Center"
-                            Width="12"
-                            Height="12"
-                            SnapsToDevicePixels="True"
-                            Foreground="White"
-                            Template="{StaticResource ExternalLink}"
-                            Visibility="Hidden" />
-
-            <TextBlock Grid.Row="2" Grid.Column="1"
-                       Margin="0,10,10,10"
-                       FontSize="13"
-                       FontWeight="Normal"
-                       TextWrapping="Wrap"
-                       VerticalAlignment="Center"
-                       Visibility="Hidden">
-                <Hyperlink Foreground="White"
-                           TextDecorations="Underline"
-                           Command="{Binding}">Learn more about monitoring</Hyperlink>
-            </TextBlock>
-
-        </Grid>
-
     </Grid>
 </UserControl>

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml
@@ -132,7 +132,7 @@
                       Unchecked="ComponentCheckBox_Changed">
                 <StackPanel Margin="5,0,0,0">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock x:Name="LblServicePulse" Style="{StaticResource ComponentLabel}" Text="Integrated ServicePulse" />
+                        <TextBlock Style="{StaticResource ComponentLabel}" Text="Integrated ServicePulse" />
                         <TextBlock FontSize="12"
                                    Foreground="{StaticResource Gray50Brush}"
                                    FontStyle="Italic"

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml
@@ -65,7 +65,6 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <!-- Header -->
@@ -115,8 +114,8 @@
                       Grid.Row="3"
                       Style="{StaticResource ComponentCheckBox}"
                       IsChecked="True"
-                      Checked="ServiceControlCheckBox_Changed"
-                      Unchecked="ServiceControlCheckBox_Changed">
+                      Checked="ComponentCheckBox_Changed"
+                      Unchecked="ComponentCheckBox_Changed">
                 <StackPanel Margin="5,0,0,0">
                     <TextBlock Style="{StaticResource ComponentLabel}" Text="ServiceControl Instance" />
                     <TextBlock Style="{StaticResource ComponentDescription}"
@@ -206,7 +205,7 @@
             </Border>
 
             <!-- Next / Cancel buttons -->
-            <StackPanel Grid.Row="10"
+            <StackPanel Grid.Row="9"
                         Orientation="Horizontal"
                         HorizontalAlignment="Right"
                         Margin="0,15,0,5">

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
@@ -41,13 +41,13 @@ namespace ServiceControl.Config.UI.Shell
 
         // The selected scenario is the only thing that decides which instances are installed;
         // integrated ServicePulse is the single option layered on top of it.
-        public bool InstallServiceControl => selectedMode is SetupMode.ErrorHandling or SetupMode.ErrorAndAudit;
+        bool InstallServiceControl => selectedMode is SetupMode.ErrorHandling or SetupMode.ErrorAndAudit;
 
-        public bool InstallAudit => selectedMode is SetupMode.ErrorAndAudit or SetupMode.AuditOnly;
+        bool InstallAudit => selectedMode is SetupMode.ErrorAndAudit or SetupMode.AuditOnly;
 
-        public bool InstallMonitoring => selectedMode is SetupMode.MonitoringOnly;
+        bool InstallMonitoring => selectedMode is SetupMode.MonitoringOnly;
 
-        public bool InstallServicePulse => InstallServiceControl && installServicePulse;
+        bool InstallServicePulse => InstallServiceControl && installServicePulse;
 
         void Mode_Checked(object sender, RoutedEventArgs e)
         {
@@ -91,7 +91,10 @@ namespace ServiceControl.Config.UI.Shell
 
         static Visibility Visible(bool visible) => visible ? Visibility.Visible : Visibility.Collapsed;
 
-        void Next_Click(object sender, RoutedEventArgs e)
+        // async void is deliberate: this is an event handler, so awaiting here routes any
+        // failure to the dispatcher's unhandled exception handler rather than dropping it
+        // on an unobserved task.
+        async void Next_Click(object sender, RoutedEventArgs e)
         {
             ClosePopup();
 
@@ -99,11 +102,11 @@ namespace ServiceControl.Config.UI.Shell
             {
                 if (InstallMonitoring)
                 {
-                    shell.AddMonitoringInstance.Execute(null);
+                    shell.LaunchMonitoringAdd();
                 }
                 else
                 {
-                    _ = shell.LaunchServiceControlAdd(InstallServiceControl, InstallAudit, InstallServicePulse);
+                    await shell.LaunchServiceControlAdd(InstallServiceControl, InstallAudit, InstallServicePulse);
                 }
             }
         }

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
@@ -81,9 +81,7 @@ namespace ServiceControl.Config.UI.Shell
 
         static Visibility Visible(bool visible) => visible ? Visibility.Visible : Visibility.Collapsed;
 
-        // async void is deliberate: this is an event handler, so awaiting here routes any
-        // failure to the dispatcher's unhandled exception handler rather than dropping it
-        // on an unobserved task.
+#pragma warning disable PS0027 // Click is an event delegate, so there is nothing to return the task to. Awaiting routes failures to the dispatcher's unhandled exception handler instead of dropping them on an unobserved task.
         async void Next_Click(object sender, RoutedEventArgs e)
         {
             ClosePopup();
@@ -100,6 +98,7 @@ namespace ServiceControl.Config.UI.Shell
                 }
             }
         }
+#pragma warning restore PS0027
 
         void Cancel_Click(object sender, RoutedEventArgs e)
         {

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
@@ -29,9 +29,9 @@ namespace ServiceControl.Config.UI.Shell
 
             CbServiceControl.IsChecked = true;
             CbServicePulse.IsChecked = true;
+            CbServicePulse.Opacity = 1.0;
             CbAudit.IsChecked = true;
 
-            CbServicePulse.Opacity = 1.0;
             NextButton.IsEnabled = true;
 
             suppressPresetEvents = true;
@@ -48,7 +48,7 @@ namespace ServiceControl.Config.UI.Shell
 
         void Preset_Checked(object sender, RoutedEventArgs e)
         {
-            if (CbServiceControl == null || suppressPresetEvents)
+            if (!IsLoaded || suppressPresetEvents)
             {
                 return;
             }
@@ -78,21 +78,9 @@ namespace ServiceControl.Config.UI.Shell
                 CbAudit.IsChecked = true;
             }
 
-            UpdateServicePulseEnabled();
+            UpdateServicePulseState();
             UpdateNextButton();
             suppressCheckBoxEvents = false;
-        }
-
-        void ServiceControlCheckBox_Changed(object sender, RoutedEventArgs e)
-        {
-            if (suppressCheckBoxEvents || !IsLoaded)
-            {
-                return;
-            }
-
-            UpdateServicePulseEnabled();
-            SyncPresetSelection();
-            UpdateNextButton();
         }
 
         void ComponentCheckBox_Changed(object sender, RoutedEventArgs e)
@@ -100,6 +88,11 @@ namespace ServiceControl.Config.UI.Shell
             if (suppressCheckBoxEvents || !IsLoaded)
             {
                 return;
+            }
+
+            if (sender == CbServiceControl)
+            {
+                UpdateServicePulseState();
             }
 
             SyncPresetSelection();
@@ -114,6 +107,7 @@ namespace ServiceControl.Config.UI.Shell
             CbServicePulse.IsChecked = false;
             CbAudit.IsChecked = false;
             SetServiceControlCheckboxesEnabled(false);
+            UpdateServicePulseState();
             SyncPresetSelection();
             MonitoringInfoBox.Visibility = Visibility.Visible;
             UpdateNextButton();
@@ -157,7 +151,7 @@ namespace ServiceControl.Config.UI.Shell
             }
         }
 
-        void UpdateServicePulseEnabled()
+        void UpdateServicePulseState()
         {
             if (!IsLoaded)
             {

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
@@ -1,13 +1,226 @@
-﻿namespace ServiceControl.Config.UI.Shell
+namespace ServiceControl.Config.UI.Shell
 {
-    /// <summary>
-    /// Interaction logic for NewInstanceOverlay.xaml
-    /// </summary>
+    using System.Windows;
+    using System.Windows.Controls.Primitives;
+
     public partial class NewInstanceOverlay
     {
         public NewInstanceOverlay()
         {
             InitializeComponent();
+            IsVisibleChanged += OnIsVisibleChanged;
         }
+
+        void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if ((bool)e.NewValue)
+            {
+                ResetToDefaults();
+            }
+        }
+
+        void ResetToDefaults()
+        {
+            suppressCheckBoxEvents = true;
+
+            CbMonitoring.IsChecked = false;
+            MonitoringInfoBox.Visibility = Visibility.Collapsed;
+            SetServiceControlCheckboxesEnabled(true);
+
+            CbServiceControl.IsChecked = true;
+            CbServicePulse.IsChecked = true;
+            CbAudit.IsChecked = true;
+
+            CbServicePulse.Opacity = 1.0;
+            NextButton.IsEnabled = true;
+
+            suppressPresetEvents = true;
+            PresetFull.IsChecked = true;
+            suppressPresetEvents = false;
+
+            suppressCheckBoxEvents = false;
+        }
+
+        public bool InstallServiceControl => CbServiceControl.IsChecked == true;
+        public bool InstallServicePulse => CbServicePulse.IsChecked == true;
+        public bool InstallAudit => CbAudit.IsChecked == true;
+        public bool InstallMonitoring => CbMonitoring.IsChecked == true;
+
+        void Preset_Checked(object sender, RoutedEventArgs e)
+        {
+            if (CbServiceControl == null || suppressPresetEvents)
+            {
+                return;
+            }
+
+            suppressCheckBoxEvents = true;
+
+            CbMonitoring.IsChecked = false;
+            MonitoringInfoBox.Visibility = Visibility.Collapsed;
+            SetServiceControlCheckboxesEnabled(true);
+
+            if (sender == PresetMinimal)
+            {
+                CbServiceControl.IsChecked = true;
+                CbServicePulse.IsChecked = true;
+                CbAudit.IsChecked = false;
+            }
+            else if (sender == PresetFull)
+            {
+                CbServiceControl.IsChecked = true;
+                CbServicePulse.IsChecked = true;
+                CbAudit.IsChecked = true;
+            }
+            else if (sender == PresetAuditOnly)
+            {
+                CbServiceControl.IsChecked = false;
+                CbServicePulse.IsChecked = false;
+                CbAudit.IsChecked = true;
+            }
+
+            UpdateServicePulseEnabled();
+            UpdateNextButton();
+            suppressCheckBoxEvents = false;
+        }
+
+        void ServiceControlCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (suppressCheckBoxEvents || !IsLoaded)
+            {
+                return;
+            }
+
+            UpdateServicePulseEnabled();
+            SyncPresetSelection();
+            UpdateNextButton();
+        }
+
+        void ComponentCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            if (suppressCheckBoxEvents || !IsLoaded)
+            {
+                return;
+            }
+
+            SyncPresetSelection();
+            UpdateNextButton();
+        }
+
+        void MonitoringCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            suppressCheckBoxEvents = true;
+
+            CbServiceControl.IsChecked = false;
+            CbServicePulse.IsChecked = false;
+            CbAudit.IsChecked = false;
+            SetServiceControlCheckboxesEnabled(false);
+            SyncPresetSelection();
+            MonitoringInfoBox.Visibility = Visibility.Visible;
+            UpdateNextButton();
+
+            suppressCheckBoxEvents = false;
+        }
+
+        void MonitoringCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            MonitoringInfoBox.Visibility = Visibility.Collapsed;
+            PresetFull.IsChecked = true;
+        }
+
+        void Next_Click(object sender, RoutedEventArgs e)
+        {
+            ClosePopup();
+
+            if (DataContext is ShellViewModel shell)
+            {
+                if (InstallMonitoring)
+                {
+                    shell.AddMonitoringInstance.Execute(null);
+                }
+                else
+                {
+                    _ = shell.LaunchServiceControlAdd(InstallServiceControl, InstallAudit, InstallServicePulse);
+                }
+            }
+        }
+
+        void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            ClosePopup();
+        }
+
+        void ClosePopup()
+        {
+            if (Parent is Popup popup)
+            {
+                popup.IsOpen = false;
+            }
+        }
+
+        void UpdateServicePulseEnabled()
+        {
+            if (!IsLoaded)
+            {
+                return;
+            }
+
+            var errorChecked = CbServiceControl.IsChecked == true;
+            CbServicePulse.IsEnabled = errorChecked;
+            CbServicePulse.Opacity = errorChecked ? 1.0 : 0.4;
+            if (!errorChecked)
+            {
+                CbServicePulse.IsChecked = false;
+            }
+        }
+
+        void SetServiceControlCheckboxesEnabled(bool enabled)
+        {
+            CbServiceControl.IsEnabled = enabled;
+            CbServicePulse.IsEnabled = enabled;
+            CbAudit.IsEnabled = enabled;
+        }
+
+        void SyncPresetSelection()
+        {
+            var sc = CbServiceControl.IsChecked == true;
+            var sp = CbServicePulse.IsChecked == true;
+            var audit = CbAudit.IsChecked == true;
+
+            suppressPresetEvents = true;
+
+            if (sc && sp && audit)
+            {
+                PresetFull.IsChecked = true;
+            }
+            else if (sc && sp && !audit)
+            {
+                PresetMinimal.IsChecked = true;
+            }
+            else if (!sc && !sp && audit)
+            {
+                PresetAuditOnly.IsChecked = true;
+            }
+            else
+            {
+                PresetMinimal.IsChecked = false;
+                PresetFull.IsChecked = false;
+                PresetAuditOnly.IsChecked = false;
+            }
+
+            suppressPresetEvents = false;
+        }
+
+        void UpdateNextButton()
+        {
+            if (!IsLoaded)
+            {
+                return;
+            }
+
+            NextButton.IsEnabled = InstallServiceControl || InstallAudit || InstallMonitoring;
+        }
+
+        bool suppressCheckBoxEvents;
+        bool suppressPresetEvents;
     }
 }

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
@@ -11,6 +11,14 @@ namespace ServiceControl.Config.UI.Shell
             IsVisibleChanged += OnIsVisibleChanged;
         }
 
+        enum SetupMode
+        {
+            ErrorHandling,
+            ErrorAndAudit,
+            AuditOnly,
+            MonitoringOnly
+        }
+
         void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if ((bool)e.NewValue)
@@ -21,98 +29,67 @@ namespace ServiceControl.Config.UI.Shell
 
         void ResetToDefaults()
         {
-            suppressCheckBoxEvents = true;
+            installServicePulse = true;
 
-            CbMonitoring.IsChecked = false;
-            MonitoringInfoBox.Visibility = Visibility.Collapsed;
-            SetServiceControlCheckboxesEnabled(true);
+            // Assigning IsChecked when it is already true raises no Checked event, so the
+            // mode is set directly rather than relying on the radio button to report it.
+            selectedMode = SetupMode.ErrorAndAudit;
+            ModeErrorAndAudit.IsChecked = true;
 
-            CbServiceControl.IsChecked = true;
-            CbServicePulse.IsChecked = true;
-            CbServicePulse.Opacity = 1.0;
-            CbAudit.IsChecked = true;
-
-            NextButton.IsEnabled = true;
-
-            suppressPresetEvents = true;
-            PresetFull.IsChecked = true;
-            suppressPresetEvents = false;
-
-            suppressCheckBoxEvents = false;
+            UpdateComponentList();
         }
 
-        public bool InstallServiceControl => CbServiceControl.IsChecked == true;
-        public bool InstallServicePulse => CbServicePulse.IsChecked == true;
-        public bool InstallAudit => CbAudit.IsChecked == true;
-        public bool InstallMonitoring => CbMonitoring.IsChecked == true;
+        // The selected scenario is the only thing that decides which instances are installed;
+        // integrated ServicePulse is the single option layered on top of it.
+        public bool InstallServiceControl => selectedMode is SetupMode.ErrorHandling or SetupMode.ErrorAndAudit;
 
-        void Preset_Checked(object sender, RoutedEventArgs e)
+        public bool InstallAudit => selectedMode is SetupMode.ErrorAndAudit or SetupMode.AuditOnly;
+
+        public bool InstallMonitoring => selectedMode is SetupMode.MonitoringOnly;
+
+        public bool InstallServicePulse => InstallServiceControl && installServicePulse;
+
+        void Mode_Checked(object sender, RoutedEventArgs e)
         {
-            if (!IsLoaded || suppressPresetEvents)
+            if (!IsLoaded)
             {
                 return;
             }
 
-            suppressCheckBoxEvents = true;
-
-            CbMonitoring.IsChecked = false;
-            MonitoringInfoBox.Visibility = Visibility.Collapsed;
-            SetServiceControlCheckboxesEnabled(true);
-
-            var (sc, sp, audit) = sender switch
+            selectedMode = sender switch
             {
-                _ when sender == PresetMinimal => (true, true, false),
-                _ when sender == PresetFull => (true, true, true),
-                _ when sender == PresetAuditOnly => (false, false, true),
-                _ => (false, false, false)
+                _ when sender == ModeErrorHandling => SetupMode.ErrorHandling,
+                _ when sender == ModeAuditOnly => SetupMode.AuditOnly,
+                _ when sender == ModeMonitoringOnly => SetupMode.MonitoringOnly,
+                _ => SetupMode.ErrorAndAudit
             };
 
-            CbServiceControl.IsChecked = sc;
-            CbServicePulse.IsChecked = sp;
-            CbAudit.IsChecked = audit;
-
-            UpdateServicePulseState();
-            UpdateNextButton();
-            suppressCheckBoxEvents = false;
+            UpdateComponentList();
         }
 
-        void ComponentCheckBox_Changed(object sender, RoutedEventArgs e)
+        void ServicePulse_Changed(object sender, RoutedEventArgs e)
         {
-            if (suppressCheckBoxEvents || !IsLoaded)
+            if (!IsLoaded)
             {
                 return;
             }
 
-            if (sender == CbServiceControl)
-            {
-                UpdateServicePulseState();
-            }
-
-            SyncPresetSelection();
-            UpdateNextButton();
+            installServicePulse = CbServicePulse.IsChecked == true;
         }
 
-        void MonitoringCheckBox_Checked(object sender, RoutedEventArgs e)
+        void UpdateComponentList()
         {
-            suppressCheckBoxEvents = true;
+            ServiceControlRow.Visibility = Visible(InstallServiceControl);
+            AuditRow.Visibility = Visible(InstallAudit);
+            MonitoringRow.Visibility = Visible(InstallMonitoring);
 
-            CbServiceControl.IsChecked = false;
-            CbServicePulse.IsChecked = false;
-            CbAudit.IsChecked = false;
-            SetServiceControlCheckboxesEnabled(false);
-            UpdateServicePulseState();
-            SyncPresetSelection();
-            MonitoringInfoBox.Visibility = Visibility.Visible;
-            UpdateNextButton();
-
-            suppressCheckBoxEvents = false;
+            // ServicePulse is hosted by the error instance, so it is only on offer in the
+            // scenarios that install one. The choice is remembered across scenario changes.
+            CbServicePulse.Visibility = Visible(InstallServiceControl);
+            CbServicePulse.IsChecked = installServicePulse;
         }
 
-        void MonitoringCheckBox_Unchecked(object sender, RoutedEventArgs e)
-        {
-            MonitoringInfoBox.Visibility = Visibility.Collapsed;
-            PresetFull.IsChecked = true;
-        }
+        static Visibility Visible(bool visible) => visible ? Visibility.Visible : Visibility.Collapsed;
 
         void Next_Click(object sender, RoutedEventArgs e)
         {
@@ -144,65 +121,7 @@ namespace ServiceControl.Config.UI.Shell
             }
         }
 
-        void UpdateServicePulseState()
-        {
-            if (!IsLoaded)
-            {
-                return;
-            }
-
-            var errorChecked = CbServiceControl.IsChecked == true;
-            CbServicePulse.IsEnabled = errorChecked;
-            CbServicePulse.Opacity = errorChecked ? 1.0 : 0.4;
-            if (!errorChecked)
-            {
-                CbServicePulse.IsChecked = false;
-            }
-        }
-
-        void SetServiceControlCheckboxesEnabled(bool enabled)
-        {
-            CbServiceControl.IsEnabled = enabled;
-            CbServicePulse.IsEnabled = enabled;
-            CbAudit.IsEnabled = enabled;
-        }
-
-        void SyncPresetSelection()
-        {
-            suppressPresetEvents = true;
-
-            switch (InstallServiceControl, InstallServicePulse, InstallAudit)
-            {
-                case (true, true, true):
-                    PresetFull.IsChecked = true;
-                    break;
-                case (true, true, false):
-                    PresetMinimal.IsChecked = true;
-                    break;
-                case (false, false, true):
-                    PresetAuditOnly.IsChecked = true;
-                    break;
-                default:
-                    PresetMinimal.IsChecked = false;
-                    PresetFull.IsChecked = false;
-                    PresetAuditOnly.IsChecked = false;
-                    break;
-            }
-
-            suppressPresetEvents = false;
-        }
-
-        void UpdateNextButton()
-        {
-            if (!IsLoaded)
-            {
-                return;
-            }
-
-            NextButton.IsEnabled = InstallServiceControl || InstallAudit || InstallMonitoring;
-        }
-
-        bool suppressCheckBoxEvents;
-        bool suppressPresetEvents;
+        SetupMode selectedMode = SetupMode.ErrorAndAudit;
+        bool installServicePulse = true;
     }
 }

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
@@ -11,14 +11,6 @@ namespace ServiceControl.Config.UI.Shell
             IsVisibleChanged += OnIsVisibleChanged;
         }
 
-        enum SetupMode
-        {
-            ErrorHandling,
-            ErrorAndAudit,
-            AuditOnly,
-            MonitoringOnly
-        }
-
         void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if ((bool)e.NewValue)
@@ -39,15 +31,13 @@ namespace ServiceControl.Config.UI.Shell
             UpdateComponentList();
         }
 
-        // The selected scenario is the only thing that decides which instances are installed;
-        // integrated ServicePulse is the single option layered on top of it.
-        bool InstallServiceControl => selectedMode is SetupMode.ErrorHandling or SetupMode.ErrorAndAudit;
+        bool InstallServiceControl => selectedMode.InstallsServiceControl();
 
-        bool InstallAudit => selectedMode is SetupMode.ErrorAndAudit or SetupMode.AuditOnly;
+        bool InstallAudit => selectedMode.InstallsAudit();
 
-        bool InstallMonitoring => selectedMode is SetupMode.MonitoringOnly;
+        bool InstallMonitoring => selectedMode.InstallsMonitoring();
 
-        bool InstallServicePulse => InstallServiceControl && installServicePulse;
+        bool InstallServicePulse => selectedMode.InstallsServicePulse(installServicePulse);
 
         void Mode_Checked(object sender, RoutedEventArgs e)
         {

--- a/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
+++ b/src/ServiceControl.Config/UI/Shell/NewInstancePopup.xaml.cs
@@ -59,24 +59,17 @@ namespace ServiceControl.Config.UI.Shell
             MonitoringInfoBox.Visibility = Visibility.Collapsed;
             SetServiceControlCheckboxesEnabled(true);
 
-            if (sender == PresetMinimal)
+            var (sc, sp, audit) = sender switch
             {
-                CbServiceControl.IsChecked = true;
-                CbServicePulse.IsChecked = true;
-                CbAudit.IsChecked = false;
-            }
-            else if (sender == PresetFull)
-            {
-                CbServiceControl.IsChecked = true;
-                CbServicePulse.IsChecked = true;
-                CbAudit.IsChecked = true;
-            }
-            else if (sender == PresetAuditOnly)
-            {
-                CbServiceControl.IsChecked = false;
-                CbServicePulse.IsChecked = false;
-                CbAudit.IsChecked = true;
-            }
+                _ when sender == PresetMinimal => (true, true, false),
+                _ when sender == PresetFull => (true, true, true),
+                _ when sender == PresetAuditOnly => (false, false, true),
+                _ => (false, false, false)
+            };
+
+            CbServiceControl.IsChecked = sc;
+            CbServicePulse.IsChecked = sp;
+            CbAudit.IsChecked = audit;
 
             UpdateServicePulseState();
             UpdateNextButton();
@@ -176,29 +169,24 @@ namespace ServiceControl.Config.UI.Shell
 
         void SyncPresetSelection()
         {
-            var sc = CbServiceControl.IsChecked == true;
-            var sp = CbServicePulse.IsChecked == true;
-            var audit = CbAudit.IsChecked == true;
-
             suppressPresetEvents = true;
 
-            if (sc && sp && audit)
+            switch (InstallServiceControl, InstallServicePulse, InstallAudit)
             {
-                PresetFull.IsChecked = true;
-            }
-            else if (sc && sp && !audit)
-            {
-                PresetMinimal.IsChecked = true;
-            }
-            else if (!sc && !sp && audit)
-            {
-                PresetAuditOnly.IsChecked = true;
-            }
-            else
-            {
-                PresetMinimal.IsChecked = false;
-                PresetFull.IsChecked = false;
-                PresetAuditOnly.IsChecked = false;
+                case (true, true, true):
+                    PresetFull.IsChecked = true;
+                    break;
+                case (true, true, false):
+                    PresetMinimal.IsChecked = true;
+                    break;
+                case (false, false, true):
+                    PresetAuditOnly.IsChecked = true;
+                    break;
+                default:
+                    PresetMinimal.IsChecked = false;
+                    PresetFull.IsChecked = false;
+                    PresetAuditOnly.IsChecked = false;
+                    break;
             }
 
             suppressPresetEvents = false;

--- a/src/ServiceControl.Config/UI/Shell/SetupMode.cs
+++ b/src/ServiceControl.Config/UI/Shell/SetupMode.cs
@@ -1,0 +1,30 @@
+namespace ServiceControl.Config.UI.Shell
+{
+    // The scenario chosen in the new-instance popup. It is the only thing that decides
+    // which instances get installed, so the mapping lives here rather than in the code
+    // behind, where it would sit behind WPF's IsLoaded guard and be untestable.
+    enum SetupMode
+    {
+        ErrorHandling,
+        ErrorAndAudit,
+        AuditOnly,
+        MonitoringOnly
+    }
+
+    static class SetupModeExtensions
+    {
+        public static bool InstallsServiceControl(this SetupMode mode) =>
+            mode is SetupMode.ErrorHandling or SetupMode.ErrorAndAudit;
+
+        public static bool InstallsAudit(this SetupMode mode) =>
+            mode is SetupMode.ErrorAndAudit or SetupMode.AuditOnly;
+
+        public static bool InstallsMonitoring(this SetupMode mode) =>
+            mode is SetupMode.MonitoringOnly;
+
+        // Integrated ServicePulse is hosted by the error instance, so it is only on offer
+        // in the scenarios that install one.
+        public static bool InstallsServicePulse(this SetupMode mode, bool wanted) =>
+            mode.InstallsServiceControl() && wanted;
+    }
+}

--- a/src/ServiceControl.Config/UI/Shell/ShellView.xaml
+++ b/src/ServiceControl.Config/UI/Shell/ShellView.xaml
@@ -73,15 +73,9 @@
                         Visibility="{Binding IsModal,
                                              Converter={StaticResource boolToVisInverted}}">
 
-                <Button Command="{Binding AddInstance}" Style="{StaticResource OriginalNewButton}"
-                        Visibility="{Binding ShowMonitoringInstances,
-                                     Converter={StaticResource boolToVisInverted}}" />
-
                 <ToggleButton Name="AddInstanceButton"
                               Style="{StaticResource NewButton}"
-                              IsChecked="{Binding ShowingMenuOverlay, Mode=TwoWay}"
-                              Visibility="{Binding ShowMonitoringInstances,
-                                                   Converter={StaticResource boolToVis}}" />
+                              IsChecked="{Binding ShowingMenuOverlay, Mode=TwoWay}" />
 
                 <Popup PlacementTarget="{Binding ElementName=RootBorder}"
                        Focusable="False"

--- a/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
+++ b/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
@@ -70,9 +70,6 @@
 
         public bool HasInstances { get; private set; }
 
-        [FeatureToggle(Feature.MonitoringInstances)]
-        public bool ShowMonitoringInstances { get; set; }
-
         public ICommand AddMonitoringInstance { get; private set; }
 
         public ICommand OpenUrl { get; private set; }

--- a/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
+++ b/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
@@ -30,14 +30,12 @@
             this.noInstances = noInstances;
             this.addInstance = addInstance;
             OpenUrl = new OpenURLCommand();
-            AddInstance = addInstance;
             AddMonitoringInstance = addMonitoringInstance;
             LicenseStatusManager = licenseStatusManager;
             DisplayName = "ServiceControl Config";
             IsModal = false;
             LoadAppVersion();
             CopyrightInfo = $"{DateTime.UtcNow.Year} © Particular Software";
-            addInstance.OnCommandExecuting = () => ShowingMenuOverlay = false;
             addMonitoringInstance.OnCommandExecuting = () => ShowingMenuOverlay = false;
 
             RefreshInstancesCmd = Command.Create(async () =>
@@ -74,8 +72,6 @@
 
         [FeatureToggle(Feature.MonitoringInstances)]
         public bool ShowMonitoringInstances { get; set; }
-
-        public ICommand AddInstance { get; private set; }
 
         public ICommand AddMonitoringInstance { get; private set; }
 

--- a/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
+++ b/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
@@ -28,6 +28,7 @@
         {
             this.listInstances = listInstances;
             this.noInstances = noInstances;
+            this.addInstance = addInstance;
             OpenUrl = new OpenURLCommand();
             AddInstance = addInstance;
             AddMonitoringInstance = addMonitoringInstance;
@@ -45,6 +46,12 @@
                 // Used to "blink" the refresh button to indicate the refresh actually ran.
                 await Task.Delay(500);
             });
+        }
+
+        public async Task LaunchServiceControlAdd(bool installError, bool installAudit, bool installServicePulse, CancellationToken cancellationToken = default)
+        {
+            ShowingMenuOverlay = false;
+            await addInstance.ExecuteWithOptions(installError, installAudit, installServicePulse, cancellationToken);
         }
 
         public object ActiveContext { get; set; }
@@ -171,5 +178,6 @@
         Task updateCheckTask;
         readonly ListInstancesViewModel listInstances;
         readonly NoInstancesViewModel noInstances;
+        readonly AddServiceControlInstanceCommand addInstance;
     }
 }

--- a/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
+++ b/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
@@ -29,14 +29,13 @@
             this.listInstances = listInstances;
             this.noInstances = noInstances;
             this.addInstance = addInstance;
+            this.addMonitoringInstance = addMonitoringInstance;
             OpenUrl = new OpenURLCommand();
-            AddMonitoringInstance = addMonitoringInstance;
             LicenseStatusManager = licenseStatusManager;
             DisplayName = "ServiceControl Config";
             IsModal = false;
             LoadAppVersion();
             CopyrightInfo = $"{DateTime.UtcNow.Year} © Particular Software";
-            addMonitoringInstance.OnCommandExecuting = () => ShowingMenuOverlay = false;
 
             RefreshInstancesCmd = Command.Create(async () =>
             {
@@ -50,6 +49,12 @@
         {
             ShowingMenuOverlay = false;
             await addInstance.ExecuteWithOptions(installError, installAudit, installServicePulse, cancellationToken);
+        }
+
+        public void LaunchMonitoringAdd()
+        {
+            ShowingMenuOverlay = false;
+            addMonitoringInstance.Execute(null);
         }
 
         public object ActiveContext { get; set; }
@@ -69,8 +74,6 @@
         public string CopyrightInfo { get; }
 
         public bool HasInstances { get; private set; }
-
-        public ICommand AddMonitoringInstance { get; private set; }
 
         public ICommand OpenUrl { get; private set; }
 
@@ -172,5 +175,6 @@
         readonly ListInstancesViewModel listInstances;
         readonly NoInstancesViewModel noInstances;
         readonly AddServiceControlInstanceCommand addInstance;
+        readonly ICommand addMonitoringInstance;
     }
 }


### PR DESCRIPTION
Reduce the friction for the minimal install of the platform needed to provide the usage report, by making the intent of what is being installed clear from the start.

Changes based on the below mockups:

<img width="784" height="481" alt="image" src="https://github.com/user-attachments/assets/8752f574-1247-436d-95a3-a42a615dfe87" />

<img width="782" height="477" alt="image" src="https://github.com/user-attachments/assets/50ee2478-07a6-42f5-b4a3-2da47ab0951b" />

<img width="769" height="472" alt="image" src="https://github.com/user-attachments/assets/4d7ee467-863e-4ab2-bd45-038bae4990b2" />

<img width="776" height="476" alt="image" src="https://github.com/user-attachments/assets/31033868-d3f4-4f6e-bb53-02d594f5b87f" />


