### PR TITLE
Standardise the use of TimeProvider across the error instance

### DIFF
--- a/src/ServiceControl.AcceptanceTests.RavenDB/ServiceControl.AcceptanceTests.RavenDB.csproj
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/ServiceControl.AcceptanceTests.RavenDB.csproj
@@ -39,6 +39,9 @@
 
     <!-- The file system body storage custom check is an EF Core persister feature; RavenDB stores bodies in the database. -->
     <Compile Remove="..\ServiceControl.AcceptanceTests\Monitoring\CustomChecks\When_the_body_storage_check_is_reported.cs" />
+
+    <!-- RavenDB is the one persister that supports maintenance mode; StartupModeTests covers it. -->
+    <Compile Remove="..\ServiceControl.AcceptanceTests\MaintenanceModeTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.AcceptanceTests.RavenDB/StartupModeTests.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/StartupModeTests.cs
@@ -51,6 +51,10 @@
 
             using var host = hostBuilder.Build();
             await host.StartAsync();
+
+            // Maintenance mode never calls AddServiceControl, so the persister has to supply the clock itself.
+            Assert.That(host.Services.GetRequiredService<TimeProvider>(), Is.Not.Null);
+
             await host.StopAsync();
         }
 

--- a/src/ServiceControl.AcceptanceTests/ClockRegistrationTests.cs
+++ b/src/ServiceControl.AcceptanceTests/ClockRegistrationTests.cs
@@ -1,0 +1,67 @@
+namespace ServiceControl.AcceptanceTests
+{
+    using System;
+    using System.Runtime.Loader;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using NServiceBus;
+    using NUnit.Framework;
+    using Particular.ServiceControl;
+    using Persistence;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    class ClockRegistrationTests : AcceptanceTest
+    {
+        Settings settings;
+
+        [SetUp]
+        public async Task InitializeSettings()
+        {
+            settings = new Settings(
+                transportType: TransportIntegration.TypeName,
+                persisterType: StorageConfiguration.PersistenceType,
+                forwardErrorMessages: false,
+                errorRetentionPeriod: TimeSpan.FromDays(1))
+            {
+                TransportConnectionString = TransportIntegration.ConnectionString,
+                IngestErrorMessages = false,
+                RunRetryProcessor = false,
+                DisableHealthChecks = true,
+                AssemblyLoadContextResolver = static _ => AssemblyLoadContext.Default
+            };
+
+            await StorageConfiguration.CustomizeSettings(settings);
+        }
+
+        [Test]
+        public void Should_keep_the_clock_the_host_registered()
+        {
+            TimeProvider hostClock = new StubTimeProvider();
+
+            var endpointConfiguration = new EndpointConfiguration(settings.InstanceName);
+            endpointConfiguration.AssemblyScanner().Disable = true;
+
+            var hostBuilder = Host.CreateApplicationBuilder();
+            hostBuilder.Services.AddSingleton(hostClock);
+            hostBuilder.AddServiceControl(settings, endpointConfiguration);
+
+            using var host = hostBuilder.Build();
+
+            Assert.That(host.Services.GetRequiredService<TimeProvider>(), Is.SameAs(hostClock));
+        }
+
+        [Test]
+        public async Task Should_start_a_persistence_only_host()
+        {
+            var hostBuilder = Host.CreateApplicationBuilder();
+            hostBuilder.Services.AddPersistence(settings, maintenanceMode: true);
+
+            using var host = hostBuilder.Build();
+            await host.StartAsync();
+            await host.StopAsync();
+        }
+
+        sealed class StubTimeProvider : TimeProvider;
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/ClockRegistrationTests.cs
+++ b/src/ServiceControl.AcceptanceTests/ClockRegistrationTests.cs
@@ -8,7 +8,6 @@ namespace ServiceControl.AcceptanceTests
     using NServiceBus;
     using NUnit.Framework;
     using Particular.ServiceControl;
-    using Persistence;
     using ServiceBus.Management.Infrastructure.Settings;
 
     class ClockRegistrationTests : AcceptanceTest
@@ -49,20 +48,6 @@ namespace ServiceControl.AcceptanceTests
             using var host = hostBuilder.Build();
 
             Assert.That(host.Services.GetRequiredService<TimeProvider>(), Is.SameAs(hostClock));
-        }
-
-        [Test]
-        public async Task Should_register_a_clock_in_a_persistence_only_host()
-        {
-            var hostBuilder = Host.CreateApplicationBuilder();
-            hostBuilder.Services.AddPersistence(settings, maintenanceMode: true);
-
-            using var host = hostBuilder.Build();
-            await host.StartAsync();
-
-            Assert.That(host.Services.GetRequiredService<TimeProvider>(), Is.Not.Null);
-
-            await host.StopAsync();
         }
 
         sealed class StubTimeProvider : TimeProvider;

--- a/src/ServiceControl.AcceptanceTests/ClockRegistrationTests.cs
+++ b/src/ServiceControl.AcceptanceTests/ClockRegistrationTests.cs
@@ -52,13 +52,16 @@ namespace ServiceControl.AcceptanceTests
         }
 
         [Test]
-        public async Task Should_start_a_persistence_only_host()
+        public async Task Should_register_a_clock_in_a_persistence_only_host()
         {
             var hostBuilder = Host.CreateApplicationBuilder();
             hostBuilder.Services.AddPersistence(settings, maintenanceMode: true);
 
             using var host = hostBuilder.Build();
             await host.StartAsync();
+
+            Assert.That(host.Services.GetRequiredService<TimeProvider>(), Is.Not.Null);
+
             await host.StopAsync();
         }
 

