### PR TITLE
Stop persisting computed ETag fields into RavenDB documents

### DIFF
--- a/src/ServiceControl.Persistence/CustomCheck.cs
+++ b/src/ServiceControl.Persistence/CustomCheck.cs
@@ -14,7 +14,7 @@
         public DateTime ReportedAt { get; set; }
         public string? FailureReason { get; set; }
         public EndpointDetails? OriginatingEndpoint { get; set; }
-        object?[] IVersionedRow.VersionFields =>
+        object?[] IVersionedRow.GetVersionFields() =>
         [
             Id, CustomCheckId, Category, Status, ReportedAt, FailureReason,
             OriginatingEndpoint?.Name, OriginatingEndpoint?.HostId, OriginatingEndpoint?.Host

--- a/src/ServiceControl.Persistence/EndpointsView.cs
+++ b/src/ServiceControl.Persistence/EndpointsView.cs
@@ -12,7 +12,7 @@ namespace ServiceControl.Persistence
         public bool MonitorHeartbeat { get; set; }
         public HeartbeatInformation? HeartbeatInformation { get; set; }
         public bool IsSendingHeartbeats { get; set; }
-        object?[] IVersionedRow.VersionFields =>
+        object?[] IVersionedRow.GetVersionFields() =>
         [
             Id, Name, HostDisplayName, Monitored, MonitorHeartbeat, IsSendingHeartbeats,
             HeartbeatInformation?.LastReportAt, HeartbeatInformation?.ReportedStatus

--- a/src/ServiceControl.Persistence/EventLog/EventLogItemView.cs
+++ b/src/ServiceControl.Persistence/EventLog/EventLogItemView.cs
@@ -19,7 +19,7 @@ namespace ServiceControl.EventLog
         public List<string> RelatedTo { get; set; } = [];
         public required string Category { get; set; }
         public required string EventType { get; set; }
-        object?[] IVersionedRow.VersionFields =>
+        object?[] IVersionedRow.GetVersionFields() =>
             [Id, Description, Severity, RaisedAt, Category, EventType, .. RelatedTo];
     }
 }

--- a/src/ServiceControl.Persistence/FailureGroupView.cs
+++ b/src/ServiceControl.Persistence/FailureGroupView.cs
@@ -12,6 +12,6 @@ namespace ServiceControl.Recoverability
         public string? Comment { get; set; }
         public DateTime First { get; set; }
         public DateTime Last { get; set; }
-        object?[] IVersionedRow.VersionFields => [Id, Title, Type, Count, Comment, First, Last];
+        object?[] IVersionedRow.GetVersionFields() => [Id, Title, Type, Count, Comment, First, Last];
     }
 }

--- a/src/ServiceControl.Persistence/GroupOperation.cs
+++ b/src/ServiceControl.Persistence/GroupOperation.cs
@@ -18,7 +18,7 @@ public class GroupOperation : IVersionedRow
     public DateTime? OperationStartTime { get; set; }
     public DateTime? OperationCompletionTime { get; set; }
     public bool NeedUserAcknowledgement { get; set; }
-    object?[] IVersionedRow.VersionFields =>
+    object?[] IVersionedRow.GetVersionFields() =>
     [
         Id, Title, Type, Count, Comment, First, Last, OperationStatus, OperationFailed, OperationProgress,
         OperationMessagesCompletedCount, OperationRemainingCount, OperationStartTime, OperationCompletionTime,

--- a/src/ServiceControl.Persistence/History/HistoricRetryOperation.cs
+++ b/src/ServiceControl.Persistence/History/HistoricRetryOperation.cs
@@ -13,7 +13,7 @@
         public string? Originator { get; set; }
         public bool Failed { get; set; }
         public int NumberOfMessagesProcessed { get; set; }
-        object?[] IVersionedRow.VersionFields =>
+        object?[] IVersionedRow.GetVersionFields() =>
             [RequestId, RetryType, StartTime, CompletionTime, Originator, Failed, NumberOfMessagesProcessed];
     }
 }

--- a/src/ServiceControl.Persistence/History/UnacknowledgedRetryOperation.cs
+++ b/src/ServiceControl.Persistence/History/UnacknowledgedRetryOperation.cs
@@ -15,7 +15,7 @@
         public string? Classifier { get; set; }
         public bool Failed { get; set; }
         public int NumberOfMessagesProcessed { get; set; }
-        object?[] IVersionedRow.VersionFields =>
+        object?[] IVersionedRow.GetVersionFields() =>
             [RequestId, RetryType, StartTime, CompletionTime, Last, Originator, Classifier, Failed, NumberOfMessagesProcessed];
     }
 }

--- a/src/ServiceControl.Persistence/Infrastructure/DataVersion.cs
+++ b/src/ServiceControl.Persistence/Infrastructure/DataVersion.cs
@@ -69,7 +69,7 @@ namespace ServiceControl.Persistence.Infrastructure
 
         public static DataVersion OverRows<TRow>((string Name, object? Value)[]? summary, IEnumerable<TRow> rows)
             where TRow : IVersionedRow =>
-            OverRows(summary, rows, row => row.VersionFields);
+            OverRows(summary, rows, row => row.GetVersionFields());
 
         /// <summary>
         /// One version for a result gathered from several instances. Missing anywhere means missing overall.

