### PR TITLE
Fix cloud database tests calling the removed tools/run-tests.ps1

### DIFF
--- a/.github/workflows/cloud-database-tests.yml
+++ b/.github/workflows/cloud-database-tests.yml
@@ -132,7 +132,10 @@ jobs:
       - name: Wait for build
         wait: build
       - name: Run tests
-        run: ./tools/run-tests.ps1 -Projects "$Env:PERSISTENCE_PROJECT`n$Env:ACCEPTANCE_PROJECT" -MaxParallel 2
+        uses: Particular/run-tests-action@v1.9.0
+        with:
+          projects: ${{ env.PERSISTENCE_PROJECT }};${{ env.ACCEPTANCE_PROJECT }}
+          max-parallel: 2
         env:
           ServiceControl_TESTS_FILTER: ${{ matrix.provider }}
           PARTICULARSOFTWARE_LICENSE: ${{ secrets.LICENSETEXT }}


### PR DESCRIPTION
## What

Every `cloud-tests` job in the [6.21.0 release run](https://github.com/Particular/ServiceControl/actions/runs/34605498546) failed at the **Run tests** step:

```
The term './tools/run-tests.ps1' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

`cloud-database-tests.yml` (added in #5863) still invokes `tools/run-tests.ps1`, but 9ceb32b22 deleted that script on 2026-09-07 when `ci.yml` moved to `Particular/run-tests-action` (which grew a `projects` input for exactly this purpose). The two changes never conflicted in git because #5863 introduced a new file, and the cloud workflow only runs via `workflow_call` from the release workflow or manual dispatch, so the reference was never exercised until the tag was pushed.

## Fix

Call `Particular/run-tests-action@v1.9.0` the same way `ci.yml` does, passing the persistence and acceptance projects via the `projects` input (semicolon-delimited, matching `ci.yml`) with `max-parallel: 2`.

## Impact of the failure

The release itself is unaffected: `windows-installers`, `containers` and `db-container` are independent jobs with no `needs` on `cloud-tests`, and all succeeded. Only the cloud database verification did not run for 6.21.0. Once merged, the workflow can be re-run for that tag via `workflow_dispatch` if that coverage is wanted.