--- a/src/ServiceControl.AcceptanceTests/MaintenanceModeTests.cs
+++ b/src/ServiceControl.AcceptanceTests/MaintenanceModeTests.cs
@@ -1,0 +1,31 @@
+namespace ServiceControl.AcceptanceTests
+{
+    using System;
+    using System.Runtime.Loader;
+    using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
+    using Persistence;
+    using ServiceBus.Management.Infrastructure.Settings;
+
+    class MaintenanceModeTests : AcceptanceTest
+    {
+        // The refusal happens before any database is touched, so this needs no storage set up.
+        [Test]
+        public void Should_refuse_maintenance_mode()
+        {
+            var settings = new Settings(
+                transportType: TransportIntegration.TypeName,
+                persisterType: StorageConfiguration.PersistenceType,
+                forwardErrorMessages: false,
+                errorRetentionPeriod: TimeSpan.FromDays(1))
+            {
+                TransportConnectionString = TransportIntegration.ConnectionString,
+                AssemblyLoadContextResolver = static _ => AssemblyLoadContext.Default
+            };
+
+            var exception = Assert.Throws<Exception>(() => new ServiceCollection().AddPersistence(settings, maintenanceMode: true));
+
+            Assert.That(exception.Message, Does.Contain("Maintenance mode is not supported").And.Contain(StorageConfiguration.PersistenceType));
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.EFCore/Abstractions/BasePersistence.cs
+++ b/src/ServiceControl.Persistence.EFCore/Abstractions/BasePersistence.cs
@@ -23,7 +23,9 @@ public abstract class BasePersistence
 {
     protected static void RegisterDataStores(IServiceCollection services, EFPersisterSettings settings)
     {
-        services.AddSingleton(TimeProvider.System);
+        // Usually provided by AddServiceControl, but also required here for maintenance mode.
+        services.TryAddSingleton(TimeProvider.System);
+
         services.AddSingleton<MinimumRequiredStorageState>();
 
         services.AddSingleton<IServiceControlSubscriptionStorage, SubscriptionStorage>();

--- a/src/ServiceControl.Persistence.EFCore/Abstractions/BasePersistence.cs
+++ b/src/ServiceControl.Persistence.EFCore/Abstractions/BasePersistence.cs
@@ -23,7 +23,6 @@ public abstract class BasePersistence
 {
     protected static void RegisterDataStores(IServiceCollection services, EFPersisterSettings settings)
     {
-        // Usually provided by AddServiceControl, but a persistence-only host has to get it from here.
         services.TryAddSingleton(TimeProvider.System);
 
         services.AddSingleton<MinimumRequiredStorageState>();

--- a/src/ServiceControl.Persistence.EFCore/Abstractions/BasePersistence.cs
+++ b/src/ServiceControl.Persistence.EFCore/Abstractions/BasePersistence.cs
@@ -23,7 +23,7 @@ public abstract class BasePersistence
 {
     protected static void RegisterDataStores(IServiceCollection services, EFPersisterSettings settings)
     {
-        // Usually provided by AddServiceControl, but also required here for maintenance mode.
+        // Usually provided by AddServiceControl, but a persistence-only host has to get it from here.
         services.TryAddSingleton(TimeProvider.System);
 
         services.AddSingleton<MinimumRequiredStorageState>();

--- a/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersistenceConfigurationBase.cs
+++ b/src/ServiceControl.Persistence.EFCore/Abstractions/EFPersistenceConfigurationBase.cs
@@ -29,6 +29,8 @@ public abstract class EFPersistenceConfigurationBase : PersistenceConfiguration,
     const string SubscriptionCacheDurationKey = "SubscriptionCacheDuration";
     const string ExternalIntegrationsDispatchingBatchSizeKey = "ExternalIntegrationsDispatchingBatchSize";
 
+    public bool SupportsMaintenanceMode => false;
+
     public PersistenceSettings CreateSettings(SettingsRootNamespace settingsRootNamespace)
     {
         var settings = CreateSettings(

--- a/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageLifecycleDataStore.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/FailedMessageLifecycleDataStore.cs
@@ -7,7 +7,8 @@ using ServiceControl.MessageFailures;
 /// <summary>
 /// Every operation here has to update both StatusChangedAt and LastModified.
 /// </summary>
-public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) : DataStoreBase(scopeFactory), IFailedMessageLifecycleDataStore
+public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory, TimeProvider timeProvider)
+    : DataStoreBase(scopeFactory), IFailedMessageLifecycleDataStore
 {
     public async Task MarkAsArchived(string failedMessageId, CancellationToken cancellationToken = default)
     {
@@ -18,7 +19,7 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
                 return;
             }
 
-            var now = DateTime.UtcNow;
+            var now = timeProvider.GetUtcNow().UtcDateTime;
 
             await dbContext.FailedMessages
                 .Where(fm => fm.UniqueMessageId == uniqueMessageId)
@@ -38,7 +39,7 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
                 return false;
             }
 
-            var now = DateTime.UtcNow;
+            var now = timeProvider.GetUtcNow().UtcDateTime;
 
             var affected = await dbContext.FailedMessages
                 .Where(fm => fm.UniqueMessageId == uniqueMessageId && fm.Status != FailedMessageStatus.Resolved)
@@ -65,7 +66,7 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
 
         return await ExecuteWithDbContext(async (dbContext, token) =>
         {
-            var now = DateTime.UtcNow;
+            var now = timeProvider.GetUtcNow().UtcDateTime;
 
             // Query which messages will actually be unarchived (must be Archived status)
             var unarchivableIds = await dbContext.FailedMessages
@@ -93,7 +94,7 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
     {
         return await ExecuteWithDbContext(async (dbContext, token) =>
         {
-            var now = DateTime.UtcNow;
+            var now = timeProvider.GetUtcNow().UtcDateTime;
 
             // Query which messages will be unarchived (must be Archived and within the date range)
             var unarchivableIds = await dbContext.FailedMessages
@@ -128,7 +129,7 @@ public class FailedMessageLifecycleDataStore(IServiceScopeFactory scopeFactory) 
                 return;
             }
 
-            var now = DateTime.UtcNow;
+            var now = timeProvider.GetUtcNow().UtcDateTime;
 
             await dbContext.FailedMessages
                 .Where(fm => fm.UniqueMessageId == uniqueMessageId && fm.Status == FailedMessageStatus.RetryIssued)

--- a/src/ServiceControl.Persistence.EFCore/Implementation/Recoverability/EFCoreArchivingManager.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/Recoverability/EFCoreArchivingManager.cs
@@ -9,7 +9,7 @@ using ServiceControl.Recoverability.Archiving.Metrics;
 /// EFCore equivalent of the RavenDB <see cref="ArchivingManager"/>. Wraps the shared
 /// <see cref="OperationsManager"/> singleton to manage in-memory archive progress state.
 /// </summary>
-class EFCoreArchivingManager(IDomainEvents domainEvents, OperationsManager operationsManager, ArchiveMetrics metrics)
+class EFCoreArchivingManager(IDomainEvents domainEvents, OperationsManager operationsManager, ArchiveMetrics metrics, TimeProvider timeProvider)
 {
     InMemoryArchive GetOrCreate(ArchiveType archiveType, string requestId)
     {
@@ -43,7 +43,7 @@ class EFCoreArchivingManager(IDomainEvents domainEvents, OperationsManager opera
 
         summary.TotalNumberOfMessages = 0;
         summary.NumberOfMessagesArchived = 0;
-        summary.Started = DateTime.UtcNow;
+        summary.Started = timeProvider.GetUtcNow().UtcDateTime;
         summary.GroupName = "Undefined";
         summary.NumberOfBatches = 0;
         summary.CurrentBatch = 0;

--- a/src/ServiceControl.Persistence.EFCore/Implementation/Recoverability/EFCoreArchivingManager.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/Recoverability/EFCoreArchivingManager.cs
@@ -16,7 +16,7 @@ class EFCoreArchivingManager(IDomainEvents domainEvents, OperationsManager opera
         var id = InMemoryArchive.MakeId(requestId, archiveType);
         if (!operationsManager.ArchiveOperations.TryGetValue(id, out var summary))
         {
-            summary = new InMemoryArchive(requestId, archiveType, domainEvents, metrics);
+            summary = new InMemoryArchive(requestId, archiveType, domainEvents, timeProvider, metrics);
             operationsManager.ArchiveOperations[id] = summary;
         }
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/Recoverability/EFCoreUnarchivingManager.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/Recoverability/EFCoreUnarchivingManager.cs
@@ -9,7 +9,7 @@ using ServiceControl.Recoverability.Archiving.Metrics;
 /// EFCore equivalent of the RavenDB <see cref="UnarchivingManager"/>. Wraps the shared
 /// <see cref="OperationsManager"/> singleton to manage in-memory unarchive progress state.
 /// </summary>
-class EFCoreUnarchivingManager(IDomainEvents domainEvents, OperationsManager operationsManager, ArchiveMetrics metrics)
+class EFCoreUnarchivingManager(IDomainEvents domainEvents, OperationsManager operationsManager, ArchiveMetrics metrics, TimeProvider timeProvider)
 {
     InMemoryUnarchive GetOrCreate(ArchiveType archiveType, string requestId)
     {
@@ -43,7 +43,7 @@ class EFCoreUnarchivingManager(IDomainEvents domainEvents, OperationsManager ope
 
         summary.TotalNumberOfMessages = 0;
         summary.NumberOfMessagesUnarchived = 0;
-        summary.Started = DateTime.UtcNow;
+        summary.Started = timeProvider.GetUtcNow().UtcDateTime;
         summary.GroupName = "Undefined";
         summary.NumberOfBatches = 0;
         summary.CurrentBatch = 0;

--- a/src/ServiceControl.Persistence.EFCore/Implementation/Recoverability/EFCoreUnarchivingManager.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/Recoverability/EFCoreUnarchivingManager.cs
@@ -16,7 +16,7 @@ class EFCoreUnarchivingManager(IDomainEvents domainEvents, OperationsManager ope
         var id = InMemoryUnarchive.MakeId(requestId, archiveType);
         if (!operationsManager.UnarchiveOperations.TryGetValue(id, out var summary))
         {
-            summary = new InMemoryUnarchive(requestId, archiveType, domainEvents, metrics);
+            summary = new InMemoryUnarchive(requestId, archiveType, domainEvents, timeProvider, metrics);
             operationsManager.UnarchiveOperations[id] = summary;
         }
 

--- a/src/ServiceControl.Persistence.EFCore/Implementation/Recoverability/MessageArchiver.cs
+++ b/src/ServiceControl.Persistence.EFCore/Implementation/Recoverability/MessageArchiver.cs
@@ -31,8 +31,8 @@ public class MessageArchiver : IArchiveMessages
         this.logger = logger;
         this.domainEvents = domainEvents;
 
-        archivingManager = new EFCoreArchivingManager(domainEvents, operationsManager, metrics);
-        unarchivingManager = new EFCoreUnarchivingManager(domainEvents, operationsManager, metrics);
+        archivingManager = new EFCoreArchivingManager(domainEvents, operationsManager, metrics, timeProvider);
+        unarchivingManager = new EFCoreUnarchivingManager(domainEvents, operationsManager, metrics, timeProvider);
     }
 
     public async Task ArchiveAllInGroup(string groupId, AuditUser? initiatedBy = null, string? operationId = null, CancellationToken cancellationToken = default)

--- a/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckRavenDBIndexLag.cs
+++ b/src/ServiceControl.Persistence.RavenDB/CustomChecks/CheckRavenDBIndexLag.cs
@@ -39,6 +39,7 @@
             {
                 if (indexStats.IsStale && indexStats.LastIndexingTime.HasValue)
                 {
+                    // Machine clock on purpose: LastIndexingTime comes from the server, so an injected clock would give a meaningless lag.
                     var indexLag = DateTime.UtcNow - indexStats.LastIndexingTime.Value;
 
                     if (indexLag > IndexLagThresholdError)

--- a/src/ServiceControl.Persistence.RavenDB/ExpirationManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/ExpirationManager.cs
@@ -12,12 +12,14 @@
         public const string DeleteExpirationFieldExpression = "delete msg['@metadata']['@expires']";
 
         readonly TimeSpan errorRetentionPeriod;
+        readonly TimeProvider timeProvider;
         readonly TimeSpan eventsRetentionPeriod;
 
-        public ExpirationManager(RavenPersisterSettings settings)
+        public ExpirationManager(RavenPersisterSettings settings, TimeProvider timeProvider)
         {
             errorRetentionPeriod = settings.ErrorRetentionPeriod;
             eventsRetentionPeriod = settings.EventsRetentionPeriod;
+            this.timeProvider = timeProvider;
         }
 
         public void CancelExpiration(IAsyncDocumentSession session, FailedMessage failedMessage)
@@ -27,14 +29,14 @@
 
         public void EnableExpiration(IAsyncDocumentSession session, FailedMessage failedMessage)
         {
-            var expiresAt = DateTime.UtcNow + errorRetentionPeriod;
+            var expiresAt = timeProvider.GetUtcNow().UtcDateTime + errorRetentionPeriod;
 
             session.Advanced.GetMetadataFor(failedMessage)[Constants.Documents.Metadata.Expires] = expiresAt;
         }
 
         public void EnableExpiration(IAsyncDocumentSession session, EventLogItem eventLogItem)
         {
-            var expiresAt = DateTime.UtcNow + eventsRetentionPeriod;
+            var expiresAt = timeProvider.GetUtcNow().UtcDateTime + eventsRetentionPeriod;
 
             session.Advanced.GetMetadataFor(eventLogItem)[Constants.Documents.Metadata.Expires] = expiresAt;
         }
@@ -45,7 +47,7 @@
         // document down one branch and so cannot have it appended to the end.
         public string EnableExpirationScript(PatchRequest request)
         {
-            var expiredAt = DateTime.UtcNow + errorRetentionPeriod;
+            var expiredAt = timeProvider.GetUtcNow().UtcDateTime + errorRetentionPeriod;
 
             request.Values.Add("Expires", expiredAt);
 

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistence.cs
@@ -1,9 +1,11 @@
 namespace ServiceControl.Persistence.RavenDB;
 
+using System;
 using CustomChecks;
 using Editing;
 using MessageRedirects;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
 using Operations.BodyStorage;
 using Operations.BodyStorage.RavenAttachments;
@@ -82,6 +84,8 @@ class RavenPersistence(RavenPersisterSettings settings) : IPersistence
 
     void ConfigureLifecycle(IServiceCollection services)
     {
+        services.TryAddSingleton(TimeProvider.System);
+
         services.AddSingleton<PersistenceSettings>(settings);
         services.AddSingleton(settings);
 

--- a/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence.RavenDB/RavenPersistenceConfiguration.cs
@@ -18,6 +18,8 @@ namespace ServiceControl.Persistence.RavenDB
         const string ExternalIntegrationsDispatchingBatchSizeKey = "ExternalIntegrationsDispatchingBatchSize";
         const string MaintenanceModeKey = "MaintenanceMode";
 
+        public bool SupportsMaintenanceMode => true;
+
         public PersistenceSettings CreateSettings(SettingsRootNamespace settingsRootNamespace)
         {
             var ravenDbLogLevel = SettingsReader.Read(settingsRootNamespace, RavenBootstrapper.RavenDbLogLevelKey, "Warn");

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/ArchiveDocumentManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/ArchiveDocumentManager.cs
@@ -13,7 +13,7 @@
     using Raven.Client.Documents.Operations;
     using Raven.Client.Documents.Session;
 
-    class ArchiveDocumentManager(ExpirationManager expirationManager, ILogger logger)
+    class ArchiveDocumentManager(ExpirationManager expirationManager, ILogger logger, TimeProvider timeProvider)
     {
         public Task<ArchiveOperation> LoadArchiveOperation(IAsyncDocumentSession session, string groupId, ArchiveType archiveType, CancellationToken cancellationToken = default) => session.LoadAsync<ArchiveOperation>(ArchiveOperation.MakeId(groupId, archiveType), cancellationToken);
 
@@ -26,7 +26,7 @@
                 ArchiveType = archiveType,
                 TotalNumberOfMessages = numberOfMessages,
                 NumberOfMessagesArchived = 0,
-                Started = DateTime.UtcNow,
+                Started = timeProvider.GetUtcNow().UtcDateTime,
                 GroupName = groupName,
                 NumberOfBatches = (int)Math.Ceiling(numberOfMessages / (float)batchSize),
                 CurrentBatch = 0,

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/ArchivingManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/ArchivingManager.cs
@@ -9,10 +9,11 @@
 
     class ArchivingManager
     {
-        public ArchivingManager(IDomainEvents domainEvents, OperationsManager operationsManager)
+        public ArchivingManager(IDomainEvents domainEvents, OperationsManager operationsManager, TimeProvider timeProvider)
         {
             this.domainEvents = domainEvents;
             this.operationsManager = operationsManager;
+            this.timeProvider = timeProvider;
         }
 
         public bool IsArchiveInProgressFor(string requestId)
@@ -34,7 +35,7 @@
         {
             if (!operationsManager.ArchiveOperations.TryGetValue(InMemoryArchive.MakeId(requestId, archiveType), out var summary))
             {
-                summary = new InMemoryArchive(requestId, archiveType, domainEvents);
+                summary = new InMemoryArchive(requestId, archiveType, domainEvents, timeProvider);
                 operationsManager.ArchiveOperations[InMemoryArchive.MakeId(requestId, archiveType)] = summary;
             }
 
@@ -61,7 +62,7 @@
 
             summary.TotalNumberOfMessages = 0;
             summary.NumberOfMessagesArchived = 0;
-            summary.Started = DateTime.UtcNow;
+            summary.Started = timeProvider.GetUtcNow().UtcDateTime;
             summary.GroupName = "Undefined";
             summary.NumberOfBatches = 0;
             summary.CurrentBatch = 0;
@@ -106,6 +107,7 @@
         }
 
         IDomainEvents domainEvents;
+        readonly TimeProvider timeProvider;
 
         OperationsManager operationsManager;
 

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/MessageArchiver.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/MessageArchiver.cs
@@ -20,6 +20,7 @@
             IDomainEvents domainEvents,
             ExpirationManager expirationManager,
             IMessageActionAuditLog auditLog,
+            TimeProvider timeProvider,
             ILogger<MessageArchiver> logger
             )
         {
@@ -30,11 +31,11 @@
             this.logger = logger;
             this.operationsManager = operationsManager;
 
-            archiveDocumentManager = new ArchiveDocumentManager(expirationManager, logger);
-            archivingManager = new ArchivingManager(domainEvents, operationsManager);
+            archiveDocumentManager = new ArchiveDocumentManager(expirationManager, logger, timeProvider);
+            archivingManager = new ArchivingManager(domainEvents, operationsManager, timeProvider);
 
-            unarchiveDocumentManager = new UnarchiveDocumentManager();
-            unarchivingManager = new UnarchivingManager(domainEvents, operationsManager);
+            unarchiveDocumentManager = new UnarchiveDocumentManager(timeProvider);
+            unarchivingManager = new UnarchivingManager(domainEvents, operationsManager, timeProvider);
         }
 
         public async Task ArchiveAllInGroup(string groupId, AuditUser? initiatedBy = null, string operationId = null, CancellationToken cancellationToken = default)

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/UnarchiveDocumentManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/UnarchiveDocumentManager.cs
@@ -12,7 +12,7 @@
     using Raven.Client.Documents.Operations;
     using Raven.Client.Documents.Session;
 
-    class UnarchiveDocumentManager
+    class UnarchiveDocumentManager(TimeProvider timeProvider)
     {
         public Task<UnarchiveOperation> LoadUnarchiveOperation(IAsyncDocumentSession session, string groupId, ArchiveType archiveType, CancellationToken cancellationToken = default) => session.LoadAsync<UnarchiveOperation>(UnarchiveOperation.MakeId(groupId, archiveType), cancellationToken);
 
@@ -25,7 +25,7 @@
                 ArchiveType = archiveType,
                 TotalNumberOfMessages = numberOfMessages,
                 NumberOfMessagesUnarchived = 0,
-                Started = DateTime.UtcNow,
+                Started = timeProvider.GetUtcNow().UtcDateTime,
                 GroupName = groupName,
                 NumberOfBatches = (int)Math.Ceiling(numberOfMessages / (float)batchSize),
                 CurrentBatch = 0,

--- a/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/UnarchivingManager.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Recoverability/Archiving/UnarchivingManager.cs
@@ -9,10 +9,11 @@
 
     class UnarchivingManager
     {
-        public UnarchivingManager(IDomainEvents domainEvents, OperationsManager operationsManager)
+        public UnarchivingManager(IDomainEvents domainEvents, OperationsManager operationsManager, TimeProvider timeProvider)
         {
             this.domainEvents = domainEvents;
             this.operationsManager = operationsManager;
+            this.timeProvider = timeProvider;
         }
 
         public bool IsUnarchiveInProgressFor(string requestId)
@@ -34,7 +35,7 @@
         {
             if (!operationsManager.UnarchiveOperations.TryGetValue(InMemoryUnarchive.MakeId(requestId, archiveType), out var summary))
             {
-                summary = new InMemoryUnarchive(requestId, archiveType, domainEvents);
+                summary = new InMemoryUnarchive(requestId, archiveType, domainEvents, timeProvider);
                 operationsManager.UnarchiveOperations[InMemoryUnarchive.MakeId(requestId, archiveType)] = summary;
             }
 
@@ -61,7 +62,7 @@
 
             summary.TotalNumberOfMessages = 0;
             summary.NumberOfMessagesUnarchived = 0;
-            summary.Started = DateTime.UtcNow;
+            summary.Started = timeProvider.GetUtcNow().UtcDateTime;
             summary.GroupName = "Undefined";
             summary.NumberOfBatches = 0;
             summary.CurrentBatch = 0;
@@ -106,6 +107,7 @@
         }
 
         IDomainEvents domainEvents;
+        readonly TimeProvider timeProvider;
         OperationsManager operationsManager;
     }
 }

--- a/src/ServiceControl.Persistence.RavenDB/Throughput/LicensingDataStore.cs
+++ b/src/ServiceControl.Persistence.RavenDB/Throughput/LicensingDataStore.cs
@@ -17,7 +17,8 @@ using Raven.Client.Documents.Session;
 
 class LicensingDataStore(
     IRavenDocumentStoreProvider storeProvider,
-    ThroughputDatabaseConfiguration databaseConfiguration) : ILicensingDataStore
+    ThroughputDatabaseConfiguration databaseConfiguration,
+    TimeProvider timeProvider) : ILicensingDataStore
 {
     internal const string ThroughputTimeSeriesName = "INC: throughput data";
     const string AuditServiceMetadataDocumentId = "AuditServiceMetadata";
@@ -142,7 +143,7 @@ class LicensingDataStore(
         var store = await storeProvider.GetDocumentStore(cancellationToken);
         using IAsyncDocumentSession session = store.OpenAsyncSession(databaseConfiguration.Name);
 
-        var from = DateTime.UtcNow.AddMonths(-ThroughputReporting.ReportedMonths);
+        var from = timeProvider.GetUtcNow().UtcDateTime.AddMonths(-ThroughputReporting.ReportedMonths);
         var query = session.Query<EndpointDocument>()
             .Where(document => document.SanitizedName.In(queueNames))
             .Include(builder => builder.IncludeTimeSeries(ThroughputTimeSeriesName, from));
@@ -270,10 +271,11 @@ class LicensingDataStore(
         return result;
     }
 
-    static async Task<bool> IsThereThroughputForLastXDaysInternal(IRavenQueryable<EndpointDocument> baseQuery, int days, bool includeToday, CancellationToken cancellationToken)
+    async Task<bool> IsThereThroughputForLastXDaysInternal(IRavenQueryable<EndpointDocument> baseQuery, int days, bool includeToday, CancellationToken cancellationToken)
     {
-        DateTime fromDate = DateTime.UtcNow.AddDays(-days).Date;
-        DateTime toDate = includeToday ? DateTime.UtcNow.Date : DateTime.UtcNow.AddDays(-1).Date;
+        DateTime today = timeProvider.GetUtcNow().UtcDateTime.Date;
+        DateTime fromDate = today.AddDays(-days);
+        DateTime toDate = includeToday ? today : today.AddDays(-1);
 
         var documents = await baseQuery
             .Select(e => RavenQuery.TimeSeries(e, ThroughputTimeSeriesName, fromDate, toDate).ToList())

--- a/src/ServiceControl.Persistence.Tests.PostgreSql/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.PostgreSql/PersistenceTestsContext.cs
@@ -40,7 +40,9 @@ public partial class PersistenceTestsContext : IPersistenceTestsContext
         PersistenceSettings = new PostgreSqlPersisterSettings
         {
             ConnectionString = connectionStringBuilder.ConnectionString,
-            BodyStorage = new FileSystemBodyStorageSettings { StoragePath = bodyStoragePath }
+            BodyStorage = new FileSystemBodyStorageSettings { StoragePath = bodyStoragePath },
+            ErrorRetentionPeriod = DefaultRetentionPeriod,
+            EventsRetentionPeriod = DefaultRetentionPeriod
         };
 
         var persistence = new PostgreSqlPersistenceConfiguration().Create(PersistenceSettings);

--- a/src/ServiceControl.Persistence.Tests.RavenDB/Archiving/ArchiveGroupPerMessageAuditTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/Archiving/ArchiveGroupPerMessageAuditTests.cs
@@ -21,7 +21,7 @@ class ArchiveGroupPerMessageAuditTests : RavenPersistenceTestBase
         {
             services.AddSingleton<ArchiveAllInGroupHandler>();
             services.AddSingleton<RetryingManager>();
-            services.AddSingleton(TestRetryMetrics.Create());
+            services.AddSingleton(TestRetryMetrics.Create(TimeProvider.System));
             services.AddSingleton<IMessageActionAuditLog>(audit);
         };
 

--- a/src/ServiceControl.Persistence.Tests.RavenDB/Archiving/ArchiveGroupTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/Archiving/ArchiveGroupTests.cs
@@ -15,7 +15,7 @@
             {
                 services.AddSingleton<ArchiveAllInGroupHandler>();
                 services.AddSingleton<RetryingManager>();
-                services.AddSingleton(TestRetryMetrics.Create());
+                services.AddSingleton(TestRetryMetrics.Create(TimeProvider.System));
             };
 
         [Test]

--- a/src/ServiceControl.Persistence.Tests.RavenDB/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/PersistenceTestsContext.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Time.Testing;
 using NUnit.Framework;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
@@ -42,6 +43,8 @@ public class PersistenceTestsContext : IPersistenceTestsContext
         };
 
         var persistence = new RavenPersistenceConfiguration().Create(PersistenceSettings);
+
+        hostBuilder.Services.AddSingleton<TimeProvider>(FakeTime);
 
         persistence.AddPersistence(hostBuilder.Services);
         persistence.AddInstaller(hostBuilder.Services);
@@ -81,13 +84,13 @@ public class PersistenceTestsContext : IPersistenceTestsContext
 
     public IRavenSessionProvider SessionProvider { get; private set; }
 
-    // Nothing to do: Raven versions come from document and index etags, which move on every write, so
-    // no test needs to push its clock. There is no hook for the server clock anyway.
-    public void AdvanceClock(TimeSpan by)
-    {
-    }
+    public FakeTimeProvider FakeTime { get; } = new(DateTimeOffset.UtcNow);
 
-    public DateTime UtcNow => DateTime.UtcNow;
+    // Moves only what the persister stamps itself. The Raven server expires documents on its own
+    // clock, so advancing this changes the @expires value written, never when the server acts on it.
+    public void AdvanceClock(TimeSpan by) => FakeTime.Advance(by);
+
+    public DateTime UtcNow => FakeTime.GetUtcNow().UtcDateTime;
 
     public Task CompleteDatabaseOperation()
     {

--- a/src/ServiceControl.Persistence.Tests.RavenDB/QueryTimeoutTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/QueryTimeoutTests.cs
@@ -41,7 +41,7 @@ class QueryTimeoutTests
             QueryTimeout = queryTimeout
         };
 
-        return new ErrorMessagesDataStore(new NeverCompletingSessionProvider(), null, new ExpirationManager(settings), settings, NullLogger<ErrorMessagesDataStore>.Instance);
+        return new ErrorMessagesDataStore(new NeverCompletingSessionProvider(), null, new ExpirationManager(settings, TimeProvider.System), settings, NullLogger<ErrorMessagesDataStore>.Instance);
     }
 
     class NeverCompletingSessionProvider : IRavenSessionProvider

--- a/src/ServiceControl.Persistence.Tests.RavenDB/ServiceControl.Persistence.Tests.RavenDB.csproj
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/ServiceControl.Persistence.Tests.RavenDB.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NServiceBus.Testing" />
     <PackageReference Include="NUnit" />

--- a/src/ServiceControl.Persistence.Tests.RavenDB/Unarchiving/UnarchiveGroupTests.cs
+++ b/src/ServiceControl.Persistence.Tests.RavenDB/Unarchiving/UnarchiveGroupTests.cs
@@ -15,7 +15,7 @@
             {
                 services.AddSingleton<UnarchiveAllInGroupHandler>();
                 services.AddSingleton<RetryingManager>();
-                services.AddSingleton(TestRetryMetrics.Create());
+                services.AddSingleton(TestRetryMetrics.Create(TimeProvider.System));
             };
 
         [Test]

--- a/src/ServiceControl.Persistence.Tests.SqlServer/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests.SqlServer/PersistenceTestsContext.cs
@@ -39,7 +39,9 @@ public partial class PersistenceTestsContext : IPersistenceTestsContext
         PersistenceSettings = new SqlServerPersisterSettings
         {
             ConnectionString = connectionStringBuilder.ConnectionString,
-            BodyStorage = new FileSystemBodyStorageSettings { StoragePath = bodyStoragePath }
+            BodyStorage = new FileSystemBodyStorageSettings { StoragePath = bodyStoragePath },
+            ErrorRetentionPeriod = DefaultRetentionPeriod,
+            EventsRetentionPeriod = DefaultRetentionPeriod
         };
 
         var persistence = new SqlServerPersistenceConfiguration().Create(PersistenceSettings);

--- a/src/ServiceControl.Persistence.Tests/EFCore/ArchiveMetricsTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/ArchiveMetricsTests.cs
@@ -62,7 +62,7 @@ class ArchiveMetricsTests
     {
         var metrics = new ArchiveMetrics(MeterFactory, fakeTime);
         using var recorded = new RecordedArchiveMetrics(MeterFactory);
-        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), metrics) { TotalNumberOfMessages = 1500 };
+        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), TimeProvider.System, metrics) { TotalNumberOfMessages = 1500 };
 
         await archive.Start();
         Assert.That(recorded.InProgress(ArchiveOperationKind.Archive, "started"), Is.EqualTo(1));
@@ -96,7 +96,7 @@ class ArchiveMetricsTests
     {
         var metrics = new ArchiveMetrics(MeterFactory, fakeTime);
         using var recorded = new RecordedArchiveMetrics(MeterFactory);
-        var unarchive = new InMemoryUnarchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), metrics) { TotalNumberOfMessages = 200 };
+        var unarchive = new InMemoryUnarchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), TimeProvider.System, metrics) { TotalNumberOfMessages = 200 };
 
         await unarchive.Start();
         fakeTime.Advance(TimeSpan.FromSeconds(5));
@@ -118,7 +118,7 @@ class ArchiveMetricsTests
     {
         var metrics = new ArchiveMetrics(MeterFactory, fakeTime);
         using var recorded = new RecordedArchiveMetrics(MeterFactory);
-        var archive = new InMemoryArchive("group-stuck", ArchiveType.FailureGroup, new FakeDomainEvents(), metrics) { TotalNumberOfMessages = 2000 };
+        var archive = new InMemoryArchive("group-stuck", ArchiveType.FailureGroup, new FakeDomainEvents(), TimeProvider.System, metrics) { TotalNumberOfMessages = 2000 };
 
         await archive.Start();
         await archive.BatchArchived(1000);
@@ -135,7 +135,7 @@ class ArchiveMetricsTests
     {
         var metrics = new ArchiveMetrics(MeterFactory, fakeTime);
         using var recorded = new RecordedArchiveMetrics(MeterFactory);
-        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), metrics) { TotalNumberOfMessages = 10 };
+        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), TimeProvider.System, metrics) { TotalNumberOfMessages = 10 };
 
         await archive.Start();
         await archive.BatchArchived(10);
@@ -153,7 +153,7 @@ class ArchiveMetricsTests
     [Test]
     public async Task Without_metrics_the_state_machine_runs_unchanged()
     {
-        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents()) { TotalNumberOfMessages = 10 };
+        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), TimeProvider.System) { TotalNumberOfMessages = 10 };
 
         await archive.Start();
         await archive.BatchArchived(10);

--- a/src/ServiceControl.Persistence.Tests/EFCore/ArchiveMetricsTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/ArchiveMetricsTests.cs
@@ -62,7 +62,7 @@ class ArchiveMetricsTests
     {
         var metrics = new ArchiveMetrics(MeterFactory, fakeTime);
         using var recorded = new RecordedArchiveMetrics(MeterFactory);
-        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), TimeProvider.System, metrics) { TotalNumberOfMessages = 1500 };
+        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), fakeTime, metrics) { TotalNumberOfMessages = 1500 };
 
         await archive.Start();
         Assert.That(recorded.InProgress(ArchiveOperationKind.Archive, "started"), Is.EqualTo(1));
@@ -96,7 +96,7 @@ class ArchiveMetricsTests
     {
         var metrics = new ArchiveMetrics(MeterFactory, fakeTime);
         using var recorded = new RecordedArchiveMetrics(MeterFactory);
-        var unarchive = new InMemoryUnarchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), TimeProvider.System, metrics) { TotalNumberOfMessages = 200 };
+        var unarchive = new InMemoryUnarchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), fakeTime, metrics) { TotalNumberOfMessages = 200 };
 
         await unarchive.Start();
         fakeTime.Advance(TimeSpan.FromSeconds(5));
@@ -118,7 +118,7 @@ class ArchiveMetricsTests
     {
         var metrics = new ArchiveMetrics(MeterFactory, fakeTime);
         using var recorded = new RecordedArchiveMetrics(MeterFactory);
-        var archive = new InMemoryArchive("group-stuck", ArchiveType.FailureGroup, new FakeDomainEvents(), TimeProvider.System, metrics) { TotalNumberOfMessages = 2000 };
+        var archive = new InMemoryArchive("group-stuck", ArchiveType.FailureGroup, new FakeDomainEvents(), fakeTime, metrics) { TotalNumberOfMessages = 2000 };
 
         await archive.Start();
         await archive.BatchArchived(1000);
@@ -135,7 +135,7 @@ class ArchiveMetricsTests
     {
         var metrics = new ArchiveMetrics(MeterFactory, fakeTime);
         using var recorded = new RecordedArchiveMetrics(MeterFactory);
-        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), TimeProvider.System, metrics) { TotalNumberOfMessages = 10 };
+        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), fakeTime, metrics) { TotalNumberOfMessages = 10 };
 
         await archive.Start();
         await archive.BatchArchived(10);
@@ -153,7 +153,7 @@ class ArchiveMetricsTests
     [Test]
     public async Task Without_metrics_the_state_machine_runs_unchanged()
     {
-        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), TimeProvider.System) { TotalNumberOfMessages = 10 };
+        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), fakeTime) { TotalNumberOfMessages = 10 };
 
         await archive.Start();
         await archive.BatchArchived(10);

--- a/src/ServiceControl.Persistence.Tests/EFCore/ArchivingProgressClockTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/ArchivingProgressClockTests.cs
@@ -1,0 +1,58 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using ServiceControl.Infrastructure.DomainEvents;
+using ServiceControl.Recoverability;
+
+class ArchivingProgressClockTests : PersistenceTestBase
+{
+    readonly CapturingDomainEvents events = new();
+
+    public ArchivingProgressClockTests() =>
+        RegisterServices = services => services.AddSingleton<IDomainEvents>(events);
+
+    [Test]
+    public async Task Starting_an_archive_stamps_the_injected_clock()
+    {
+        AdvanceClock(TimeSpan.FromDays(7));
+
+        await ArchiveMessages.StartArchiving("group-1", ArchiveType.FailureGroup);
+
+        var starting = events.Raised.OfType<ArchiveOperationStarting>().Single();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(starting.StartTime, Is.EqualTo(Now));
+            Assert.That(ArchiveMessages.GetArchivalOperations().Single().Started, Is.EqualTo(Now));
+        }
+    }
+
+    [Test]
+    public async Task Starting_an_unarchive_stamps_the_injected_clock()
+    {
+        AdvanceClock(TimeSpan.FromDays(7));
+
+        await ArchiveMessages.StartUnarchiving("group-1", ArchiveType.FailureGroup);
+
+        var starting = events.Raised.OfType<UnarchiveOperationStarting>().Single();
+
+        Assert.That(starting.StartTime, Is.EqualTo(Now));
+    }
+
+    sealed class CapturingDomainEvents : IDomainEvents
+    {
+        public List<object> Raised { get; } = [];
+
+        public Task Raise<T>(T domainEvent, CancellationToken cancellationToken = default) where T : IDomainEvent
+        {
+            Raised.Add(domainEvent);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/ServiceControl.Persistence.Tests/EFCore/FailedMessageLifecycleDataStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/FailedMessageLifecycleDataStoreTests.cs
@@ -8,10 +8,6 @@ using ServiceControl.Persistence.EFCore.Entities;
 
 class FailedMessageLifecycleDataStoreTests : ErrorIngestionTestBase
 {
-    // Advancing the clock wakes the live sweeper, so retention has to outrun every advance below.
-    [SetUp]
-    public void SetRetention() => EFSettings.ErrorRetentionPeriod = TimeSpan.FromDays(365);
-
     [Test]
     public async Task Marking_as_archived_stamps_the_injected_clock()
     {

--- a/src/ServiceControl.Persistence.Tests/EFCore/FailedMessageLifecycleDataStoreTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/FailedMessageLifecycleDataStoreTests.cs
@@ -1,0 +1,114 @@
+namespace ServiceControl.Persistence.Tests;
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ServiceControl.MessageFailures;
+using ServiceControl.Persistence.EFCore.Entities;
+
+class FailedMessageLifecycleDataStoreTests : ErrorIngestionTestBase
+{
+    // Advancing the clock wakes the live sweeper, so retention has to outrun every advance below.
+    [SetUp]
+    public void SetRetention() => EFSettings.ErrorRetentionPeriod = TimeSpan.FromDays(365);
+
+    [Test]
+    public async Task Marking_as_archived_stamps_the_injected_clock()
+    {
+        var messageId = await Seed(FailedMessageStatus.Unresolved);
+
+        AdvanceClock(TimeSpan.FromDays(7));
+
+        await FailedMessageLifecycleStore.MarkAsArchived(messageId.ToString());
+
+        await AssertStampedWithCurrentTime(messageId, FailedMessageStatus.Archived);
+    }
+
+    [Test]
+    public async Task Marking_as_resolved_stamps_the_injected_clock()
+    {
+        var messageId = await Seed(FailedMessageStatus.Unresolved);
+
+        AdvanceClock(TimeSpan.FromDays(7));
+
+        Assert.That(await FailedMessageLifecycleStore.MarkAsResolved(messageId.ToString()), Is.True);
+
+        await AssertStampedWithCurrentTime(messageId, FailedMessageStatus.Resolved);
+    }
+
+    [Test]
+    public async Task Unarchiving_stamps_the_injected_clock()
+    {
+        var messageId = await Seed(FailedMessageStatus.Archived);
+
+        AdvanceClock(TimeSpan.FromDays(7));
+
+        var unarchived = await FailedMessageLifecycleStore.UnArchiveMessages([messageId.ToString()]);
+        Assert.That(unarchived, Is.EquivalentTo(new[] { messageId.ToString() }));
+
+        await AssertStampedWithCurrentTime(messageId, FailedMessageStatus.Unresolved);
+    }
+
+    [Test]
+    public async Task Unarchiving_by_range_stamps_the_injected_clock()
+    {
+        var archivedAt = Now;
+        var messageId = await Seed(FailedMessageStatus.Archived, archivedAt);
+
+        AdvanceClock(TimeSpan.FromDays(7));
+
+        var unarchived = await FailedMessageLifecycleStore.UnArchiveMessagesByRange(archivedAt.AddDays(-1), archivedAt.AddDays(1));
+        Assert.That(unarchived, Is.EquivalentTo(new[] { messageId.ToString() }));
+
+        await AssertStampedWithCurrentTime(messageId, FailedMessageStatus.Unresolved);
+    }
+
+    [Test]
+    public async Task Reverting_a_retry_stamps_the_injected_clock()
+    {
+        var messageId = await Seed(FailedMessageStatus.RetryIssued);
+
+        AdvanceClock(TimeSpan.FromDays(7));
+
+        await FailedMessageLifecycleStore.RevertRetry(messageId.ToString());
+
+        await AssertStampedWithCurrentTime(messageId, FailedMessageStatus.Unresolved);
+    }
+
+    async Task AssertStampedWithCurrentTime(Guid messageId, FailedMessageStatus expectedStatus)
+    {
+        var row = await GetFailedMessage(messageId);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(row.Status, Is.EqualTo(expectedStatus));
+            Assert.That(row.StatusChangedAt, Is.EqualTo(Now));
+            Assert.That(row.LastModified, Is.EqualTo(Now));
+        }
+    }
+
+    async Task<Guid> Seed(FailedMessageStatus status, DateTime? statusChangedAt = null)
+    {
+        var id = Guid.NewGuid();
+        var timestamp = statusChangedAt ?? Now;
+
+        await Store(new FailedMessageEntity
+        {
+            UniqueMessageId = id,
+            Status = status,
+            StatusChangedAt = timestamp,
+            LastModified = timestamp,
+            NumberOfProcessingAttempts = 1,
+            FirstTimeOfFailure = timestamp,
+            LastTimeOfFailure = timestamp,
+            LastAttemptedAt = timestamp,
+            IsSystemMessage = false,
+            HeadersJson = "{}",
+            BodyStoredExternally = false,
+            BodySize = 0,
+            FailingEndpointAddress = "Shipping"
+        });
+
+        return id;
+    }
+}

--- a/src/ServiceControl.Persistence.Tests/EFCore/PersistenceTestsContext.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/PersistenceTestsContext.cs
@@ -18,6 +18,9 @@ using Operations;
 
 public partial class PersistenceTestsContext
 {
+    // Advancing the clock wakes the live retention sweeper, so retention has to outrun every advance a test makes.
+    public static readonly TimeSpan DefaultRetentionPeriod = TimeSpan.FromDays(365);
+
     public FakeTimeProvider FakeTime { get; } = new(StorableUtcNow());
 
     // PostgreSQL timestamps only keep microseconds, so a clock seeded straight from

--- a/src/ServiceControl.Persistence.Tests/EFCore/RetentionSweepTests.cs
+++ b/src/ServiceControl.Persistence.Tests/EFCore/RetentionSweepTests.cs
@@ -191,6 +191,44 @@ class RetentionSweepTests : ErrorIngestionTestBase
     }
 
     [Test]
+    public async Task Archived_messages_are_swept_after_the_lifecycle_store_updates_the_timestamp()
+    {
+        var messageId = await SeedFailedMessage(FailedMessageStatus.Unresolved, Now.AddDays(-40));
+
+        await FailedMessageLifecycleStore.MarkAsArchived(messageId.ToString());
+
+        var archived = await FindFailedMessage(messageId);
+        Assert.That(archived, Is.Not.Null);
+        Assert.That(archived!.Status, Is.EqualTo(FailedMessageStatus.Archived));
+        Assert.That(archived.StatusChangedAt, Is.EqualTo(Now), "the lifecycle store should stamp the current fake time");
+
+        AdvanceClock(TimeSpan.FromDays(31));
+
+        await RunRetentionSweep();
+
+        Assert.That(await FindFailedMessage(messageId), Is.Null);
+    }
+
+    [Test]
+    public async Task Resolved_messages_are_swept_after_the_lifecycle_store_updates_the_timestamp()
+    {
+        var messageId = await SeedFailedMessage(FailedMessageStatus.Unresolved, Now.AddDays(-40));
+
+        Assert.That(await FailedMessageLifecycleStore.MarkAsResolved(messageId.ToString()), Is.True);
+
+        var resolved = await FindFailedMessage(messageId);
+        Assert.That(resolved, Is.Not.Null);
+        Assert.That(resolved!.Status, Is.EqualTo(FailedMessageStatus.Resolved));
+        Assert.That(resolved.StatusChangedAt, Is.EqualTo(Now), "the lifecycle store should stamp the current fake time");
+
+        AdvanceClock(TimeSpan.FromDays(31));
+
+        await RunRetentionSweep();
+
+        Assert.That(await FindFailedMessage(messageId), Is.Null);
+    }
+
+    [Test]
     public async Task Counts_the_rows_it_deletes()
     {
         EFSettings.EventsRetentionPeriod = TimeSpan.FromDays(14);

--- a/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
+++ b/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
@@ -40,8 +39,6 @@ public abstract class PersistenceTestBase
         hostBuilder.Logging.ConfigureLogging(LogLevel.Information);
 
         await PersistenceTestsContext.Setup(hostBuilder);
-
-        hostBuilder.Services.TryAddSingleton(TimeProvider.System);
 
         // This is not cool. We have things that are registered as part of "the persistence" that then require parts
         // of the infrastructure to be registered and assume NServiceBus is around. This is a hack to get around that.

--- a/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
+++ b/src/ServiceControl.Persistence.Tests/PersistenceTestBase.cs
@@ -1,9 +1,9 @@
 ﻿namespace ServiceControl.Persistence.Tests;
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NServiceBus;
@@ -40,6 +40,8 @@ public abstract class PersistenceTestBase
         hostBuilder.Logging.ConfigureLogging(LogLevel.Information);
 
         await PersistenceTestsContext.Setup(hostBuilder);
+
+        hostBuilder.Services.TryAddSingleton(TimeProvider.System);
 
         // This is not cool. We have things that are registered as part of "the persistence" that then require parts
         // of the infrastructure to be registered and assume NServiceBus is around. This is a hack to get around that.

--- a/src/ServiceControl.Persistence.Tests/Recoverability/ArchivingProgressClockTests.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/ArchivingProgressClockTests.cs
@@ -1,4 +1,4 @@
-namespace ServiceControl.Persistence.Tests;
+namespace ServiceControl.Persistence.Tests.Recoverability;
 
 using System;
 using System.Collections.Generic;

--- a/src/ServiceControl.Persistence.Tests/Recoverability/TestRetryMetrics.cs
+++ b/src/ServiceControl.Persistence.Tests/Recoverability/TestRetryMetrics.cs
@@ -6,7 +6,7 @@ namespace ServiceControl.Persistence.Tests
 
     static class TestRetryMetrics
     {
-        public static RetryMetrics Create() => new(new TestMeterFactory(), TimeProvider.System);
+        public static RetryMetrics Create(TimeProvider timeProvider) => new(new TestMeterFactory(), timeProvider);
     }
 
     sealed class TestMeterFactory : IMeterFactory

--- a/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
+++ b/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
@@ -426,7 +426,7 @@
         class CustomRetriesGateway : RetriesGateway
         {
             public CustomRetriesGateway(bool progressToStaged, IRetryBatchStore store, RetryingManager retryManager)
-                : base(store, retryManager, TestRetryMetrics.Create(), NullLogger<RetriesGateway>.Instance)
+                : base(store, retryManager, TestRetryMetrics.Create(), NullLogger<RetriesGateway>.Instance, TimeProvider.System)
             {
                 this.progressToStaged = progressToStaged;
             }

--- a/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
+++ b/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
@@ -30,7 +30,7 @@
         public async Task When_a_group_is_processed_it_is_set_to_the_Preparing_state()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", true, 1);
             var status = retryManager.GetStatusForRetryOperation("Test-group", RetryType.FailureGroup);
@@ -42,7 +42,7 @@
         public async Task When_a_group_is_prepared_and_SC_is_started_the_group_is_marked_as_failed()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", false, 1);
 
@@ -83,7 +83,7 @@
         public async Task When_a_group_is_prepared_with_three_batches_and_SC_is_restarted_while_the_first_group_is_being_forwarded_then_the_count_still_matches()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", true, 2001);
 
@@ -110,7 +110,7 @@
             await processor.ProcessBatches(); // mark ready
 
             // Simulate SC restart
-            retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+            retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
 
             var documentManager = new CustomRetryDocumentManager(false, RetryBatchStore, retryManager);
 
@@ -142,7 +142,7 @@
         public async Task When_a_group_is_forwarded_the_status_is_Completed()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", true, 1);
 
@@ -197,7 +197,7 @@
         public async Task When_there_is_one_poison_message_it_is_removed_from_batch_and_the_status_is_Complete()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", true, "A", "B", "C");
 
@@ -246,7 +246,7 @@
         public async Task When_a_group_has_one_batch_out_of_two_forwarded_the_status_is_Forwarding()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", true, 1001);
 
@@ -269,7 +269,7 @@
         public async Task When_a_selection_is_staged_each_message_is_audited_as_a_batch()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
             var user = new AuditUser("alice-sub", "Alice");
             const string operationId = "op-sel";
             var ids = new[] { "A", "B" };
@@ -319,7 +319,7 @@
         public async Task When_a_group_is_staged_each_message_is_audited_with_the_initiating_user()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
             var user = new AuditUser("alice-sub", "Alice");
             const string operationId = "op-abc";
 
@@ -363,7 +363,7 @@
                 MessageRedirectsDataStore,
                 domainEvents,
                 new TestReturnToSenderDequeuer(new ReturnToSender(BodyStorage, NullLogger<ReturnToSender>.Instance), FailedMessageLifecycleStore, domainEvents, "TestEndpoint", new ErrorQueueNameCache(), new TestTransportCustomization()),
-                new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance),
+                new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System),
                 TestRetryMetrics.Create(), new Lazy<IMessageDispatcher>(() => sender),
                 new RecordingMessageActionAuditLog(),
                 NullLogger<RetryProcessor>.Instance);

--- a/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
+++ b/src/ServiceControl.Persistence.Tests/RetryStateTests.cs
@@ -8,6 +8,7 @@
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging.Abstractions;
+    using Microsoft.Extensions.Time.Testing;
     using NServiceBus.Transport;
     using NUnit.Framework;
     using ServiceBus.Management.Infrastructure.Settings;
@@ -26,11 +27,13 @@
     [NonParallelizable]
     class RetryStateTests : PersistenceTestBase
     {
+        readonly FakeTimeProvider fakeTime = new(DateTimeOffset.UtcNow);
+
         [Test]
         public async Task When_a_group_is_processed_it_is_set_to_the_Preparing_state()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", true, 1);
             var status = retryManager.GetStatusForRetryOperation("Test-group", RetryType.FailureGroup);
@@ -42,7 +45,7 @@
         public async Task When_a_group_is_prepared_and_SC_is_started_the_group_is_marked_as_failed()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", false, 1);
 
@@ -83,7 +86,7 @@
         public async Task When_a_group_is_prepared_with_three_batches_and_SC_is_restarted_while_the_first_group_is_being_forwarded_then_the_count_still_matches()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", true, 2001);
 
@@ -100,7 +103,7 @@
                     new ErrorQueueNameCache(),
                     new TestTransportCustomization()),
                 retryManager,
-                TestRetryMetrics.Create(), new Lazy<IMessageDispatcher>(() => sender),
+                TestRetryMetrics.Create(fakeTime), new Lazy<IMessageDispatcher>(() => sender),
                 new RecordingMessageActionAuditLog(),
                 NullLogger<RetryProcessor>.Instance);
 
@@ -110,7 +113,7 @@
             await processor.ProcessBatches(); // mark ready
 
             // Simulate SC restart
-            retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
+            retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
 
             var documentManager = new CustomRetryDocumentManager(false, RetryBatchStore, retryManager);
 
@@ -128,7 +131,7 @@
                     new ErrorQueueNameCache(),
                     new TestTransportCustomization()),
                 retryManager,
-                TestRetryMetrics.Create(), new Lazy<IMessageDispatcher>(() => sender),
+                TestRetryMetrics.Create(fakeTime), new Lazy<IMessageDispatcher>(() => sender),
                 new RecordingMessageActionAuditLog(),
                 NullLogger<RetryProcessor>.Instance);
 
@@ -142,14 +145,14 @@
         public async Task When_a_group_is_forwarded_the_status_is_Completed()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", true, 1);
 
             var sender = new TestSender();
 
             var returnToSender = new TestReturnToSenderDequeuer(new ReturnToSender(BodyStorage, NullLogger<ReturnToSender>.Instance), FailedMessageLifecycleStore, domainEvents, "TestEndpoint", new ErrorQueueNameCache(), new TestTransportCustomization());
-            var processor = new RetryProcessor(RetryStagingStore, MessageRedirectsDataStore, domainEvents, returnToSender, retryManager, TestRetryMetrics.Create(), new Lazy<IMessageDispatcher>(() => sender), new RecordingMessageActionAuditLog(), NullLogger<RetryProcessor>.Instance);
+            var processor = new RetryProcessor(RetryStagingStore, MessageRedirectsDataStore, domainEvents, returnToSender, retryManager, TestRetryMetrics.Create(fakeTime), new Lazy<IMessageDispatcher>(() => sender), new RecordingMessageActionAuditLog(), NullLogger<RetryProcessor>.Instance);
 
             await processor.ProcessBatches(); // mark ready
             await processor.ProcessBatches();
@@ -197,7 +200,7 @@
         public async Task When_there_is_one_poison_message_it_is_removed_from_batch_and_the_status_is_Complete()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", true, "A", "B", "C");
 
@@ -214,7 +217,7 @@
             };
 
             var returnToSender = new TestReturnToSenderDequeuer(new ReturnToSender(BodyStorage, NullLogger<ReturnToSender>.Instance), FailedMessageLifecycleStore, domainEvents, "TestEndpoint", new ErrorQueueNameCache(), new TestTransportCustomization());
-            var processor = new RetryProcessor(RetryStagingStore, MessageRedirectsDataStore, domainEvents, returnToSender, retryManager, TestRetryMetrics.Create(), new Lazy<IMessageDispatcher>(() => sender), new RecordingMessageActionAuditLog(), NullLogger<RetryProcessor>.Instance);
+            var processor = new RetryProcessor(RetryStagingStore, MessageRedirectsDataStore, domainEvents, returnToSender, retryManager, TestRetryMetrics.Create(fakeTime), new Lazy<IMessageDispatcher>(() => sender), new RecordingMessageActionAuditLog(), NullLogger<RetryProcessor>.Instance);
 
             bool c;
             do
@@ -246,7 +249,7 @@
         public async Task When_a_group_has_one_batch_out_of_two_forwarded_the_status_is_Forwarding()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
 
             await CreateAFailedMessageAndMarkAsPartOfRetryBatch(retryManager, "Test-group", true, 1001);
 
@@ -254,7 +257,7 @@
 
             var sender = new TestSender();
 
-            var processor = new RetryProcessor(RetryStagingStore, MessageRedirectsDataStore, domainEvents, new TestReturnToSenderDequeuer(returnToSender, FailedMessageLifecycleStore, domainEvents, "TestEndpoint", new ErrorQueueNameCache(), new TestTransportCustomization()), retryManager, TestRetryMetrics.Create(), new Lazy<IMessageDispatcher>(() => sender), new RecordingMessageActionAuditLog(), NullLogger<RetryProcessor>.Instance);
+            var processor = new RetryProcessor(RetryStagingStore, MessageRedirectsDataStore, domainEvents, new TestReturnToSenderDequeuer(returnToSender, FailedMessageLifecycleStore, domainEvents, "TestEndpoint", new ErrorQueueNameCache(), new TestTransportCustomization()), retryManager, TestRetryMetrics.Create(fakeTime), new Lazy<IMessageDispatcher>(() => sender), new RecordingMessageActionAuditLog(), NullLogger<RetryProcessor>.Instance);
 
             await CompleteDatabaseOperation();
 
@@ -269,7 +272,7 @@
         public async Task When_a_selection_is_staged_each_message_is_audited_as_a_batch()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
             var user = new AuditUser("alice-sub", "Alice");
             const string operationId = "op-sel";
             var ids = new[] { "A", "B" };
@@ -294,14 +297,14 @@
             await PersistenceTestsContext.InsertFailedMessages(messages);
             await CompleteDatabaseOperation();
 
-            var gateway = new CustomRetriesGateway(true, RetryBatchStore, retryManager);
+            var gateway = new CustomRetriesGateway(true, RetryBatchStore, retryManager, fakeTime);
             await gateway.StartRetryForMessageSelection(ids, user, operationId);
             await CompleteDatabaseOperation();
 
             var audit = new RecordingMessageActionAuditLog();
             var sender = new TestSender();
             var returnToSender = new TestReturnToSenderDequeuer(new ReturnToSender(BodyStorage, NullLogger<ReturnToSender>.Instance), FailedMessageLifecycleStore, domainEvents, "TestEndpoint", new ErrorQueueNameCache(), new TestTransportCustomization());
-            var processor = new RetryProcessor(RetryStagingStore, MessageRedirectsDataStore, domainEvents, returnToSender, retryManager, TestRetryMetrics.Create(), new Lazy<IMessageDispatcher>(() => sender), audit, NullLogger<RetryProcessor>.Instance);
+            var processor = new RetryProcessor(RetryStagingStore, MessageRedirectsDataStore, domainEvents, returnToSender, retryManager, TestRetryMetrics.Create(fakeTime), new Lazy<IMessageDispatcher>(() => sender), audit, NullLogger<RetryProcessor>.Instance);
 
             await processor.ProcessBatches(); // stage
             await processor.ProcessBatches(); // forward
@@ -319,7 +322,7 @@
         public async Task When_a_group_is_staged_each_message_is_audited_with_the_initiating_user()
         {
             var domainEvents = new FakeDomainEvents();
-            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
+            var retryManager = new RetryingManager(domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
             var user = new AuditUser("alice-sub", "Alice");
             const string operationId = "op-abc";
 
@@ -328,7 +331,7 @@
             var audit = new RecordingMessageActionAuditLog();
             var sender = new TestSender();
             var returnToSender = new TestReturnToSenderDequeuer(new ReturnToSender(BodyStorage, NullLogger<ReturnToSender>.Instance), FailedMessageLifecycleStore, domainEvents, "TestEndpoint", new ErrorQueueNameCache(), new TestTransportCustomization());
-            var processor = new RetryProcessor(RetryStagingStore, MessageRedirectsDataStore, domainEvents, returnToSender, retryManager, TestRetryMetrics.Create(), new Lazy<IMessageDispatcher>(() => sender), audit, NullLogger<RetryProcessor>.Instance);
+            var processor = new RetryProcessor(RetryStagingStore, MessageRedirectsDataStore, domainEvents, returnToSender, retryManager, TestRetryMetrics.Create(fakeTime), new Lazy<IMessageDispatcher>(() => sender), audit, NullLogger<RetryProcessor>.Instance);
 
             await processor.ProcessBatches(); // stage (emits per-message audit)
             await processor.ProcessBatches(); // forward
@@ -363,8 +366,8 @@
                 MessageRedirectsDataStore,
                 domainEvents,
                 new TestReturnToSenderDequeuer(new ReturnToSender(BodyStorage, NullLogger<ReturnToSender>.Instance), FailedMessageLifecycleStore, domainEvents, "TestEndpoint", new ErrorQueueNameCache(), new TestTransportCustomization()),
-                new RetryingManager(domainEvents, TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System),
-                TestRetryMetrics.Create(), new Lazy<IMessageDispatcher>(() => sender),
+                new RetryingManager(domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime),
+                TestRetryMetrics.Create(fakeTime), new Lazy<IMessageDispatcher>(() => sender),
                 new RecordingMessageActionAuditLog(),
                 NullLogger<RetryProcessor>.Instance);
 
@@ -411,7 +414,7 @@
             await CompleteDatabaseOperation();
 
             var documentManager = new CustomRetryDocumentManager(progressToStaged, RetryBatchStore, retryManager);
-            var gateway = new CustomRetriesGateway(progressToStaged, RetryBatchStore, retryManager);
+            var gateway = new CustomRetriesGateway(progressToStaged, RetryBatchStore, retryManager, fakeTime);
 
             gateway.EnqueueRetryForFailureGroup(new RetriesGateway.RetryForFailureGroup(groupId, "Test-Context", groupType: null, DateTime.UtcNow, initiatedBy, operationId));
 
@@ -425,8 +428,8 @@
 
         class CustomRetriesGateway : RetriesGateway
         {
-            public CustomRetriesGateway(bool progressToStaged, IRetryBatchStore store, RetryingManager retryManager)
-                : base(store, retryManager, TestRetryMetrics.Create(), NullLogger<RetriesGateway>.Instance, TimeProvider.System)
+            public CustomRetriesGateway(bool progressToStaged, IRetryBatchStore store, RetryingManager retryManager, TimeProvider timeProvider)
+                : base(store, retryManager, TestRetryMetrics.Create(timeProvider), NullLogger<RetriesGateway>.Instance, timeProvider)
             {
                 this.progressToStaged = progressToStaged;
             }

--- a/src/ServiceControl.Persistence/IPersistenceConfiguration.cs
+++ b/src/ServiceControl.Persistence/IPersistenceConfiguration.cs
@@ -4,6 +4,9 @@
 
     public interface IPersistenceConfiguration
     {
+        /// <summary>Whether maintenance mode has anything to expose: only RavenDB, which hosts the database in-process.</summary>
+        bool SupportsMaintenanceMode { get; }
+
         PersistenceSettings CreateSettings(SettingsRootNamespace settingsRootNamespace);
         IPersistence Create(PersistenceSettings settings);
     }

--- a/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryArchive.cs
+++ b/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryArchive.cs
@@ -8,12 +8,13 @@
 
     public class InMemoryArchive // in memory
     {
-        public InMemoryArchive(string requestId, ArchiveType archiveType, IDomainEvents domainEvents, ArchiveMetrics? metrics = null)
+        public InMemoryArchive(string requestId, ArchiveType archiveType, IDomainEvents domainEvents, TimeProvider timeProvider, ArchiveMetrics? metrics = null)
         {
             RequestId = requestId;
             ArchiveType = archiveType;
             this.domainEvents = domainEvents;
             operationMetrics = metrics?.CreateOperation(ArchiveOperationKind.Archive);
+            this.timeProvider = timeProvider;
         }
 
         public int TotalNumberOfMessages { get; set; }
@@ -63,7 +64,7 @@
             ArchiveState = ArchiveState.ArchiveProgressing;
             NumberOfMessagesArchived += numberOfMessagesArchivedInBatch;
             CurrentBatch++;
-            Last = DateTime.UtcNow;
+            Last = timeProvider.GetUtcNow().UtcDateTime;
             operationMetrics?.BatchCompleted(numberOfMessagesArchivedInBatch);
 
             return domainEvents.Raise(new ArchiveOperationBatchCompleted
@@ -80,7 +81,7 @@
         {
             ArchiveState = ArchiveState.ArchiveFinalizing;
             NumberOfMessagesArchived = TotalNumberOfMessages;
-            Last = DateTime.UtcNow;
+            Last = timeProvider.GetUtcNow().UtcDateTime;
             operationMetrics?.Finalizing();
 
             return domainEvents.Raise(new ArchiveOperationFinalizing
@@ -97,8 +98,9 @@
         {
             ArchiveState = ArchiveState.ArchiveCompleted;
             NumberOfMessagesArchived = TotalNumberOfMessages;
-            CompletionTime = DateTime.UtcNow;
-            Last = DateTime.UtcNow;
+            var completedAt = timeProvider.GetUtcNow().UtcDateTime;
+            CompletionTime = completedAt;
+            Last = completedAt;
             operationMetrics?.Completed();
 
             return domainEvents.Raise(new ArchiveOperationCompleted
@@ -120,5 +122,6 @@
 
         IDomainEvents domainEvents;
         readonly ArchiveOperationMetrics? operationMetrics;
+        readonly TimeProvider timeProvider;
     }
 }

--- a/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryUnarchive.cs
+++ b/src/ServiceControl.Persistence/Recoverability/Archiving/InMemoryUnarchive.cs
@@ -8,12 +8,13 @@
 
     public class InMemoryUnarchive // in memory
     {
-        public InMemoryUnarchive(string requestId, ArchiveType archiveType, IDomainEvents domainEvents, ArchiveMetrics? metrics = null)
+        public InMemoryUnarchive(string requestId, ArchiveType archiveType, IDomainEvents domainEvents, TimeProvider timeProvider, ArchiveMetrics? metrics = null)
         {
             RequestId = requestId;
             ArchiveType = archiveType;
             this.domainEvents = domainEvents;
             operationMetrics = metrics?.CreateOperation(ArchiveOperationKind.Unarchive);
+            this.timeProvider = timeProvider;
         }
 
         public int TotalNumberOfMessages { get; set; }
@@ -63,7 +64,7 @@
             ArchiveState = ArchiveState.ArchiveProgressing;
             NumberOfMessagesUnarchived += numberOfMessagesUnarchivedInBatch;
             CurrentBatch++;
-            Last = DateTime.UtcNow;
+            Last = timeProvider.GetUtcNow().UtcDateTime;
             operationMetrics?.BatchCompleted(numberOfMessagesUnarchivedInBatch);
 
             return domainEvents.Raise(new UnarchiveOperationBatchCompleted
@@ -80,7 +81,7 @@
         {
             ArchiveState = ArchiveState.ArchiveFinalizing;
             NumberOfMessagesUnarchived = TotalNumberOfMessages;
-            Last = DateTime.UtcNow;
+            Last = timeProvider.GetUtcNow().UtcDateTime;
             operationMetrics?.Finalizing();
 
             return domainEvents.Raise(new UnarchiveOperationFinalizing
@@ -97,8 +98,9 @@
         {
             ArchiveState = ArchiveState.ArchiveCompleted;
             NumberOfMessagesUnarchived = TotalNumberOfMessages;
-            CompletionTime = DateTime.UtcNow;
-            Last = DateTime.UtcNow;
+            var completedAt = timeProvider.GetUtcNow().UtcDateTime;
+            CompletionTime = completedAt;
+            Last = completedAt;
             operationMetrics?.Completed();
 
             return domainEvents.Raise(new UnarchiveOperationCompleted
@@ -120,5 +122,6 @@
 
         IDomainEvents domainEvents;
         readonly ArchiveOperationMetrics? operationMetrics;
+        readonly TimeProvider timeProvider;
     }
 }

--- a/src/ServiceControl.UnitTests/MessageRedirects/MessageRedirectsControllerClockTests.cs
+++ b/src/ServiceControl.UnitTests/MessageRedirects/MessageRedirectsControllerClockTests.cs
@@ -1,0 +1,78 @@
+namespace ServiceControl.UnitTests.MessageRedirects;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NServiceBus.Testing;
+using NUnit.Framework;
+using ServiceControl.MessageRedirects.Api;
+using ServiceControl.Persistence.MessageRedirects;
+using ServiceControl.UnitTests.Operations;
+
+[TestFixture]
+public class MessageRedirectsControllerClockTests
+{
+    static readonly DateTime FixedNow = new(2026, 3, 4, 5, 6, 7, DateTimeKind.Utc);
+
+    [Test]
+    public async Task Creating_a_redirect_stamps_the_injected_clock()
+    {
+        var store = new RecordingRedirectsStore();
+        var controller = NewController(store);
+
+        await controller.NewRedirects(new MessageRedirectsController.MessageRedirectRequest { FromPhysicalAddress = "A", ToPhysicalAddress = "B" });
+
+        Assert.That(store.Redirects.Single().LastModified, Is.EqualTo(FixedNow));
+    }
+
+    [Test]
+    public async Task Updating_a_redirect_stamps_the_injected_clock()
+    {
+        var existing = new MessageRedirect
+        {
+            FromPhysicalAddress = "A",
+            ToPhysicalAddress = "B",
+            LastModified = FixedNow.AddDays(-10)
+        };
+
+        var store = new RecordingRedirectsStore();
+        store.Redirects.Add(existing);
+        var controller = NewController(store);
+
+        await controller.UpdateRedirect(existing.MessageRedirectId, new MessageRedirectsController.MessageRedirectRequest { ToPhysicalAddress = "C" });
+
+        Assert.That(store.Redirects.Single().LastModified, Is.EqualTo(FixedNow));
+    }
+
+    static MessageRedirectsController NewController(IMessageRedirectsDataStore store) =>
+        new(new TestableMessageSession(), store, new FakeDomainEvents(), new FixedClock(FixedNow));
+
+    sealed class RecordingRedirectsStore : IMessageRedirectsDataStore
+    {
+        public List<MessageRedirect> Redirects { get; } = [];
+
+        public Task<IReadOnlyList<MessageRedirect>> GetRedirects(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MessageRedirect>>(Redirects);
+
+        public Task AddRedirect(MessageRedirect redirect, CancellationToken cancellationToken = default)
+        {
+            Redirects.Add(redirect);
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateRedirect(MessageRedirect redirect, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task RemoveRedirect(MessageRedirect redirect, CancellationToken cancellationToken = default)
+        {
+            Redirects.Remove(redirect);
+            return Task.CompletedTask;
+        }
+    }
+
+    sealed class FixedClock(DateTime now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => new(now, TimeSpan.Zero);
+    }
+}

--- a/src/ServiceControl.UnitTests/Recoverability/FailureGroupsRetryControllerAuditTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/FailureGroupsRetryControllerAuditTests.cs
@@ -23,7 +23,7 @@ public class FailureGroupsRetryControllerAuditTests
         var audit = new RecordingMessageActionAuditLog();
         var user = new AuditUser("alice-sub", "Alice");
         var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
-        var controller = new FailureGroupsRetryController(session, retryingManager, new StubCurrentUserAccessor(user), audit);
+        var controller = new FailureGroupsRetryController(session, retryingManager, new StubCurrentUserAccessor(user), audit, TimeProvider.System);
 
         await controller.ArchiveGroupErrors("group-42");
 
@@ -43,7 +43,7 @@ public class FailureGroupsRetryControllerAuditTests
         var audit = new RecordingMessageActionAuditLog();
         var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
         await retryingManager.Preparing("group-42", RetryType.FailureGroup, totalNumberOfMessages: 10);
-        var controller = new FailureGroupsRetryController(session, retryingManager, new StubCurrentUserAccessor(new AuditUser("alice-sub", "Alice")), audit);
+        var controller = new FailureGroupsRetryController(session, retryingManager, new StubCurrentUserAccessor(new AuditUser("alice-sub", "Alice")), audit, TimeProvider.System);
 
         await controller.ArchiveGroupErrors("group-42");
 

--- a/src/ServiceControl.UnitTests/Recoverability/FailureGroupsRetryControllerAuditTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/FailureGroupsRetryControllerAuditTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using NServiceBus.Testing;
 using NUnit.Framework;
 using ServiceControl.Infrastructure.Auth;
@@ -16,14 +17,16 @@ using ServiceControl.UnitTests.Operations;
 [TestFixture]
 public class FailureGroupsRetryControllerAuditTests
 {
+    readonly FakeTimeProvider fakeTime = new(DateTimeOffset.UtcNow);
+
     [Test]
     public async Task Emits_group_retry_operation_entry()
     {
         var session = new TestableMessageSession();
         var audit = new RecordingMessageActionAuditLog();
         var user = new AuditUser("alice-sub", "Alice");
-        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
-        var controller = new FailureGroupsRetryController(session, retryingManager, new StubCurrentUserAccessor(user), audit, TimeProvider.System);
+        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
+        var controller = new FailureGroupsRetryController(session, retryingManager, new StubCurrentUserAccessor(user), audit, fakeTime);
 
         await controller.ArchiveGroupErrors("group-42");
 
@@ -41,9 +44,9 @@ public class FailureGroupsRetryControllerAuditTests
     {
         var session = new TestableMessageSession();
         var audit = new RecordingMessageActionAuditLog();
-        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
+        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger<RetryingManager>.Instance, fakeTime);
         await retryingManager.Preparing("group-42", RetryType.FailureGroup, totalNumberOfMessages: 10);
-        var controller = new FailureGroupsRetryController(session, retryingManager, new StubCurrentUserAccessor(new AuditUser("alice-sub", "Alice")), audit, TimeProvider.System);
+        var controller = new FailureGroupsRetryController(session, retryingManager, new StubCurrentUserAccessor(new AuditUser("alice-sub", "Alice")), audit, fakeTime);
 
         await controller.ArchiveGroupErrors("group-42");
 

--- a/src/ServiceControl.UnitTests/Recoverability/FailureGroupsRetryControllerAuditTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/FailureGroupsRetryControllerAuditTests.cs
@@ -22,7 +22,7 @@ public class FailureGroupsRetryControllerAuditTests
         var session = new TestableMessageSession();
         var audit = new RecordingMessageActionAuditLog();
         var user = new AuditUser("alice-sub", "Alice");
-        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
         var controller = new FailureGroupsRetryController(session, retryingManager, new StubCurrentUserAccessor(user), audit);
 
         await controller.ArchiveGroupErrors("group-42");
@@ -41,7 +41,7 @@ public class FailureGroupsRetryControllerAuditTests
     {
         var session = new TestableMessageSession();
         var audit = new RecordingMessageActionAuditLog();
-        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance);
+        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, TimeProvider.System);
         await retryingManager.Preparing("group-42", RetryType.FailureGroup, totalNumberOfMessages: 10);
         var controller = new FailureGroupsRetryController(session, retryingManager, new StubCurrentUserAccessor(new AuditUser("alice-sub", "Alice")), audit);
 

--- a/src/ServiceControl.UnitTests/Recoverability/Metrics/RetryMetricsTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/Metrics/RetryMetricsTests.cs
@@ -6,6 +6,7 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
     using System.Linq;
     using System.Threading;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Time.Testing;
     using NUnit.Framework;
     using ServiceControl.Persistence;
     using ServiceControl.Recoverability;
@@ -19,7 +20,11 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
     class RetryMetricsTests
     {
         [SetUp]
-        public void CreateMeterFactory() => provider = new ServiceCollection().AddMetrics().BuildServiceProvider();
+        public void CreateMeterFactory()
+        {
+            provider = new ServiceCollection().AddMetrics().BuildServiceProvider();
+            fakeTime = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        }
 
         [TearDown]
         public void DisposeMeterFactory() => provider.Dispose();
@@ -42,7 +47,7 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
 
             listener.Start();
 
-            var metrics = new RetryMetrics(MeterFactory, TimeProvider.System);
+            var metrics = new RetryMetrics(MeterFactory, fakeTime);
             metrics.ObserveOperationsInProgress(() => []);
             metrics.ObservePendingBulkRequests(() => 0);
 
@@ -61,7 +66,7 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
         [Test]
         public void Every_retry_type_maps_to_its_own_tag_value()
         {
-            var metrics = new RetryMetrics(MeterFactory, TimeProvider.System);
+            var metrics = new RetryMetrics(MeterFactory, fakeTime);
             using var recorded = new RecordedRetryMetrics(MeterFactory);
 
             foreach (var retryType in Enum.GetValues<RetryType>())
@@ -77,7 +82,7 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
         [Test]
         public void Operation_completion_is_tagged_with_its_result()
         {
-            var metrics = new RetryMetrics(MeterFactory, TimeProvider.System);
+            var metrics = new RetryMetrics(MeterFactory, fakeTime);
             using var recorded = new RecordedRetryMetrics(MeterFactory);
 
             metrics.RecordOperationCompleted(RetryType.FailureGroup, metrics.GetTimestamp(), failed: false);
@@ -94,7 +99,7 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
         [Test]
         public void A_scope_records_the_outcome_it_was_given()
         {
-            var metrics = new RetryMetrics(MeterFactory, TimeProvider.System);
+            var metrics = new RetryMetrics(MeterFactory, fakeTime);
             using var recorded = new RecordedRetryMetrics(MeterFactory);
 
             using (var staging = metrics.BeginStaging(RetryType.FailureGroup))
@@ -119,7 +124,7 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
         [Test]
         public void A_scope_cut_short_by_shutdown_is_recorded_as_cancelled()
         {
-            var metrics = new RetryMetrics(MeterFactory, TimeProvider.System);
+            var metrics = new RetryMetrics(MeterFactory, fakeTime);
             using var recorded = new RecordedRetryMetrics(MeterFactory);
             using var shutdown = new CancellationTokenSource();
 
@@ -134,7 +139,7 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
         [Test]
         public void A_scope_that_finished_before_shutdown_is_still_a_success()
         {
-            var metrics = new RetryMetrics(MeterFactory, TimeProvider.System);
+            var metrics = new RetryMetrics(MeterFactory, fakeTime);
             using var recorded = new RecordedRetryMetrics(MeterFactory);
             using var shutdown = new CancellationTokenSource();
 
@@ -150,7 +155,7 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
         [Test]
         public void Forwarding_is_tagged_with_its_mode()
         {
-            var metrics = new RetryMetrics(MeterFactory, TimeProvider.System);
+            var metrics = new RetryMetrics(MeterFactory, fakeTime);
             using var recorded = new RecordedRetryMetrics(MeterFactory);
 
             using (var forwarding = metrics.BeginForwarding(RetryType.FailureGroup, recoveringFromPrematureShutdown: false))
@@ -171,7 +176,7 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
         [Test]
         public void The_gauge_counts_operations_by_type_and_state_and_excludes_completed()
         {
-            var metrics = new RetryMetrics(MeterFactory, TimeProvider.System);
+            var metrics = new RetryMetrics(MeterFactory, fakeTime);
             using var recorded = new RecordedRetryMetrics(MeterFactory);
 
             metrics.ObserveOperationsInProgress(() =>
@@ -197,7 +202,7 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
         [Test]
         public void The_bulk_request_gauge_reads_the_queue_depth()
         {
-            var metrics = new RetryMetrics(MeterFactory, TimeProvider.System);
+            var metrics = new RetryMetrics(MeterFactory, fakeTime);
             using var recorded = new RecordedRetryMetrics(MeterFactory);
 
             var depth = 3;
@@ -218,5 +223,6 @@ namespace ServiceControl.UnitTests.Recoverability.Metrics
         IMeterFactory MeterFactory => provider.GetRequiredService<IMeterFactory>();
 
         ServiceProvider provider;
+        FakeTimeProvider fakeTime;
     }
 }

--- a/src/ServiceControl.UnitTests/Recoverability/OperationProgressClockTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/OperationProgressClockTests.cs
@@ -82,7 +82,7 @@ public class OperationProgressClockTests
     [Test]
     public async Task Retry_completion_comes_from_the_injected_clock()
     {
-        var retry = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, new FixedClock(FixedNow));
+        var retry = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(new FixedClock(FixedNow)), NullLogger.Instance, new FixedClock(FixedNow));
 
         await retry.Prepare(1000);
         await retry.PrepareBatch(1000);

--- a/src/ServiceControl.UnitTests/Recoverability/OperationProgressClockTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/OperationProgressClockTests.cs
@@ -58,7 +58,11 @@ public class OperationProgressClockTests
 
         await archive.Complete();
 
-        Assert.That(archive.CompletionTime, Is.EqualTo(archive.Last));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(archive.CompletionTime, Is.EqualTo(FixedNow));
+            Assert.That(archive.Last, Is.EqualTo(FixedNow));
+        }
     }
 
     [Test]
@@ -68,7 +72,11 @@ public class OperationProgressClockTests
 
         await unarchive.Complete();
 
-        Assert.That(unarchive.CompletionTime, Is.EqualTo(unarchive.Last));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(unarchive.CompletionTime, Is.EqualTo(FixedNow));
+            Assert.That(unarchive.Last, Is.EqualTo(FixedNow));
+        }
     }
 
     [Test]

--- a/src/ServiceControl.UnitTests/Recoverability/OperationProgressClockTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/OperationProgressClockTests.cs
@@ -1,0 +1,108 @@
+namespace ServiceControl.UnitTests.Recoverability;
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using ServiceControl.Persistence;
+using ServiceControl.Recoverability;
+using ServiceControl.UnitTests.Operations;
+
+[TestFixture]
+public class OperationProgressClockTests
+{
+    static readonly DateTime FixedNow = new(2026, 3, 4, 5, 6, 7, DateTimeKind.Utc);
+
+    [Test]
+    public async Task Archive_progress_and_completion_come_from_the_injected_clock()
+    {
+        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), new FixedClock(FixedNow));
+
+        await archive.BatchArchived(1);
+        Assert.That(archive.Last, Is.EqualTo(FixedNow));
+
+        await archive.FinalizeArchive();
+        Assert.That(archive.Last, Is.EqualTo(FixedNow));
+
+        await archive.Complete();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(archive.CompletionTime, Is.EqualTo(FixedNow));
+            Assert.That(archive.Last, Is.EqualTo(FixedNow));
+        }
+    }
+
+    [Test]
+    public async Task Unarchive_progress_and_completion_come_from_the_injected_clock()
+    {
+        var unarchive = new InMemoryUnarchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), new FixedClock(FixedNow));
+
+        await unarchive.BatchUnarchived(1);
+        Assert.That(unarchive.Last, Is.EqualTo(FixedNow));
+
+        await unarchive.FinalizeUnarchive();
+        Assert.That(unarchive.Last, Is.EqualTo(FixedNow));
+
+        await unarchive.Complete();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(unarchive.CompletionTime, Is.EqualTo(FixedNow));
+            Assert.That(unarchive.Last, Is.EqualTo(FixedNow));
+        }
+    }
+
+    [Test]
+    public async Task Completing_an_archive_reads_the_clock_once()
+    {
+        var archive = new InMemoryArchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), new TickingClock(FixedNow));
+
+        await archive.Complete();
+
+        Assert.That(archive.CompletionTime, Is.EqualTo(archive.Last));
+    }
+
+    [Test]
+    public async Task Completing_an_unarchive_reads_the_clock_once()
+    {
+        var unarchive = new InMemoryUnarchive("group-1", ArchiveType.FailureGroup, new FakeDomainEvents(), new TickingClock(FixedNow));
+
+        await unarchive.Complete();
+
+        Assert.That(unarchive.CompletionTime, Is.EqualTo(unarchive.Last));
+    }
+
+    [Test]
+    public async Task Retry_completion_comes_from_the_injected_clock()
+    {
+        var retry = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, new FixedClock(FixedNow));
+
+        await retry.Prepare(1000);
+        await retry.PrepareBatch(1000);
+        await retry.Forwarding();
+        await retry.BatchForwarded(1000);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(retry.RetryState, Is.EqualTo(RetryState.Completed));
+            Assert.That(retry.CompletionTime, Is.EqualTo(FixedNow));
+        }
+    }
+
+    sealed class FixedClock(DateTime now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => new(now, TimeSpan.Zero);
+    }
+
+    // Moves on every read, so a member that reads twice cannot get the same value twice.
+    sealed class TickingClock(DateTime start) : TimeProvider
+    {
+        DateTime next = start;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            var value = next;
+            next = next.AddSeconds(1);
+            return new DateTimeOffset(value, TimeSpan.Zero);
+        }
+    }
+}

--- a/src/ServiceControl.UnitTests/Recoverability/RetryOperationTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/RetryOperationTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging.Abstractions;
+    using Microsoft.Extensions.Time.Testing;
     using NUnit.Framework;
     using ServiceControl.Persistence;
     using ServiceControl.Recoverability;
@@ -11,10 +12,12 @@
     [TestFixture]
     public class RetryOperationTests
     {
+        readonly FakeTimeProvider fakeTime = new(DateTimeOffset.UtcNow);
+
         [Test]
         public async Task Wait_should_set_wait_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             await summary.Wait(DateTime.UtcNow, "FailureGroup1");
             using (Assert.EnterMultipleScope())
             {
@@ -30,7 +33,7 @@
         [Test]
         public void Fail_should_set_failed()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             summary.Fail();
             Assert.That(summary.Failed, Is.True);
         }
@@ -38,7 +41,7 @@
         [Test]
         public async Task Prepare_should_set_prepare_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             await summary.Prepare(1000);
             using (Assert.EnterMultipleScope())
             {
@@ -51,7 +54,7 @@
         [Test]
         public async Task Prepared_batch_should_set_prepare_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
             using (Assert.EnterMultipleScope())
@@ -65,7 +68,7 @@
         [Test]
         public async Task Forwarding_should_set_forwarding_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
             await summary.Forwarding();
@@ -81,7 +84,7 @@
         [Test]
         public async Task Batch_forwarded_should_set_forwarding_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
             await summary.Forwarding();
@@ -99,7 +102,7 @@
         public async Task Should_raise_domain_events()
         {
             var domainEvents = new FakeDomainEvents();
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, domainEvents, TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, domainEvents, TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
             await summary.Forwarding();
@@ -118,7 +121,7 @@
         [Test]
         public async Task Batch_forwarded_all_forwarded_should_set_completed_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
             await summary.Forwarding();
@@ -135,7 +138,7 @@
         [Test]
         public async Task Skip_should_set_update_skipped_messages()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             await summary.Wait(DateTime.UtcNow);
             await summary.Prepare(2000);
             await summary.PrepareBatch(1000);
@@ -151,7 +154,7 @@
         [Test]
         public async Task Skip_should_complete_when_all_skipped()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             await summary.Wait(DateTime.UtcNow);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
@@ -167,7 +170,7 @@
         [Test]
         public async Task Skip_and_forward_combination_should_complete_when_done()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(fakeTime), NullLogger.Instance, fakeTime);
             await summary.Wait(DateTime.UtcNow);
             await summary.Prepare(2000);
             await summary.PrepareBatch(1000);

--- a/src/ServiceControl.UnitTests/Recoverability/RetryOperationTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/RetryOperationTests.cs
@@ -14,7 +14,7 @@
         [Test]
         public async Task Wait_should_set_wait_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             await summary.Wait(DateTime.UtcNow, "FailureGroup1");
             using (Assert.EnterMultipleScope())
             {
@@ -30,7 +30,7 @@
         [Test]
         public void Fail_should_set_failed()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             summary.Fail();
             Assert.That(summary.Failed, Is.True);
         }
@@ -38,7 +38,7 @@
         [Test]
         public async Task Prepare_should_set_prepare_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             await summary.Prepare(1000);
             using (Assert.EnterMultipleScope())
             {
@@ -51,7 +51,7 @@
         [Test]
         public async Task Prepared_batch_should_set_prepare_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
             using (Assert.EnterMultipleScope())
@@ -65,7 +65,7 @@
         [Test]
         public async Task Forwarding_should_set_forwarding_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
             await summary.Forwarding();
@@ -81,7 +81,7 @@
         [Test]
         public async Task Batch_forwarded_should_set_forwarding_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
             await summary.Forwarding();
@@ -99,7 +99,7 @@
         public async Task Should_raise_domain_events()
         {
             var domainEvents = new FakeDomainEvents();
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, domainEvents, TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, domainEvents, TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
             await summary.Forwarding();
@@ -118,7 +118,7 @@
         [Test]
         public async Task Batch_forwarded_all_forwarded_should_set_completed_state()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
             await summary.Forwarding();
@@ -135,7 +135,7 @@
         [Test]
         public async Task Skip_should_set_update_skipped_messages()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             await summary.Wait(DateTime.UtcNow);
             await summary.Prepare(2000);
             await summary.PrepareBatch(1000);
@@ -151,7 +151,7 @@
         [Test]
         public async Task Skip_should_complete_when_all_skipped()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             await summary.Wait(DateTime.UtcNow);
             await summary.Prepare(1000);
             await summary.PrepareBatch(1000);
@@ -167,7 +167,7 @@
         [Test]
         public async Task Skip_and_forward_combination_should_complete_when_done()
         {
-            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance);
+            var summary = new InMemoryRetry("abc123", RetryType.FailureGroup, new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger.Instance, TimeProvider.System);
             await summary.Wait(DateTime.UtcNow);
             await summary.Prepare(2000);
             await summary.PrepareBatch(1000);

--- a/src/ServiceControl.UnitTests/Recoverability/RetryStartTimeTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/RetryStartTimeTests.cs
@@ -1,0 +1,63 @@
+#nullable enable
+namespace ServiceControl.UnitTests.Recoverability;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using NServiceBus.Testing;
+using NUnit.Framework;
+using ServiceControl.Infrastructure.Auth;
+using ServiceControl.Persistence;
+using ServiceControl.Recoverability;
+using ServiceControl.Recoverability.API;
+using ServiceControl.UnitTests.Operations;
+
+[TestFixture]
+public class RetryStartTimeTests
+{
+    static readonly DateTimeOffset ClockStart = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [Test]
+    public async Task Group_retry_takes_its_start_time_from_the_injected_clock()
+    {
+        var clock = new FakeTimeProvider(ClockStart);
+        var session = new TestableMessageSession();
+        var retryingManager = new RetryingManager(new FakeDomainEvents(), NullLogger<RetryingManager>.Instance, clock);
+
+        await NewController(session, retryingManager, clock).ArchiveGroupErrors("group-42");
+
+        var sent = (RetryAllInGroup)session.SentMessages.Single().Message;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sent.Started, Is.EqualTo(ClockStart.UtcDateTime));
+            Assert.That(retryingManager.GetStatusForRetryOperation("group-42", RetryType.FailureGroup).Started, Is.EqualTo(ClockStart.UtcDateTime));
+        }
+    }
+
+    [Test]
+    public async Task A_completed_group_retry_never_finishes_before_it_started()
+    {
+        var clock = new FakeTimeProvider(ClockStart);
+        var retryingManager = new RetryingManager(new FakeDomainEvents(), NullLogger<RetryingManager>.Instance, clock);
+
+        await NewController(new TestableMessageSession(), retryingManager, clock).ArchiveGroupErrors("group-42");
+
+        clock.Advance(TimeSpan.FromMinutes(5));
+        await retryingManager.Preparing("group-42", RetryType.FailureGroup, totalNumberOfMessages: 1);
+        await retryingManager.PreparedBatch("group-42", RetryType.FailureGroup, numberOfMessagesPrepared: 1);
+        await retryingManager.Forwarding("group-42", RetryType.FailureGroup);
+        await retryingManager.ForwardedBatch("group-42", RetryType.FailureGroup, numberOfMessagesForwarded: 1);
+
+        var operation = retryingManager.GetStatusForRetryOperation("group-42", RetryType.FailureGroup);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(operation.Started, Is.EqualTo(ClockStart.UtcDateTime));
+            Assert.That(operation.CompletionTime, Is.EqualTo(ClockStart.UtcDateTime.AddMinutes(5)));
+        }
+    }
+
+    static FailureGroupsRetryController NewController(TestableMessageSession session, RetryingManager retryingManager, TimeProvider clock) =>
+        new(session, retryingManager, new StubCurrentUserAccessor(new AuditUser("alice-sub", "Alice")), new RecordingMessageActionAuditLog(), clock);
+}

--- a/src/ServiceControl.UnitTests/Recoverability/RetryStartTimeTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/RetryStartTimeTests.cs
@@ -24,7 +24,7 @@ public class RetryStartTimeTests
     {
         var clock = new FakeTimeProvider(ClockStart);
         var session = new TestableMessageSession();
-        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, clock);
+        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(clock), NullLogger<RetryingManager>.Instance, clock);
 
         await NewController(session, retryingManager, clock).ArchiveGroupErrors("group-42");
 
@@ -40,7 +40,7 @@ public class RetryStartTimeTests
     public async Task A_completed_group_retry_never_finishes_before_it_started()
     {
         var clock = new FakeTimeProvider(ClockStart);
-        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, clock);
+        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(clock), NullLogger<RetryingManager>.Instance, clock);
 
         await NewController(new TestableMessageSession(), retryingManager, clock).ArchiveGroupErrors("group-42");
 

--- a/src/ServiceControl.UnitTests/Recoverability/RetryStartTimeTests.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/RetryStartTimeTests.cs
@@ -24,7 +24,7 @@ public class RetryStartTimeTests
     {
         var clock = new FakeTimeProvider(ClockStart);
         var session = new TestableMessageSession();
-        var retryingManager = new RetryingManager(new FakeDomainEvents(), NullLogger<RetryingManager>.Instance, clock);
+        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, clock);
 
         await NewController(session, retryingManager, clock).ArchiveGroupErrors("group-42");
 
@@ -40,7 +40,7 @@ public class RetryStartTimeTests
     public async Task A_completed_group_retry_never_finishes_before_it_started()
     {
         var clock = new FakeTimeProvider(ClockStart);
-        var retryingManager = new RetryingManager(new FakeDomainEvents(), NullLogger<RetryingManager>.Instance, clock);
+        var retryingManager = new RetryingManager(new FakeDomainEvents(), TestRetryMetrics.Create(), NullLogger<RetryingManager>.Instance, clock);
 
         await NewController(new TestableMessageSession(), retryingManager, clock).ArchiveGroupErrors("group-42");
 

--- a/src/ServiceControl.UnitTests/Recoverability/TestRetryMetrics.cs
+++ b/src/ServiceControl.UnitTests/Recoverability/TestRetryMetrics.cs
@@ -6,7 +6,7 @@ namespace ServiceControl.UnitTests.Recoverability
 
     static class TestRetryMetrics
     {
-        public static RetryMetrics Create() => new(new TestMeterFactory(), TimeProvider.System);
+        public static RetryMetrics Create(TimeProvider timeProvider) => new(new TestMeterFactory(), timeProvider);
     }
 
     sealed class TestMeterFactory : IMeterFactory

--- a/src/ServiceControl/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl/HostApplicationBuilderExtensions.cs
@@ -70,6 +70,9 @@
             transportCustomization.AddTransportForPrimary(services, transportSettings);
 
             services.Configure<HostOptions>(options => options.ShutdownTimeout = settings.ShutdownTimeout);
+
+            services.TryAddSingleton(TimeProvider.System);
+
             services.AddSingleton<IDomainEvents, DomainEvents>();
 
             // Message-action audit trail. Registered here rather than in AddServiceControlAuthorization

--- a/src/ServiceControl/MessageRedirects/Api/MessageRedirectsController.cs
+++ b/src/ServiceControl/MessageRedirects/Api/MessageRedirectsController.cs
@@ -39,11 +39,13 @@
                 return BadRequest();
             }
 
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+
             var messageRedirect = new MessageRedirect
             {
                 FromPhysicalAddress = request.FromPhysicalAddress,
                 ToPhysicalAddress = request.ToPhysicalAddress,
-                LastModified = timeProvider.GetUtcNow().UtcDateTime
+                LastModified = now
             };
 
             var redirects = await store.GetRedirects(cancellationToken);
@@ -88,7 +90,7 @@
                 {
                     QueueAddress = messageRedirect.FromPhysicalAddress,
                     PeriodFrom = DateTime.MinValue,
-                    PeriodTo = timeProvider.GetUtcNow().UtcDateTime
+                    PeriodTo = now
                 }, cancellationToken);
             }
 

--- a/src/ServiceControl/MessageRedirects/Api/MessageRedirectsController.cs
+++ b/src/ServiceControl/MessageRedirects/Api/MessageRedirectsController.cs
@@ -25,7 +25,8 @@
     public class MessageRedirectsController(
         IMessageSession session,
         IMessageRedirectsDataStore store,
-        IDomainEvents events)
+        IDomainEvents events,
+        TimeProvider timeProvider)
         : ControllerBase
     {
         [Authorize(Policy = Permissions.ErrorRedirectsManage)]
@@ -42,7 +43,7 @@
             {
                 FromPhysicalAddress = request.FromPhysicalAddress,
                 ToPhysicalAddress = request.ToPhysicalAddress,
-                LastModified = DateTime.UtcNow
+                LastModified = timeProvider.GetUtcNow().UtcDateTime
             };
 
             var redirects = await store.GetRedirects(cancellationToken);
@@ -87,7 +88,7 @@
                 {
                     QueueAddress = messageRedirect.FromPhysicalAddress,
                     PeriodFrom = DateTime.MinValue,
-                    PeriodTo = DateTime.UtcNow
+                    PeriodTo = timeProvider.GetUtcNow().UtcDateTime
                 }, cancellationToken);
             }
 
@@ -129,7 +130,7 @@
                 ToPhysicalAddress = messageRedirect.ToPhysicalAddress = request.ToPhysicalAddress
             };
 
-            messageRedirect.LastModified = DateTime.UtcNow;
+            messageRedirect.LastModified = timeProvider.GetUtcNow().UtcDateTime;
 
             await store.UpdateRedirect(messageRedirect, cancellationToken);
 

--- a/src/ServiceControl/Persistence/PersistenceFactory.cs
+++ b/src/ServiceControl/Persistence/PersistenceFactory.cs
@@ -10,6 +10,11 @@ namespace ServiceControl.Persistence
         {
             var persistenceConfiguration = CreatePersistenceConfiguration(settings);
 
+            if (maintenanceMode && !persistenceConfiguration.SupportsMaintenanceMode)
+            {
+                throw new Exception($"Maintenance mode is not supported by the {settings.PersistenceType} persister. It is only available on RavenDB, where it starts the embedded database so RavenDB Studio can be used.");
+            }
+
             //HINT: This is false when executed from acceptance tests
             settings.PersisterSpecificSettings ??= persistenceConfiguration.CreateSettings(Settings.SettingsRootNamespace);
             settings.PersisterSpecificSettings.MaintenanceMode = maintenanceMode;

--- a/src/ServiceControl/Recoverability/API/FailureGroupsRetryController.cs
+++ b/src/ServiceControl/Recoverability/API/FailureGroupsRetryController.cs
@@ -16,14 +16,15 @@ namespace ServiceControl.Recoverability.API
         IMessageSession bus,
         RetryingManager retryingManager,
         ICurrentUserAccessor userAccessor,
-        IMessageActionAuditLog auditLog) : ControllerBase
+        IMessageActionAuditLog auditLog,
+        TimeProvider timeProvider) : ControllerBase
     {
         [Authorize(Policy = Permissions.ErrorRecoverabilityGroupsRetry)]
         [Route("recoverability/groups/{groupId:required:minlength(1)}/errors/retry")]
         [HttpPost]
         public async Task<IActionResult> ArchiveGroupErrors(string groupId, CancellationToken cancellationToken = default)
         {
-            var started = DateTime.UtcNow;
+            var started = timeProvider.GetUtcNow().UtcDateTime;
 
             if (!retryingManager.IsOperationInProgressFor(groupId, RetryType.FailureGroup))
             {

--- a/src/ServiceControl/Recoverability/Retrying/Handlers/RetryAllInGroupHandler.cs
+++ b/src/ServiceControl/Recoverability/Retrying/Handlers/RetryAllInGroupHandler.cs
@@ -9,7 +9,7 @@ namespace ServiceControl.Recoverability
     using ServiceControl.Persistence.Recoverability;
 
     [Handler]
-    class RetryAllInGroupHandler(RetriesGateway retries, RetryingManager retryingManager, IArchiveMessages archiver, IGroupsDataStore dataStore, ILogger<RetryAllInGroupHandler> logger)
+    class RetryAllInGroupHandler(RetriesGateway retries, RetryingManager retryingManager, IArchiveMessages archiver, IGroupsDataStore dataStore, ILogger<RetryAllInGroupHandler> logger, TimeProvider timeProvider)
         : IHandleMessages<RetryAllInGroup>
     {
         public async Task Handle(RetryAllInGroup message, IMessageHandlerContext context)
@@ -35,7 +35,7 @@ namespace ServiceControl.Recoverability
                 originator = group.Title;
             }
 
-            var started = message.Started ?? DateTime.UtcNow;
+            var started = message.Started ?? timeProvider.GetUtcNow().UtcDateTime;
             await retryingManager.Wait(message.GroupId, RetryType.FailureGroup, started, originator, group?.Type, group?.Last, context.CancellationToken);
 
             var (user, operationId) = AuditHeaders.Read(context.MessageHeaders);

--- a/src/ServiceControl/Recoverability/Retrying/InMemoryRetry.cs
+++ b/src/ServiceControl/Recoverability/Retrying/InMemoryRetry.cs
@@ -10,7 +10,7 @@
 
     public class InMemoryRetry
     {
-        public InMemoryRetry(string requestId, RetryType retryType, IDomainEvents domainEvents, RetryMetrics metrics, ILogger logger)
+        public InMemoryRetry(string requestId, RetryType retryType, IDomainEvents domainEvents, RetryMetrics metrics, ILogger logger, TimeProvider timeProvider)
         {
             RequestId = requestId;
             RetryType = retryType;
@@ -18,6 +18,7 @@
             this.metrics = metrics;
             this.logger = logger;
             operationStartTimestamp = metrics.GetTimestamp();
+            this.timeProvider = timeProvider;
         }
 
         public string RequestId { get; }
@@ -166,7 +167,7 @@
             }
 
             RetryState = RetryState.Completed;
-            CompletionTime = DateTime.UtcNow;
+            CompletionTime = timeProvider.GetUtcNow().UtcDateTime;
             metrics.RecordOperationCompleted(RetryType, operationStartTimestamp, Failed);
 
             await domainEvents.Raise(new RetryOperationCompleted
@@ -226,5 +227,6 @@
         IDomainEvents domainEvents;
         readonly RetryMetrics metrics;
         readonly ILogger logger;
+        readonly TimeProvider timeProvider;
     }
 }

--- a/src/ServiceControl/Recoverability/Retrying/RetriesGateway.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetriesGateway.cs
@@ -15,12 +15,13 @@ namespace ServiceControl.Recoverability
 
     class RetriesGateway
     {
-        public RetriesGateway(IRetryBatchStore store, RetryingManager operationManager, RetryMetrics metrics, ILogger<RetriesGateway> logger)
+        public RetriesGateway(IRetryBatchStore store, RetryingManager operationManager, RetryMetrics metrics, ILogger<RetriesGateway> logger, TimeProvider timeProvider)
         {
             this.store = store;
             this.operationManager = operationManager;
             this.metrics = metrics;
             this.logger = logger;
+            this.timeProvider = timeProvider;
 
             metrics.ObservePendingBulkRequests(() => bulkRequests.Count);
         }
@@ -36,7 +37,7 @@ namespace ServiceControl.Recoverability
             using var preparation = metrics.BeginPreparation(retryType, cancellationToken);
 
             await operationManager.Preparing(requestId, retryType, numberOfMessages, cancellationToken);
-            await AssignMessagesToBatch(requestId, retryType, new[] { uniqueMessageId }, DateTime.UtcNow, cancellationToken, initiatedBy: initiatedBy, operationId: operationId);
+            await AssignMessagesToBatch(requestId, retryType, new[] { uniqueMessageId }, timeProvider.GetUtcNow().UtcDateTime, cancellationToken, initiatedBy: initiatedBy, operationId: operationId);
             await operationManager.PreparedBatch(requestId, retryType, numberOfMessages, cancellationToken);
 
             preparation.Complete();
@@ -53,7 +54,7 @@ namespace ServiceControl.Recoverability
             using var preparation = metrics.BeginPreparation(retryType, cancellationToken);
 
             await operationManager.Preparing(requestId, retryType, numberOfMessages, cancellationToken);
-            await AssignMessagesToBatch(requestId, retryType, uniqueMessageIds, DateTime.UtcNow, cancellationToken, initiatedBy: initiatedBy, operationId: operationId);
+            await AssignMessagesToBatch(requestId, retryType, uniqueMessageIds, timeProvider.GetUtcNow().UtcDateTime, cancellationToken, initiatedBy: initiatedBy, operationId: operationId);
             await operationManager.PreparedBatch(requestId, retryType, numberOfMessages, cancellationToken);
 
             preparation.Complete();
@@ -132,21 +133,21 @@ namespace ServiceControl.Recoverability
 
         public void StartRetryForAllMessages(AuditUser? initiatedBy = null, string operationId = null)
         {
-            var item = new RetryForAllMessages(initiatedBy, operationId);
+            var item = new RetryForAllMessages(timeProvider.GetUtcNow().UtcDateTime, initiatedBy, operationId);
             logger.LogInformation("Enqueuing index based bulk retry '{Item}'", item);
             bulkRequests.Enqueue(item);
         }
 
         public void StartRetryForEndpoint(string endpoint, AuditUser? initiatedBy = null, string operationId = null)
         {
-            var item = new RetryForEndpoint(endpoint, initiatedBy, operationId);
+            var item = new RetryForEndpoint(endpoint, timeProvider.GetUtcNow().UtcDateTime, initiatedBy, operationId);
             logger.LogInformation("Enqueuing index based bulk retry '{Item}'", item);
             bulkRequests.Enqueue(item);
         }
 
         public void StartRetryForFailedQueueAddress(string failedQueueAddress, FailedMessageStatus status, AuditUser? initiatedBy = null, string operationId = null)
         {
-            var item = new RetryForFailedQueueAddress(failedQueueAddress, status, initiatedBy, operationId);
+            var item = new RetryForFailedQueueAddress(failedQueueAddress, status, timeProvider.GetUtcNow().UtcDateTime, initiatedBy, operationId);
             logger.LogInformation("Enqueuing index based bulk retry '{Item}'", item);
             bulkRequests.Enqueue(item);
         }
@@ -164,6 +165,7 @@ namespace ServiceControl.Recoverability
         const int BatchSize = 1000;
 
         readonly ILogger<RetriesGateway> logger;
+        readonly TimeProvider timeProvider;
 
         public abstract class BulkRetryRequest
         {
@@ -234,7 +236,7 @@ namespace ServiceControl.Recoverability
 
         class RetryForAllMessages : BulkRetryRequest
         {
-            public RetryForAllMessages(AuditUser? initiatedBy = null, string operationId = null) : base(requestId: "All", RetryType.All, DateTime.UtcNow, "all messages", initiatedBy, operationId)
+            public RetryForAllMessages(DateTime startTime, AuditUser? initiatedBy = null, string operationId = null) : base(requestId: "All", RetryType.All, startTime, "all messages", initiatedBy, operationId)
             {
             }
 
@@ -248,7 +250,7 @@ namespace ServiceControl.Recoverability
         {
             public string Endpoint { get; }
 
-            public RetryForEndpoint(string endpoint, AuditUser? initiatedBy = null, string operationId = null) : base(requestId: endpoint, RetryType.AllForEndpoint, DateTime.UtcNow, originator: $"all messages for endpoint {endpoint}", initiatedBy, operationId)
+            public RetryForEndpoint(string endpoint, DateTime startTime, AuditUser? initiatedBy = null, string operationId = null) : base(requestId: endpoint, RetryType.AllForEndpoint, startTime, originator: $"all messages for endpoint {endpoint}", initiatedBy, operationId)
             {
                 Endpoint = endpoint;
             }
@@ -287,9 +289,10 @@ namespace ServiceControl.Recoverability
             public RetryForFailedQueueAddress(
                 string failedQueueAddress,
                 FailedMessageStatus status,
+                DateTime startTime,
                 AuditUser? initiatedBy = null,
                 string operationId = null
-                ) : base(requestId: failedQueueAddress, RetryType.ByQueueAddress, DateTime.UtcNow, originator: $"all messages for failed queue address '{failedQueueAddress}'", initiatedBy, operationId)
+                ) : base(requestId: failedQueueAddress, RetryType.ByQueueAddress, startTime, originator: $"all messages for failed queue address '{failedQueueAddress}'", initiatedBy, operationId)
             {
                 FailedQueueAddress = failedQueueAddress;
                 Status = status;

--- a/src/ServiceControl/Recoverability/Retrying/RetryingManager.cs
+++ b/src/ServiceControl/Recoverability/Retrying/RetryingManager.cs
@@ -12,11 +12,12 @@
 
     public class RetryingManager
     {
-        public RetryingManager(IDomainEvents domainEvents, RetryMetrics metrics, ILogger<RetryingManager> logger)
+        public RetryingManager(IDomainEvents domainEvents, RetryMetrics metrics, ILogger<RetryingManager> logger, TimeProvider timeProvider)
         {
             this.domainEvents = domainEvents;
             this.metrics = metrics;
             this.logger = logger;
+            this.timeProvider = timeProvider;
 
             metrics.ObserveOperationsInProgress(() => retryOperations.Values.Select(operation => (operation.RetryType, operation.RetryState)));
         }
@@ -97,7 +98,7 @@
             ArgumentException.ThrowIfNullOrWhiteSpace(requestId);
 
             var key = InMemoryRetry.MakeOperationId(requestId, retryType);
-            return retryOperations.GetOrAdd(key, _ => new InMemoryRetry(requestId, retryType, domainEvents, metrics, logger));
+            return retryOperations.GetOrAdd(key, _ => new InMemoryRetry(requestId, retryType, domainEvents, metrics, logger, timeProvider));
         }
 
         public InMemoryRetry GetStatusForRetryOperation(string requestId, RetryType retryType)
@@ -110,6 +111,7 @@
         IDomainEvents domainEvents;
         readonly RetryMetrics metrics;
         readonly ILogger<RetryingManager> logger;
+        readonly TimeProvider timeProvider;
         ConcurrentDictionary<string, InMemoryRetry> retryOperations = new ConcurrentDictionary<string, InMemoryRetry>();
     }
 }


### PR DESCRIPTION
# Every time-sensitive decision now reads an injected clock

Timestamps across the error instance came from `DateTime.UtcNow`, so nothing time-dependent could be tested. They now come from a constructor-injected `TimeProvider`. Production gets `TimeProvider.System` and behaves identically; tests get a fake clock they can advance.

## What is wrong today

- **The host never registered a clock.** One arrived anyway, from telemetry, HTTP logging or YARP, whichever was switched on.
- **The EF persister overwrote the host's choice.** `BasePersistence` used `AddSingleton`, and the container returns the last registration. A host-supplied clock was silently replaced, no error.
- **RavenDB tests faked nothing.** `AdvanceClock` was an empty method, `UtcNow` returned the real one.
- **Three places read the clock twice for one instant**, so two fields describing the same moment could differ by however long the code between them took: `InMemoryArchive.Complete` and `InMemoryUnarchive.Complete` (`CompletionTime` and `Last`), `MessageRedirectsController.NewRedirects` (the redirect's `LastModified` and the retry request's `PeriodTo`), and `LicensingDataStore`, where three reads built one date range so a call straddling midnight got a `from` and `to` from different days.
- **Maintenance mode dies on both EF persisters, and the clock's own test is what exposed it.** Maintenance mode starts ServiceControl with storage and nothing else, so it is the one startup path that never calls `AddServiceControl`, which is why it is the right place to prove the persister supplies its own clock. It is also where NServiceBus's `CriticalError` goes missing, since that is registered only inside `AddServiceControl` while the EF persister's `ExternalIntegrationRequestsDataStore` asks for it in its constructor. So `--maintenance` on SQL Server or PostgreSQL exits with an unresolved-service error instead of starting. RavenDB returns early from its own registration in maintenance mode, so it never reaches the equivalent class. Not a regression: it fails the same way on `master`.

## What it looks like afterwards

- `AddServiceControl` registers `TimeProvider.System` with `TryAddSingleton`, so a host that supplies its own keeps it.
- Both persisters do the same, so a host built from the persistence layer alone still resolves a clock, and neither persister can override the host's.
- **Maintenance mode is now RavenDB-only in the code, as it always was in the help text.** It exists to start RavenDB's in-process database so RavenDB Studio can reach it, and a SQL Server or PostgreSQL instance has no such database to start; `--maintenance` has read `Run RavenDB only - use for DB maintenance` all along. `IPersistenceConfiguration` gained `SupportsMaintenanceMode`, true on RavenDB and false on the EF persisters, and `PersistenceFactory` turns the request down with a sentence naming the configured persister rather than letting the container throw.
- The three double reads each read once now, tested with a clock that advances on every read.
- RavenDB persistence tests get a real fake clock, level with SQL Server and PostgreSQL.
- **Raven:** `ExpirationManager` computes `@expires` from it; `ArchiveDocumentManager`, `UnarchiveDocumentManager`, `ArchivingManager` and `UnarchivingManager` take it, with `MessageArchiver` passing its own down; `LicensingDataStore` throughput windows use it.
- **EF Core, so SQL Server and PostgreSQL:** `FailedMessageLifecycleDataStore` stamps `StatusChangedAt` and `LastModified` from it across all five transitions; `EFCoreArchivingManager` and `EFCoreUnarchivingManager` pass it to the operation summaries.
- **API and retries:** `MessageRedirectsController` stamps `LastModified` on create and update; `FailureGroupsRetryController` takes the operation start time from it, so the message sent and the operation opened agree; `RetriesGateway` bulk request types receive their start time instead of calling `DateTime.UtcNow` in a base constructor argument where nothing could reach it; `RetryingManager`, `InMemoryRetry` and `RetryAllInGroupHandler` take it.
- **Deliberately still on the machine clock:** `CheckRavenDBIndexLag` subtracts `LastIndexingTime`, which the Raven server reports against its own clock, so an injected one would make the lag meaningless. Comment added so nobody "finishes the job".

## Test coverage

- **Registration:** a host-registered clock survives `AddServiceControl`, which is what catches the `AddSingleton` override. On RavenDB, `StartupModeTests.CanRunMaintenanceMode` now also asserts that the maintenance host resolves a clock of its own. On SQL Server and PostgreSQL, a new `MaintenanceModeTests` asserts the refusal instead, and is excluded from the RavenDB project the same way `When_hosting_error_ingestion_only` already is.
- **Lifecycle:** five tests, one per transition, clock advanced a week, both stamps asserted.
- **Retention sweeps:** seven tests. Cutoff both ways, statuses never swept, retention shrunk between runs, external body deletion limited to swept rows, group cascade, row kept when its body will not delete.
- **Archive progress:** event start time and operation start time both from the clock, plus batch, finalize and complete for both directions.
- **Retry:** start time from the clock, completion five fake minutes later reports exactly that.
- **Redirects:** create and update both stamp it.
- **RavenDB fake clock** registered before the persister, whose `TryAddSingleton` respects it. Caveat in the code: it moves only what the persister stamps, since the Raven server expires on its own clock.
- **365 day retention on SQL Server and PostgreSQL.** Advancing the clock wakes the live retention sweeper, which then deletes rows a test is still using. Retention now outruns any advance; tests that care set their own.
- `PersistenceTestBase` no longer registers a clock, now that each backend context supplies one.
