### PR TITLE
Update Particular/run-tests-action to v1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
           azure-credentials: ${{ secrets.AZURE_ACI_CREDENTIALS }}
           tag: ServiceControl
       - name: Run tests
-        uses: Particular/run-tests-action@v1.8.0
+        uses: Particular/run-tests-action@v1.9.0
         with:
           projects: ${{ steps.select.outputs.test-projects }}
           max-parallel: ${{ matrix.max-parallel || 1 }}


### PR DESCRIPTION
Picks up Particular/run-tests-action#17: buffered output of a test run that was still going when the job was cancelled or hit its timeout is no longer lost, the action's final step prints it.