### PR TITLE
Bound acceptance tests by the test's CancelAfter budget via an explicit CancellationToken

### DIFF
--- a/src/ServiceControl.AcceptanceTesting/NServiceBusAcceptanceTest.cs
+++ b/src/ServiceControl.AcceptanceTesting/NServiceBusAcceptanceTest.cs
@@ -13,6 +13,7 @@
     /// </summary>
     [TestFixture]
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+    [CancelAfter(180_000)]
     public abstract partial class NServiceBusAcceptanceTest
     {
         [SetUp]

--- a/src/ServiceControl.AcceptanceTests.PostgreSql/ServiceControl.AcceptanceTests.PostgreSql.csproj
+++ b/src/ServiceControl.AcceptanceTests.PostgreSql/ServiceControl.AcceptanceTests.PostgreSql.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TestCategory>PostgreSql</TestCategory>
+    <!-- Every test inherits [CancelAfter] from NServiceBusAcceptanceTest, which NUnit honours but the analyzer does not
+         see, so it reports the CancellationToken parameter as an unsupplied argument. -->
+    <NoWarn>$(NoWarn);NUnit1027</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.AcceptanceTests.RavenDB/Monitoring/CustomChecks/When_a_persister_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/Monitoring/CustomChecks/When_a_persister_check_fails.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTests.RavenDB.Monitoring.CustomChecks
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -30,7 +31,7 @@ namespace ServiceControl.AcceptanceTests.RavenDB.Monitoring.CustomChecks
         RavenPersisterSettings PersisterSettings => (RavenPersisterSettings)Settings.PersisterSpecificSettings;
 
         [Test]
-        public async Task Forced_failure_is_classified_internal()
+        public async Task Forced_failure_is_classified_internal(CancellationToken cancellationToken = default)
         {
             CustomCheckView ingestionCheck = null;
 
@@ -49,7 +50,7 @@ namespace ServiceControl.AcceptanceTests.RavenDB.Monitoring.CustomChecks
                     ingestionCheck = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests.RavenDB/Monitoring/CustomChecks/When_critical_storage_threshold_reached.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/Monitoring/CustomChecks/When_critical_storage_threshold_reached.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTests.RavenDB.Monitoring.CustomChecks
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -26,7 +27,7 @@ namespace ServiceControl.AcceptanceTests.RavenDB.Monitoring.CustomChecks
         RavenPersisterSettings PersisterSettings => (RavenPersisterSettings)Settings.PersisterSpecificSettings;
 
         [Test]
-        public async Task Should_stop_ingestion() =>
+        public async Task Should_stop_ingestion(CancellationToken cancellationToken = default) =>
             await Define<ScenarioContext>()
                 .WithEndpoint<Sender>(b => b
                     .When(context =>
@@ -45,10 +46,10 @@ namespace ServiceControl.AcceptanceTests.RavenDB.Monitoring.CustomChecks
                     )
                     .DoNotFailOnErrorMessages())
                 .Done(async c => await this.TryGetSingle<FailedMessageView>("/api/errors") == false)
-                .Run();
+                .Run(cancellationToken);
 
         [Test]
-        public async Task Should_stop_ingestion_and_resume_when_more_space_is_available()
+        public async Task Should_stop_ingestion_and_resume_when_more_space_is_available(CancellationToken cancellationToken = default)
         {
             var ingestionShutdown = false;
 
@@ -76,7 +77,7 @@ namespace ServiceControl.AcceptanceTests.RavenDB.Monitoring.CustomChecks
                     })
                     .DoNotFailOnErrorMessages())
                 .Done(async c => await this.TryGetSingle<FailedMessageView>("/api/errors"))
-                .Run();
+                .Run(cancellationToken);
         }
 
         public class Sender : EndpointConfigurationBuilder

