### PR TITLE
Bound acceptance tests by the test's CancelAfter budget instead of the fixed 90 s Done limit

### DIFF
--- a/src/ServiceControl.AcceptanceTesting/NServiceBusAcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTesting/NServiceBusAcceptanceTest.cs
@@ -13,6 +13,7 @@
     /// </summary>
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    [CancelAfter(180_000)]
     public abstract partial class NServiceBusAcceptanceTest
     {
         [SetUp]

--- a/src/ServiceControl.AcceptanceTesting/TestTimeoutScenario.cs
+++ b/src/ServiceControl.AcceptanceTesting/TestTimeoutScenario.cs
@@ -1,0 +1,109 @@
+namespace ServiceControl.AcceptanceTesting;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTesting.Support;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+public static class TestTimeoutScenarioExtensions
+{
+    /// <summary>
+    /// Bounds the scenario by the test's own cancellation token instead of the framework's fixed 90 second
+    /// <c>Done</c> limit. The token comes from <see cref="CancelAfterAttribute"/>, which
+    /// <see cref="NServiceBusAcceptanceTest"/> applies to every test and which a test can override.
+    /// </summary>
+    public static IScenarioWithEndpointBehavior<TContext> WithTestTimeout<TContext>(this IScenarioWithEndpointBehavior<TContext> scenario)
+        where TContext : ScenarioContext =>
+        new TestTimeoutScenario<TContext>(scenario);
+}
+
+class TestTimeoutScenario<TContext>(IScenarioWithEndpointBehavior<TContext> inner) : IScenarioWithEndpointBehavior<TContext>
+    where TContext : ScenarioContext
+{
+    public IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>() where T : EndpointConfigurationBuilder, new()
+    {
+        inner = inner.WithEndpoint<T>();
+        return this;
+    }
+
+    public IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>(Action<EndpointBehaviorBuilder<TContext>> behavior) where T : EndpointConfigurationBuilder, new()
+    {
+        inner = inner.WithEndpoint<T>(behavior);
+        return this;
+    }
+
+    public IScenarioWithEndpointBehavior<TContext> WithEndpoint(EndpointConfigurationBuilder endpointConfigurationBuilder, Action<EndpointBehaviorBuilder<TContext>> defineBehavior)
+    {
+        inner = inner.WithEndpoint(endpointConfigurationBuilder, defineBehavior);
+        return this;
+    }
+
+    public IScenarioWithEndpointBehavior<TContext> WithComponent(IComponentBehavior componentBehavior)
+    {
+        inner = inner.WithComponent(componentBehavior);
+        return this;
+    }
+
+    public IScenarioWithEndpointBehavior<TContext> WithServices(Action<IServiceCollection> configureServices)
+    {
+        inner = inner.WithServices(configureServices);
+        return this;
+    }
+
+    public IScenarioWithEndpointBehavior<TContext> WithServices(Action<IServiceCollection, TContext> configureServices)
+    {
+        inner = inner.WithServices(configureServices);
+        return this;
+    }
+
+    public IScenarioWithEndpointBehavior<TContext> WithServiceResolve(Func<IServiceProvider, CancellationToken, Task> resolve, ServiceResolveMode resolveMode = ServiceResolveMode.BeforeStart)
+    {
+        inner = inner.WithServiceResolve(resolve, resolveMode);
+        return this;
+    }
+
+    public IScenarioWithEndpointBehavior<TContext> WithServiceResolve(Func<IServiceProvider, TContext, CancellationToken, Task> resolve, ServiceResolveMode resolveMode = ServiceResolveMode.BeforeStart)
+    {
+        inner = inner.WithServiceResolve(resolve, resolveMode);
+        return this;
+    }
+
+    public IScenarioWithEndpointBehavior<TContext> Done(Func<TContext, bool> func)
+    {
+        inner = inner.Done(func);
+        return this;
+    }
+
+    public IScenarioWithEndpointBehavior<TContext> Done(Func<TContext, TaskCompletionSource> func)
+    {
+        inner = inner.Done(func);
+        return this;
+    }
+
+    public Task<TContext> Run(CancellationToken cancellationToken = default) => Run(new RunSettings(), cancellationToken);
+
+    public async Task<TContext> Run(RunSettings settings, CancellationToken cancellationToken = default)
+    {
+        // The framework only lifts its fixed 90 second Done limit when handed a token that can actually be
+        // cancelled, so a caller that passes nothing gets the test's own token instead.
+        if (!cancellationToken.CanBeCanceled)
+        {
+            cancellationToken = TestContext.CurrentContext.CancellationToken;
+        }
+
+        try
+        {
+            return await inner.Run(settings, cancellationToken);
+        }
+        catch (Exception e) when (e is TimeoutException or OperationCanceledException && cancellationToken.IsCancellationRequested)
+        {
+            // Done wraps the cancellation in a TimeoutException naming the framework's own limit, which is
+            // infinite for a cancellable token and prints as a negative number of seconds.
+            throw new TimeoutException($"The scenario did not complete within the test's CancelAfter budget of {TestExecutionContext.CurrentContext.TestCaseTimeout} ms.", e);
+        }
+    }
+}

--- a/src/ServiceControl.AcceptanceTests/TestSupport/AcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/AcceptanceTest.cs
@@ -90,7 +90,8 @@ namespace ServiceControl.AcceptanceTests
 
         protected IScenarioWithEndpointBehavior<T> Define<T>(Action<T> contextInitializer) where T : ScenarioContext, new() =>
             Scenario.Define(contextInitializer)
-                .WithComponent(serviceControlRunnerBehavior);
+                .WithComponent(serviceControlRunnerBehavior)
+                .WithTestTimeout();
 
         protected Action<EndpointConfiguration> CustomConfiguration = _ => { };
         protected Action<Settings> SetSettings = _ => { };

--- a/src/ServiceControl.Audit.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/AcceptanceTest.cs
@@ -65,7 +65,8 @@ namespace ServiceControl.Audit.AcceptanceTests
 
         protected IScenarioWithEndpointBehavior<T> Define<T>(Action<T> contextInitializer) where T : ScenarioContext, new() =>
             Scenario.Define(contextInitializer)
-                .WithComponent(serviceControlRunnerBehavior);
+                .WithComponent(serviceControlRunnerBehavior)
+                .WithTestTimeout();
 
         protected Action<EndpointConfiguration> CustomConfiguration = _ => { };
         protected Action<Settings> SetSettings = _ => { };

--- a/src/ServiceControl.Monitoring.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/AcceptanceTest.cs
@@ -55,7 +55,8 @@ namespace ServiceControl.Monitoring.AcceptanceTests
 
         protected IScenarioWithEndpointBehavior<T> Define<T>(Action<T> contextInitializer) where T : ScenarioContext, new() =>
             Scenario.Define(contextInitializer)
-                .WithComponent(serviceControlRunnerBehavior);
+                .WithComponent(serviceControlRunnerBehavior)
+                .WithTestTimeout();
 
         protected Action<EndpointConfiguration> CustomConfiguration = _ => { };
         protected Action<Settings> SetSettings = _ => { };

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/AcceptanceTest.cs
@@ -71,7 +71,8 @@ namespace ServiceControl.MultiInstance.AcceptanceTests
 
         protected IScenarioWithEndpointBehavior<T> Define<T>(Action<T> contextInitializer) where T : ScenarioContext, new() =>
             Scenario.Define(contextInitializer)
-                .WithComponent(serviceControlRunnerBehavior);
+                .WithComponent(serviceControlRunnerBehavior)
+                .WithTestTimeout();
 
         protected Action<EndpointConfiguration> CustomPrimaryEndpointConfiguration = c => { };
         protected Action<EndpointConfiguration> CustomAuditEndpointConfiguration = c => { };


### PR DESCRIPTION
NServiceBus.AcceptanceTesting caps `Done` at 90 seconds unless `Run` receives a cancellable token. The journey tests added in #5810 (`When_deleted_messages_are_restored`, `When_a_failing_custom_check_is_dismissed`) regularly exceed that on Windows runners and account for most Windows-Raven failures across all branches over the past week.

`NServiceBusAcceptanceTest` now carries `[CancelAfter(180_000)]`, which NUnit applies to every derived fixture, and `Define` wraps the scenario so that `Run()` without a token uses `TestContext.CurrentContext.CancellationToken`. A test that already declares `[CancelAfter]` keeps its own value. The runsettings `DefaultTimeout` route does not work here: NUnit3TestAdapter only forwards it under `#if NET462`.

Verified locally with a throwaway test: a method-level `[CancelAfter(5_000)]` on a never-completing scenario fails after 5.9 s with `The scenario did not complete within the test's CancelAfter budget of 5000 ms.`, and existing Primary, Audit and Monitoring tests pass unchanged.



Pairs with #5872: without it a timed-out test reports the `TaskCanceledException` from the aborted host shutdown instead of the timeout.
