### PR TITLE
Provision WSL and the test containers after the build instead of alongside it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,16 +90,6 @@ jobs:
         id: build
         background: true
         run: dotnet build tests.proj --configuration Release -graph
-      # Provisions the WSL2 Docker host that the SQL Server, PostgreSQL, RabbitMQ and IBM MQ containers
-      # run in on Windows. A no-op on Linux, but still run there so those actions see the same
-      # environment variables on both runners.
-      - name: Setup WSL
-        if: contains(fromJSON('["RabbitMQ", "SqlServer", "PostgreSql", "IBMMQ"]'), matrix.test-category)
-        uses: Particular/setup-wsl-action@v1.2.0
-        with:
-          # The action defaults to 4GB. The runner has 16GB and the build runs concurrently with the
-          # container starting up, so give the VM real headroom.
-          memory: 8GB
       # there is an issue with az cli and python 3.14, so for now we need to pin it
       # once the issue is resolved it should be able to be re-floated
       # https://github.com/Azure/azure-cli/issues/32980.
@@ -116,6 +106,30 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --user "azure-cli==2.64.0"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Setup SQS environment variables
+        if: matrix.test-category == 'SQS'
+        run: |
+          echo "AWS_REGION=${{ secrets.AWS_REGION }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+
+          # Cleanup of queues starting with `GHA-` handled by https://github.com/Particular/NServiceBus.AmazonSQS/blob/master/.github/workflows/tests-cleanup.yml
+          $connectString = "AccessKeyId=${{ secrets.AWS_ACCESS_KEY_ID }};SecretAccessKey=${{ secrets.AWS_SECRET_ACCESS_KEY }};Region=${{ secrets.AWS_REGION }};QueueNamePrefix=GHA-${{ github.run_id }}"
+          echo "ServiceControl_TransportTests_SQS_ConnectionString=$connectString" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+      # The Azure steps below create real cloud resources, so they sit behind the wait as well.
+      - name: Wait for build
+        wait: build
+      # Provisions the WSL2 Docker host that the SQL Server, PostgreSQL, RabbitMQ and IBM MQ containers
+      # run in on Windows. A no-op on Linux, but still run there so those actions see the same
+      # environment variables on both runners. It and the container setups run after the build on
+      # purpose: with the VM and the build competing for the runner's memory, jobs have died with "The
+      # hosted runner lost communication with the server".
+      - name: Setup WSL
+        if: contains(fromJSON('["RabbitMQ", "SqlServer", "PostgreSql", "IBMMQ"]'), matrix.test-category)
+        uses: Particular/setup-wsl-action@v1.2.0
+        with:
+          # The action defaults to 4GB. The runner has 16GB, so give the VM real headroom.
+          memory: 8GB
       - name: Setup SQL Server
         uses: Particular/install-sql-server-action@v3.0.0
         if: matrix.test-category == 'SqlServer'
@@ -148,20 +162,6 @@ jobs:
         if: matrix.test-category == 'IBMMQ'
         with:
           connection-string-name: ServiceControl_TransportTests_IBMMQ_ConnectionString
-      - name: Setup SQS environment variables
-        if: matrix.test-category == 'SQS'
-        run: |
-          echo "AWS_REGION=${{ secrets.AWS_REGION }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-
-          # Cleanup of queues starting with `GHA-` handled by https://github.com/Particular/NServiceBus.AmazonSQS/blob/master/.github/workflows/tests-cleanup.yml
-          $connectString = "AccessKeyId=${{ secrets.AWS_ACCESS_KEY_ID }};SecretAccessKey=${{ secrets.AWS_SECRET_ACCESS_KEY }};Region=${{ secrets.AWS_REGION }};QueueNamePrefix=GHA-${{ github.run_id }}"
-          echo "ServiceControl_TransportTests_SQS_ConnectionString=$connectString" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-      # Everything above provisions local containers, so it overlaps the build freely. The Azure steps
-      # below create real cloud resources, so they sit behind the wait too.
-      - name: Wait for build
-        wait: build
       - name: Azure login
         uses: azure/login@v3.0.2
         if: matrix.test-category == 'AzureServiceBus' || matrix.test-category == 'AzureStorageQueues'


### PR DESCRIPTION
Two Windows jobs in the last 60 CI runs (Windows-IBMMQ, 46 min; Windows-SqlServer on release-6.19, 52 min) ended with "The hosted runner lost communication with the server", GitHub's annotation for a runner starved of CPU or memory. Both were running the background build alongside the 8 GB WSL2 VM on a 16 GB runner.

The WSL, SQL Server, PostgreSQL, RabbitMQ and IBM MQ setup steps now sit behind `Wait for build`, as the Azure steps already did. Costs those jobs the setup time that used to overlap the build, roughly a minute for WSL and up to three for SQL Server with full-text search.