--- a/src/ServiceControl.AcceptanceTests.RavenDB/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/Recoverability/MessageFailures/When_a_failed_message_is_retried.cs
@@ -21,7 +21,7 @@
     class When_a_failed_message_is_retried : AcceptanceTest
     {
         [Test]
-        public async Task Should_remove_failedmessageretries_when_retrying_groups()
+        public async Task Should_remove_failedmessageretries_when_retrying_groups(CancellationToken cancellationToken = default)
         {
             FailedMessageRetriesCountReponse failedMessageRetries = null;
 
@@ -58,13 +58,13 @@
 
                     return false;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(failedMessageRetries.Count, Is.EqualTo(0), "FailedMessageRetries not removed");
         }
 
         [Test]
-        public async Task Should_remove_failedmessageretries_when_retrying_individual_messages()
+        public async Task Should_remove_failedmessageretries_when_retrying_individual_messages(CancellationToken cancellationToken = default)
         {
             FailedMessageRetriesCountReponse failedMessageRetries = null;
 
@@ -99,13 +99,13 @@
 
                     return false;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(failedMessageRetries.Count, Is.EqualTo(0), "FailedMessageRetries not removed");
         }
 
         [Test]
-        public async Task Should_remove_UnacknowledgedOperation_when_retrying_individual_messages()
+        public async Task Should_remove_UnacknowledgedOperation_when_retrying_individual_messages(CancellationToken cancellationToken = default)
         {
             RetryHistory retryHistory = null;
 
@@ -140,13 +140,13 @@
 
                     return false;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(retryHistory.UnacknowledgedOperations, Is.Empty, "Unucknowledged retry operation not removed");
         }
 
         [Test]
-        public async Task Should_remove_failedmessageretries_after_expiration_process_passes()
+        public async Task Should_remove_failedmessageretries_after_expiration_process_passes(CancellationToken cancellationToken = default)
         {
             FailedMessageRetriesCountReponse failedMessageRetries = null;
 
@@ -186,7 +186,7 @@
 
                     return false;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(failedMessageRetries.Count, Is.EqualTo(0), "FailedMessageRetries not removed");
         }

--- a/src/ServiceControl.AcceptanceTests.RavenDB/Recoverability/MessageFailures/When_a_message_fails_to_import.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/Recoverability/MessageFailures/When_a_message_fails_to_import.cs
@@ -22,7 +22,7 @@
     class When_a_message_fails_to_import : AcceptanceTest
     {
         [Test]
-        public async Task It_can_be_reimported()
+        public async Task It_can_be_reimported(CancellationToken cancellationToken = default)
         {
             CustomizeHostBuilder = hostBuilder =>
             {
@@ -66,7 +66,7 @@
 
                     return await this.TryGet<FailedMessage>($"/api/errors/{c.UniqueMessageId}") && c.ErrorForwarded;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests.RavenDB/Recoverability/MessageFailures/When_body_search_is_disabled.cs
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/Recoverability/MessageFailures/When_body_search_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.RavenDB.Recoverability.MessageFailures
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -15,7 +16,7 @@ namespace ServiceControl.AcceptanceTests.RavenDB.Recoverability.MessageFailures
     class When_body_search_is_disabled : AcceptanceTest
     {
         [Test]
-        public async Task Should_not_be_found()
+        public async Task Should_not_be_found(CancellationToken cancellationToken = default)
         {
             SetSettings = settings => settings.PersisterSpecificSettings.EnableFullTextSearchOnBodies = false;
 
@@ -42,7 +43,7 @@ namespace ServiceControl.AcceptanceTests.RavenDB.Recoverability.MessageFailures
                     c.MessageFound = await this.TryGetMany<MessagesView>($"/api/messages/search/{searchString}");
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests.RavenDB/ServiceControl.AcceptanceTests.RavenDB.csproj
+++ b/src/ServiceControl.AcceptanceTests.RavenDB/ServiceControl.AcceptanceTests.RavenDB.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TestCategory>Raven</TestCategory>
+    <!-- Every test inherits [CancelAfter] from NServiceBusAcceptanceTest, which NUnit honours but the analyzer does not
+         see, so it reports the CancellationToken parameter as an unsupplied argument. -->
+    <NoWarn>$(NoWarn);NUnit1027</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.AcceptanceTests.SqlServer/ServiceControl.AcceptanceTests.SqlServer.csproj
+++ b/src/ServiceControl.AcceptanceTests.SqlServer/ServiceControl.AcceptanceTests.SqlServer.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TestCategory>SqlServer</TestCategory>
+    <!-- Every test inherits [CancelAfter] from NServiceBusAcceptanceTest, which NUnit honours but the analyzer does not
+         see, so it reports the CancellationToken parameter as an unsupplied argument. -->
+    <NoWarn>$(NoWarn);NUnit1027</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.AcceptanceTests/EventLogs/When_the_event_log_is_polled_with_an_etag.cs
+++ b/src/ServiceControl.AcceptanceTests/EventLogs/When_the_event_log_is_polled_with_an_etag.cs
@@ -5,6 +5,7 @@ namespace ServiceControl.AcceptanceTests.EventLogs
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@ namespace ServiceControl.AcceptanceTests.EventLogs
     class When_the_event_log_is_polled_with_an_etag : AcceptanceTest
     {
         [Test]
-        public async Task Should_answer_not_modified_only_for_the_current_etag()
+        public async Task Should_answer_not_modified_only_for_the_current_etag(CancellationToken cancellationToken = default)
         {
             string etag = null;
             HttpStatusCode currentEtagStatus = default;
@@ -70,7 +71,7 @@ namespace ServiceControl.AcceptanceTests.EventLogs
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_broker_transport.cs
+++ b/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_broker_transport.cs
@@ -6,6 +6,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
     using System.IO.Compression;
     using System.Linq;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -27,7 +28,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
     class When_creating_a_usage_report_on_a_broker_transport : AcceptanceTest
     {
         [Test]
-        public async Task Should_report_what_the_broker_measured()
+        public async Task Should_report_what_the_broker_measured(CancellationToken cancellationToken = default)
         {
             ReportGenerationState reportState = null;
             ThroughputConnectionSettings connectionSettings = null;
@@ -76,7 +77,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
                     report = ReadReport(archive);
                 })
                 .Done(_ => true)
-                .Run();
+                .Run(cancellationToken);
 
             var reportData = report.RootElement.GetProperty("ReportData");
             var queues = reportData.GetProperty("Queues").EnumerateArray().ToArray();

--- a/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_non_broker_transport.cs
+++ b/src/ServiceControl.AcceptanceTests/Licensing/When_creating_a_usage_report_on_a_non_broker_transport.cs
@@ -6,6 +6,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
     using System.IO.Compression;
     using System.Linq;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -21,7 +22,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
     class When_creating_a_usage_report_on_a_non_broker_transport : AcceptanceTest
     {
         [Test]
-        public async Task Should_report_the_corrected_and_redacted_throughput()
+        public async Task Should_report_the_corrected_and_redacted_throughput(CancellationToken cancellationToken = default)
         {
             ReportGenerationState reportState = null;
             ThroughputConnectionSettings connectionSettings = null;
@@ -80,7 +81,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
                     report = ReadReport(archive);
                 })
                 .Done(_ => true)
-                .Run();
+                .Run(cancellationToken);
 
             var queues = report.RootElement.GetProperty("ReportData").GetProperty("Queues").EnumerateArray().ToArray();
 

--- a/src/ServiceControl.AcceptanceTests/Licensing/When_reporting_the_environment.cs
+++ b/src/ServiceControl.AcceptanceTests/Licensing/When_reporting_the_environment.cs
@@ -5,6 +5,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
     using System.IO.Compression;
     using System.Linq;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -20,7 +21,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
     class When_reporting_the_environment : AcceptanceTest
     {
         [Test]
-        public async Task Should_describe_how_the_instance_is_deployed()
+        public async Task Should_describe_how_the_instance_is_deployed(CancellationToken cancellationToken = default)
         {
             JsonDocument report = null;
 
@@ -42,7 +43,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
                     return true;
                 })
                 .Done(_ => true)
-                .Run();
+                .Run(cancellationToken);
 
             var data = report.RootElement
                 .GetProperty("ReportData")

--- a/src/ServiceControl.AcceptanceTests/Licensing/When_the_license_is_requested.cs
+++ b/src/ServiceControl.AcceptanceTests/Licensing/When_the_license_is_requested.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Licensing
 {
     using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTesting;
@@ -10,7 +11,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
     class When_the_license_is_requested : AcceptanceTest
     {
         [Test]
-        public async Task Should_report_the_instance_and_where_to_extend_the_trial()
+        public async Task Should_report_the_instance_and_where_to_extend_the_trial(CancellationToken cancellationToken = default)
         {
             LicenseInfo license = null;
 
@@ -21,7 +22,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
                     license = result.Item;
                     return result.HasResult;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -37,7 +38,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
         }
 
         [Test]
-        public async Task Should_reject_a_request_that_names_no_client()
+        public async Task Should_reject_a_request_that_names_no_client(CancellationToken cancellationToken = default)
         {
             HttpStatusCode status = default;
 
@@ -48,7 +49,7 @@ namespace ServiceControl.AcceptanceTests.Licensing
                     status = response.StatusCode;
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(status, Is.EqualTo(HttpStatusCode.BadRequest));
         }

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_a_custom_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_a_custom_check_fails.cs
@@ -18,7 +18,7 @@
     class When_a_custom_check_fails : AcceptanceTest
     {
         [Test]
-        public async Task Should_result_in_a_custom_check_failed_event()
+        public async Task Should_result_in_a_custom_check_failed_event(CancellationToken cancellationToken = default)
         {
             EventLogItem entry = null;
 
@@ -30,7 +30,7 @@
                     entry = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_a_failing_custom_check_is_dismissed.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_a_failing_custom_check_is_dismissed.cs
@@ -18,7 +18,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
     class When_a_failing_custom_check_is_dismissed : AcceptanceTest
     {
         [Test]
-        public async Task Should_come_back_while_the_check_is_still_failing()
+        public async Task Should_come_back_while_the_check_is_still_failing(CancellationToken cancellationToken = default)
         {
             CustomCheckView dismissed = null;
             CustomCheckView returned = null;
@@ -52,7 +52,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
                     return returned != null;
                 })
                 .Done(_ => true)
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(returned.FailureReason, Is.EqualTo(dismissed.FailureReason),
                 "Dismissing a check that is still failing cannot silence it for good, or a real failure disappears from the page for as long as it lasts");

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_a_periodic_custom_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_a_periodic_custom_check_fails.cs
@@ -19,7 +19,7 @@
     class When_a_periodic_custom_check_fails : AcceptanceTest
     {
         [Test]
-        public async Task Should_result_in_a_custom_check_failed_event()
+        public async Task Should_result_in_a_custom_check_failed_event(CancellationToken cancellationToken = default)
         {
             EventLogItem entry = null;
 
@@ -31,7 +31,7 @@
                     entry = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_custom_check_events_are_triggered.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_custom_check_events_are_triggered.cs
@@ -17,7 +17,7 @@
     class When_custom_check_events_are_triggered : AcceptanceTest
     {
         [Test]
-        public async Task Should_result_in_a_custom_check_failed_event()
+        public async Task Should_result_in_a_custom_check_failed_event(CancellationToken cancellationToken = default)
         {
             EventLogItem entry = null;
 
@@ -29,7 +29,7 @@
                     entry = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_custom_checks_are_classified.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_custom_checks_are_classified.cs
@@ -21,7 +21,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
         const string InternalId = "ServiceControl Primary Instance";
 
         [Test]
-        public async Task Internal_checks_are_flagged_internal_and_endpoint_checks_are_not()
+        public async Task Internal_checks_are_flagged_internal_and_endpoint_checks_are_not(CancellationToken cancellationToken = default)
         {
             // The acceptance test runner disables internal custom checks by default; this test needs them.
             SetSettings = settings => { settings.DisableHealthChecks = false; };
@@ -49,7 +49,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
 
                     return internalCheck != null && endpointCheck != null && wireBody != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -66,7 +66,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
         }
 
         [Test]
-        public async Task Every_expected_internal_check_is_flagged_internal()
+        public async Task Every_expected_internal_check_is_flagged_internal(CancellationToken cancellationToken = default)
         {
             // The acceptance test runner disables internal custom checks by default; this test needs them.
             SetSettings = settings => { settings.DisableHealthChecks = false; };
@@ -98,7 +98,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
 
                     return expectedIds.All(e => seen.Any(s => s.CustomCheckId == e));
                 })
-                .Run();
+                .Run(cancellationToken);
 
             foreach (var id in expectedIds)
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_email_notifications_are_configured.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_email_notifications_are_configured.cs
@@ -23,7 +23,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
     class When_email_notifications_are_configured : AcceptanceTest
     {
         [Test]
-        public async Task Should_gate_notifications_on_the_settings_the_page_saved()
+        public async Task Should_gate_notifications_on_the_settings_the_page_saved(CancellationToken cancellationToken = default)
         {
             var emailDropPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(emailDropPath);
@@ -93,7 +93,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
                         return delivered != null;
                     })
                     .Done(_ => true)
-                    .Run();
+                    .Run(cancellationToken);
 
                 using (Assert.EnterMultipleScope())
                 {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_email_notifications_are_enabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_email_notifications_are_enabled.cs
@@ -20,7 +20,7 @@
     class When_email_notifications_are_enabled : AcceptanceTest
     {
         [Test]
-        public async Task Should_send_custom_check_status_change_emails()
+        public async Task Should_send_custom_check_status_change_emails(CancellationToken cancellationToken = default)
         {
             var emailDropPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(emailDropPath);
@@ -44,7 +44,7 @@
 
                     return emails.Length > 0 && TryReadHeaders(emails[0], out emailHeaders);
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(emailHeaders, Is.Not.Empty);
 

--- a/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_the_body_storage_check_is_reported.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/CustomChecks/When_the_body_storage_check_is_reported.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTesting;
@@ -14,7 +15,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
             SetSettings = static s => s.DisableHealthChecks = false;
 
         [Test]
-        public async Task Should_be_classified_internal()
+        public async Task Should_be_classified_internal(CancellationToken cancellationToken = default)
         {
             CustomCheckView bodyStorageCheck = null;
 
@@ -25,7 +26,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.CustomChecks
                     bodyStorageCheck = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_fails.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_a_custom_check_fails : AcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             var externalProcessorSubscribed = false;
             CustomConfiguration = config => config.OnEndpointSubscribed<MyContext>((s, ctx) =>
@@ -55,7 +56,7 @@
                     }
                 }))
                 .Done(c => c.CustomCheckFailedReceived)
-                .Run();
+                .Run(cancellationToken);
 
             var enclosedType = context.IntegrationEventHeaders[Headers.EnclosedMessageTypes];
             Assert.That(enclosedType, Is.EqualTo("ServiceControl.Contracts.CustomCheckFailed, ServiceControl.Contracts"));

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_succeeds.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_a_custom_check_succeeds.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_a_custom_check_succeeds : AcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             var externalProcessorSubscribed = false;
             CustomConfiguration = config => config.OnEndpointSubscribed<MyContext>((s, ctx) =>
@@ -54,7 +55,7 @@
                     }
                 }))
                 .Done(c => c.CustomCheckSucceededReceived)
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.IntegrationEventHeaders[Headers.EnclosedMessageTypes],
                 Is.EqualTo("ServiceControl.Contracts.CustomCheckSucceeded, ServiceControl.Contracts"),

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_is_restored.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_is_restored.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.ExternalIntegration
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -20,7 +21,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.ExternalIntegration
     class When_heartbeat_is_restored : AcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             var externalProcessorSubscribed = false;
 
@@ -54,7 +55,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.ExternalIntegration
                     }
                 }))
                 .Done(c => c.NotificationDelivered)
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.IntegrationEventHeaders[Headers.EnclosedMessageTypes],
                 Is.EqualTo("ServiceControl.Contracts.HeartbeatRestored, ServiceControl.Contracts"),

--- a/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_loss_is_detected.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/ExternalIntegration/When_heartbeat_loss_is_detected.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.ExternalIntegration
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -21,7 +22,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.ExternalIntegration
     class When_heartbeat_loss_is_detected : AcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             var externalProcessorSubscribed = false;
 
@@ -56,7 +57,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring.ExternalIntegration
                     }
                 }))
                 .Done(c => c.NotificationDelivered)
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.IntegrationEventHeaders[Headers.EnclosedMessageTypes],
                 Is.EqualTo("ServiceControl.Contracts.HeartbeatStopped, ServiceControl.Contracts"),

--- a/src/ServiceControl.AcceptanceTests/Monitoring/InternalCustomChecks/When_a_critical_error_is_triggered.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/InternalCustomChecks/When_a_critical_error_is_triggered.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using Contracts.CustomChecks;
@@ -18,7 +19,7 @@
     class When_a_critical_error_is_triggered : AcceptanceTest
     {
         [Test]
-        public async Task Service_control_is_not_killed_and_error_is_reported_via_custom_check()
+        public async Task Service_control_is_not_killed_and_error_is_reported_via_custom_check(CancellationToken cancellationToken = default)
         {
             CustomizeHostBuilder = builder =>
             {
@@ -50,7 +51,7 @@
                     entry = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/InternalCustomChecks/When_a_custom_check_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/InternalCustomChecks/When_a_custom_check_fails.cs
@@ -28,7 +28,7 @@
         }
 
         [Test]
-        public async Task Should_result_in_a_custom_check_failed_event()
+        public async Task Should_result_in_a_custom_check_failed_event(CancellationToken cancellationToken = default)
         {
             SetSettings = settings =>
             {
@@ -49,7 +49,7 @@
                     entry = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_a_failed_message_from_unmonitored_endpoint_is_imported.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_a_failed_message_from_unmonitored_endpoint_is_imported.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@
     class When_a_failed_message_from_unmonitored_endpoint_is_imported : AcceptanceTest
     {
         [Test]
-        public async Task It_is_detected()
+        public async Task It_is_detected(CancellationToken cancellationToken = default)
         {
             EndpointsView[] endpoints = null;
 
@@ -29,14 +30,14 @@
                     endpoints = result;
                     return endpoints.Length > 0;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(endpoints.Length, Is.EqualTo(1));
             Assert.That(endpoints.First().Name, Is.EqualTo(context.EndpointNameOfReceivingEndpoint));
         }
 
         [Test]
-        public async Task It_is_persisted()
+        public async Task It_is_persisted(CancellationToken cancellationToken = default)
         {
             var endpointName = Conventions.EndpointNamingConvention(typeof(Receiver));
             KnownEndpoint endpoint = default;
@@ -51,7 +52,7 @@
                     endpoint = knownEndpoints.Item;
                     return knownEndpoints.HasResult;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(endpoint.Monitored, Is.False, "Endpoint detected through error ingestion should not be monitored");
         }

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_is_removed.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_is_removed.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
     class When_an_endpoint_is_removed : AcceptanceTest
     {
         [Test]
-        public async Task Should_signal_support_for_delete()
+        public async Task Should_signal_support_for_delete(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -26,7 +27,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
                     response = await this.Options("/api/endpoints");
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -36,7 +37,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
         }
 
         [Test]
-        public async Task Should_be_successfully_deleted()
+        public async Task Should_be_successfully_deleted(CancellationToken cancellationToken = default)
         {
             var endpointsAfterDelete = new List<EndpointsView>();
 
@@ -55,7 +56,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
                     endpointsAfterDelete = await this.TryGetMany<EndpointsView>("/api/endpoints");
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(endpointsAfterDelete, Is.Empty);
         }

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_starts_up.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_starts_up.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@
     class When_an_endpoint_starts_up : AcceptanceTest
     {
         [Test]
-        public async Task Should_result_in_a_startup_event()
+        public async Task Should_result_in_a_startup_event(CancellationToken cancellationToken = default)
         {
             EventLogItem entry = null;
 
@@ -29,7 +30,7 @@
                     entry = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_with_heartbeat_plugin_starts_up.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_an_endpoint_with_heartbeat_plugin_starts_up.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.AcceptanceTests.Monitoring
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
         static string EndpointName => Conventions.EndpointNamingConvention(typeof(StartingEndpoint));
 
         [Test]
-        public async Task Should_be_monitored_and_active()
+        public async Task Should_be_monitored_and_active(CancellationToken cancellationToken = default)
         {
             EndpointsView endpoint = null;
 
@@ -28,7 +29,7 @@
                     endpoint = result.Item;
                     return result.HasResult;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -38,7 +39,7 @@
         }
 
         [Test]
-        public async Task Should_be_persisted()
+        public async Task Should_be_persisted(CancellationToken cancellationToken = default)
         {
             var endpointName = Conventions.EndpointNamingConvention(typeof(StartingEndpoint));
             KnownEndpoint endpoint = default;
@@ -52,7 +53,7 @@
                     endpoint = result;
                     return result.HasResult;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(endpoint.Monitored, Is.True, "An endpoint discovered from heartbeats should be monitored");
         }

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_an_unmonitored_endpoint_is_marked_as_monitored.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_an_unmonitored_endpoint_is_marked_as_monitored.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -22,7 +23,7 @@
         static string EndpointName => Conventions.EndpointNamingConvention(typeof(MyEndpoint));
 
         [Test]
-        public async Task It_is_shown_as_inactive_if_it_does_not_send_heartbeats()
+        public async Task It_is_shown_as_inactive_if_it_does_not_send_heartbeats(CancellationToken cancellationToken = default)
         {
             List<EndpointsView> endpoints = null;
             var state = State.WaitingForEndpointDetection;
@@ -69,7 +70,7 @@
                     endpoints = result;
                     return state == State.WaitingForHeartbeatFailure && result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             var myEndpoint = endpoints.FirstOrDefault(e => e.Name == EndpointName);
             Assert.That(myEndpoint, Is.Not.Null);

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_endpoint_tracking_is_configured.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_endpoint_tracking_is_configured.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -15,7 +16,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
     class When_endpoint_tracking_is_configured : AcceptanceTest
     {
         [Test]
-        public async Task Should_read_and_change_tracking_for_one_endpoint_and_for_the_default()
+        public async Task Should_read_and_change_tracking_for_one_endpoint_and_for_the_default(CancellationToken cancellationToken = default)
         {
             List<SettingsData> initial = null;
             List<SettingsData> afterEndpointChange = null;
@@ -56,7 +57,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
                     return afterDefaultChange != null;
                 })
                 .Done(_ => true)
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_heartbeat_stats_are_requested.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_heartbeat_stats_are_requested.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Monitoring
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -12,7 +13,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
     class When_heartbeat_stats_are_requested : AcceptanceTest
     {
         [Test]
-        public async Task Should_count_a_heartbeating_endpoint_as_active()
+        public async Task Should_count_a_heartbeating_endpoint_as_active(CancellationToken cancellationToken = default)
         {
             HeartbeatStats stats = null;
 
@@ -24,14 +25,14 @@ namespace ServiceControl.AcceptanceTests.Monitoring
                     stats = result.Item;
                     return result.HasResult;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(stats.Failing, Is.Zero,
                 "An endpoint still sending heartbeats must not also be counted against the failing tile");
         }
 
         [Test]
-        public async Task Should_count_an_endpoint_past_its_grace_period_as_failing()
+        public async Task Should_count_an_endpoint_past_its_grace_period_as_failing(CancellationToken cancellationToken = default)
         {
             HeartbeatStats stats = null;
 
@@ -47,7 +48,7 @@ namespace ServiceControl.AcceptanceTests.Monitoring
                     stats = result.Item;
                     return result.HasResult;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(stats.Active, Is.Zero,
                 "An endpoint counted as failing must have left the active tile, or the two tiles double count it");

--- a/src/ServiceControl.AcceptanceTests/Monitoring/When_unmonitored_endpoint_starts_to_sends_heartbeats.cs
+++ b/src/ServiceControl.AcceptanceTests/Monitoring/When_unmonitored_endpoint_starts_to_sends_heartbeats.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTests.Monitoring
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -19,7 +20,7 @@
         static string EndpointName => Conventions.EndpointNamingConvention(typeof(WithoutHeartbeat));
 
         [Test]
-        public async Task Should_be_marked_as_monitored()
+        public async Task Should_be_marked_as_monitored(CancellationToken cancellationToken = default)
         {
             EndpointsView endpoint = null;
 
@@ -50,7 +51,7 @@
 
                     return result.HasResult;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -68,7 +69,7 @@
 
                     return result.HasResult;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_edit_is_resolved_by_retry.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_edit_is_resolved_by_retry.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
     class When_a_failed_edit_is_resolved_by_retry : AcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = config => config.OnEndpointSubscribed<EditMessageResolutionContext>((s, ctx) =>
             {
@@ -96,7 +97,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
                     }
 
                     return true;
-                }).Run();
+                }).Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_archived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_archived.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
 {
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -14,7 +15,7 @@
     class When_a_failed_message_is_archived : ExternalIntegrationAcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = config => config.OnEndpointSubscribed<Context>((s, ctx) =>
             {
@@ -48,7 +49,7 @@
                         e => e.Status == FailedMessageStatus.Archived);
                 })
                 .Done(ctx => ctx.EventDelivered) //Done when sequence is finished
-                .Run();
+                .Run(cancellationToken);
 
             var deserializedEvent = JsonSerializer.Deserialize<FailedMessagesArchived>(context.Event);
             Assert.That(deserializedEvent.FailedMessagesIds, Has.Member(context.FailedMessageId.ToString()));

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_resolved_by_retry.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_resolved_by_retry.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -14,7 +15,7 @@
     class When_a_failed_message_is_resolved_by_retry : ExternalIntegrationAcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = config => config.OnEndpointSubscribed<Context>((s, ctx) =>
             {
@@ -46,7 +47,7 @@
                         e => e.Status == FailedMessageStatus.Resolved);
                 })
                 .Done(ctx => ctx.EventDelivered) //Done when sequence is finished
-                .Run();
+                .Run(cancellationToken);
 
             var deserializedEvent = JsonSerializer.Deserialize<MessageFailureResolvedByRetry>(context.Event);
             Assert.That(deserializedEvent?.FailedMessageId, Is.EqualTo(context.FailedMessageId.ToString()));

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_resolved_manually.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_resolved_manually.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus;
@@ -16,7 +17,7 @@
     class When_a_failed_message_is_resolved_manually : ExternalIntegrationAcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = config => config.OnEndpointSubscribed<Context>((s, ctx) =>
             {
@@ -57,7 +58,7 @@
                         e => e.Status == FailedMessageStatus.Resolved);
                 })
                 .Done(ctx => ctx.EventDelivered) //Done when sequence is finished
-                .Run();
+                .Run(cancellationToken);
 
             var deserializedEvent = JsonSerializer.Deserialize<MessageFailureResolvedManually>(context.Event);
             Assert.That(deserializedEvent.FailedMessageId, Is.EqualTo(context.FailedMessageId.ToString()));

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_unarchived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_message_is_unarchived.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus;
@@ -16,7 +17,7 @@
     class When_a_failed_message_is_unarchived : ExternalIntegrationAcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = config => config.OnEndpointSubscribed<Context>((s, ctx) =>
             {
@@ -63,7 +64,7 @@
                         e => e.Status == FailedMessageStatus.Unresolved);
                 })
                 .Done(ctx => ctx.EventDelivered) //Done when sequence is finished
-                .Run();
+                .Run(cancellationToken);
 
             var deserializedEvent = JsonSerializer.Deserialize<FailedMessagesUnArchived>(context.Event);
             Assert.That(deserializedEvent.FailedMessagesIds, Is.Not.Null);

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_msg_is_resolved_by_edit.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_failed_msg_is_resolved_by_edit.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
 {
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -15,7 +16,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
     class When_a_failed_msg_is_resolved_by_edit : AcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = config => config.OnEndpointSubscribed<EditMessageResolutionContext>((s, ctx) =>
             {
@@ -84,7 +85,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
                     }
 
                     return true;
-                }).Run();
+                }).Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_group_is_archived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_group_is_archived.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_a_group_is_archived : ExternalIntegrationAcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = config => config.OnEndpointSubscribed<Context>((s, ctx) =>
             {
@@ -63,7 +64,7 @@
                         e => e.Status == FailedMessageStatus.Archived);
                 })
                 .Done(ctx => ctx.EventDelivered) //Done when sequence is finished
-                .Run();
+                .Run(cancellationToken);
 
             var deserializedEvent = JsonSerializer.Deserialize<FailedMessagesArchived>(context.Event);
             Assert.That(deserializedEvent.FailedMessagesIds, Is.Not.Null);

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_message_has_failed_detected.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_message_has_failed_detected.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -14,7 +15,7 @@
     class When_a_message_has_failed_detected : AcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = config => config.OnEndpointSubscribed<MyContext>((s, ctx) =>
             {
@@ -42,7 +43,7 @@
                     }
                 }))
                 .Done(c => c.EventDelivered)
-                .Run();
+                .Run(cancellationToken);
 
             var deserializedEvent = JsonSerializer.Deserialize<MessageFailed>(context.Event);
 

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_reedit_solves_a_failed_msg.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_a_reedit_solves_a_failed_msg.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
     class When_a_reedit_solves_a_failed_msg : AcceptanceTest
     {
         [Test]
-        public async Task Should_publish_notification()
+        public async Task Should_publish_notification(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = config => config.OnEndpointSubscribed<EditMessageResolutionContext>((s, ctx) =>
             {
@@ -116,7 +117,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
                     }
 
                     return true;
-                }).Run();
+                }).Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_encountered_an_error.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/ExternalIntegration/When_encountered_an_error.cs
@@ -25,7 +25,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
     class When_encountered_an_error : AcceptanceTest
     {
         [Test]
-        public async Task Should_restart_dispatch_thread()
+        public async Task Should_restart_dispatch_thread(CancellationToken cancellationToken = default)
         {
             var externalProcessorSubscribed = false;
 
@@ -65,7 +65,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.ExternalIntegration
                     }
                 }))
                 .Done(c => c.NotificationDelivered)
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.Failed, Is.True, "The faulty publisher never ran, so the notification was not delivered in spite of one");
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_ServiceControl_has_started.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_ServiceControl_has_started.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTests.Recoverability.Groups
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTesting;
@@ -10,7 +11,7 @@
     class When_ServiceControl_has_started : AcceptanceTest
     {
         [Test]
-        public async Task All_classifiers_should_be_retrievable()
+        public async Task All_classifiers_should_be_retrievable(CancellationToken cancellationToken = default)
         {
             List<string> classifiers = null;
 
@@ -21,7 +22,7 @@
                     classifiers = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(classifiers, Is.Not.Null, "classifiers is null");
             Assert.That(classifiers, Is.Not.Empty, "No classifiers retrieved");

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_failing_endpoint_is_triaged_and_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_failing_endpoint_is_triaged_and_retried.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.Groups
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.Groups
     class When_a_failing_endpoint_is_triaged_and_retried : AcceptanceTest
     {
         [Test]
-        public async Task Should_narrow_to_the_group_annotate_it_and_clear_it_once_retried()
+        public async Task Should_narrow_to_the_group_annotate_it_and_clear_it_once_retried(CancellationToken cancellationToken = default)
         {
             Dictionary<string, Dictionary<string, int>> summary = null;
             List<FailedMessageView> broken = null;
@@ -126,7 +127,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.Groups
                     return history.HasResult;
                 })
                 .Done(_ => true)
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_archived.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_a_group_is_archived.cs
@@ -17,7 +17,7 @@
     class When_a_group_is_archived : AcceptanceTest
     {
         [Test]
-        public async Task All_messages_in_group_should_get_archived()
+        public async Task All_messages_in_group_should_get_archived(CancellationToken cancellationToken = default)
         {
             await Define<MyContext>()
                 .WithEndpoint<Receiver>(b => b.When(async bus =>
@@ -59,11 +59,11 @@
                         e => e.Status == FailedMessageStatus.Archived);
                 })
                 .Done(ctx => true) //Done when sequence is finished
-                .Run();
+                .Run(cancellationToken);
         }
 
         [Test]
-        public async Task All_archived_messages_should_be_grouped()
+        public async Task All_archived_messages_should_be_grouped(CancellationToken cancellationToken = default)
         {
             await Define<MyContext>()
                 .WithEndpoint<Receiver>(b => b.When(async bus =>
@@ -110,11 +110,11 @@
                     return failedMessages && failedMessages.Items.Count == 1 && failedMessages.Items[0].Count == 2;
                 })
                 .Done(ctx => true) //Done when sequence is finished
-                .Run();
+                .Run(cancellationToken);
         }
 
         [Test]
-        public async Task Archived_messages_group_info_should_be_accessible()
+        public async Task Archived_messages_group_info_should_be_accessible(CancellationToken cancellationToken = default)
         {
             await Define<MyContext>()
                 .WithEndpoint<Receiver>(b => b.When(async bus =>
@@ -161,7 +161,7 @@
                     return failedMessages && failedMessages.Item.Count == 2;
                 })
                 .Done(ctx => true) //Done when sequence is finished
-                .Run();
+                .Run(cancellationToken);
         }
 
         [Test]

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_message_groups_are_sorted_by_a_web_api_call.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_message_groups_are_sorted_by_a_web_api_call.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.Groups
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,9 +18,9 @@ namespace ServiceControl.AcceptanceTests.Recoverability.Groups
     class When_message_groups_are_sorted_by_a_web_api_call : AcceptanceTest
     {
         [Test]
-        public async Task All_messages_in_group_should_be_sorted_by_time_sent()
+        public async Task All_messages_in_group_should_be_sorted_by_time_sent(CancellationToken cancellationToken = default)
         {
-            var errors = await SortTest("time_sent");
+            var errors = await SortTest("time_sent", cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -30,9 +31,9 @@ namespace ServiceControl.AcceptanceTests.Recoverability.Groups
         }
 
         [Test]
-        public async Task All_messages_in_group_should_be_sorted_by_message_type()
+        public async Task All_messages_in_group_should_be_sorted_by_message_type(CancellationToken cancellationToken = default)
         {
-            var errors = await SortTest("message_type");
+            var errors = await SortTest("message_type", cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -42,7 +43,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.Groups
             }
         }
 
-        async Task<List<FailedMessageView>> SortTest(string sortProperty)
+        async Task<List<FailedMessageView>> SortTest(string sortProperty, CancellationToken cancellationToken)
         {
             List<FailedMessageView> localErrors = null;
 
@@ -76,7 +77,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.Groups
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             return localErrors;
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_messages_have_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_messages_have_failed.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@
     class When_messages_have_failed : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_grouped()
+        public async Task Should_be_grouped(CancellationToken cancellationToken = default)
         {
             List<GroupOperation> defaultGroups = null;
             List<GroupOperation> exceptionTypeAndStackTraceGroups = null;
@@ -65,7 +66,7 @@
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_two_similar_messages_have_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/Groups/When_two_similar_messages_have_failed.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@
     class When_two_similar_messages_have_failed : AcceptanceTest
     {
         [Test]
-        public async Task They_should_be_grouped_together()
+        public async Task They_should_be_grouped_together(CancellationToken cancellationToken = default)
         {
             List<GroupOperation> exceptionTypeAndStackTraceGroups = null;
             List<GroupOperation> messageTypeGroups = null;
@@ -64,7 +65,7 @@
 
                     return secondFailureResult;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/Is_System_Message_Tests.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/Is_System_Message_Tests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -15,7 +16,7 @@
     class Is_System_Message_Tests : AcceptanceTest
     {
         [Test]
-        public async Task Should_set_the_IsSystemMessage_when_message_type_is_not_a_scheduled_task()
+        public async Task Should_set_the_IsSystemMessage_when_message_type_is_not_a_scheduled_task(CancellationToken cancellationToken = default)
         {
             FailedMessageView failure = null;
             await Define<SystemMessageTestContext>(ctx =>
@@ -31,14 +32,14 @@
                     failure = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(failure, Is.Not.Null);
             Assert.That(failure.IsSystemMessage, Is.False);
         }
 
         [Test]
-        public async Task Should_set_the_IsSystemMessage_when_message_type_is_a_scheduled_task()
+        public async Task Should_set_the_IsSystemMessage_when_message_type_is_a_scheduled_task(CancellationToken cancellationToken = default)
         {
             FailedMessageView failure = null;
             await Define<SystemMessageTestContext>(ctx =>
@@ -54,13 +55,13 @@
                     failure = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
             Assert.That(failure, Is.Not.Null);
             Assert.That(failure.IsSystemMessage, Is.True);
         }
 
         [Test]
-        public async Task Should_set_the_IsSystemMessage_when_control_message_header_is_true()
+        public async Task Should_set_the_IsSystemMessage_when_control_message_header_is_true(CancellationToken cancellationToken = default)
         {
             FailedMessageView failure = null;
             await Define<SystemMessageTestContext>(ctx =>
@@ -77,13 +78,13 @@
                     failure = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
             Assert.That(failure, Is.Not.Null);
             Assert.That(failure.IsSystemMessage, Is.True);
         }
 
         [Test]
-        public async Task Should_set_the_IsSystemMessage_when_control_message_header_is_null()
+        public async Task Should_set_the_IsSystemMessage_when_control_message_header_is_null(CancellationToken cancellationToken = default)
         {
             FailedMessageView failure = null;
             await Define<SystemMessageTestContext>(ctx =>
@@ -100,14 +101,14 @@
                     failure = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(failure, Is.Not.Null);
             Assert.That(failure.IsSystemMessage, Is.True);
         }
 
         [Test]
-        public async Task Should_set_the_IsSystemMessage_for_integration_scenario()
+        public async Task Should_set_the_IsSystemMessage_for_integration_scenario(CancellationToken cancellationToken = default)
         {
             FailedMessageView failure = null;
             await Define<SystemMessageTestContext>(ctx =>
@@ -123,7 +124,7 @@
                     failure = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
             Assert.That(failure, Is.Not.Null);
             Assert.That(failure.IsSystemMessage, Is.False);
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_SagaComplete_message_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_SagaComplete_message_fails.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@
     class When_a_SagaComplete_message_fails : AcceptanceTest
     {
         [Test]
-        public async Task No_SagaType_Header_Is_Ok()
+        public async Task No_SagaType_Header_Is_Ok(CancellationToken cancellationToken = default)
         {
             FailedMessageView failure = null;
 
@@ -29,7 +30,7 @@
                     failure = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(failure, Is.Not.Null);
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_pending_retry.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_failed_message_is_pending_retry.cs
@@ -18,7 +18,7 @@
     class When_a_failed_message_is_pending_retry : AcceptanceTest
     {
         [Test]
-        public async Task Should_status_retryissued_after_retry_is_sent()
+        public async Task Should_status_retryissued_after_retry_is_sent(CancellationToken cancellationToken = default)
         {
             FailedMessage failedMessage = null;
 
@@ -37,7 +37,7 @@
                     failedMessage = await this.TryGet<FailedMessage>($"/api/errors/{ctx.UniqueMessageId}");
                 })
                 .Done()
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(failedMessage.Status, Is.EqualTo(FailedMessageStatus.RetryIssued), "Status was not set to RetryIssued");
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_message_has_failed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_message_has_failed.cs
@@ -30,7 +30,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
     class When_a_message_has_failed : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_imported_and_accessible_via_the_rest_api()
+        public async Task Should_be_imported_and_accessible_via_the_rest_api(CancellationToken cancellationToken = default)
         {
             FailedMessage failedMessage = null;
 
@@ -42,7 +42,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
                     failedMessage = result;
                     return c.MessageId != null && result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -61,7 +61,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
         [Theory]
         [TestCase(false)]
         [TestCase(true)] // creates body above 85000 bytes to make sure it is ingested into the body storage
-        public async Task Should_be_imported_and_body_via_the_rest_api(bool largeMessage)
+        public async Task Should_be_imported_and_body_via_the_rest_api(bool largeMessage, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage result = null;
 
@@ -83,16 +83,16 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
                     result = await this.GetRaw("/api/messages/" + c.MessageId + "/body");
                     return result.IsSuccessStatusCode;
                 })
-                .Run();
+                .Run(cancellationToken);
 
-            var stringResult = await result.Content.ReadAsStringAsync();
+            var stringResult = await result.Content.ReadAsStringAsync(cancellationToken);
             var expectedResult = $"{{\"Content\":\"{myMessage.Content}\"}}";
 
             Assert.That(stringResult, Is.EqualTo(expectedResult));
         }
 
         [Test]
-        public async Task Should_be_imported_with_custom_serialization_and_body_via_the_rest_api()
+        public async Task Should_be_imported_with_custom_serialization_and_body_via_the_rest_api(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage result = null;
 
@@ -114,14 +114,14 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
                     result = await this.GetRaw("/api/messages/" + c.MessageId + "/body");
                     return result.IsSuccessStatusCode;
                 })
-                .Run();
+                .Run(cancellationToken);
 
-            var content = await result.Content.ReadAsStringAsync();
+            var content = await result.Content.ReadAsStringAsync(cancellationToken);
             Assert.That(content, Does.Contain($"<Content>{myMessage.Content}</Content>"));
         }
 
         [Test]
-        public async Task Should_be_listed_in_the_error_list()
+        public async Task Should_be_listed_in_the_error_list(CancellationToken cancellationToken = default)
         {
             FailedMessageView failure = null;
 
@@ -133,7 +133,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
                     failure = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -170,7 +170,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
         }
 
         [Test]
-        public async Task Should_add_an_event_log_item()
+        public async Task Should_add_an_event_log_item(CancellationToken cancellationToken = default)
         {
             EventLogItem entry = null;
 
@@ -182,7 +182,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
                     entry = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -194,7 +194,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
         }
 
         [Test]
-        public async Task Should_be_able_to_search_queueaddresses()
+        public async Task Should_be_able_to_search_queueaddresses(CancellationToken cancellationToken = default)
         {
             var searchResults = new List<QueueAddress>();
 
@@ -216,7 +216,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
                     }, (session, ctx) => Task.CompletedTask);
                 })
                 .Done(c => searchResults.Count == 1)
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(searchResults.Count, Is.EqualTo(1), "Result count did not match");
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_message_has_failed_from_send_only_endpoint.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_message_has_failed_from_send_only_endpoint.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -15,7 +16,7 @@
     class When_a_message_has_failed_from_send_only_endpoint : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_listed_in_the_error_list_when_processing_endpoint_header_is_not_present()
+        public async Task Should_be_listed_in_the_error_list_when_processing_endpoint_header_is_not_present(CancellationToken cancellationToken = default)
         {
             FailedMessageView failure = null;
             await Define<MyContext>(ctx =>
@@ -30,13 +31,13 @@
                     failure = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
             Assert.That(failure, Is.Not.Null);
             Assert.That(failure.ReceivingEndpoint.Name, Does.Contain("SomeEndpoint"), $"The sending endpoint should be SomeEndpoint and not {failure.ReceivingEndpoint.Name}");
         }
 
         [Test]
-        public async Task Should_be_listed_in_the_error_list_when_processing_endpoint_header_is_present()
+        public async Task Should_be_listed_in_the_error_list_when_processing_endpoint_header_is_present(CancellationToken cancellationToken = default)
         {
             FailedMessageView failure = null;
             await Define<MyContext>(ctx =>
@@ -51,7 +52,7 @@
                     failure = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
             Assert.That(failure, Is.Not.Null);
             Assert.That(failure.ReceivingEndpoint.Name, Does.Contain("SomeEndpoint"), $"The sending endpoint should be SomeEndpoint and not {failure.ReceivingEndpoint.Name}");
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_messages_fails_multiple_times.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_messages_fails_multiple_times.cs
@@ -9,6 +9,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability
     using System.Collections.Generic;
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting.EndpointTemplates;
     using ServiceControl.Infrastructure;
@@ -20,7 +21,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability
         const string AttemptNumberHeaderKey = "testing.failed_attempt_no";
 
         [Test]
-        public async Task Should_report_the_most_recent_attempt_last()
+        public async Task Should_report_the_most_recent_attempt_last(CancellationToken cancellationToken = default)
         {
             FailedMessage result = null;
 
@@ -39,7 +40,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability
 
                     return result != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(LatestAttemptNumber(result), Is.EqualTo(NumberOfFailedAttempts.ToString()));
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_resolved_by_selection.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_resolved_by_selection.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_a_pending_retry_is_resolved_by_selection : AcceptanceTest
     {
         [Test]
-        public async Task Should_succeed() =>
+        public async Task Should_succeed(CancellationToken cancellationToken = default) =>
             await Define<Context>()
                 .WithEndpoint<FailingEndpoint>(b => b.When(bus => bus.SendLocal(new MyMessage())).DoNotFailOnErrorMessages())
                 .Do("DetectFailure", async ctx =>
@@ -46,7 +47,7 @@
                         message => message.Status == FailedMessageStatus.Resolved);
                 })
                 .Done(ctx => true) //We're done once the sequence is finished
-                .Run();
+                .Run(cancellationToken);
 
         public class FailingEndpoint : EndpointConfigurationBuilder
         {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_resolved_by_timeframe.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_resolved_by_timeframe.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@
     class When_a_pending_retry_is_resolved_by_timeframe : AcceptanceTest
     {
         [Test]
-        public async Task Should_succeed() =>
+        public async Task Should_succeed(CancellationToken cancellationToken = default) =>
             await Define<Context>()
                 .WithEndpoint<Failing>(b => b.When(bus => bus.SendLocal(new MyMessage())).DoNotFailOnErrorMessages())
                 .Do("DetectFailure", async ctx =>
@@ -54,7 +55,7 @@
                         message => message.Status == FailedMessageStatus.Resolved);
                 })
                 .Done(ctx => true) //We're done once the sequence is finished
-                .Run();
+                .Run(cancellationToken);
 
         public class Failing : EndpointConfigurationBuilder
         {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_retried_again.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_retried_again.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_a_pending_retry_is_retried_again : AcceptanceTest
     {
         [Test]
-        public async Task Should_succeed() =>
+        public async Task Should_succeed(CancellationToken cancellationToken = default) =>
             await Define<Context>()
                 .WithEndpoint<FailingEndpoint>(b => b.When(bus => bus.SendLocal(new MyMessage())).DoNotFailOnErrorMessages())
                 .Do("DetectFailure", async ctx =>
@@ -42,7 +43,7 @@
                     });
                 })
                 .Done(ctx => ctx.RetryCount == 2)
-                .Run();
+                .Run(cancellationToken);
 
         public class FailingEndpoint : EndpointConfigurationBuilder
         {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_retried_by_queue_and_timeframe.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_a_pending_retry_is_retried_by_queue_and_timeframe.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@
     class When_a_pending_retry_is_retried_by_queue_and_timeframe : AcceptanceTest
     {
         [Test]
-        public async Task Should_succeed() =>
+        public async Task Should_succeed(CancellationToken cancellationToken = default) =>
             await Define<Context>()
                 .WithEndpoint<Failing>(b => b.When(bus => bus.SendLocal(new MyMessage())).DoNotFailOnErrorMessages())
                 .Do("DetectFailure", async ctx =>
@@ -46,7 +47,7 @@
                     });
                 })
                 .Done(ctx => ctx.RetryCount == 2)
-                .Run();
+                .Run(cancellationToken);
 
         public class Failing : EndpointConfigurationBuilder
         {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_an_event_with_multiple_subscribers_fails.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_an_event_with_multiple_subscribers_fails.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_an_event_with_multiple_subscribers_fails : AcceptanceTest
     {
         [Test]
-        public async Task There_should_be_a_FailedMessage_for_each_subscriber()
+        public async Task There_should_be_a_FailedMessage_for_each_subscriber(CancellationToken cancellationToken = default)
         {
             var failedMessages = new List<FailedMessageView>();
 
@@ -28,7 +29,7 @@
                     failedMessages = result;
                     return result && failedMessages.Sum(x => x.NumberOfProcessingAttempts) >= 2;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             var subscriber1FailedMessage = failedMessages.SingleOrDefault(msg => msg.QueueAddress.Contains("subscriber1"));
             var subscriber2FailedMessage = failedMessages.SingleOrDefault(msg => msg.QueueAddress.Contains("subscriber2"));

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_deleted_messages_are_restored.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_deleted_messages_are_restored.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
     class When_deleted_messages_are_restored : AcceptanceTest
     {
         [Test]
-        public async Task Should_restore_a_deleted_selection_and_a_deleted_group()
+        public async Task Should_restore_a_deleted_selection_and_a_deleted_group(CancellationToken cancellationToken = default)
         {
             string[] afterSelectionDeleted = null;
             string[] afterRangeRestored = null;
@@ -115,7 +116,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
                     return afterGroupRestored != null;
                 })
                 .Done(_ => true)
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_error_forwarding_is_enabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_error_forwarding_is_enabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -11,7 +12,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
     class When_error_forwarding_is_enabled : AcceptanceTest
     {
         [Test]
-        public async Task Should_forward_the_failed_message_to_the_error_log_queue()
+        public async Task Should_forward_the_failed_message_to_the_error_log_queue(CancellationToken cancellationToken = default)
         {
             SetSettings = settings =>
             {
@@ -27,7 +28,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
                 // spy cannot deserialize, so the spy has to tolerate its own failures.
                 .WithEndpoint<Spy>(b => b.DoNotFailOnErrorMessages())
                 .Done(c => c.ForwardedMessageId != null)
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_errors_with_same_uniqueid_are_imported.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_errors_with_same_uniqueid_are_imported.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -21,7 +22,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
         const int NumberOfDuplicates = 10;
 
         [Test]
-        public async Task The_import_should_deduplicate_on_TimeOfFailure()
+        public async Task The_import_should_deduplicate_on_TimeOfFailure(CancellationToken cancellationToken = default)
         {
             var criticalErrorExecuted = false;
 
@@ -47,7 +48,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
                     failure = result;
                     return criticalErrorExecuted || result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_failed_message_is_imported.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_failed_message_is_imported.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@
     class When_failed_message_is_imported : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_accessible_via_the_rest_api()
+        public async Task Should_be_accessible_via_the_rest_api(CancellationToken cancellationToken = default)
         {
             const string Payload = "PAYLOAD";
             MessagesView failedMessage = null;
@@ -48,7 +49,7 @@
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_failed_message_searched_by_body_content.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_failed_message_searched_by_body_content.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -13,7 +14,7 @@
     class When_failed_message_searched_by_body_content : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_found()
+        public async Task Should_be_found(CancellationToken cancellationToken = default)
         {
             var searchString = "forty-two";
 
@@ -37,7 +38,7 @@
                     c.MessageFound = await this.TryGetMany<MessagesView>($"/api/messages/search/{searchString}");
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.MessageFound, Is.True);
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_ingesting_failed_message_with_missing_headers.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_ingesting_failed_message_with_missing_headers.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using AcceptanceTesting;
 using AcceptanceTesting.EndpointTemplates;
@@ -18,14 +19,14 @@ using ServiceControl.MessageFailures.Api;
 class When_ingesting_failed_message_with_missing_headers : AcceptanceTest
 {
     [Test]
-    public async Task Should_be_ingested_when_minimal_required_headers_is_present()
+    public async Task Should_be_ingested_when_minimal_required_headers_is_present(CancellationToken cancellationToken = default)
     {
         var testStartTime = DateTime.UtcNow;
 
         var context = await Define<TestContext>(c => c.AddMinimalRequiredHeaders())
             .WithEndpoint<FailingEndpoint>()
             .Done(async c => await TryGetFailureFromApi(c))
-            .Run();
+            .Run(cancellationToken);
 
         var failure = context.Failure;
 
@@ -40,7 +41,7 @@ class When_ingesting_failed_message_with_missing_headers : AcceptanceTest
     }
 
     [Test]
-    public async Task Should_include_headers_required_by_ServicePulse()
+    public async Task Should_include_headers_required_by_ServicePulse(CancellationToken cancellationToken = default)
     {
         var context = await Define<TestContext>(c =>
             {
@@ -51,7 +52,7 @@ class When_ingesting_failed_message_with_missing_headers : AcceptanceTest
             })
             .WithEndpoint<FailingEndpoint>()
             .Done(async c => await TryGetFailureFromApi(c))
-            .Run();
+            .Run(cancellationToken);
 
         var failure = context.Failure;
 
@@ -66,7 +67,7 @@ class When_ingesting_failed_message_with_missing_headers : AcceptanceTest
     }
 
     [Test]
-    public async Task TimeSent_should_not_be_casted()
+    public async Task TimeSent_should_not_be_casted(CancellationToken cancellationToken = default)
     {
         var sentTime = DateTime.Parse("2014-11-11T02:26:58.000462Z", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
 
@@ -79,7 +80,7 @@ class When_ingesting_failed_message_with_missing_headers : AcceptanceTest
             })
             .WithEndpoint<FailingEndpoint>()
             .Done(async c => await TryGetFailureFromApi(c))
-            .Run();
+            .Run(cancellationToken);
 
         var failure = context.Failure;
 

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_pending_retries_are_resolved_by_queue.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageFailures/When_pending_retries_are_resolved_by_queue.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
     class When_pending_retries_are_resolved_by_queue : AcceptanceTest
     {
         [Test]
-        public async Task Should_resolve_only_the_queue_it_was_given()
+        public async Task Should_resolve_only_the_queue_it_was_given(CancellationToken cancellationToken = default)
         {
             FailedMessage billingAfterResolve = null;
             FailedMessage shippingAfterResolve = null;
@@ -84,7 +85,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageFailures
                     shippingAfterResolve = await this.TryGet<FailedMessage>($"/api/errors/{ctx.ShippingId}");
                 })
                 .Done(_ => true)
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageRedirects/When_a_message_fails_a_retry_with_a_redirect.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageRedirects/When_a_message_fails_a_retry_with_a_redirect.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -19,7 +20,7 @@
     class When_a_message_fails_a_retry_with_a_redirect : AcceptanceTest
     {
         [Test]
-        public async Task The_original_failed_message_record_is_updated()
+        public async Task The_original_failed_message_record_is_updated(CancellationToken cancellationToken = default)
         {
             List<FailedMessageView> failedMessages = null;
 
@@ -55,7 +56,7 @@
                     failedMessages = result;
                     return ctx.ProcessedAgain && result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(failedMessages, Is.Not.Null);
             Assert.That(failedMessages, Is.Not.Empty);

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageRedirects/When_a_redirect_is_changed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageRedirects/When_a_redirect_is_changed.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
     using System;
     using System.Collections.Generic;
     using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using Infrastructure;
@@ -12,7 +13,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
     class When_a_redirect_is_changed : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_successfully_updated()
+        public async Task Should_be_successfully_updated(CancellationToken cancellationToken = default)
         {
             var redirect = new RedirectRequest
             {
@@ -40,7 +41,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
                 result = await this.TryGetMany<MessageRedirectFromJson>("/api/redirects");
                 c.Response = result;
                 return true;
-            }).Run();
+            }).Run(cancellationToken);
 
             var response = context.Response;
             Assert.That(response.Count, Is.EqualTo(1), "Expected only 1 redirect");
@@ -54,7 +55,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
         }
 
         [Test]
-        public async Task Should_fail_validation_with_blank_tophysicaladdress()
+        public async Task Should_fail_validation_with_blank_tophysicaladdress(CancellationToken cancellationToken = default)
         {
             var redirect = new RedirectRequest
             {
@@ -76,11 +77,11 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
         }
 
         [Test]
-        public async Task Should_return_not_found_if_it_does_not_exist()
+        public async Task Should_return_not_found_if_it_does_not_exist(CancellationToken cancellationToken = default)
         {
             const string newTo = "endpointC@machine3";
 
@@ -93,11 +94,11 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
                     }, status => status != HttpStatusCode.NotFound);
 
                     return true;
-                }).Run();
+                }).Run(cancellationToken);
         }
 
         [Test]
-        public async Task Should_return_conflict_when_it_will_create_a_dependency()
+        public async Task Should_return_conflict_when_it_will_create_a_dependency(CancellationToken cancellationToken = default)
         {
             var updateRedirect = new RedirectRequest
             {
@@ -126,7 +127,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
                     }, status => status != HttpStatusCode.Conflict);
 
                     return true;
-                }).Run();
+                }).Run(cancellationToken);
         }
 
         class Context : ScenarioContext

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageRedirects/When_a_redirect_is_created.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageRedirects/When_a_redirect_is_created.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using Infrastructure;
@@ -12,7 +13,7 @@
     class When_a_redirect_is_created : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_added_and_accessible_via_the_api()
+        public async Task Should_be_added_and_accessible_via_the_api(CancellationToken cancellationToken = default)
         {
             var redirect = new RedirectRequest
             {
@@ -31,7 +32,7 @@
                     response = result;
 
                     return result;
-                }).Run();
+                }).Run(cancellationToken);
 
             Assert.That(response.Count, Is.EqualTo(1), "Expected 1 redirect to be created");
             using (Assert.EnterMultipleScope())
@@ -44,7 +45,7 @@
         }
 
         [Test]
-        public async Task Should_fail_validation_with_blank_fromphysicaladdress()
+        public async Task Should_fail_validation_with_blank_fromphysicaladdress(CancellationToken cancellationToken = default)
         {
             var redirect = new RedirectRequest
             {
@@ -57,11 +58,11 @@
                 {
                     await this.Post("/api/redirects", redirect, status => status != HttpStatusCode.BadRequest);
                     return true;
-                }).Run();
+                }).Run(cancellationToken);
         }
 
         [Test]
-        public async Task Should_fail_validation_with_blank_tophysicaladdress()
+        public async Task Should_fail_validation_with_blank_tophysicaladdress(CancellationToken cancellationToken = default)
         {
             var redirect = new RedirectRequest
             {
@@ -74,11 +75,11 @@
                 {
                     await this.Post("/api/redirects", redirect, status => status != HttpStatusCode.BadRequest);
                     return true;
-                }).Run();
+                }).Run(cancellationToken);
         }
 
         [Test]
-        public async Task Should_fail_validation_with_different_tophysicaladdress()
+        public async Task Should_fail_validation_with_different_tophysicaladdress(CancellationToken cancellationToken = default)
         {
             var redirect = new RedirectRequest
             {
@@ -95,11 +96,11 @@
 
                     await this.Post("/api/redirects", redirect, status => status != HttpStatusCode.Conflict);
                     return true;
-                }).Run();
+                }).Run(cancellationToken);
         }
 
         [Test]
-        public async Task Should_ignore_exact_copies()
+        public async Task Should_ignore_exact_copies(CancellationToken cancellationToken = default)
         {
             var redirect = new RedirectRequest
             {
@@ -119,14 +120,14 @@
                     var result = await this.TryGetMany<MessageRedirectFromJson>("/api/redirects");
                     response = result;
                     return result;
-                }).Run();
+                }).Run(cancellationToken);
 
             Assert.That(response.Count, Is.EqualTo(1), "Expected only 1 redirect to be created");
         }
 
 
         [Test]
