### PR TITLE
Cap CI test jobs at 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
   build:
     name: ${{ matrix.os-name }}-${{ matrix.test-category }}
     runs-on: ${{ matrix.os }}
+    # The slowest healthy job finishes in under 18 minutes. Anything still running at 30 has lost its
+    # runner or hung on infrastructure, and without a cap it would occupy the runner for 6 hours.
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]


### PR DESCRIPTION
The build job had no `timeout-minutes`, so a job whose runner was lost or whose test host hung on infrastructure kept the runner for the 6 hour default until the next push cancelled the run (e.g. the 46 min Windows-IBMMQ and 52 min Windows-SqlServer jobs on recent runs).

Across the last 60 CI runs no healthy job took longer than 18 minutes (Windows-SqlServer, 17.6 min worst case), so 30 leaves comfortable headroom while ending dead jobs promptly.