### PR TITLE
Refactor persistence manifest handling and add unit tests for loading behavior

### DIFF
--- a/src/ServiceControl.Persistence/PersistenceManifest.cs
+++ b/src/ServiceControl.Persistence/PersistenceManifest.cs
@@ -18,9 +18,10 @@
 
         public required string Description { get; set; }
 
-        public required string AssemblyName { get; set; }
+        // Absent on manifests for persisters that no longer ship an assembly, such as RavenDB 3.5
+        public string? AssemblyName { get; set; }
 
-        public required string TypeName { get; set; }
+        public string? TypeName { get; set; }
 
         public bool IsSupported { get; set; } = true;
 
@@ -59,10 +60,7 @@
 
             try
             {
-                foreach (var manifestFile in Directory.EnumerateFiles(assemblyDirectory, "persistence.manifest", SearchOption.AllDirectories))
-                {
-                    PersistenceManifests.Add(DeserializeManifest(manifestFile));
-                }
+                PersistenceManifests.AddRange(LoadManifests(Directory.EnumerateFiles(assemblyDirectory, "persistence.manifest", SearchOption.AllDirectories)));
             }
             catch (Exception ex)
             {
@@ -71,10 +69,7 @@
 
             try
             {
-                foreach (var manifestFile in DevelopmentPersistenceLocations.ManifestFiles)
-                {
-                    PersistenceManifests.Add(DeserializeManifest(manifestFile));
-                }
+                PersistenceManifests.AddRange(LoadManifests(DevelopmentPersistenceLocations.ManifestFiles));
             }
             catch (Exception ex)
             {
@@ -82,6 +77,26 @@
             }
 
             PersistenceManifests.ForEach(m => logger.LogInformation("Found persistence manifest for {ManifestDisplayName}", m.DisplayName));
+        }
+
+        // One unreadable manifest must not hide the persisters enumerated after it
+        internal static List<PersistenceManifest> LoadManifests(IEnumerable<string> manifestFiles)
+        {
+            var manifests = new List<PersistenceManifest>();
+
+            foreach (var manifestFile in manifestFiles)
+            {
+                try
+                {
+                    manifests.Add(DeserializeManifest(manifestFile));
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to load persistence manifest {ManifestFile}", manifestFile);
+                }
+            }
+
+            return manifests;
         }
 
         static PersistenceManifest DeserializeManifest(string manifestFile)

--- a/src/ServiceControl.Persistence/ServiceControl.Persistence.csproj
+++ b/src/ServiceControl.Persistence/ServiceControl.Persistence.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="NServiceBus.CustomChecks" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ServiceControl.UnitTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/ServiceControl.UnitTests/Infrastructure/PersistenceManifestLoadingTests.cs
+++ b/src/ServiceControl.UnitTests/Infrastructure/PersistenceManifestLoadingTests.cs
@@ -1,0 +1,87 @@
+namespace ServiceControl.UnitTests.Infrastructure;
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using ServiceControl.Persistence;
+
+[TestFixture]
+public class PersistenceManifestLoadingTests
+{
+    const string RavenDB = """
+                           {
+                             "Name": "RavenDB",
+                             "DisplayName": "RavenDB",
+                             "Description": "RavenDB ServiceControl persister",
+                             "AssemblyName": "ServiceControl.Persistence.RavenDB",
+                             "TypeName": "ServiceControl.Persistence.RavenDB.RavenPersistenceConfiguration, ServiceControl.Persistence.RavenDB"
+                           }
+                           """;
+
+    // Ships so that ServiceControl Management can describe pre-v5 instances, and has no assembly left to name
+    const string RavenDB35 = """
+                             {
+                               "Name": "RavenDB35",
+                               "IsSupported": false,
+                               "DisplayName": "RavenDB 3.5 (Legacy)",
+                               "Description": "RavenDB 3.5 (Legacy) ServiceControl persister"
+                             }
+                             """;
+
+    const string SqlServer = """
+                             {
+                               "Name": "SQLServer",
+                               "DisplayName": "SQL Server",
+                               "Description": "SQL Server ServiceControl persister",
+                               "AssemblyName": "ServiceControl.Persistence.EFCore.SqlServer",
+                               "TypeName": "ServiceControl.Persistence.EFCore.SqlServer.SqlServerPersistenceConfiguration, ServiceControl.Persistence.EFCore.SqlServer"
+                             }
+                             """;
+
+    [Test]
+    public void Legacy_manifest_without_an_assembly_does_not_hide_the_persisters_after_it()
+    {
+        var manifests = LoadFrom(new()
+        {
+            ["RavenDB"] = RavenDB,
+            ["RavenDB35"] = RavenDB35,
+            ["SQLServer"] = SqlServer
+        });
+
+        Assert.That(manifests.Select(m => m.Name), Is.EquivalentTo(["RavenDB", "RavenDB35", "SQLServer"]));
+    }
+
+    [Test]
+    public void Unreadable_manifest_does_not_hide_the_persisters_after_it()
+    {
+        var manifests = LoadFrom(new()
+        {
+            ["Corrupt"] = "{ this is not json",
+            ["SQLServer"] = SqlServer
+        });
+
+        Assert.That(manifests.Select(m => m.Name), Is.EqualTo(["SQLServer"]));
+    }
+
+    static List<PersistenceManifest> LoadFrom(Dictionary<string, string> persisters)
+    {
+        var installDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, TestContext.CurrentContext.Test.ID);
+
+        foreach (var (persister, manifest) in persisters)
+        {
+            var persisterDirectory = Path.Combine(installDirectory, "Persisters", persister);
+            Directory.CreateDirectory(persisterDirectory);
+            File.WriteAllText(Path.Combine(persisterDirectory, "persistence.manifest"), manifest);
+        }
+
+        try
+        {
+            return PersistenceManifestLibrary.LoadManifests(Directory.EnumerateFiles(installDirectory, "persistence.manifest", SearchOption.AllDirectories));
+        }
+        finally
+        {
+            Directory.Delete(installDirectory, true);
+        }
+    }
+}


### PR DESCRIPTION
An instance configured for SQL Server will not start. It dies with `Could not load persistence customization type SQLServer.` over a `NullReferenceException`.

**No released version is affected.**

## What is wrong

`PersistenceManifestLibrary` reads every `Persisters\<Name>\persistence.manifest` in one loop wrapped by a single `try`, so the first file that throws discards every file after it, logged as a warning and nothing more.

The file that throws is `RavenDB35`. Its manifest has no `AssemblyName` or `TypeName`, correctly, because there is no assembly left to load, but the model marked both `required` and `System.Text.Json` rejects it. Folders are read in name order, so `RavenDB35` throws third and `SQLServer` is never read. `PostgreSQL` sorts earlier and survives, which is what makes it look SQL-Server-specific.

It is invisible from a source checkout, where manifests come from `DevelopmentPersistenceLocations` and RavenDB 3.5 never appears. Only a real install shows it.

## The fix

- Per-file `try`/`catch` in a new `LoadManifests`, so a bad manifest costs you that manifest and nothing else.
- `AssemblyName` and `TypeName` are nullable again. `Name`, `DisplayName` and `Description` keep `required`.

## Tests

Two tests, one per defect, staging a real install layout in a temp directory. Each half of the fix was reverted separately to confirm the matching test goes red.