-        public async Task Should_fail_validation_with_dependent_redirects()
+        public async Task Should_fail_validation_with_dependent_redirects(CancellationToken cancellationToken = default)
         {
             var toAddress = "endpointTo@machineTo";
             var dependentCount = 3;
@@ -151,7 +152,7 @@
                     }, status => status != HttpStatusCode.Conflict);
 
                     return true;
-                }).Run();
+                }).Run(cancellationToken);
         }
 
         class Context : ScenarioContext;

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageRedirects/When_a_redirect_is_removed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageRedirects/When_a_redirect_is_removed.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using Infrastructure;
@@ -10,7 +11,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
     class When_a_redirect_is_removed : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_successfully_deleted()
+        public async Task Should_be_successfully_deleted(CancellationToken cancellationToken = default)
         {
             var redirect = new RedirectRequest
             {
@@ -32,7 +33,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
                     response = result;
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(response, Is.Empty, "Expected no redirects after delete");
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/MessageRedirects/When_no_redirects_have_been_created.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/MessageRedirects/When_no_redirects_have_been_created.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTesting;
@@ -9,7 +10,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
     class When_no_redirects_have_been_created : AcceptanceTest
     {
         [Test]
-        public async Task Listing_redirects_should_not_error()
+        public async Task Listing_redirects_should_not_error(CancellationToken cancellationToken = default)
         {
             var response = new List<MessageRedirectFromJson>();
 
@@ -20,7 +21,7 @@ namespace ServiceControl.AcceptanceTests.Recoverability.MessageRedirects
                     response = result;
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(response, Is.Empty, "Expected 0 redirects to be created");
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_is_retried.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@
     class When_a_message_is_retried : AcceptanceTest
     {
         [Test]
-        public async Task Should_clean_headers()
+        public async Task Should_clean_headers(CancellationToken cancellationToken = default)
         {
             var context = await Define<TestContext>()
                 .WithEndpoint<VerifyHeader>()
@@ -32,7 +33,7 @@
 
                     return x.Done;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(HeadersThatShouldBeRemoved, Has.No.Member(context.Headers.Keys));
         }
@@ -42,7 +43,7 @@
         [TestCase(true, false)] // creates body above 85000 bytes to make sure it is ingested into the body storage
         [TestCase(false, true)]
         [TestCase(true, true)] // creates body above 85000 bytes to make sure it is ingested into the body storage
-        public async Task Should_work_with_various_body_size(bool largeMessageBodies, bool enableFullTextSearch)
+        public async Task Should_work_with_various_body_size(bool largeMessageBodies, bool enableFullTextSearch, CancellationToken cancellationToken = default)
         {
             SetSettings = settings =>
             {
@@ -67,7 +68,7 @@
 
                     return x.Done;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.BodyReceived, Is.EqualTo(context.BodyToSend).AsCollection);
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_is_retried_with_a_replyTo_header.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_is_retried_with_a_replyTo_header.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@
     class When_a_message_is_retried_with_a_replyTo_header : AcceptanceTest
     {
         [Test]
-        public async Task The_header_should_not_be_changed()
+        public async Task The_header_should_not_be_changed(CancellationToken cancellationToken = default)
         {
             var context = await Define<ReplyToContext>(ctx => { ctx.ReplyToAddress = "ReplyToAddress@SOMEMACHINE"; })
                 .WithEndpoint<VerifyHeader>()
@@ -32,7 +33,7 @@
 
                     return x.Done;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.ReceivedReplyToAddress, Is.EqualTo(context.ReplyToAddress));
         }

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_without_a_correlationid_header_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_a_message_without_a_correlationid_header_is_retried.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTests.Recoverability
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_a_message_without_a_correlationid_header_is_retried : AcceptanceTest
     {
         [Test]
-        public async Task The_successful_retry_should_succeed()
+        public async Task The_successful_retry_should_succeed(CancellationToken cancellationToken = default)
         {
             await Define<MyContext>()
                 .WithEndpoint<Receiver>(b => b.When(bus => bus.SendLocal(new MyMessage()))
@@ -30,7 +31,7 @@
                 })
                 .Do("Wait for the retry to be handled", ctx => Task.FromResult(ctx.RetryHandled))
                 .Done()
-                .Run();
+                .Run(cancellationToken);
         }
 
         internal class MyMessage : IMessage;

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_a_native_integration_message_is_retried.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_a_native_integration_message_is_retried.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@
     class When_a_native_integration_message_is_retried : AcceptanceTest
     {
         [Test]
-        public async Task Should_not_corrupt_headers()
+        public async Task Should_not_corrupt_headers(CancellationToken cancellationToken = default)
         {
             var context = await Define<TestContext>()
                 .WithEndpoint<VerifyHeader>()
@@ -32,7 +33,7 @@
 
                     return x.Done;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_edited_message_fails_to_process.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_edited_message_fails_to_process.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@
     class When_edited_message_fails_to_process : AcceptanceTest
     {
         [Test]
-        public async Task A_new_message_failure_is_created()
+        public async Task A_new_message_failure_is_created(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = config => config.OnEndpointSubscribed<EditMessageFailureContext>((s, ctx) =>
             {
@@ -100,7 +101,7 @@
                     ctx.EditedMessageFailure = (await this.TryGet<FailedMessage>($"/api/errors/{ctx.EditedMessageFailureId}")).Item;
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             var editedMessageBody = JsonSerializer.Deserialize<FailingMessage>(context.EditedMessageFailure.ProcessingAttempts.Last().MessageMetadata["MsgFullText"].ToString());
 

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_editing_message_body.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_editing_message_body.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@
     class When_editing_message_body : AcceptanceTest
     {
         [Test]
-        public async Task A_new_message_with_edited_body_is_sent()
+        public async Task A_new_message_with_edited_body_is_sent(CancellationToken cancellationToken = default)
         {
             var context = await Define<EditMessageContext>()
                 .WithEndpoint<EditedMessageReceiver>(e => e
@@ -61,7 +62,7 @@
                     ctx.OriginalMessageFailure = (await this.TryGet<FailedMessage>($"/api/errors/{ctx.UniqueMessageId}")).Item;
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_editing_message_headers.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_editing_message_headers.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@
     class When_editing_message_headers : AcceptanceTest
     {
         [Test]
-        public async Task A_new_message_with_edited_headers_is_sent()
+        public async Task A_new_message_with_edited_headers_is_sent(CancellationToken cancellationToken = default)
         {
             var context = await Define<EditMessageContext>()
                 .WithEndpoint<EditedMessageReceiver>(e => e
@@ -60,7 +61,7 @@
                     ctx.OriginalMessageFailure = (await this.TryGet<FailedMessage>($"/api/errors/{ctx.UniqueMessageId}")).Item;
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_retry_is_confirmed.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_retry_is_confirmed.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -15,7 +16,7 @@
     class When_retry_is_confirmed : AcceptanceTest
     {
         [Test]
-        public async Task Should_mark_message_as_successfully_resolved()
+        public async Task Should_mark_message_as_successfully_resolved(CancellationToken cancellationToken = default)
         {
             var context = await Define<Context>()
                 .WithEndpoint<RetryingEndpoint>(b => b
@@ -50,7 +51,7 @@
                     return false;
                 })
                 .Done(c => true)
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.MessagesView.Count, Is.EqualTo(1));
             var failedMessage = context.MessagesView.Single();

--- a/src/ServiceControl.AcceptanceTests/Recoverability/When_single_message_fails_in_batch.cs
+++ b/src/ServiceControl.AcceptanceTests/Recoverability/When_single_message_fails_in_batch.cs
@@ -21,7 +21,7 @@
     class When_single_message_fails_in_batch : AcceptanceTest
     {
         [Test]
-        public async Task Should_import_all_messages()
+        public async Task Should_import_all_messages(CancellationToken cancellationToken = default)
         {
             //Make sure the error import attempt fails
             CustomizeHostBuilder = builder => builder.Services.AddSingleton<IEnrichImportedErrorMessages, FailOnceEnricher>();
@@ -48,7 +48,7 @@
 
                     return messages.Count == BatchSize && messages.Select(m => m.MessageId).OrderBy(t => t).SequenceEqual(c.MessageIds.OrderBy(t => t));
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.FailureSimulated, Is.True,
                 "The enricher never threw, so nothing in the batch failed and the test proved nothing");

--- a/src/ServiceControl.AcceptanceTests/RootControllerTests.cs
+++ b/src/ServiceControl.AcceptanceTests/RootControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.AcceptanceTests.Legacy
 {
     using System.Text.Json.Nodes;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTests;
@@ -11,7 +12,7 @@
     class RootControllerTests : AcceptanceTest
     {
         [Test]
-        public async Task Should_gather_remote_data()
+        public async Task Should_gather_remote_data(CancellationToken cancellationToken = default)
         {
             // Since we don't have an audit instance running in a test, use the primary instance
             // configuration URL just to ensure the JSON is combined correctly.
@@ -37,7 +38,7 @@
                     config = result.Item;
                     return result.HasResult;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(config, Is.Not.Null);
             Assert.That(config.Count, Is.EqualTo(2));

--- a/src/ServiceControl.AcceptanceTests/Security/Cors/When_cors_allows_any_origin.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/Cors/When_cors_allows_any_origin.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -27,7 +28,7 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
         public void CleanupCors() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_return_wildcard_access_control_allow_origin_header()
+        public async Task Should_return_wildcard_access_control_allow_origin_header(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -41,13 +42,13 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowAnyOrigin(response);
         }
 
         [Test]
-        public async Task Should_return_expected_allowed_methods()
+        public async Task Should_return_expected_allowed_methods(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -61,13 +62,13 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowedMethods(response, "POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD");
         }
 
         [Test]
-        public async Task Should_return_expected_exposed_headers()
+        public async Task Should_return_expected_exposed_headers(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -81,7 +82,7 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertExposedHeaders(response, "ETag", "Last-Modified", "Link", "Total-Count", "X-Particular-Version");
         }

--- a/src/ServiceControl.AcceptanceTests/Security/Cors/When_cors_is_disabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/Cors/When_cors_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -27,7 +28,7 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
         public void CleanupCors() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_return_access_control_allow_origin_header()
+        public async Task Should_not_return_access_control_allow_origin_header(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -41,13 +42,13 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertCorsDisabled(response);
         }
 
         [Test]
-        public async Task Preflight_request_should_not_return_cors_headers()
+        public async Task Preflight_request_should_not_return_cors_headers(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -61,7 +62,7 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertCorsDisabled(response);
         }

--- a/src/ServiceControl.AcceptanceTests/Security/Cors/When_request_from_allowed_origin.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/Cors/When_request_from_allowed_origin.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -28,7 +29,7 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
 
         [TestCase("https://app.example.com")]
         [TestCase("https://admin.example.com")]
-        public async Task Should_return_matching_origin_in_access_control_allow_origin_header(string allowedOrigin)
+        public async Task Should_return_matching_origin_in_access_control_allow_origin_header(string allowedOrigin, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -41,13 +42,13 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowedOrigin(response, allowedOrigin);
         }
 
         [Test]
-        public async Task Preflight_request_should_return_correct_cors_headers()
+        public async Task Preflight_request_should_return_correct_cors_headers(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string allowedOrigin = "https://app.example.com";
@@ -61,7 +62,7 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowedOrigin(response, allowedOrigin);
             CorsAssertions.AssertAllowedMethods(response, "POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD");

--- a/src/ServiceControl.AcceptanceTests/Security/Cors/When_request_from_disallowed_origin.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/Cors/When_request_from_disallowed_origin.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -27,7 +28,7 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
         public void CleanupCors() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_return_access_control_allow_origin_header_for_disallowed_origin()
+        public async Task Should_not_return_access_control_allow_origin_header_for_disallowed_origin(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string disallowedOrigin = "https://malicious.example.com";
@@ -41,13 +42,13 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Should_not_allow_origin_with_different_scheme()
+        public async Task Should_not_allow_origin_with_different_scheme(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             // http:// instead of https://
@@ -62,13 +63,13 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Should_not_allow_origin_with_different_port()
+        public async Task Should_not_allow_origin_with_different_port(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             // Different port
@@ -83,13 +84,13 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Should_not_allow_subdomain_when_parent_domain_is_configured()
+        public async Task Should_not_allow_subdomain_when_parent_domain_is_configured(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             // Subdomain of allowed origin
@@ -104,13 +105,13 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Preflight_request_should_not_allow_disallowed_origin()
+        public async Task Preflight_request_should_not_allow_disallowed_origin(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string disallowedOrigin = "https://malicious.example.com";
@@ -124,7 +125,7 @@ namespace ServiceControl.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_disabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_disabled.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_ignored_when_disabled()
+        public async Task Headers_should_be_ignored_when_disabled(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersIgnoredWhenDisabled(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_sent.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -14,7 +15,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
     class When_forwarded_headers_are_sent : AcceptanceTest
     {
         [Test]
-        public async Task Headers_should_be_applied_when_trust_all_proxies()
+        public async Task Headers_should_be_applied_when_trust_all_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -29,7 +30,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWhenTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_known_networks_are_configured.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_known_networks_are_configured.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_applied_when_caller_matches_known_network()
+        public async Task Headers_should_be_applied_when_caller_matches_known_network(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWithKnownProxiesOrNetworks(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_known_proxies_are_configured.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_known_proxies_are_configured.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_applied_when_caller_matches_known_proxy()
+        public async Task Headers_should_be_applied_when_caller_matches_known_proxy(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWithKnownProxiesOrNetworks(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -15,7 +16,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
     class When_multiple_header_values_are_sent : AcceptanceTest
     {
         [Test]
-        public async Task Original_values_should_be_returned_when_trust_all_proxies()
+        public async Task Original_values_should_be_returned_when_trust_all_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -35,7 +36,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com, internal.proxy.local");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertMultipleHeaderValuesProcessedWithTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent_with_known_proxies.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent_with_known_proxies.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -26,7 +27,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Only_rightmost_values_should_be_processed_when_forward_limit_is_one()
+        public async Task Only_rightmost_values_should_be_processed_when_forward_limit_is_one(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -46,7 +47,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com, internal.proxy.local");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertMultipleHeaderValuesWithForwardLimitOne(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_only_proto_header_is_sent.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_only_proto_header_is_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -14,7 +15,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
     class When_only_proto_header_is_sent : AcceptanceTest
     {
         [Test]
-        public async Task Only_scheme_should_be_changed()
+        public async Task Only_scheme_should_be_changed(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -27,7 +28,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedProto: "https");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertPartialHeadersApplied(requestInfo, expectedScheme: "https");
         }

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -15,7 +16,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
     class When_proxy_chain_headers_are_sent : AcceptanceTest
     {
         [Test]
-        public async Task Original_client_ip_should_be_returned_when_trust_all_proxies()
+        public async Task Original_client_ip_should_be_returned_when_trust_all_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -33,7 +34,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertProxyChainProcessedWithTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent_with_known_proxies.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent_with_known_proxies.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Only_last_proxy_ip_should_be_processed_when_forward_limit_is_one()
+        public async Task Only_last_proxy_ip_should_be_processed_when_forward_limit_is_one(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -43,7 +44,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertProxyChainWithForwardLimitOne(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_request_has_no_forwarded_headers.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_request_has_no_forwarded_headers.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -14,7 +15,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
     class When_request_has_no_forwarded_headers : AcceptanceTest
     {
         [Test]
-        public async Task Request_values_should_remain_unchanged()
+        public async Task Request_values_should_remain_unchanged(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -29,7 +30,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                     }
                     return false;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertDirectAccessWithNoForwardedHeaders(requestInfo);
         }

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_trust_all_proxies_is_explicitly_configured.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_trust_all_proxies_is_explicitly_configured.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_applied_when_trust_all_proxies_is_explicitly_set()
+        public async Task Headers_should_be_applied_when_trust_all_proxies_is_explicitly_set(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWhenTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_unknown_network_sends_headers.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_unknown_network_sends_headers.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -26,7 +27,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_ignored_when_caller_not_in_known_networks()
+        public async Task Headers_should_be_ignored_when_caller_not_in_known_networks(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -44,7 +45,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         testRemoteIp: "203.0.113.1");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersIgnoredWhenProxyNotTrusted(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_unknown_proxy_sends_headers.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/ForwardedHeaders/When_unknown_proxy_sends_headers.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -26,7 +27,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_ignored_when_caller_not_in_known_proxies()
+        public async Task Headers_should_be_ignored_when_caller_not_in_known_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -44,7 +45,7 @@ namespace ServiceControl.AcceptanceTests.Security.ForwardedHeaders
                         testRemoteIp: "203.0.113.1");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersIgnoredWhenProxyNotTrusted(
                 requestInfo,

--- a/src/ServiceControl.AcceptanceTests/Security/Https/When_hsts_is_configured_in_development_mode.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/Https/When_hsts_is_configured_in_development_mode.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Security.Https
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Https;
@@ -29,7 +30,7 @@ namespace ServiceControl.AcceptanceTests.Security.Https
         public void CleanupHttps() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_include_hsts_header_in_development_mode()
+        public async Task Should_not_include_hsts_header_in_development_mode(CancellationToken cancellationToken = default)
         {
             // HSTS is intentionally NOT applied in development environments
             // This is ASP.NET Core's default behavior to prevent HSTS from being cached
@@ -43,7 +44,7 @@ namespace ServiceControl.AcceptanceTests.Security.Https
                     response = await this.GetRaw("/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             HttpsAssertions.AssertNoHstsHeader(response);
         }

--- a/src/ServiceControl.AcceptanceTests/Security/Https/When_https_redirect_is_disabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/Https/When_https_redirect_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Security.Https
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Https;
@@ -25,7 +26,7 @@ namespace ServiceControl.AcceptanceTests.Security.Https
         public void CleanupHttps() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_redirect_http_requests()
+        public async Task Should_not_redirect_http_requests(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -35,7 +36,7 @@ namespace ServiceControl.AcceptanceTests.Security.Https
                     response = await this.GetRaw("/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             HttpsAssertions.AssertNoHttpsRedirect(response);
         }

--- a/src/ServiceControl.AcceptanceTests/Security/Https/When_https_redirect_is_enabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/Https/When_https_redirect_is_enabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Security.Https
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Https;
@@ -26,7 +27,7 @@ namespace ServiceControl.AcceptanceTests.Security.Https
         public void CleanupHttps() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_redirect_http_requests_to_https()
+        public async Task Should_redirect_http_requests_to_https(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -36,7 +37,7 @@ namespace ServiceControl.AcceptanceTests.Security.Https
                     response = await this.GetRaw("/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             HttpsAssertions.AssertHttpsRedirect(response, expectedPort: 443);
         }

--- a/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_disabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.OpenIdConnect;
@@ -26,7 +27,7 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
         public void CleanupAuth() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_allow_requests_without_authentication()
+        public async Task Should_allow_requests_without_authentication(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -40,13 +41,13 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         "/api/errors");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertNoAuthenticationRequired(response);
         }
 
         [Test]
-        public async Task Should_return_authentication_configuration_as_disabled()
+        public async Task Should_return_authentication_configuration_as_disabled(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -59,9 +60,9 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         "/api/authentication/configuration");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
-            await OpenIdConnectAssertions.AssertAuthConfigurationResponse(response, expectedEnabled: false);
+            await OpenIdConnectAssertions.AssertAuthConfigurationResponse(response, expectedEnabled: false, cancellationToken: cancellationToken);
         }
 
         class Context : ScenarioContext;

--- a/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_enabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_enabled.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
 {
     using System.Net.Http;
     using System.Security.Claims;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.OpenIdConnect;
@@ -55,7 +56,7 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
         }
 
         [Test]
-        public async Task Should_return_authentication_configuration_with_enabled_true()
+        public async Task Should_return_authentication_configuration_with_enabled_true(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -70,7 +71,7 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         "/api/authentication/configuration");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             await OpenIdConnectAssertions.AssertAuthConfigurationResponse(
                 response,
@@ -79,11 +80,12 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                 expectedAudience: TestAudience,
                 expectedApiScopes: TestApiScopes,
                 expectedScopes: $"{TestApiScope} openid profile email offline_access",
-                expectedRoleBasedAuthorizationEnabled: true);
+                expectedRoleBasedAuthorizationEnabled: true,
+                cancellationToken: cancellationToken);
         }
 
         [Test]
-        public async Task Should_reject_requests_without_bearer_token()
+        public async Task Should_reject_requests_without_bearer_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -98,13 +100,13 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         "/api/errors");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_invalid_bearer_token()
+        public async Task Should_reject_requests_with_invalid_bearer_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -118,13 +120,13 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         "invalid-token-value");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_accept_requests_with_valid_bearer_token()
+        public async Task Should_accept_requests_with_valid_bearer_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -142,13 +144,13 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         validToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertAuthenticated(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_expired_token()
+        public async Task Should_reject_requests_with_expired_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -163,13 +165,13 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         expiredToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_wrong_audience()
+        public async Task Should_reject_requests_with_wrong_audience(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -184,13 +186,13 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         wrongAudienceToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_wrong_issuer()
+        public async Task Should_reject_requests_with_wrong_issuer(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -205,13 +207,13 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         wrongIssuerToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_forbid_authenticated_user_lacking_required_permission()
+        public async Task Should_forbid_authenticated_user_lacking_required_permission(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -230,7 +232,7 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         readerToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertForbidden(response);
         }

--- a/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_my_routes_are_requested.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_my_routes_are_requested.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using AcceptanceTesting;
 using AcceptanceTesting.OpenIdConnect;
@@ -48,7 +49,7 @@ class When_my_routes_are_requested : AcceptanceTest
     }
 
     [Test]
-    public async Task Should_reject_requests_without_bearer_token()
+    public async Task Should_reject_requests_without_bearer_token(CancellationToken cancellationToken = default)
     {
         HttpResponseMessage response = null;
 
@@ -59,13 +60,13 @@ class When_my_routes_are_requested : AcceptanceTest
                     HttpClient, HttpMethod.Get, "/api/my/routes");
                 return response != null;
             })
-            .Run();
+            .Run(cancellationToken);
 
         OpenIdConnectAssertions.AssertUnauthorized(response);
     }
 
     [Test]
-    public async Task Should_return_only_the_routes_the_callers_role_permits()
+    public async Task Should_return_only_the_routes_the_callers_role_permits(CancellationToken cancellationToken = default)
     {
         HttpResponseMessage response = null;
 
@@ -81,11 +82,11 @@ class When_my_routes_are_requested : AcceptanceTest
                     HttpClient, HttpMethod.Get, "/api/my/routes", readerToken);
                 return response != null;
             })
-            .Run();
+            .Run(cancellationToken);
 
         OpenIdConnectAssertions.AssertAuthenticated(response);
 
-        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement;
+        var root = JsonDocument.Parse(await response.Content.ReadAsStringAsync(cancellationToken)).RootElement;
 
         var roles = root.GetProperty("roles").EnumerateArray().Select(role => role.GetString());
         Assert.That(roles, Does.Contain("reader"));

--- a/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_service_pulse_authority_override_is_configured.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_service_pulse_authority_override_is_configured.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.OpenIdConnect;
@@ -40,7 +41,7 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
         public void CleanupAuth() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_return_service_pulse_authority_in_configuration()
+        public async Task Should_return_service_pulse_authority_in_configuration(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -53,7 +54,7 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         "/api/authentication/configuration");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             await OpenIdConnectAssertions.AssertAuthConfigurationResponse(
                 response,
@@ -61,7 +62,8 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                 expectedClientId: TestClientId,
                 expectedAuthority: ServicePulseAuthority,
                 expectedAudience: TestAudience,
-                expectedApiScopes: TestApiScopes);
+                expectedApiScopes: TestApiScopes,
+                cancellationToken: cancellationToken);
         }
 
         class Context : ScenarioContext;

--- a/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_service_pulse_offline_access_scope_is_disabled.cs
+++ b/src/ServiceControl.AcceptanceTests/Security/OpenIdConnect/When_service_pulse_offline_access_scope_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.OpenIdConnect;
@@ -41,7 +42,7 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
         public void CleanupAuth() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_omit_offline_access_from_composed_scopes()
+        public async Task Should_omit_offline_access_from_composed_scopes(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -54,7 +55,7 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                         "/api/authentication/configuration");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             await OpenIdConnectAssertions.AssertAuthConfigurationResponse(
                 response,
@@ -62,7 +63,8 @@ namespace ServiceControl.AcceptanceTests.Security.OpenIdConnect
                 expectedClientId: TestClientId,
                 expectedAudience: TestAudience,
                 expectedApiScopes: TestApiScopes,
-                expectedScopes: $"{TestApiScope} openid profile email");
+                expectedScopes: $"{TestApiScope} openid profile email",
+                cancellationToken: cancellationToken);
         }
 
         class Context : ScenarioContext;

--- a/src/ServiceControl.AcceptanceTests/WebApi/When_a_request_is_repeated_with_its_etag.cs
+++ b/src/ServiceControl.AcceptanceTests/WebApi/When_a_request_is_repeated_with_its_etag.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTesting;
@@ -35,7 +36,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
         [TestCase("/api/recoverability/groups/no-such-group/errors", "GET")]
         [TestCase("/api/recoverability/groups/no-such-group/errors", "HEAD")]
         [TestCase("/api/conversations/no-such-conversation", "GET")]
-        public async Task Should_answer_not_modified(string url, string method)
+        public async Task Should_answer_not_modified(string url, string method, CancellationToken cancellationToken = default)
         {
             Answer issued = null;
             Answer repeated = null;
@@ -64,7 +65,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(issued.Etag, Is.Not.Null, $"{method} {url} issued no ETag, so there is nothing for a client to revalidate against");
             Assert.That(repeated.Status, Is.EqualTo(HttpStatusCode.NotModified), $"{method} {url} sent the full payload again for a client that already held {issued.Etag}");
@@ -75,7 +76,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
         }
 
         [Test]
-        public async Task Should_answer_with_a_new_etag_once_the_data_moves()
+        public async Task Should_answer_with_a_new_etag_once_the_data_moves(CancellationToken cancellationToken = default)
         {
             Answer before = null;
             Answer after = null;
@@ -102,7 +103,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(after.Status, Is.EqualTo(HttpStatusCode.OK),
                 "a redirect was added, so the client's validator is stale and it has to be sent the new list");

--- a/src/ServiceControl.AcceptanceTests/WebApi/When_failed_messages_are_queried.cs
+++ b/src/ServiceControl.AcceptanceTests/WebApi/When_failed_messages_are_queried.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
     class When_failed_messages_are_queried : AcceptanceTest
     {
         [Test]
-        public async Task Should_filter_by_endpoint_and_by_search_term()
+        public async Task Should_filter_by_endpoint_and_by_search_term(CancellationToken cancellationToken = default)
         {
             List<MessagesView> forBilling = null;
             List<MessagesView> matchingTerm = null;
@@ -54,7 +55,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
                     endpointSearchRoute = await Paged($"/api/endpoints/{BillingEndpoint}/messages/search?q={SearchTerm}");
                 })
                 .Done(_ => true)
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/WebApi/When_requesting_health.cs
+++ b/src/ServiceControl.AcceptanceTests/WebApi/When_requesting_health.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.AcceptanceTests.WebApi
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTesting;
@@ -8,7 +9,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
     class When_requesting_health : AcceptanceTest
     {
         [Test]
-        public async Task Should_report_liveness_and_readiness_as_json()
+        public async Task Should_report_liveness_and_readiness_as_json(CancellationToken cancellationToken = default)
         {
             await Define<ScenarioContext>()
                 .Done(async c =>
@@ -30,7 +31,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
         }
     }
 }

--- a/src/ServiceControl.AcceptanceTests/WebApi/When_the_configuration_page_is_read.cs
+++ b/src/ServiceControl.AcceptanceTests/WebApi/When_the_configuration_page_is_read.cs
@@ -5,6 +5,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
     using System.Net;
     using System.Net.Http;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTesting;
@@ -14,7 +15,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
     class When_the_configuration_page_is_read : AcceptanceTest
     {
         [Test]
-        public async Task Should_report_the_instance_the_same_way_from_both_of_its_routes()
+        public async Task Should_report_the_instance_the_same_way_from_both_of_its_routes(CancellationToken cancellationToken = default)
         {
             string configuration = null;
             string instanceInfo = null;
@@ -27,7 +28,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -40,7 +41,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
         }
 
         [Test]
-        public async Task Should_accept_licensed_endpoint_details_and_report_none_without_the_licence_for_them()
+        public async Task Should_accept_licensed_endpoint_details_and_report_none_without_the_licence_for_them(CancellationToken cancellationToken = default)
         {
             HttpStatusCode upload = default;
             HttpStatusCode read = default;
@@ -64,7 +65,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.AcceptanceTests/WebApi/When_the_edit_and_retry_flag_is_read.cs
+++ b/src/ServiceControl.AcceptanceTests/WebApi/When_the_edit_and_retry_flag_is_read.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus;
@@ -14,7 +15,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
     {
         [TestCase(true)]
         [TestCase(false)]
-        public async Task Should_agree_with_whether_the_edit_route_answers(bool editingAllowed)
+        public async Task Should_agree_with_whether_the_edit_route_answers(bool editingAllowed, CancellationToken cancellationToken = default)
         {
             SetSettings = settings => settings.AllowMessageEditing = editingAllowed;
 
@@ -33,7 +34,7 @@ namespace ServiceControl.AcceptanceTests.WebApi
 
                     return config != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/Auditing/When_critical_storage_threshold_reached.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/Auditing/When_critical_storage_threshold_reached.cs
@@ -22,7 +22,7 @@
             SetSettings = static s => s.TimeToRestartAuditIngestionAfterFailure = TimeSpan.FromSeconds(1);
 
         [Test]
-        public async Task Should_stop_ingestion()
+        public async Task Should_stop_ingestion(CancellationToken cancellationToken = default)
         {
             SetStorageConfiguration = static d => d.Add(RavenPersistenceConfiguration.MinimumStorageLeftRequiredForIngestionKey, "0");
 
@@ -45,7 +45,7 @@
                 )
                 .Done(async c => await this.TryGetSingle<MessagesView>(
                     "/api/messages?include_system_messages=false&sort=id") == false)
-                .Run();
+                .Run(cancellationToken);
         }
 
         [Test]

--- a/src/ServiceControl.Audit.AcceptanceTests.RavenDB/ServiceControl.Audit.AcceptanceTests.RavenDB.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests.RavenDB/ServiceControl.Audit.AcceptanceTests.RavenDB.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TestCategory>Raven</TestCategory>
+    <!-- Every test inherits [CancelAfter] from NServiceBusAcceptanceTest, which NUnit honours but the analyzer does not
+         see, so it reports the CancellationToken parameter as an unsupplied argument. -->
+    <NoWarn>$(NoWarn);NUnit1027</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_a_message_fails_to_import.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_a_message_fails_to_import.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Audit.AcceptanceTests.Auditing
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_a_message_fails_to_import : AcceptanceTest
     {
         [Test]
-        public async Task It_can_be_reimported()
+        public async Task It_can_be_reimported(CancellationToken cancellationToken = default)
         {
             CustomizeHostBuilder = hostBuilder =>
                 //Make sure the audit import attempt fails
@@ -55,7 +56,7 @@
 
                     return await this.TryGetMany<MessagesView>($"/api/messages/search/{c.MessageId}") && c.AuditForwarded;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(runResult.AuditForwarded, Is.True);
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_a_message_sent_with_missing_metadata.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_a_message_sent_with_missing_metadata.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_a_message_sent_with_missing_metadata : AcceptanceTest
     {
         [Test]
-        public async Task Should_not_be_cast_TimeSent_to_DateTimeMin()
+        public async Task Should_not_be_cast_TimeSent_to_DateTimeMin(CancellationToken cancellationToken = default)
         {
             MessagesView auditedMessage = null;
 
@@ -28,7 +29,7 @@
                     auditedMessage = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(auditedMessage, Is.Not.Null);
             Assert.That(auditedMessage.TimeSent, Is.Null);

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_message_processed_successfully_from_sendonly.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_message_processed_successfully_from_sendonly.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Auditing
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Auditing
     class When_message_processed_successfully_from_sendonly : AcceptanceTest
     {
         [Test]
-        public async Task Should_import_messages_from_sendonly_endpoint()
+        public async Task Should_import_messages_from_sendonly_endpoint(CancellationToken cancellationToken = default)
         {
             await Define<MyContext>(ctx => { ctx.MessageId = Guid.NewGuid().ToString(); })
                 .WithEndpoint<Sendonly>()
@@ -29,7 +30,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Auditing
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
         }
 
         class Sendonly : EndpointConfigurationBuilder

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_messages_are_marked_as_system_messages.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_messages_are_marked_as_system_messages.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_messages_are_marked_as_system_messages : AcceptanceTest
     {
         [Test]
-        public async Task Should_set_the_IsSystemMessage_when_message_type_is_not_a_scheduled_task()
+        public async Task Should_set_the_IsSystemMessage_when_message_type_is_not_a_scheduled_task(CancellationToken cancellationToken = default)
         {
             MessagesView auditMessage = null;
             await Define<SystemMessageTestContext>(ctx =>
@@ -32,14 +33,14 @@
                     auditMessage = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(auditMessage, Is.Not.Null);
             Assert.That(auditMessage.IsSystemMessage, Is.False);
         }
 
         [Test]
-        public async Task Scheduled_task_messages_should_set_IsSystemMessage()
+        public async Task Scheduled_task_messages_should_set_IsSystemMessage(CancellationToken cancellationToken = default)
         {
             MessagesView auditMessage = null;
             await Define<SystemMessageTestContext>(ctx =>
@@ -55,13 +56,13 @@
                     auditMessage = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
             Assert.That(auditMessage, Is.Not.Null);
             Assert.That(auditMessage.IsSystemMessage, Is.True);
         }
 
         [Test]
-        public async Task Control_messages_should_not_be_audited()
+        public async Task Control_messages_should_not_be_audited(CancellationToken cancellationToken = default)
         {
             var containsItem = true;
 
@@ -96,13 +97,13 @@
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(containsItem, Is.False);
         }
 
         [Test]
-        public async Task Should_set_the_IsSystemMessage_for_integration_scenario()
+        public async Task Should_set_the_IsSystemMessage_for_integration_scenario(CancellationToken cancellationToken = default)
         {
             MessagesView auditMessage = null;
             await Define<SystemMessageTestContext>(ctx =>
@@ -118,7 +119,7 @@
                     auditMessage = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(auditMessage, Is.Not.Null);
             Assert.That(auditMessage.IsSystemMessage, Is.False);

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_messages_with_big_bodies_are_ingested.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_messages_with_big_bodies_are_ingested.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Audit.AcceptanceTests.Auditing
 {
     using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -12,7 +13,7 @@
     class When_messages_with_big_bodies_are_ingested : AcceptanceTest
     {
         [Test]
-        public async Task Should_not_get_an_empty_audit_message_body_when_configured_MaxBodySizeToStore_is_greater_then_message_size()
+        public async Task Should_not_get_an_empty_audit_message_body_when_configured_MaxBodySizeToStore_is_greater_then_message_size(CancellationToken cancellationToken = default)
         {
             //Arrange
             SetSettings = settings => settings.MaxBodySizeToStore = MAX_BODY_SIZE;
@@ -46,14 +47,14 @@
 
                         return true;
                     })
-                .Run();
+                .Run(cancellationToken);
 
             //Assert
             Assert.That(body, Is.Not.Null);
         }
 
         [Test]
-        public async Task Should_get_an_empty_audit_message_body_when_configured_MaxBodySizeToStore_is_less_then_message_size()
+        public async Task Should_get_an_empty_audit_message_body_when_configured_MaxBodySizeToStore_is_less_then_message_size(CancellationToken cancellationToken = default)
         {
             //Arrange
             SetSettings = settings => settings.MaxBodySizeToStore = MAX_BODY_SIZE;
@@ -87,14 +88,14 @@
 
                         return true;
                     })
-                .Run();
+                .Run(cancellationToken);
 
             //Assert
             Assert.That(body, Is.Empty);
         }
 
         [Test]
-        public async Task Should_not_get_an_empty_audit_message_body_when_body_is_above_loh_but_below_max_body_size()
+        public async Task Should_not_get_an_empty_audit_message_body_when_body_is_above_loh_but_below_max_body_size(CancellationToken cancellationToken = default)
         {
             //Arrange
             SetSettings = settings => settings.MaxBodySizeToStore = 2 * MAX_BODY_SIZE_BIGGER_THAN_LOH;
@@ -128,7 +129,7 @@
 
                         return true;
                     })
-                .Run();
+                .Run(cancellationToken);
 
             //Assert
             Assert.That(body, Is.Not.Null);

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_processed_message_is_imported.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_processed_message_is_imported.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -19,7 +20,7 @@
     class When_processed_message_is_imported : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_accessible_via_the_rest_api()
+        public async Task Should_be_accessible_via_the_rest_api(CancellationToken cancellationToken = default)
         {
             const string Payload = "PAYLOAD";
             MessagesView auditedMessage = null;
@@ -49,7 +50,7 @@
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {
@@ -87,7 +88,7 @@
         }
 
         [Test]
-        public async Task Should_be_counted()
+        public async Task Should_be_counted(CancellationToken cancellationToken = default)
         {
             const string Payload = "PAYLOAD";
             List<AuditCount> counts = null;
@@ -114,7 +115,7 @@
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(counts, Has.Count.EqualTo(1));
             using (Assert.EnterMultipleScope())

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_processed_message_searched_by_body_content.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_processed_message_searched_by_body_content.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Audit.AcceptanceTests.Auditing
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -12,7 +13,7 @@
     class When_processed_message_searched_by_body_content : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_found_when_fulltext_search_enabled()
+        public async Task Should_be_found_when_fulltext_search_enabled(CancellationToken cancellationToken = default)
         {
             // setting it even if it is the default
             SetSettings = settings => settings.EnableFullTextSearchOnBodies = true;
@@ -39,13 +40,13 @@
                     c.MessageFound = await this.TryGetMany<MessagesView>($"/api/messages/search/{searchString}");
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.MessageFound, Is.True);
         }
 
         [Test]
-        public async Task Should_not_be_found_when_fulltext_search_disabled()
+        public async Task Should_not_be_found_when_fulltext_search_disabled(CancellationToken cancellationToken = default)
         {
             SetSettings = settings => settings.EnableFullTextSearchOnBodies = false;
 
@@ -72,7 +73,7 @@
                     c.MessageFound = await this.TryGetMany<MessagesView>($"/api/messages/search/{searchString}");
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_processed_message_searched_by_messageid.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_processed_message_searched_by_messageid.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Audit.AcceptanceTests.Auditing
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -13,12 +14,12 @@
     class When_processed_message_searched_by_messageid : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_found() =>
+        public async Task Should_be_found(CancellationToken cancellationToken = default) =>
             await Define<MyContext>()
                 .WithEndpoint<Sender>(b => b.When((bus, c) => bus.Send(new MyMessage())))
                 .WithEndpoint<Receiver>()
                 .Done(async c => c.MessageId != null && await this.TryGetMany<MessagesView>("/api/messages/search/" + c.MessageId))
-                .Run();
+                .Run(cancellationToken);
 
         public class Sender : EndpointConfigurationBuilder
         {

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_processed_message_searched_by_msgid_for_endpoint.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_processed_message_searched_by_msgid_for_endpoint.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.Audit.AcceptanceTests.Auditing
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -13,12 +14,12 @@
     class When_processed_message_searched_by_msgid_for_endpoint : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_found() =>
+        public async Task Should_be_found(CancellationToken cancellationToken = default) =>
             await Define<MyContext>()
                 .WithEndpoint<Sender>(b => b.When((bus, c) => bus.Send(new MyMessage())))
                 .WithEndpoint<Receiver>()
                 .Done(async c => c.MessageId != null && await this.TryGetMany<MessagesView>($"/api/endpoints/{c.EndpointNameOfReceivingEndpoint}/messages/search/{c.MessageId}"))
-                .Run();
+                .Run(cancellationToken);
 
         public class Sender : EndpointConfigurationBuilder
         {

--- a/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_single_message_fails_in_batch.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Auditing/When_single_message_fails_in_batch.cs
@@ -20,7 +20,7 @@
     class When_single_message_fails_in_batch : AcceptanceTest
     {
         [Test]
-        public async Task Should_import_all_messages()
+        public async Task Should_import_all_messages(CancellationToken cancellationToken = default)
         {
             CustomizeHostBuilder = hostBuilder =>
                 //Make sure the audit import attempt fails
@@ -49,7 +49,7 @@
 
                     return false;
                 })
-                .Run();
+                .Run(cancellationToken);
         }
 
         class FailOnceEnricher(MyContext testContext) : IEnrichImportedAuditMessages

--- a/src/ServiceControl.Audit.AcceptanceTests/Monitoring/When_a_new_endpoint_is_detected.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Monitoring/When_a_new_endpoint_is_detected.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Audit.AcceptanceTests.Monitoring
 {
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting.EndpointTemplates;
     using NServiceBus;
@@ -12,7 +13,7 @@
     class When_a_new_endpoint_is_detected : AcceptanceTest
     {
         [Test]
-        public async Task Should_notify_service_control()
+        public async Task Should_notify_service_control(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = endpointConfiguration =>
             {
@@ -23,7 +24,7 @@
             var context = await Define<InterceptedMessagesScenarioContext>()
                 .WithEndpoint<Receiver>(b => b.When((bus, c) => bus.SendLocal(new MyMessage())))
                 .Done(c => c.SentRegisterEndpointCommands.Any())
-                .Run();
+                .Run(cancellationToken);
 
             var command = context.SentRegisterEndpointCommands.Single();
             Assert.That(command.Endpoint.Name, Is.EqualTo(Conventions.EndpointNamingConvention(typeof(Receiver))));

--- a/src/ServiceControl.Audit.AcceptanceTests/Recoverability/When_a_successful_retry_at_old_endpoint_is_detected.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Recoverability/When_a_successful_retry_at_old_endpoint_is_detected.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Audit.AcceptanceTests.Recoverability
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting.EndpointTemplates;
     using Microsoft.Extensions.DependencyInjection;
@@ -15,7 +16,7 @@
     class When_a_successful_retry_at_old_endpoint_is_detected : AcceptanceTest
     {
         [Test]
-        public async Task Should_send_acknowledgement()
+        public async Task Should_send_acknowledgement(CancellationToken cancellationToken = default)
         {
             var failedMessageId = Guid.NewGuid().ToString();
             var context = await Define<Context>()
@@ -30,7 +31,7 @@
                     return s.Send(new MyMessage(), options);
                 }))
                 .Done(c => c.AcknowledgementSent)
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(context.AcknowledgementSent, Is.True);
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Recoverability/When_importing_a_message_resolved_by_a_retry.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Recoverability/When_importing_a_message_resolved_by_a_retry.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Audit.AcceptanceTests.Recoverability
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -14,7 +15,7 @@
     class When_importing_a_message_resolved_by_a_retry : AcceptanceTest
     {
         [Test]
-        public async Task Should_set_status_to_resolved()
+        public async Task Should_set_status_to_resolved(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = endpointConfiguration =>
             {
@@ -43,7 +44,7 @@
 
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(auditedMessage.Status, Is.EqualTo(MessageStatus.ResolvedSuccessfully));
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/SagaAudit/When_a_message_emitted_by_a_saga_is_audited.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/SagaAudit/When_a_message_emitted_by_a_saga_is_audited.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Audit.AcceptanceTests.SagaAudit
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -12,7 +13,7 @@
     class When_a_message_emitted_by_a_saga_is_audited : AcceptanceTest
     {
         [Test]
-        public async Task Info_on_emitted_saga_should_be_available_through_the_http_api()
+        public async Task Info_on_emitted_saga_should_be_available_through_the_http_api(CancellationToken cancellationToken = default)
         {
             MessagesView auditedMessage = null;
 
@@ -24,7 +25,7 @@
                     auditedMessage = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(auditedMessage.OriginatesFromSaga, Is.Not.Null);
 

--- a/src/ServiceControl.Audit.AcceptanceTests/SagaAudit/When_a_message_hitting_a_saga_is_audited.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/SagaAudit/When_a_message_hitting_a_saga_is_audited.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -15,7 +16,7 @@
     class When_a_message_hitting_a_saga_is_audited : AcceptanceTest
     {
         [Test]
-        public async Task Saga_info_should_be_available_through_the_http_api()
+        public async Task Saga_info_should_be_available_through_the_http_api(CancellationToken cancellationToken = default)
         {
             MessagesView auditedMessage = null;
 
@@ -33,7 +34,7 @@
                     auditedMessage = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
 
             Assert.That(auditedMessage, Is.Not.Null);

--- a/src/ServiceControl.Audit.AcceptanceTests/SagaAudit/When_a_message_hitting_multiple_sagas_is_audited.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/SagaAudit/When_a_message_hitting_multiple_sagas_is_audited.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -15,7 +16,7 @@
     class When_a_message_hitting_multiple_sagas_is_audited : AcceptanceTest
     {
         [Test]
-        public async Task Saga_info_should_be_available_through_the_http_api()
+        public async Task Saga_info_should_be_available_through_the_http_api(CancellationToken cancellationToken = default)
         {
             MessagesView auditedMessage = null;
 
@@ -33,7 +34,7 @@
                     auditedMessage = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(auditedMessage, Is.Not.Null);
 

--- a/src/ServiceControl.Audit.AcceptanceTests/SagaAudit/When_a_message_that_is_handled_by_a_saga.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/SagaAudit/When_a_message_that_is_handled_by_a_saga.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_a_message_that_is_handled_by_a_saga : AcceptanceTest
     {
         [Test]
-        public async Task Message_should_be_enriched_with_saga_state_changes()
+        public async Task Message_should_be_enriched_with_saga_state_changes(CancellationToken cancellationToken = default)
         {
             var messages = new List<MessagesView>();
 
@@ -41,7 +42,7 @@
 
                     return false;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(messages, Has.Count.EqualTo(5));
 

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/Cors/When_cors_allows_any_origin.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/Cors/When_cors_allows_any_origin.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -27,7 +28,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
         public void CleanupCors() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_return_wildcard_access_control_allow_origin_header()
+        public async Task Should_return_wildcard_access_control_allow_origin_header(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -41,13 +42,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowAnyOrigin(response);
         }
 
         [Test]
-        public async Task Should_return_expected_allowed_methods()
+        public async Task Should_return_expected_allowed_methods(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -61,13 +62,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowedMethods(response, "POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD");
         }
 
         [Test]
-        public async Task Should_return_expected_exposed_headers()
+        public async Task Should_return_expected_exposed_headers(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -81,7 +82,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertExposedHeaders(response, "ETag", "Last-Modified", "Link", "Total-Count", "X-Particular-Version");
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/Cors/When_cors_is_disabled.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/Cors/When_cors_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -27,7 +28,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
         public void CleanupCors() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_return_access_control_allow_origin_header()
+        public async Task Should_not_return_access_control_allow_origin_header(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -41,13 +42,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertCorsDisabled(response);
         }
 
         [Test]
-        public async Task Preflight_request_should_not_return_cors_headers()
+        public async Task Preflight_request_should_not_return_cors_headers(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -61,7 +62,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertCorsDisabled(response);
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/Cors/When_request_from_allowed_origin.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/Cors/When_request_from_allowed_origin.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -28,7 +29,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
 
         [TestCase("https://app.example.com")]
         [TestCase("https://admin.example.com")]
-        public async Task Should_return_matching_origin_in_access_control_allow_origin_header(string allowedOrigin)
+        public async Task Should_return_matching_origin_in_access_control_allow_origin_header(string allowedOrigin, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -41,13 +42,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowedOrigin(response, allowedOrigin);
         }
 
         [Test]
-        public async Task Preflight_request_should_return_correct_cors_headers()
+        public async Task Preflight_request_should_return_correct_cors_headers(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string allowedOrigin = "https://app.example.com";
@@ -61,7 +62,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowedOrigin(response, allowedOrigin);
             CorsAssertions.AssertAllowedMethods(response, "POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD");

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/Cors/When_request_from_disallowed_origin.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/Cors/When_request_from_disallowed_origin.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -27,7 +28,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
         public void CleanupCors() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_return_access_control_allow_origin_header_for_disallowed_origin()
+        public async Task Should_not_return_access_control_allow_origin_header_for_disallowed_origin(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string disallowedOrigin = "https://malicious.example.com";
@@ -41,13 +42,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Should_not_allow_origin_with_different_scheme()
+        public async Task Should_not_allow_origin_with_different_scheme(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             // http:// instead of https://
@@ -62,13 +63,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Should_not_allow_origin_with_different_port()
+        public async Task Should_not_allow_origin_with_different_port(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             // Different port
@@ -83,13 +84,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Should_not_allow_subdomain_when_parent_domain_is_configured()
+        public async Task Should_not_allow_subdomain_when_parent_domain_is_configured(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             // Subdomain of allowed origin
@@ -104,13 +105,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         endpoint: "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Preflight_request_should_not_allow_disallowed_origin()
+        public async Task Preflight_request_should_not_allow_disallowed_origin(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string disallowedOrigin = "https://malicious.example.com";
@@ -124,7 +125,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_disabled.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_disabled.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_ignored_when_disabled()
+        public async Task Headers_should_be_ignored_when_disabled(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersIgnoredWhenDisabled(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_sent.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -14,7 +15,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
     class When_forwarded_headers_are_sent : AcceptanceTest
     {
         [Test]
-        public async Task Headers_should_be_applied_when_trust_all_proxies()
+        public async Task Headers_should_be_applied_when_trust_all_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -29,7 +30,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWhenTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_known_networks_are_configured.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_known_networks_are_configured.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_applied_when_caller_matches_known_network()
+        public async Task Headers_should_be_applied_when_caller_matches_known_network(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWithKnownProxiesOrNetworks(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_known_proxies_are_configured.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_known_proxies_are_configured.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_applied_when_caller_matches_known_proxy()
+        public async Task Headers_should_be_applied_when_caller_matches_known_proxy(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWithKnownProxiesOrNetworks(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -15,7 +16,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
     class When_multiple_header_values_are_sent : AcceptanceTest
     {
         [Test]
-        public async Task Original_values_should_be_returned_when_trust_all_proxies()
+        public async Task Original_values_should_be_returned_when_trust_all_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -35,7 +36,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com, internal.proxy.local");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertMultipleHeaderValuesProcessedWithTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent_with_known_proxies.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent_with_known_proxies.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -26,7 +27,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Only_rightmost_values_should_be_processed_when_forward_limit_is_one()
+        public async Task Only_rightmost_values_should_be_processed_when_forward_limit_is_one(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -46,7 +47,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com, internal.proxy.local");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertMultipleHeaderValuesWithForwardLimitOne(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_only_proto_header_is_sent.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_only_proto_header_is_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -14,7 +15,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
     class When_only_proto_header_is_sent : AcceptanceTest
     {
         [Test]
-        public async Task Only_scheme_should_be_changed()
+        public async Task Only_scheme_should_be_changed(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -27,7 +28,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedProto: "https");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertPartialHeadersApplied(requestInfo, expectedScheme: "https");
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -15,7 +16,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
     class When_proxy_chain_headers_are_sent : AcceptanceTest
     {
         [Test]
-        public async Task Original_client_ip_should_be_returned_when_trust_all_proxies()
+        public async Task Original_client_ip_should_be_returned_when_trust_all_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -33,7 +34,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertProxyChainProcessedWithTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent_with_known_proxies.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent_with_known_proxies.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Only_last_proxy_ip_should_be_processed_when_forward_limit_is_one()
+        public async Task Only_last_proxy_ip_should_be_processed_when_forward_limit_is_one(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -43,7 +44,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertProxyChainWithForwardLimitOne(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_request_has_no_forwarded_headers.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_request_has_no_forwarded_headers.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -14,7 +15,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
     class When_request_has_no_forwarded_headers : AcceptanceTest
     {
         [Test]
-        public async Task Request_values_should_remain_unchanged()
+        public async Task Request_values_should_remain_unchanged(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -29,7 +30,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                     }
                     return false;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertDirectAccessWithNoForwardedHeaders(requestInfo);
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_trust_all_proxies_is_explicitly_configured.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_trust_all_proxies_is_explicitly_configured.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_applied_when_trust_all_proxies_is_explicitly_set()
+        public async Task Headers_should_be_applied_when_trust_all_proxies_is_explicitly_set(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWhenTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_unknown_network_sends_headers.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_unknown_network_sends_headers.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -26,7 +27,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_ignored_when_caller_not_in_known_networks()
+        public async Task Headers_should_be_ignored_when_caller_not_in_known_networks(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -44,7 +45,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         testRemoteIp: "203.0.113.1");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersIgnoredWhenProxyNotTrusted(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_unknown_proxy_sends_headers.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/ForwardedHeaders/When_unknown_proxy_sends_headers.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -26,7 +27,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_ignored_when_caller_not_in_known_proxies()
+        public async Task Headers_should_be_ignored_when_caller_not_in_known_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -44,7 +45,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.ForwardedHeaders
                         testRemoteIp: "203.0.113.1");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersIgnoredWhenProxyNotTrusted(
                 requestInfo,

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/Https/When_hsts_is_configured_in_development_mode.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/Https/When_hsts_is_configured_in_development_mode.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.Https
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Https;
@@ -29,7 +30,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Https
         public void CleanupHttps() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_include_hsts_header_in_development_mode()
+        public async Task Should_not_include_hsts_header_in_development_mode(CancellationToken cancellationToken = default)
         {
             // HSTS is intentionally NOT applied in development environments
             // This is ASP.NET Core's default behavior to prevent HSTS from being cached
@@ -43,7 +44,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Https
                     response = await this.GetRaw("/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             HttpsAssertions.AssertNoHstsHeader(response);
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/Https/When_https_redirect_is_disabled.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/Https/When_https_redirect_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.Https
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Https;
@@ -25,7 +26,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Https
         public void CleanupHttps() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_redirect_http_requests()
+        public async Task Should_not_redirect_http_requests(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -35,7 +36,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Https
                     response = await this.GetRaw("/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             HttpsAssertions.AssertNoHttpsRedirect(response);
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/Https/When_https_redirect_is_enabled.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/Https/When_https_redirect_is_enabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.Https
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Https;
@@ -26,7 +27,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Https
         public void CleanupHttps() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_redirect_http_requests_to_https()
+        public async Task Should_redirect_http_requests_to_https(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -36,7 +37,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.Https
                     response = await this.GetRaw("/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             HttpsAssertions.AssertHttpsRedirect(response, expectedPort: 443);
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_disabled.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.OpenIdConnect;
@@ -26,7 +27,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
         public void CleanupAuth() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_allow_requests_without_authentication()
+        public async Task Should_allow_requests_without_authentication(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
                         "/api/messages");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertNoAuthenticationRequired(response);
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_enabled.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_enabled.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
 {
     using System.Net.Http;
     using System.Security.Claims;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.OpenIdConnect;
@@ -48,7 +49,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
         }
 
         [Test]
-        public async Task Should_reject_requests_without_bearer_token()
+        public async Task Should_reject_requests_without_bearer_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -62,13 +63,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
                         "/api/messages");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_invalid_bearer_token()
+        public async Task Should_reject_requests_with_invalid_bearer_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -82,13 +83,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
                         "invalid-token-value");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_accept_requests_with_valid_bearer_token()
+        public async Task Should_accept_requests_with_valid_bearer_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -106,13 +107,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
                         validToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertAuthenticated(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_expired_token()
+        public async Task Should_reject_requests_with_expired_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -127,13 +128,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
                         expiredToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_wrong_audience()
+        public async Task Should_reject_requests_with_wrong_audience(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -148,13 +149,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
                         wrongAudienceToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_wrong_issuer()
+        public async Task Should_reject_requests_with_wrong_issuer(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -169,13 +170,13 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
                         wrongIssuerToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_allow_anonymous_access_to_root_endpoint()
+        public async Task Should_allow_anonymous_access_to_root_endpoint(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -189,7 +190,7 @@ namespace ServiceControl.Audit.AcceptanceTests.Security.OpenIdConnect
                         "/api");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertNoAuthenticationRequired(response);
         }

--- a/src/ServiceControl.Audit.AcceptanceTests/ServiceControl.Audit.AcceptanceTests.csproj
+++ b/src/ServiceControl.Audit.AcceptanceTests/ServiceControl.Audit.AcceptanceTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TestCategory>Raven</TestCategory>
+    <!-- Every test inherits [CancelAfter] from NServiceBusAcceptanceTest, which NUnit honours but the analyzer does not
+         see, so it reports the CancellationToken parameter as an unsupplied argument. -->
+    <NoWarn>$(NoWarn);NUnit1027</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Audit.AcceptanceTests/WebApi/When_a_message_body_is_requested_twice.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/WebApi/When_a_message_body_is_requested_twice.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.Audit.AcceptanceTests.WebApi
 {
     using System.Net;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -14,7 +15,7 @@ namespace ServiceControl.Audit.AcceptanceTests.WebApi
     class When_a_message_body_is_requested_twice : AcceptanceTest
     {
         [Test]
-        public async Task Should_answer_not_modified()
+        public async Task Should_answer_not_modified(CancellationToken cancellationToken = default)
         {
             string issued = null;
             HttpStatusCode? repeated = null;
@@ -55,7 +56,7 @@ namespace ServiceControl.Audit.AcceptanceTests.WebApi
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(issued, Is.Not.Null, "the body response carried no validator, so a client can never revalidate it");
             Assert.That(repeated, Is.EqualTo(HttpStatusCode.NotModified), $"the body was sent again to a client that already held {issued}");

--- a/src/ServiceControl.Monitoring.AcceptanceTests/PlatformConnectionTests.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/PlatformConnectionTests.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Tests
 {
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting.EndpointTemplates;
     using NServiceBus.AcceptanceTesting;
@@ -12,7 +13,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Tests
     class PlatformConnectionTests : AcceptanceTest
     {
         [Test]
-        public async Task ExposesConnectionDetails()
+        public async Task ExposesConnectionDetails(CancellationToken cancellationToken = default)
         {
             var config = await Define<MyContext>()
                 .WithEndpoint<MyEndpoint>()
@@ -22,7 +23,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Tests
                     x.Connection = await result.Content.ReadAsStringAsync();
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Approver.Verify(JsonSerializer.Deserialize<object>(config.Connection));
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/Cors/When_cors_allows_any_origin.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/Cors/When_cors_allows_any_origin.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -27,7 +28,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
         public void CleanupCors() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_return_wildcard_access_control_allow_origin_header()
+        public async Task Should_return_wildcard_access_control_allow_origin_header(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -41,13 +42,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         endpoint: "/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowAnyOrigin(response);
         }
 
         [Test]
-        public async Task Should_return_expected_allowed_methods()
+        public async Task Should_return_expected_allowed_methods(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -61,13 +62,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowedMethods(response, "POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD");
         }
 
         [Test]
-        public async Task Should_return_expected_exposed_headers()
+        public async Task Should_return_expected_exposed_headers(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -81,7 +82,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         endpoint: "/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertExposedHeaders(response, "ETag", "Last-Modified", "Link", "Total-Count", "X-Particular-Version");
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/Cors/When_cors_is_disabled.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/Cors/When_cors_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -27,7 +28,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
         public void CleanupCors() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_return_access_control_allow_origin_header()
+        public async Task Should_not_return_access_control_allow_origin_header(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -41,13 +42,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         endpoint: "/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertCorsDisabled(response);
         }
 
         [Test]
-        public async Task Preflight_request_should_not_return_cors_headers()
+        public async Task Preflight_request_should_not_return_cors_headers(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string testOrigin = "https://app.example.com";
@@ -61,7 +62,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertCorsDisabled(response);
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/Cors/When_request_from_allowed_origin.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/Cors/When_request_from_allowed_origin.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -28,7 +29,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
 
         [TestCase("https://app.example.com")]
         [TestCase("https://admin.example.com")]
-        public async Task Should_return_matching_origin_in_access_control_allow_origin_header(string allowedOrigin)
+        public async Task Should_return_matching_origin_in_access_control_allow_origin_header(string allowedOrigin, CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -41,13 +42,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         endpoint: "/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowedOrigin(response, allowedOrigin);
         }
 
         [Test]
-        public async Task Preflight_request_should_return_correct_cors_headers()
+        public async Task Preflight_request_should_return_correct_cors_headers(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string allowedOrigin = "https://app.example.com";
@@ -61,7 +62,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertAllowedOrigin(response, allowedOrigin);
             CorsAssertions.AssertAllowedMethods(response, "POST", "GET", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD");

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/Cors/When_request_from_disallowed_origin.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/Cors/When_request_from_disallowed_origin.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Cors;
@@ -27,7 +28,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
         public void CleanupCors() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_return_access_control_allow_origin_header_for_disallowed_origin()
+        public async Task Should_not_return_access_control_allow_origin_header_for_disallowed_origin(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string disallowedOrigin = "https://malicious.example.com";
@@ -41,13 +42,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         endpoint: "/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Should_not_allow_origin_with_different_scheme()
+        public async Task Should_not_allow_origin_with_different_scheme(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             // http:// instead of https://
@@ -62,13 +63,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         endpoint: "/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Should_not_allow_origin_with_different_port()
+        public async Task Should_not_allow_origin_with_different_port(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             // Different port
@@ -83,13 +84,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         endpoint: "/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Should_not_allow_subdomain_when_parent_domain_is_configured()
+        public async Task Should_not_allow_subdomain_when_parent_domain_is_configured(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             // Subdomain of allowed origin
@@ -104,13 +105,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         endpoint: "/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }
 
         [Test]
-        public async Task Preflight_request_should_not_allow_disallowed_origin()
+        public async Task Preflight_request_should_not_allow_disallowed_origin(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
             const string disallowedOrigin = "https://malicious.example.com";
@@ -124,7 +125,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Cors
                         requestMethod: "POST");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             CorsAssertions.AssertOriginNotAllowed(response, disallowedOrigin);
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_disabled.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_disabled.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -24,7 +25,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_ignored_when_disabled()
+        public async Task Headers_should_be_ignored_when_disabled(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -39,7 +40,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersIgnoredWhenDisabled(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_sent.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_forwarded_headers_are_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -13,7 +14,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
     class When_forwarded_headers_are_sent : AcceptanceTest
     {
         [Test]
-        public async Task Headers_should_be_applied_when_trust_all_proxies()
+        public async Task Headers_should_be_applied_when_trust_all_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -28,7 +29,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWhenTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_known_networks_are_configured.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_known_networks_are_configured.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -24,7 +25,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_applied_when_caller_matches_known_network()
+        public async Task Headers_should_be_applied_when_caller_matches_known_network(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -39,7 +40,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWithKnownProxiesOrNetworks(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_known_proxies_are_configured.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_known_proxies_are_configured.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -24,7 +25,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_applied_when_caller_matches_known_proxy()
+        public async Task Headers_should_be_applied_when_caller_matches_known_proxy(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -39,7 +40,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWithKnownProxiesOrNetworks(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -14,7 +15,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
     class When_multiple_header_values_are_sent : AcceptanceTest
     {
         [Test]
-        public async Task Original_values_should_be_returned_when_trust_all_proxies()
+        public async Task Original_values_should_be_returned_when_trust_all_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -34,7 +35,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com, internal.proxy.local");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertMultipleHeaderValuesProcessedWithTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent_with_known_proxies.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_multiple_header_values_are_sent_with_known_proxies.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Only_rightmost_values_should_be_processed_when_forward_limit_is_one()
+        public async Task Only_rightmost_values_should_be_processed_when_forward_limit_is_one(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -45,7 +46,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com, internal.proxy.local");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertMultipleHeaderValuesWithForwardLimitOne(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_only_proto_header_is_sent.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_only_proto_header_is_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -13,7 +14,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
     class When_only_proto_header_is_sent : AcceptanceTest
     {
         [Test]
-        public async Task Only_scheme_should_be_changed()
+        public async Task Only_scheme_should_be_changed(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -26,7 +27,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedProto: "https");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertPartialHeadersApplied(requestInfo, expectedScheme: "https");
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -14,7 +15,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
     class When_proxy_chain_headers_are_sent : AcceptanceTest
     {
         [Test]
-        public async Task Original_client_ip_should_be_returned_when_trust_all_proxies()
+        public async Task Original_client_ip_should_be_returned_when_trust_all_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -32,7 +33,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertProxyChainProcessedWithTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent_with_known_proxies.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_proxy_chain_headers_are_sent_with_known_proxies.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -24,7 +25,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Only_last_proxy_ip_should_be_processed_when_forward_limit_is_one()
+        public async Task Only_last_proxy_ip_should_be_processed_when_forward_limit_is_one(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -42,7 +43,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertProxyChainWithForwardLimitOne(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_request_has_no_forwarded_headers.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_request_has_no_forwarded_headers.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -13,7 +14,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
     class When_request_has_no_forwarded_headers : AcceptanceTest
     {
         [Test]
-        public async Task Request_values_should_remain_unchanged()
+        public async Task Request_values_should_remain_unchanged(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -28,7 +29,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                     }
                     return false;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertDirectAccessWithNoForwardedHeaders(requestInfo);
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_trust_all_proxies_is_explicitly_configured.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_trust_all_proxies_is_explicitly_configured.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_applied_when_trust_all_proxies_is_explicitly_set()
+        public async Task Headers_should_be_applied_when_trust_all_proxies_is_explicitly_set(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         xForwardedHost: "example.com");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersAppliedWhenTrustAllProxies(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_unknown_network_sends_headers.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_unknown_network_sends_headers.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_ignored_when_caller_not_in_known_networks()
+        public async Task Headers_should_be_ignored_when_caller_not_in_known_networks(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -43,7 +44,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         testRemoteIp: "203.0.113.1");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersIgnoredWhenProxyNotTrusted(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_unknown_proxy_sends_headers.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/ForwardedHeaders/When_unknown_proxy_sends_headers.cs
@@ -1,5 +1,6 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.ForwardedHeaders;
@@ -25,7 +26,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
         public void CleanupForwardedHeaders() => configuration?.Dispose();
 
         [Test]
-        public async Task Headers_should_be_ignored_when_caller_not_in_known_proxies()
+        public async Task Headers_should_be_ignored_when_caller_not_in_known_proxies(CancellationToken cancellationToken = default)
         {
             RequestInfoResponse requestInfo = null;
 
@@ -43,7 +44,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.ForwardedHeaders
                         testRemoteIp: "203.0.113.1");
                     return requestInfo != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             ForwardedHeadersAssertions.AssertHeadersIgnoredWhenProxyNotTrusted(
                 requestInfo,

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/Https/When_hsts_is_configured_in_development_mode.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/Https/When_hsts_is_configured_in_development_mode.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.Https
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Https;
@@ -29,7 +30,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Https
         public void CleanupHttps() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_include_hsts_header_in_development_mode()
+        public async Task Should_not_include_hsts_header_in_development_mode(CancellationToken cancellationToken = default)
         {
             // HSTS is intentionally NOT applied in development environments
             // This is ASP.NET Core's default behavior to prevent HSTS from being cached
@@ -43,7 +44,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Https
                     response = await this.GetRaw("/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             HttpsAssertions.AssertNoHstsHeader(response);
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/Https/When_https_redirect_is_disabled.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/Https/When_https_redirect_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.Https
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Https;
@@ -25,7 +26,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Https
         public void CleanupHttps() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_not_redirect_http_requests()
+        public async Task Should_not_redirect_http_requests(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -35,7 +36,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Https
                     response = await this.GetRaw("/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             HttpsAssertions.AssertNoHttpsRedirect(response);
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/Https/When_https_redirect_is_enabled.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/Https/When_https_redirect_is_enabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.Https
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Https;
@@ -26,7 +27,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Https
         public void CleanupHttps() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_redirect_http_requests_to_https()
+        public async Task Should_redirect_http_requests_to_https(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -36,7 +37,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.Https
                     response = await this.GetRaw("/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             HttpsAssertions.AssertHttpsRedirect(response, expectedPort: 443);
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_disabled.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_disabled.cs
@@ -1,6 +1,7 @@
 namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.OpenIdConnect;
@@ -26,7 +27,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
         public void CleanupAuth() => configuration?.Dispose();
 
         [Test]
-        public async Task Should_allow_requests_without_authentication()
+        public async Task Should_allow_requests_without_authentication(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -40,7 +41,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
                         "/monitored-endpoints");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertNoAuthenticationRequired(response);
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_enabled.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/Security/OpenIdConnect/When_authentication_is_enabled.cs
@@ -2,6 +2,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
 {
     using System.Net.Http;
     using System.Security.Claims;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.OpenIdConnect;
@@ -48,7 +49,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
         }
 
         [Test]
-        public async Task Should_reject_requests_without_bearer_token()
+        public async Task Should_reject_requests_without_bearer_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -62,13 +63,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
                         "/monitored-endpoints");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_invalid_bearer_token()
+        public async Task Should_reject_requests_with_invalid_bearer_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -82,13 +83,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
                         "invalid-token-value");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_accept_requests_with_valid_bearer_token()
+        public async Task Should_accept_requests_with_valid_bearer_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -107,13 +108,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
                         validToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertAuthenticated(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_expired_token()
+        public async Task Should_reject_requests_with_expired_token(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -128,13 +129,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
                         expiredToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_wrong_audience()
+        public async Task Should_reject_requests_with_wrong_audience(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -149,13 +150,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
                         wrongAudienceToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_reject_requests_with_wrong_issuer()
+        public async Task Should_reject_requests_with_wrong_issuer(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -170,13 +171,13 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
                         wrongIssuerToken);
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertUnauthorized(response);
         }
 
         [Test]
-        public async Task Should_allow_anonymous_access_to_root_endpoint()
+        public async Task Should_allow_anonymous_access_to_root_endpoint(CancellationToken cancellationToken = default)
         {
             HttpResponseMessage response = null;
 
@@ -190,7 +191,7 @@ namespace ServiceControl.Monitoring.AcceptanceTests.Security.OpenIdConnect
                         "/");
                     return response != null;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             OpenIdConnectAssertions.AssertNoAuthenticationRequired(response);
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/ServiceControl.Monitoring.AcceptanceTests.csproj
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/ServiceControl.Monitoring.AcceptanceTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TestCategory>DefaultMonitoring</TestCategory>
+    <!-- Every test inherits [CancelAfter] from NServiceBusAcceptanceTest, which NUnit honours but the analyzer does not
+         see, so it reports the CancellationToken parameter as an unsupplied argument. -->
+    <NoWarn>$(NoWarn);NUnit1027</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_ingesting_multiple_metrics_messages.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_ingesting_multiple_metrics_messages.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -14,7 +15,7 @@
     class When_ingesting_multiple_metrics_messages : AcceptanceTest
     {
         [Test]
-        public async Task Should_not_fail()
+        public async Task Should_not_fail(CancellationToken cancellationToken = default)
         {
             CustomConfiguration = endpointConfiguration =>
             {
@@ -43,7 +44,7 @@
 
                     return metricReported;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_disconnected_count.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_disconnected_count.cs
@@ -14,7 +14,7 @@
     class When_querying_disconnected_count : AcceptanceTest
     {
         [Test]
-        public async Task Should_report_via_http()
+        public async Task Should_report_via_http(CancellationToken cancellationToken = default)
         {
             TestContext context = null;
 
@@ -74,7 +74,7 @@
                     c.AfterSecondStoppedCount = disconnectedCount;
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_queue_length_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_queue_length_data.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -14,7 +15,7 @@
     class When_querying_queue_length_data : AcceptanceTest
     {
         [Test]
-        public async Task Should_report_via_http()
+        public async Task Should_report_via_http(CancellationToken cancellationToken = default)
         {
             var endpointName = NServiceBus.AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(SendingEndpoint));
             var instanceId = Guid.NewGuid();
@@ -91,7 +92,7 @@
 
                      return true;
                  })
-                 .Run();
+                 .Run(cancellationToken);
         }
 
         public class SendingEndpoint : EndpointConfigurationBuilder

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_retries_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_retries_data.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Monitoring.AcceptanceTests.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -12,7 +13,7 @@
     class When_querying_retries_data : AcceptanceTest
     {
         [Test]
-        public async Task Should_report_via_http()
+        public async Task Should_report_via_http(CancellationToken cancellationToken = default)
         {
             var metricReported = false;
 
@@ -36,7 +37,7 @@
 
                     return metricReported;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(metricReported, Is.True);
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_timings_data.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_querying_timings_data.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Monitoring.AcceptanceTests.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -13,7 +14,7 @@
     {
 
         [Test]
-        public async Task Should_report_via_http()
+        public async Task Should_report_via_http(CancellationToken cancellationToken = default)
         {
             var metricReported = false;
 
@@ -27,7 +28,7 @@
 
                     return metricReported;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(metricReported, Is.True);
         }

--- a/src/ServiceControl.Monitoring.AcceptanceTests/When_sending_legacy_metric_report.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/When_sending_legacy_metric_report.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.Monitoring.AcceptanceTests.Tests
 {
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting.EndpointTemplates;
     using Infrastructure;
@@ -12,7 +13,7 @@
     class When_sending_legacy_metric_report : AcceptanceTest
     {
         [Test]
-        public async Task Should_report_legacy_queue_length_reporting()
+        public async Task Should_report_legacy_queue_length_reporting(CancellationToken cancellationToken = default)
         {
             await Define<SomeContext>()
                 .WithEndpoint<EndpointSendingLegacyMetricReport>(b =>
@@ -24,7 +25,7 @@
                         return session.Send(new MetricReport { Data = "{}" }, sendOptions);
                     }))
                 .Done(ctx => ctx.Logs.Any(x => x.Message == "Legacy queue length report received from MetricInstanceId instance of SendingLegacyMetricReport.EndpointSendingLegacyMetricReport"))
-                .Run();
+                .Run(cancellationToken);
         }
 
         class EndpointSendingLegacyMetricReport : EndpointConfigurationBuilder

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_audit_counts_for_an_endpoint_are_requested.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_audit_counts_for_an_endpoint_are_requested.cs
@@ -3,6 +3,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.Auditing
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.Auditing
     class When_audit_counts_for_an_endpoint_are_requested : AcceptanceTest
     {
         [Test]
-        public async Task Should_come_from_the_audit_instance_only()
+        public async Task Should_come_from_the_audit_instance_only(CancellationToken cancellationToken = default)
         {
             List<AuditCount> counted = null;
             List<AuditCount> unknownEndpoint = null;
@@ -45,7 +46,7 @@ namespace ServiceControl.MultiInstance.AcceptanceTests.Auditing
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             using (Assert.EnterMultipleScope())
             {

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_endpoint_known_to_audit_instance.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_endpoint_known_to_audit_instance.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -15,7 +16,7 @@
     class When_endpoint_known_to_audit_instance : AcceptanceTest
     {
         [Test]
-        public async Task Should_appear_in_list_of_known_endpoints()
+        public async Task Should_appear_in_list_of_known_endpoints(CancellationToken cancellationToken = default)
         {
             var knownEndpoints = new List<KnownEndpointsView>();
 
@@ -32,7 +33,7 @@
                     knownEndpoints = result.Items;
                     return result.HasResult;
                 })
-                .Run();
+                .Run(cancellationToken);
             Assert.That(knownEndpoints, Has.Count.EqualTo(1));
             var knownEndpoint = knownEndpoints.FirstOrDefault(x => x.EndpointDetails.Name == Conventions.EndpointNamingConvention(typeof(Sender)));
             Assert.That(knownEndpoint, Is.Not.Null);

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_event_processed_by_multiple_endpoints.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_event_processed_by_multiple_endpoints.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.MultiInstance.AcceptanceTests.Auditing
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@
     class When_event_processed_by_multiple_endpoints : AcceptanceTest
     {
         [Test]
-        public async Task Should_find_both_occurrences()
+        public async Task Should_find_both_occurrences(CancellationToken cancellationToken = default)
         {
             CustomPrimaryEndpointConfiguration = config => config.OnEndpointSubscribed<MyContext>(
                 (subscription, context) =>
@@ -52,7 +53,7 @@
                     ctx => ctx.Subscriber1Subscribed && ctx.Subscriber2Subscribed,
                     session => session.Publish(new SomeEvent())))
                 .Done(async c => c.MessageId != null && (await this.TryGetMany<MessagesView>("/api/messages")).Items.Count == 2)
-                .Run();
+                .Run(cancellationToken);
         }
 
         class Publisher : EndpointConfigurationBuilder

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_conversationId.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_conversationId.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.MultiInstance.AcceptanceTests.Auditing
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -14,7 +15,7 @@
     class When_message_searched_by_conversationId : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_found()
+        public async Task Should_be_found(CancellationToken cancellationToken = default)
         {
             await Define<MyContext>()
                 .WithEndpoint<Sender>(b => b.When((bus, c) => bus.SendLocal(new TriggeringMessage())))
@@ -25,7 +26,7 @@
                     List<MessagesView> response = result;
                     return c.ConversationId != null && result && response.Count == 2;
                 })
-                .Run();
+                .Run(cancellationToken);
         }
 
         public class Sender : EndpointConfigurationBuilder

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_endpoint_by_messages.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_endpoint_by_messages.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@
     class When_message_searched_by_endpoint_by_messages : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_found()
+        public async Task Should_be_found(CancellationToken cancellationToken = default)
         {
             var response = new List<MessagesView>();
 
@@ -33,7 +34,7 @@
                     response = result;
                     return result && response.Count == 1;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             var expectedRemote1InstanceId = InstanceIdGenerator.FromApiUrl(SettingsPerInstance[ServiceControlAuditInstanceName].RootUrl);
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_endpoint_by_messagetype.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_endpoint_by_messagetype.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@
     class When_message_searched_by_endpoint_by_messagetype : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_found()
+        public async Task Should_be_found(CancellationToken cancellationToken = default)
         {
             var response = new List<MessagesView>();
 
@@ -36,7 +37,7 @@
                     response = result;
                     return result && response.Count == 1;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             var expectedRemote1InstanceId = InstanceIdGenerator.FromApiUrl(SettingsPerInstance[ServiceControlAuditInstanceName].RootUrl);
 

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_messageid.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_messageid.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceControl.MultiInstance.AcceptanceTests.Auditing
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -14,12 +15,12 @@
     class When_message_searched_by_messageid : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_found() =>
+        public async Task Should_be_found(CancellationToken cancellationToken = default) =>
             await Define<MyContext>()
                 .WithEndpoint<Sender>(b => b.When((bus, c) => bus.Send(new MyMessage())))
                 .WithEndpoint<Receiver>()
                 .Done(async c => c.MessageId != null && await this.TryGetMany<MessagesView>("/api/messages/search/" + c.MessageId, instanceName: ServiceControlInstanceName))
-                .Run();
+                .Run(cancellationToken);
 
 
         public class Sender : EndpointConfigurationBuilder

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_messages.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_messages.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -18,7 +19,7 @@
     class When_message_searched_by_messages : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_found()
+        public async Task Should_be_found(CancellationToken cancellationToken = default)
         {
             var response = new List<MessagesView>();
 
@@ -35,7 +36,7 @@
                     response = result;
                     return result && response.Count == 2;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             var expectedMasterInstanceId = InstanceIdGenerator.FromApiUrl(SettingsPerInstance[ServiceControlInstanceName].RootUrl);
             var expectedAuditInstanceId = InstanceIdGenerator.FromApiUrl(SettingsPerInstance[ServiceControlAuditInstanceName].RootUrl);

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_messagetype.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Auditing/When_message_searched_by_messagetype.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -17,7 +18,7 @@
     class When_message_searched_by_messagetype : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_found()
+        public async Task Should_be_found(CancellationToken cancellationToken = default)
         {
             var response = new List<MessagesView>();
 
@@ -37,7 +38,7 @@
                     response = result;
                     return result && response.Count == 2;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             var expectedMasterInstanceId = InstanceIdGenerator.FromApiUrl(SettingsPerInstance[ServiceControlInstanceName].RootUrl);
             var expectedAuditInstanceId = InstanceIdGenerator.FromApiUrl(SettingsPerInstance[ServiceControlAuditInstanceName].RootUrl);

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Connection/PlatformConnectionTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.MultiInstance.AcceptanceTests
 {
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting.EndpointTemplates;
     using NServiceBus.AcceptanceTesting;
@@ -13,7 +14,7 @@
     class PlatformConnectionTests : AcceptanceTest
     {
         [Test]
-        public async Task ExposesConnectionDetails()
+        public async Task ExposesConnectionDetails(CancellationToken cancellationToken = default)
         {
             var config = await Define<MyContext>()
                 .WithEndpoint<MyEndpoint>()
@@ -23,7 +24,7 @@
                     x.Connection = await result.Content.ReadAsStringAsync();
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Approver.Verify(JsonSerializer.Deserialize<object>(config.Connection));
         }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Infrastructure/When_remote_instance_is_not_reachable.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Infrastructure/When_remote_instance_is_not_reachable.cs
@@ -19,7 +19,7 @@
     {
         [TestCase(true)]
         [TestCase(false)]
-        public async Task Should_not_fail(bool disableHealthChecks)
+        public async Task Should_not_fail(bool disableHealthChecks, CancellationToken cancellationToken = default)
         {
             var remoteInstanceSetting = new RemoteInstanceSetting("http://localhost:12121");
             CustomServiceControlPrimarySettings = settings =>
@@ -44,7 +44,7 @@
             await Define<MyContext>()
                 .WithEndpoint<Sender>(b => b.When((bus, c) => bus.SendLocal(new MyMessage())))
                 .Done(async c => await this.TryGetMany<MessagesView>("/api/messages/search/" + searchString, instanceName: ServiceControlInstanceName))
-                .Run();
+                .Run(cancellationToken);
         }
 
         class RemoteNotAvailableHandler : HttpMessageHandler

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Monitoring/When_a_message_is_imported_twice.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Monitoring/When_a_message_is_imported_twice.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceControl.MultiInstance.AcceptanceTests.Monitoring
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_a_message_is_imported_twice : AcceptanceTest
     {
         [Test]
-        public async Task Should_register_a_new_endpoint()
+        public async Task Should_register_a_new_endpoint(CancellationToken cancellationToken = default)
         {
             var endpointName = Conventions.EndpointNamingConvention(typeof(Sender));
 
@@ -36,7 +37,7 @@
 
                     return true;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(endpoint?.Name, Is.EqualTo(endpointName));
         }

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/Monitoring/When_endpoint_detected_via_audits.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/Monitoring/When_endpoint_detected_via_audits.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -16,7 +17,7 @@
     class When_endpoint_detected_via_audits : AcceptanceTest
     {
         [Test]
-        public async Task Should_be_configurable()
+        public async Task Should_be_configurable(CancellationToken cancellationToken = default)
         {
             List<EndpointsView> response = null;
 
@@ -47,7 +48,7 @@
 
                     return false;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(response.First(), Is.Not.Null);
             Assert.That(response.First().MonitorHeartbeat, Is.True);

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/SagaAudit/When_sending_saga_audit_to_audit_instance.cs
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/SagaAudit/When_sending_saga_audit_to_audit_instance.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Configuration;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.EndpointTemplates;
@@ -38,7 +39,7 @@
         }
 
         [Test]
-        public async Task Saga_history_can_be_fetched_from_main_instance()
+        public async Task Saga_history_can_be_fetched_from_main_instance(CancellationToken cancellationToken = default)
         {
             SagaHistory sagaHistory = null;
 
@@ -55,7 +56,7 @@
                     sagaHistory = result;
                     return result;
                 })
-                .Run();
+                .Run(cancellationToken);
 
             Assert.That(sagaHistory, Is.Not.Null);
             using (Assert.EnterMultipleScope())

--- a/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
+++ b/src/ServiceControl.MultiInstance.AcceptanceTests/ServiceControl.MultiInstance.AcceptanceTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TestCategory>DefaultCore</TestCategory>
+    <!-- Every test inherits [CancelAfter] from NServiceBusAcceptanceTest, which NUnit honours but the analyzer does not
+         see, so it reports the CancellationToken parameter as an unsupplied argument. -->
+    <NoWarn>$(NoWarn);NUnit1027</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Alternative to #5870 without the scenario wrapper. Same motivation: NServiceBus.AcceptanceTesting caps `Done` at 90 seconds unless `Run` receives a cancellable token, and the journey tests from #5810 regularly exceed that on Windows runners.

`NServiceBusAcceptanceTest` carries `[CancelAfter(180_000)]`, which NUnit applies to every derived fixture. Every test that runs a scenario now takes a trailing `CancellationToken cancellationToken = default`, which NUnit fills from that budget (also for `[TestCase]` methods), and passes it to `Run`. The rewrite is mechanical: 282 methods across 195 files, plus forwarding the token to the few `ReadAsStringAsync` and `AssertAuthConfigurationResponse` calls CA2016 then flags. A test that already declares `[CancelAfter]` keeps its own value.

NUnit1027 is suppressed in the acceptance projects: the analyzer only looks for `[CancelAfter]` on the method and its direct containing class, so it reports the token parameter as unsupplied even though NUnit honours the inherited attribute. Reported upstream as nunit/nunit.analyzers#1019, fix in nunit/nunit.analyzers#1020.

Verified locally: a `[CancelAfter(5_000)]` test with a never-completing `Done` is cancelled after 5 s, and Primary, Audit and Monitoring fixtures pass unchanged.


Pairs with #5872: without it a timed-out test reports the `TaskCanceledException` from the aborted host shutdown instead of the timeout.