--- a/src/ServiceControl.Persistence/Infrastructure/IVersionedRow.cs
+++ b/src/ServiceControl.Persistence/Infrastructure/IVersionedRow.cs
@@ -1,11 +1,13 @@
 namespace ServiceControl.Persistence.Infrastructure
 {
     /// <summary>
-    /// A row the API sends to ServicePulse to be rendered. Every field the response shows has to appear in <c>VersionFields</c>, or it
-    /// can change without the cache tag moving and the client keeps a stale page.
+    /// A row the API sends to ServicePulse to be rendered. Every field the response shows has to appear in
+    /// <c>GetVersionFields</c>, or it can change without the cache tag moving and the client keeps a stale page.
     /// </summary>
     public interface IVersionedRow
     {
-        object?[] VersionFields { get; }
+        // A method, not a property: We dont want a serialiser to persist computed properties into the document, and these
+        // values are derived from the fields beside them.
+        object?[] GetVersionFields();
     }
 }

--- a/src/ServiceControl.Persistence/MessageRedirects/MessageRedirect.cs
+++ b/src/ServiceControl.Persistence/MessageRedirects/MessageRedirect.cs
@@ -11,7 +11,7 @@
         public required string FromPhysicalAddress { get; set; }
         public required string ToPhysicalAddress { get; set; }
         public DateTime LastModified { get; set; }
-        object?[] IVersionedRow.VersionFields => [MessageRedirectId, ToPhysicalAddress, LastModified];
+        object?[] IVersionedRow.GetVersionFields() => [MessageRedirectId, ToPhysicalAddress, LastModified];
         static ConcurrentDictionary<string, Guid> idCache = new ConcurrentDictionary<string, Guid>();
     }
 }

--- a/src/ServiceControl.Persistence/QueueAddress.cs
+++ b/src/ServiceControl.Persistence/QueueAddress.cs
@@ -6,6 +6,6 @@
     {
         public string? PhysicalAddress { get; set; }
         public int FailedMessageCount { get; set; }
-        object?[] IVersionedRow.VersionFields => [PhysicalAddress, FailedMessageCount];
+        object?[] IVersionedRow.GetVersionFields() => [PhysicalAddress, FailedMessageCount];
     }
 }

--- a/src/ServiceControl.UnitTests/Infrastructure/VersionedRowTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/VersionedRowTests.cs
@@ -6,12 +6,13 @@ namespace ServiceControl.UnitTests.Infrastructure
     using System.Linq;
     using System.Reflection;
     using NUnit.Framework;
+    using Raven.Client.Documents.Conventions;
     using ServiceControl.EventLog;
     using ServiceControl.Infrastructure.WebApi;
     using ServiceControl.Operations;
     using ServiceControl.Persistence;
     using ServiceControl.Persistence.Infrastructure;
-    using JsonSerializer = System.Text.Json.JsonSerializer;
+    using Sparrow.Json;
 
     [TestFixture]
     public class VersionedRowTests
@@ -30,15 +31,19 @@ namespace ServiceControl.UnitTests.Infrastructure
                 "the scan below found nothing, so every other test here would pass without checking anything");
         }
 
-        // The declaration is implemented explicitly so the member stays off the type's public surface.
-        // Declared as an ordinary public property it would be serialised alongside the real fields.
+        // RavenDB serialises explicit interface implementations, under their fully qualified name, where
+        // System.Text.Json ignores them. Some of these rows are stored as-is, so a computed member lands in the document.
         [TestCaseSource(nameof(RowTypes))]
-        public void The_covered_field_list_is_not_part_of_the_response(Type type)
+        public void Only_the_rows_own_fields_are_stored(Type type)
         {
-            var row = Seeded(type);
+            var conventions = new DocumentConventions();
+            conventions.Serialization.Initialize(conventions);
 
-            Assert.That(JsonSerializer.Serialize(row, type, SerializerOptions.Default),
-                Does.Not.Contain("version_fields").IgnoreCase);
+            using var context = JsonOperationContext.ShortTermSingleUse();
+            using var stored = conventions.Serialization.DefaultConverter.ToBlittable(Seeded(type), context);
+
+            Assert.That(stored.GetPropertyNames(), Is.EquivalentTo(Stored(type)),
+                $"{type.Name} would be written to the database with something other than its own properties, so a value computed from the fields beside it gets stored next to them");
         }
 
         [TestCaseSource(nameof(RowTypes))]
@@ -74,6 +79,10 @@ namespace ServiceControl.UnitTests.Infrastructure
 
         static PropertyInfo[] Rendered(Type type) =>
             [.. type.GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(property => property.CanWrite)];
+
+        // Read-only ones count: a serialiser stores them too, and they are legitimate data.
+        static string[] Stored(Type type) =>
+            [.. type.GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(property => property.Name)];
 
         // Every field set to something, so a row is never checked with a null standing in for a real value
         // and a computed property never has to cope with an unset one.


### PR DESCRIPTION
`IVersionedRow.VersionFields` is a computed property that exists only to feed ETag computation, but RavenDB's serialiser persists it into the stored documents. It appears wherever a type is both the storage shape and the API row shape, which is `CustomCheck` and the two retry-operation types nested inside `RetryHistory`. This changes the member from a property to a method, `GetVersionFields()`: serialisers do not serialise methods, so the problem cannot recur on any type or any serialiser.