### PR TITLE
Show the "add instance" screen if no instances are installed when using ServiceControl Management

### DIFF
--- a/src/ServiceControl.Config/UI/NoInstances/NoInstancesView.xaml
+++ b/src/ServiceControl.Config/UI/NoInstances/NoInstancesView.xaml
@@ -12,6 +12,6 @@
                    VerticalAlignment="Center"
                    FontSize="20"
                    Foreground="{StaticResource Gray60Brush}"
-                   Text="No service instances installed" />
+                   Text="Add an instance to get started" />
     </Grid>
 </UserControl>

--- a/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
+++ b/src/ServiceControl.Config/UI/Shell/ShellViewModel.cs
@@ -102,6 +102,21 @@
             BeginCheckForUpdates();
         }
 
+        protected override void OnViewLoaded(object view)
+        {
+            base.OnViewLoaded(view);
+
+            // First run: nothing is installed yet, so open the "choose a setup scenario"
+            // popup immediately instead of leaving the user on the empty instance list.
+            // OnViewLoaded fires once, so alt-tabbing back or hitting refresh (both of
+            // which re-run RefreshInstances) won't re-trigger it, and dismissing the
+            // popup leaves the user on the NoInstances view.
+            if (!HasInstances)
+            {
+                ShowingMenuOverlay = true;
+            }
+        }
+
         public async Task RefreshInstances(CancellationToken cancellationToken = default)
         {
             HasInstances = InstanceFinder.AllInstances().Any();


### PR DESCRIPTION
Auto load the "Add instance" screen in SCMU if no instances are installed.