### PR TITLE
Classify the search engine custom checks as built-in

### DIFF
--- a/src/ServiceControl.Persistence/InternalCustomCheckClassification.cs
+++ b/src/ServiceControl.Persistence/InternalCustomCheckClassification.cs
@@ -40,6 +40,7 @@ namespace ServiceControl.Contracts.CustomChecks
                 "RavenDB dirty memory",          // primary AND audit
                 "ServiceControl database",       // RavenDB persister
                 "Message Ingestion Process",     // RavenDB persister
+                "Error Database Search Engine",  // RavenDB persister
                 "ServiceControl body storage",   // EF Core persisters
                 "Dead Letter Queue",             // ASBS / IBMMQ / MSMQ
 
@@ -47,6 +48,7 @@ namespace ServiceControl.Contracts.CustomChecks
                 "Audit Message Ingestion",
                 "Audit Message Ingestion Process",
                 "Audit Database Index Lag",
+                "Audit Database Search Engine",
                 "ServiceControl.Audit database",
             };
 


### PR DESCRIPTION
#5840 and #5833 merged independently, so the `Error Database Search Engine` and `Audit Database Search Engine` custom checks were never added to `InternalCustomCheckClassification`. `CustomCheckTests.VerifyCustomChecks` fails on master in both RavenDB persistence test projects.