### PR TITLE
Stop ServiceControl test hosts with their own budget instead of the test's cancelled token

### DIFF
--- a/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -158,14 +158,21 @@
 
         public override async Task Stop(CancellationToken cancellationToken = default)
         {
+            // The scenario passes the test's own token here, which has already fired when the test timed out.
+            // Stopping with it aborts the host mid-shutdown, and the exception that produces replaces the
+            // timeout as the reported failure. Shutdown gets its own budget instead.
+            using var shutdown = new CancellationTokenSource(ShutdownTimeout);
+
             using (new DiagnosticTimer($"Test TearDown for {instanceName}"))
             {
-                await host.StopAsync(cancellationToken);
+                await host.StopAsync(shutdown.Token);
                 HttpClient.Dispose();
                 await host.DisposeAsync();
-                await persistenceToUse.Cleanup(cancellationToken);
+                await persistenceToUse.Cleanup(shutdown.Token);
             }
         }
+
+        static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(30);
 
         WebApplication host;
         readonly ITransportIntegration transportToUse;

--- a/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Audit.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -169,13 +169,20 @@ namespace ServiceControl.Audit.AcceptanceTests.TestSupport
 
         public override async Task Stop(CancellationToken cancellationToken = default)
         {
+            // The scenario passes the test's own token here, which has already fired when the test timed out.
+            // Stopping with it aborts the host mid-shutdown, and the exception that produces replaces the
+            // timeout as the reported failure. Shutdown gets its own budget instead.
+            using var shutdown = new CancellationTokenSource(ShutdownTimeout);
+
             using (new DiagnosticTimer($"Test TearDown for {instanceName}"))
             {
-                await host.StopAsync(cancellationToken);
+                await host.StopAsync(shutdown.Token);
                 HttpClient.Dispose();
                 await host.DisposeAsync();
             }
         }
+
+        static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(30);
 
         string instanceName = Settings.DEFAULT_INSTANCE_NAME;
         WebApplication host;

--- a/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
+++ b/src/ServiceControl.Monitoring.AcceptanceTests/TestSupport/ServiceControlComponentRunner.cs
@@ -135,13 +135,20 @@ namespace ServiceControl.Monitoring.AcceptanceTests.TestSupport
 
         public override async Task Stop(CancellationToken cancellationToken = default)
         {
+            // The scenario passes the test's own token here, which has already fired when the test timed out.
+            // Stopping with it aborts the host mid-shutdown, and the exception that produces replaces the
+            // timeout as the reported failure. Shutdown gets its own budget instead.
+            using var shutdown = new CancellationTokenSource(ShutdownTimeout);
+
             using (new DiagnosticTimer($"Test TearDown for {settings.InstanceName}"))
             {
-                await host.StopAsync(cancellationToken);
+                await host.StopAsync(shutdown.Token);
                 HttpClient.Dispose();
                 await host.DisposeAsync();
             }
         }
+
+        static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(30);
 
         WebApplication host;
         Settings settings;


### PR DESCRIPTION
The scenario runner's `finally` stops every component with the test's cancellation token. When a test has timed out that token has already fired, so `host.StopAsync` aborts inside `ErrorIngestion.EnsureStopped` and its `TaskCanceledException` replaces the timeout as the reported failure. That is what a slow acceptance test looks like in CI today: "A task was canceled" with no hint that it ran out of time, and a host that was never shut down cleanly.

The three `ServiceControlComponentRunner.Stop` implementations now shut down on a 30 second budget of their own. Applies to the 23 tests that already use `[CancelAfter]` and to whichever of #5870 / #5871 lands.

Verified locally: a `[CancelAfter(5_000)]` test with a never-completing `Done` now fails with the framework's `TimeoutException` and teardown completes in 0.14 s, where before it failed with the `TaskCanceledException` from `EnsureStopped`.